### PR TITLE
feat(stage-ui): animate idle eye saccades on VRMs

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -90,6 +90,8 @@ words:
   - pthread
   - rehype
   - rushstack
+  - Saccade
+  - saccades
   - Shadcn
   - shiki
   - shikijs

--- a/packages/moonshine-web/netlify.toml
+++ b/packages/moonshine-web/netlify.toml
@@ -3,7 +3,7 @@ publish = "packages/moonshine-web/dist"
 command = "pnpm run packages:stub && pnpm run build"
 
 [build.environment]
-NODE_VERSION = "22"
+NODE_VERSION = "23"
 
 [[redirects]]
 from = "/assets/*"

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -6,6 +6,7 @@ import { ref } from 'vue'
 import Collapsable from '../Collapsable.vue'
 import DataGuiRange from '../DataGui/Range.vue'
 import Screen from '../Screen.vue'
+import TransitionVertical from '../TransitionVertical.vue'
 import VRMModel from '../VRM/Model.vue'
 
 const props = defineProps<{

--- a/packages/stage-ui/src/composables/vrm/animation.ts
+++ b/packages/stage-ui/src/composables/vrm/animation.ts
@@ -1,6 +1,8 @@
 import type { VRMAnimation } from '@pixiv/three-vrm-animation'
 import type { VRMCore } from '@pixiv/three-vrm-core'
 import { createVRMAnimationClip } from '@pixiv/three-vrm-animation'
+import { Object3D, Vector3 } from 'three'
+import { randFloat } from 'three/src/math/MathUtils.js'
 import { ref } from 'vue'
 import { useVRMLoader } from './loader'
 
@@ -83,6 +85,79 @@ export function useBlink() {
         nextBlinkTime.value = Math.random() * (MAX_BLINK_INTERVAL - MIN_BLINK_INTERVAL) + MIN_BLINK_INTERVAL
       }
     }
+  }
+
+  return { update }
+}
+
+/**
+ * This is to simulate idle eye saccades in a *pretty* naive way.
+ * Not using any reactivity here as it's not yet needed.
+ * Keeping it here as a composable for future extension.
+ */
+export function useIdleEyeSaccades() {
+  let nextSaccadeAfter = -1
+  let fixationTarget: Vector3 | undefined
+  let timeSinceLastSaccade = 0
+
+  const STEP = 400
+  const P = [
+    [0.075, 800],
+    [0.110, 0],
+    [0.125, 0],
+    [0.140, 0],
+    [0.125, 0],
+    [0.050, 0],
+    [0.040, 0],
+    [0.030, 0],
+    [0.020, 0],
+    [1.000, 0],
+  ]
+  for (let i = 1; i < P.length; i++) {
+    P[i][0] += P[i - 1][0]
+    P[i][1] = P[i - 1][1] + STEP
+  }
+
+  function nextSaccadeTimeMs() {
+    const r = Math.random()
+    for (let i = 0; i < P.length; i++) {
+      if (r <= P[i][0]) {
+        return P[i][1] + Math.random() * STEP
+      }
+    }
+    return P[P.length - 1][1] + Math.random() * STEP
+  }
+
+  // Just a naive vector generator - Simulating random content on a 27in monitor at 65cm distance
+  function updateFixationTarget() {
+    if (!fixationTarget) {
+      fixationTarget = new Vector3(randFloat(-0.25, 0.25), randFloat(-0.2, 0.15), -0.65)
+    }
+    else {
+      fixationTarget.set(randFloat(-0.25, 0.25), randFloat(-0.2, 0.15), -0.65)
+    }
+  }
+
+  // Function to handle idle eye saccades
+  function update(vrm: VRMCore | undefined, delta: number) {
+    if (!vrm?.expressionManager || !vrm.lookAt)
+      return
+
+    if (timeSinceLastSaccade >= nextSaccadeAfter) {
+      updateFixationTarget()
+      timeSinceLastSaccade = 0
+      nextSaccadeAfter = nextSaccadeTimeMs() / 1000
+    }
+    else if (!fixationTarget) {
+      updateFixationTarget()
+    }
+
+    if (!vrm.lookAt.target) {
+      vrm.lookAt.target = new Object3D()
+    }
+    vrm.lookAt.target.position.lerp(fixationTarget!, randFloat(0.2, 0.5))
+    vrm.lookAt?.update(delta)
+    timeSinceLastSaccade += delta
   }
 
   return { update }

--- a/packages/stage-web/netlify.toml
+++ b/packages/stage-web/netlify.toml
@@ -3,7 +3,7 @@ publish = "packages/stage-web/dist"
 command = "pnpm run packages:stub && pnpm run build"
 
 [build.environment]
-NODE_VERSION = "22"
+NODE_VERSION = "23"
 
 [[redirects]]
 from = "/assets/*"

--- a/packages/stage-web/src/components/Layouts/InteractiveArea.vue
+++ b/packages/stage-web/src/components/Layouts/InteractiveArea.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
+import { BasicTextarea, TransitionVertical } from '@proj-airi/stage-ui/components'
 import { useMicVAD, useWhisper } from '@proj-airi/stage-ui/composables'
 
 import WhisperWorker from '@proj-airi/stage-ui/libs/workers/worker?worker&url'
 import { useAudioContext, useChatStore, useSettings } from '@proj-airi/stage-ui/stores'
-
 import { useDevicesList } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { ref, watch } from 'vue'

--- a/packages/whisper-webgpu/netlify.toml
+++ b/packages/whisper-webgpu/netlify.toml
@@ -3,7 +3,7 @@ publish = "packages/whisper-webgpu/dist"
 command = "pnpm run packages:stub && pnpm run build"
 
 [build.environment]
-NODE_VERSION = "22"
+NODE_VERSION = "23"
 
 [[redirects]]
 from = "/assets/*"


### PR DESCRIPTION
### Feature

* Animate (synthetic) idle eye saccades with a simple implementation (Please feel free to tune these parameters)

  ![Screen recording](https://github.com/user-attachments/assets/c911a7d2-577b-49b8-96b1-b04cf91ce232)

### Misc

* Clean up VRM and before-render callbacks upon unmounting (to avoid duplicating VRMs on hot reload and crashing the browser)

  <details>
  <summary>Duplicate VRMs look like this (Viewer discretion is advised)</summary>
  <img src="https://github.com/user-attachments/assets/12649fd6-680e-4180-b80e-b6d6bd77d349">
  </details>

* Fix missing component imports (warnings)