### PR TITLE
feat(stage-web): add dotted background to settings buttons

### DIFF
--- a/apps/stage-web/src/components/Menu/IconItem.vue
+++ b/apps/stage-web/src/components/Menu/IconItem.vue
@@ -13,7 +13,7 @@ defineProps<{
     flex="~ row" bg="white dark:neutral-800"
     border="neutral-100 dark:neutral-700 hover:pink-300 dark:hover:pink-200/40 solid 2"
     drop-shadow="none hover:[0px_4px_4px_rgba(220,220,220,0.4)] active:[0px_0px_0px_rgba(220,220,220,0.25)] dark:hover:none"
-    class="[&_.settings-section-icon]:hover:scale-120 [&_.settings-section-description]:hover:text-pink-400/80 [&_.settings-section-icon]:hover:text-pink-200 [&_.settings-section-title]:hover:text-pink-500 dark:[&_.settings-section-icon]:hover:text-pink-200/40 dark:[&_.settings-section-title]:hover:text-pink-400"
+    class="after:mask-[linear-gradient(165deg,white_30%,transparent_50%)] after:bg-dotted-[neutral-200] after:hover:bg-dotted-[pink-300/50] dark:after:bg-dotted-[neutral-700/80] dark:after:hover:bg-dotted-[pink-200/20] after:absolute after:left-0 after:top-0 after-z--1 after:h-full after:w-full after:bg-[size:10px_10px] after:content-empty [&_.settings-section-icon]:hover:scale-120 [&_.settings-section-description]:hover:text-pink-400/80 [&_.settings-section-icon]:hover:text-pink-200 [&_.settings-section-title]:hover:text-pink-500 dark:[&_.settings-section-icon]:hover:text-pink-200/40 dark:[&_.settings-section-title]:hover:text-pink-400"
     transition="all ease-in-out duration-200" relative w-full items-center overflow-hidden rounded-lg p-5 text-left
     :to="to"
   >

--- a/apps/stage-web/src/components/Menu/IconItem.vue
+++ b/apps/stage-web/src/components/Menu/IconItem.vue
@@ -13,7 +13,7 @@ defineProps<{
     flex="~ row" bg="white dark:neutral-800"
     border="neutral-100 dark:neutral-700 hover:pink-300 dark:hover:pink-200/40 solid 2"
     drop-shadow="none hover:[0px_4px_4px_rgba(220,220,220,0.4)] active:[0px_0px_0px_rgba(220,220,220,0.25)] dark:hover:none"
-    class="after:mask-[linear-gradient(165deg,white_30%,transparent_50%)] after:bg-dotted-[neutral-200] after:hover:bg-dotted-[pink-300/50] dark:after:bg-dotted-[neutral-700/80] dark:after:hover:bg-dotted-[pink-200/20] after:absolute after:left-0 after:top-0 after-z--1 after:h-full after:w-full after:bg-[size:10px_10px] after:content-empty [&_.settings-section-icon]:hover:scale-120 [&_.settings-section-description]:hover:text-pink-400/80 [&_.settings-section-icon]:hover:text-pink-200 [&_.settings-section-title]:hover:text-pink-500 dark:[&_.settings-section-icon]:hover:text-pink-200/40 dark:[&_.settings-section-title]:hover:text-pink-400"
+    class="after:mask-[linear-gradient(165deg,white_30%,transparent_50%)] after:bg-dotted-[neutral-200] after:hover:bg-dotted-[pink-300/50] dark:after:bg-dotted-[neutral-700/80] dark:after:hover:bg-dotted-[pink-200/20] after:absolute after:left-0 after:top-0 after:z--1 after:h-full after:w-full after:bg-[size:10px_10px] after:content-empty [&_.settings-section-icon]:hover:scale-120 [&_.settings-section-description]:hover:text-pink-400/80 [&_.settings-section-icon]:hover:text-pink-200 [&_.settings-section-title]:hover:text-pink-500 dark:[&_.settings-section-icon]:hover:text-pink-200/40 dark:[&_.settings-section-title]:hover:text-pink-400"
     transition="all ease-in-out duration-200" relative w-full items-center overflow-hidden rounded-lg p-5 text-left
     :to="to"
   >

--- a/apps/stage-web/uno.config.ts
+++ b/apps/stage-web/uno.config.ts
@@ -1,4 +1,5 @@
 import { createExternalPackageIconLoader } from '@iconify/utils/lib/loader/external-pkg'
+import { colorToString } from '@unocss/preset-mini/utils'
 import {
   defineConfig,
   presetAttributify,
@@ -9,6 +10,7 @@ import {
   transformerDirectives,
   transformerVariantGroup,
 } from 'unocss'
+import { parseColor } from 'unocss/preset-mini'
 
 export default defineConfig({
   presets: [
@@ -56,4 +58,15 @@ export default defineConfig({
       ],
     },
   },
+  rules: [
+    [/^mask-\[(.*)\]$/, ([, suffix]) => ({ '-webkit-mask-image': suffix.replace(/_/g, ' ') })],
+    [/^bg-dotted-\[(.*)\]$/, ([, color], { theme }) => {
+      const parsedColor = parseColor(color, theme)
+      // Util usage: https://github.com/unocss/unocss/blob/f57ef6ae50006a92f444738e50f3601c0d1121f2/packages-presets/preset-mini/src/_utils/utilities.ts#L186
+      return {
+        'background-image': `radial-gradient(circle at 1px 1px, ${colorToString(parsedColor?.cssColor ?? parsedColor?.color ?? color, 'var(--un-background-opacity)')} 1px, transparent 0)`,
+        '--un-background-opacity': parsedColor?.cssColor?.alpha ?? parsedColor?.alpha ?? 1,
+      }
+    }],
+  ],
 })


### PR DESCRIPTION
## Description

This pull request adds dotted-pattern backgrounds to buttons on the Settings page and adds some reusable UnoCSS rules.

### Screenshots

|Normal|Hovered|
|:-:|:-:|
|<img width="874" alt="Screenshot 2025-03-08 at 0 18 14" src="https://github.com/user-attachments/assets/ee01c374-38e3-4b07-abfb-7a20c3a45c9c" />|<img width="874" alt="Screenshot 2025-03-08 at 0 18 23" src="https://github.com/user-attachments/assets/cc0b9350-70d6-4059-84ff-94fb2a25a899" />|