### PR TITLE
fix(stage-web): add back button to settings root

### DIFF
--- a/apps/stage-web/src/pages/settings/index.vue
+++ b/apps/stage-web/src/pages/settings/index.vue
@@ -3,9 +3,11 @@ import { useSettings } from '@proj-airi/stage-ui/stores'
 import { useDark } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 
 import IconItem from '../../components/Menu/IconItem.vue'
 
+const router = useRouter()
 const { t } = useI18n()
 const settings = storeToRefs(useSettings())
 const dark = useDark()
@@ -17,7 +19,10 @@ function handleLanguageChange(event: Event) {
 </script>
 
 <template>
-  <div>
+  <div flex="~ row" items-center gap-2>
+    <button @click="router.back()">
+      <div i-solar:alt-arrow-left-line-duotone text-2xl />
+    </button>
     <h1 text-3xl>
       Settings
     </h1>


### PR DESCRIPTION
## Description

> This PR is optional as I'm not sure if it was intended

Adds a back button for the Settings root page b/c I found myself getting lost until I realized the HeaderLink is clickable:

|Before|After|
|:-|:-|
|<img width="827" alt="Screenshot 2025-03-08 at 3 38 30" src="https://github.com/user-attachments/assets/34215a58-7584-43c7-a2c8-0d722a854c17" />|<img width="827" alt="Screenshot 2025-03-08 at 3 38 12" src="https://github.com/user-attachments/assets/f05ef3e4-bf77-4f50-bc57-37bf5916b73e" />|