### PR TITLE
fix(ui-transitions): the outermost div should be fixed

### DIFF
--- a/packages/ui-transitions/src/components/ArrowTransition.vue
+++ b/packages/ui-transitions/src/components/ArrowTransition.vue
@@ -38,7 +38,7 @@ onMounted(() => {
   --delay: 0s;
   --sharpness: 40%;
 
-  position: absolute;
+  position: fixed;
   inset: 0;
   overflow: hidden;
 

--- a/packages/ui-transitions/src/components/BubbleWaveOutTransition.vue
+++ b/packages/ui-transitions/src/components/BubbleWaveOutTransition.vue
@@ -29,7 +29,7 @@ onMounted(() => {
 
 <style scoped>
 .circle-expansion-transition {
-  position: absolute;
+  position: fixed;
   top: calc(50% - 75vmax);
   left: calc(50% - 75vmax);
   width: 150vmax;

--- a/packages/ui-transitions/src/components/FantasyFallTransition.vue
+++ b/packages/ui-transitions/src/components/FantasyFallTransition.vue
@@ -35,7 +35,7 @@ onMounted(() => {
 
 <style scoped>
 .fantasy-fall-transition {
-  position: absolute;
+  position: fixed;
   inset: 0;
   overflow: hidden;
 }

--- a/packages/ui-transitions/src/components/MultipleBlocksRevealTransition.vue
+++ b/packages/ui-transitions/src/components/MultipleBlocksRevealTransition.vue
@@ -38,7 +38,7 @@ onMounted(() => {
 .stage-transition-4 {
   --delay: 0s;
 
-  position: absolute;
+  position: fixed;
   inset: 0;
   overflow: hidden;
   display: grid;

--- a/packages/ui-transitions/src/components/RectanglesRotateTransition.vue
+++ b/packages/ui-transitions/src/components/RectanglesRotateTransition.vue
@@ -47,7 +47,7 @@ onMounted(() => {
 
 <style scoped>
 .rectangle-rotate-transition {
-  position: absolute;
+  position: fixed;
   inset: 0;
   overflow: hidden;
 }

--- a/packages/ui-transitions/src/components/SlideTransition.vue
+++ b/packages/ui-transitions/src/components/SlideTransition.vue
@@ -37,7 +37,7 @@ onMounted(() => {
 .stage-transition-1 {
   --delay: 0s;
 
-  position: absolute;
+  position: fixed;
   inset: 0;
   overflow: hidden;
 

--- a/packages/ui-transitions/src/components/SlopeSlideTransition.vue
+++ b/packages/ui-transitions/src/components/SlopeSlideTransition.vue
@@ -33,7 +33,7 @@ onMounted(() => {
   --delay: 0s;
   --skew-x: 100%;
 
-  position: absolute;
+  position: fixed;
   inset: 0;
   overflow: hidden;
 


### PR DESCRIPTION
instead of `absolute` as the web page might be scrolled down

reproduce:

https://github.com/user-attachments/assets/11d2ebcd-509e-40f2-ba94-0eb13d6ced4f

