### PR TITLE
feat(stage-ui): integrate histoire storyboard

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -64,6 +64,7 @@ words:
   - hfup
   - higress
   - histoire
+  - histoire
   - hiyori
   - huggingface
   - huggingspace
@@ -138,6 +139,7 @@ words:
   - sizecheck
   - smallserial
   - Sniglet
+  - ssml
   - stepfun
   - supergroup
   - superjson
@@ -161,6 +163,5 @@ words:
   - xsai
   - xsschema
   - zhipu
-  - ssml
 ignoreWords: []
 import: []

--- a/packages/stage-ui/README.md
+++ b/packages/stage-ui/README.md
@@ -1,0 +1,16 @@
+# Stage UI
+
+Shared core for stage
+
+## Histoire (UI storyboard)
+
+https://histoire.dev/
+
+```
+pnpm -F @proj-airi/stage-ui run story:dev
+```
+
+### Project structure
+
+1. If a story is bound to a specific component, it can be placed beside the component in the `src` folder. e.g., `MyComponent.story.vue`
+2. If a story is not bound to a specific component, then it should be placed in the `stories` folder. e.g., `MyStory.story.vue`

--- a/packages/stage-ui/build.config.ts
+++ b/packages/stage-ui/build.config.ts
@@ -2,7 +2,7 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   entries: [
-    { builder: 'mkdist', input: './src/components/', outDir: './dist/components', pattern: '**/*.vue', loaders: ['vue'] },
+    { builder: 'mkdist', input: './src/components/', outDir: './dist/components', pattern: ['**/*.vue', '!**/*.story.vue'], loaders: ['vue'] },
     { builder: 'mkdist', input: './src/components/', outDir: './dist/components', pattern: '**/*.ts', format: 'esm', loaders: ['js'] },
     { builder: 'mkdist', input: './src/stores/', outDir: './dist/stores', pattern: '**/*.ts', format: 'esm', loaders: ['js'] },
     { builder: 'mkdist', input: './src/constants/', outDir: './dist/constants', pattern: '**/*.ts', format: 'esm', loaders: ['js'] },

--- a/packages/stage-ui/env.d.ts
+++ b/packages/stage-ui/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@histoire/plugin-vue/components.d.ts" />

--- a/packages/stage-ui/histoire.config.ts
+++ b/packages/stage-ui/histoire.config.ts
@@ -1,0 +1,15 @@
+import { HstVue } from '@histoire/plugin-vue'
+import { defineConfig } from 'histoire'
+
+export default defineConfig({
+  plugins: [HstVue()],
+  setupFile: 'stories/setup.ts',
+  tree: {
+    groups: [
+      {
+        id: 'design-system',
+        title: 'Design System',
+      },
+    ],
+  },
+})

--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -61,6 +61,7 @@
     "@proj-airi/utils-transformers": "workspace:^",
     "@unocss/reset": "^66.1.0-beta.3",
     "@vitejs/plugin-vue": "^5.2.1",
+    "@xsai/embed": "catalog:",
     "histoire": "1.0.0-alpha.2",
     "unocss": "^66.1.0-beta.3",
     "vite": "^6.2.1"

--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -61,7 +61,6 @@
     "@proj-airi/utils-transformers": "workspace:^",
     "@unocss/reset": "^66.1.0-beta.3",
     "@vitejs/plugin-vue": "^5.2.1",
-    "@xsai/embed": "catalog:",
     "histoire": "1.0.0-alpha.2",
     "unocss": "^66.1.0-beta.3",
     "vite": "^6.2.1"

--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -49,12 +49,21 @@
     "dev": "pnpm run stub",
     "stub": "unbuild --stub",
     "build": "unbuild",
-    "typecheck": "vue-tsc --noEmit"
+    "typecheck": "vue-tsc --noEmit",
+    "story:dev": "histoire dev",
+    "story:build": "histoire build",
+    "story:preview": "histoire preview"
   },
   "devDependencies": {
     "@electron-toolkit/preload": "^3.0.1",
+    "@histoire/plugin-vue": "1.0.0-alpha.2",
     "@proj-airi/provider-transformers": "workspace:^",
     "@proj-airi/utils-transformers": "workspace:^",
-    "@xsai/embed": "catalog:"
+    "@unocss/reset": "^66.1.0-beta.3",
+    "@vitejs/plugin-vue": "^5.2.1",
+    "@xsai/embed": "catalog:",
+    "histoire": "1.0.0-alpha.2",
+    "unocss": "^66.1.0-beta.3",
+    "vite": "^6.2.1"
   }
 }

--- a/packages/stage-ui/src/components/Menu/IconItem.story.vue
+++ b/packages/stage-ui/src/components/Menu/IconItem.story.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import ThemeColorsHueControl from '../../../stories/ThemeColorsHueControl.vue'
+import IconItem from './IconItem.vue'
+</script>
+
+<template>
+  <Story
+    :layout="{ type: 'grid', width: 500 }"
+  >
+    <template #controls>
+      <ThemeColorsHueControl />
+    </template>
+
+    <Variant
+      id="global"
+      title="IconItem"
+    >
+      <IconItem title="Modules" description="Thinking, vision, speech synthesis, gaming, etc." icon="i-lucide:blocks" to="/settings/modules" />
+    </Variant>
+  </Story>
+</template>

--- a/packages/stage-ui/src/components/Menu/IconItem.vue
+++ b/packages/stage-ui/src/components/Menu/IconItem.vue
@@ -10,6 +10,7 @@ defineProps<{
 
 <template>
   <RouterLink
+    box="border"
     flex="~ row"
     bg="neutral-50 dark:neutral-800"
     border="neutral-100 dark:neutral-700 hover:primary-500/30 dark:hover:primary-400/30 solid 2"
@@ -17,6 +18,7 @@ defineProps<{
     class="menu-icon-item"
     transition="all ease-in-out duration-200"
     relative w-full items-center overflow-hidden rounded-lg p-5 text-left
+    cursor="pointer"
     :to="to"
   >
     <div z-1 flex-1>

--- a/packages/stage-ui/src/components/Menu/IconStatusItem.story.vue
+++ b/packages/stage-ui/src/components/Menu/IconStatusItem.story.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import ThemeColorsHueControl from '../../../stories/ThemeColorsHueControl.vue'
+import IconStatusItem from './IconStatusItem.vue'
+</script>
+
+<template>
+  <Story
+    :layout="{ type: 'grid', width: 500 }"
+  >
+    <template #controls>
+      <ThemeColorsHueControl />
+    </template>
+
+    <Variant
+      id="global"
+      title="IconItem"
+    >
+      <IconStatusItem
+        title="Title"
+        description="Description"
+        icon=" i-lucide:ghost"
+        to="/"
+        :configured="false"
+      />
+    </Variant>
+  </Story>
+</template>

--- a/packages/stage-ui/stories/Colors.story.vue
+++ b/packages/stage-ui/stories/Colors.story.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import ThemeColorsHueControl from './ThemeColorsHueControl.vue'
+
+const shades = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
+const opacities = [5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+</script>
+
+<template>
+  <Story
+    group="design-system"
+    title="Colors"
+    :layout="{ type: 'single', iframe: false }"
+    responsive-disabled
+  >
+    <template #controls>
+      <ThemeColorsHueControl />
+    </template>
+
+    <Variant title="Shades in opacities">
+      <div grid="~ cols-12 rows-12" class="transparency-grid" items-center justify-center>
+        <template
+          v-for="(shade, c) in shades"
+          :key="`primary-${shade}`"
+        >
+          <div self-end p-4 text-center font-mono :style="{ gridArea: `1 / ${c + 2} / span 1 / span 1` }">
+            {{ shade }}
+          </div>
+        </template>
+
+        <template
+          v-for="(opacity, r) in opacities"
+          :key="`primary-${opacity}`"
+        >
+          <div p-4 text-right font-mono :style="{ gridArea: `${r + 2} / 1 / span 1 / span 1` }">
+            /{{ opacity }}
+          </div>
+
+          <div
+            v-for="(shade, c) in shades"
+            :key="`primary-${shade}/${opacity}`"
+            class="cursor-crosshair [&_.color-label]:hover:op-100" :class="[`bg-primary-${shade}/${opacity}`]"
+            h-82px flex items-center justify-center p-4
+            :style="{ gridArea: `${r + 2} / ${c + 2} / span 1 / span 1` }"
+          >
+            <div
+
+              bg="light op-80"
+              text-primary-700 dark:text-primary-300 rounded-md px-1 py-0.5 text-xs font-mono op-0 dark:bg-dark
+              transition="opacity duration-100"
+              class="color-label"
+            >
+              {{ shade }}/{{ opacity }}
+            </div>
+          </div>
+        </template>
+      </div>
+    </Variant>
+  </Story>
+</template>
+
+<style>
+.primary-color-bar {
+  @apply w-full h-full flex-1 flex items-center justify-center;
+}
+
+.theme-hue-slider {
+  @apply flex-1 w-full h-2 rounded-full appearance-none;
+  background: linear-gradient(
+    to right,
+    oklch(85% 0.2 0),
+    oklch(85% 0.2 60),
+    oklch(85% 0.2 120),
+    oklch(85% 0.2 180),
+    oklch(85% 0.2 240),
+    oklch(85% 0.2 300),
+    oklch(85% 0.2 360)
+  );
+}
+
+.transparency-grid::before {
+  content: '';
+  grid-area: 2 / 2 / span 11 / span 11;
+  width: 100%;
+  height: 100%;
+  background-image: linear-gradient(45deg, oklch(90% 0 0) 25%, transparent 25%),
+    linear-gradient(-45deg, oklch(90% 0 0) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, oklch(90% 0 0) 75%),
+    linear-gradient(-45deg, transparent 75%, oklch(90% 0 0) 75%);
+  background-size: 20px 20px;
+  background-position:
+    0 0,
+    0 10px,
+    10px -10px,
+    -10px 0px;
+  background-color: oklch(100% 0 0);
+}
+
+.dark .transparency-grid::before {
+  background-image: linear-gradient(45deg, oklch(40% 0 0) 25%, transparent 25%),
+    linear-gradient(-45deg, oklch(40% 0 0) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, oklch(40% 0 0) 75%),
+    linear-gradient(-45deg, transparent 75%, oklch(40% 0 0) 75%);
+  background-color: oklch(25% 0 0);
+}
+</style>

--- a/packages/stage-ui/stories/ThemeColorsHueControl.vue
+++ b/packages/stage-ui/stories/ThemeColorsHueControl.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+
+const DEFAULT_THEME_COLORS_HUE = 354.31
+
+const themeColorsHue = ref(DEFAULT_THEME_COLORS_HUE)
+
+function resetToDefault() {
+  themeColorsHue.value = DEFAULT_THEME_COLORS_HUE
+}
+
+onMounted(() => {
+  const hue = document.documentElement.style.getPropertyValue('--theme-colors-hue')
+  const hueF = Number.parseFloat(hue)
+  themeColorsHue.value = hueF >= 0 && hueF <= 360 ? hueF : DEFAULT_THEME_COLORS_HUE
+})
+
+watch(themeColorsHue, () => {
+  document.documentElement.style.setProperty('--theme-colors-hue', themeColorsHue.value.toString())
+})
+</script>
+
+<template>
+  <div px-4 py-2>
+    <input
+      v-model="themeColorsHue"
+      type="range"
+      min="0"
+      max="360"
+      step="0.01"
+      class="theme-hue-slider"
+    >
+
+    <button
+      class="mt-2 rounded-md bg-neutral-100 px-2 py-1 text-xs transition-colors dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700"
+      @click="resetToDefault"
+    >
+      Reset to Default
+    </button>
+  </div>
+</template>

--- a/packages/stage-ui/stories/main.css
+++ b/packages/stage-ui/stories/main.css
@@ -1,0 +1,41 @@
+@import './themes.css';
+@import './transitions.css';
+
+html,
+body,
+#app {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overscroll-behavior: none;
+}
+
+html {
+  background: #fff;
+  transition: all 0.3s ease-in-out;
+}
+
+html.dark {
+  background: #121212;
+  color-scheme: dark;
+}
+
+html.htw-dark {
+  background: #27272a;
+  color: #e9e9ed;
+}
+
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: #f472b6;
+  opacity: 0.75;
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+}

--- a/packages/stage-ui/stories/setup.ts
+++ b/packages/stage-ui/stories/setup.ts
@@ -1,0 +1,3 @@
+import 'uno.css'
+import '@unocss/reset/tailwind.css'
+import './main.css'

--- a/packages/stage-ui/stories/themes.css
+++ b/packages/stage-ui/stories/themes.css
@@ -1,0 +1,26 @@
+:root {
+  --airi-theme-primary-50: #fff0f2;
+  --airi-theme-primary-100: #ffe3e6;
+  --airi-theme-primary-200: #ffcad4;
+  --airi-theme-primary-300: #ff9fb0;
+  --airi-theme-primary-400: #ff6988;
+  --airi-theme-primary-500: #fe456e;
+  --airi-theme-primary-600: #ec124d;
+  --airi-theme-primary-700: #c70941;
+  --airi-theme-primary-800: #a70a3e;
+  --airi-theme-primary-900: #8e0d3b;
+  --airi-theme-primary-950: #50011b;
+
+  --theme-colors-hue: 354.31;
+  --theme-colors-chroma: calc(0.18 + (cos(var(--theme-colors-hue) * 3.14159265 / 180) * 0.04));
+  --theme-colors-chroma-50: calc(var(--theme-colors-chroma) * 0.3);
+  --theme-colors-chroma-100: calc(var(--theme-colors-chroma) * 0.5);
+  --theme-colors-chroma-200: calc(var(--theme-colors-chroma) * 0.6);
+  --theme-colors-chroma-300: calc(var(--theme-colors-chroma) * 0.75);
+  --theme-colors-chroma-400: var(--theme-colors-chroma);
+  --theme-colors-chroma-600: calc(var(--theme-colors-chroma) * 1.15);
+  --theme-colors-chroma-700: calc(var(--theme-colors-chroma) * 1.1);
+  --theme-colors-chroma-800: calc(var(--theme-colors-chroma) * 0.85);
+  --theme-colors-chroma-900: calc(var(--theme-colors-chroma) * 0.7);
+  --theme-colors-chroma-950: calc(var(--theme-colors-chroma) * 0.5);
+}

--- a/packages/stage-ui/stories/transitions.css
+++ b/packages/stage-ui/stories/transitions.css
@@ -1,0 +1,18 @@
+.slide-away-enter-active,
+.slide-away-leave-active {
+  transition:
+    transform 0.3s ease-in-out,
+    opacity 0.3s ease-in-out;
+}
+
+.slide-away-enter,
+.slide-away-leave-to {
+  transform: translateY(-10px);
+  opacity: 0;
+}
+
+.slide-away-enter-from,
+.slide-away-leave {
+  transform: translateY(10px);
+  opacity: 0;
+}

--- a/packages/stage-ui/tsconfig.json
+++ b/packages/stage-ui/tsconfig.json
@@ -30,6 +30,11 @@
       "@vue-macros/volar/define-slots"
     ]
   },
+  "include": [
+    "env.d.ts",
+    "**/*.vue",
+    "**/*.story.vue"
+  ],
   "exclude": [
     "dist",
     "node_modules"

--- a/packages/stage-ui/uno.config.ts
+++ b/packages/stage-ui/uno.config.ts
@@ -1,0 +1,109 @@
+import { createExternalPackageIconLoader } from '@iconify/utils/lib/loader/external-pkg'
+import { colorToString } from '@unocss/preset-mini/utils'
+import { createLocalFontProcessor } from '@unocss/preset-web-fonts/local'
+import {
+  defineConfig,
+  presetAttributify,
+  presetIcons,
+  presetTypography,
+  presetWebFonts,
+  presetWind3,
+  transformerDirectives,
+  transformerVariantGroup,
+} from 'unocss'
+import { presetScrollbar } from 'unocss-preset-scrollbar'
+import { parseColor } from 'unocss/preset-mini'
+
+function createColorSchemeConfig(hueOffset = 0) {
+  return {
+    DEFAULT: `oklch(62% var(--theme-colors-chroma) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    50: `color-mix(in srgb, oklch(95% var(--theme-colors-chroma-50) calc(var(--theme-colors-hue) + ${hueOffset})) 30%, oklch(100% 0 360))`,
+    100: `color-mix(in srgb, oklch(95% var(--theme-colors-chroma-100) calc(var(--theme-colors-hue) + ${hueOffset})) 80%, oklch(100% 0 360))`,
+    200: `oklch(90% var(--theme-colors-chroma-200) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    300: `oklch(85% var(--theme-colors-chroma-300) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    400: `oklch(74% var(--theme-colors-chroma-400) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    500: `oklch(62% var(--theme-colors-chroma) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    600: `oklch(54% var(--theme-colors-chroma-600) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    700: `oklch(49% var(--theme-colors-chroma-700) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    800: `oklch(42% var(--theme-colors-chroma-800) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    900: `oklch(37% var(--theme-colors-chroma-900) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+    950: `oklch(29% var(--theme-colors-chroma-950) calc(var(--theme-colors-hue) + ${hueOffset}))`,
+  }
+}
+
+export default defineConfig({
+  presets: [
+    presetWind3(),
+    presetAttributify(),
+    presetTypography(),
+    presetWebFonts({
+      fonts: {
+        sans: 'DM Sans',
+        serif: 'DM Serif Display',
+        mono: 'DM Mono',
+        cute: 'Kiwi Maru',
+        cuteen: 'Sniglet',
+      },
+      // Web fonts preset
+      // https://unocss.dev/presets/web-fonts#serve-fonts-locally
+      processors: createLocalFontProcessor(),
+    }),
+    presetIcons({
+      scale: 1.2,
+      collections: {
+        ...createExternalPackageIconLoader('@proj-airi/lobe-icons'),
+      },
+    }),
+    presetScrollbar(),
+  ],
+  transformers: [
+    transformerDirectives({
+      applyVariable: ['--at-apply'],
+    }),
+    transformerVariantGroup(),
+  ],
+  safelist: [
+    ...'prose prose-sm m-auto text-left'.split(' '),
+    ...[50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950].map(shade => [`bg-primary-${shade}`, ...[5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(opacity => `bg-primary-${shade}/${opacity}`)]).flat(),
+  ],
+  // hyoban/unocss-preset-shadcn: Use shadcn ui with UnoCSS
+  // https://github.com/hyoban/unocss-preset-shadcn
+  //
+  // Thanks to
+  // https://github.com/unovue/shadcn-vue/issues/34#issuecomment-2467318118
+  // https://github.com/hyoban-template/shadcn-vue-unocss-starter
+  //
+  // By default, `.ts` and `.js` files are NOT extracted.
+  // If you want to extract them, use the following configuration.
+  // It's necessary to add the following configuration if you use shadcn-vue or shadcn-svelte.
+  content: {
+    pipeline: {
+      include: [
+      // the default
+        /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
+        // include js/ts files
+        '(components|src)/**/*.{js,ts}',
+      ],
+    },
+    // filesystem: [
+    //   'src/**/*.{vue,ts,js}',
+    // ],
+  },
+  rules: [
+    [/^mask-\[(.*)\]$/, ([, suffix]) => ({ '-webkit-mask-image': suffix.replace(/_/g, ' ') })],
+    [/^bg-dotted-\[(.*)\]$/, ([, color], { theme }) => {
+      const parsedColor = parseColor(color, theme)
+      // Util usage: https://github.com/unocss/unocss/blob/f57ef6ae50006a92f444738e50f3601c0d1121f2/packages-presets/preset-mini/src/_utils/utilities.ts#L186
+      return {
+        'background-image': `radial-gradient(circle at 1px 1px, ${colorToString(parsedColor?.cssColor ?? parsedColor?.color ?? color, 'var(--un-background-opacity)')} 1px, transparent 0)`,
+        '--un-background-opacity': parsedColor?.cssColor?.alpha ?? parsedColor?.alpha ?? 1,
+      }
+    }],
+  ],
+  theme: {
+    colors: {
+      primary: createColorSchemeConfig(),
+      complementary: createColorSchemeConfig(180),
+    },
+  },
+})

--- a/packages/stage-ui/vite.config.ts
+++ b/packages/stage-ui/vite.config.ts
@@ -1,0 +1,11 @@
+import vue from '@vitejs/plugin-vue'
+import Unocss from 'unocss/vite'
+import { defineConfig } from 'vite'
+
+// For Histoire
+export default defineConfig({
+  plugins: [
+    vue(),
+    Unocss(),
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,15 +1056,33 @@ importers:
       '@electron-toolkit/preload':
         specifier: ^3.0.1
         version: 3.0.1(electron@34.3.1)
+      '@histoire/plugin-vue':
+        specifier: 1.0.0-alpha.2
+        version: 1.0.0-alpha.2(histoire@1.0.0-alpha.2(@types/node@22.13.9)(bufferutil@4.0.9)(less@4.2.2)(terser@5.17.6)(utf-8-validate@5.0.10)(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.2))
       '@proj-airi/provider-transformers':
         specifier: workspace:^
         version: link:../provider-transformers
       '@proj-airi/utils-transformers':
         specifier: workspace:^
         version: link:../utils-transformers
+      '@unocss/reset':
+        specifier: ^66.1.0-beta.3
+        version: 66.1.0-beta.3
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.1
+        version: 5.2.1(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.2))
       '@xsai/embed':
         specifier: 'catalog:'
         version: 0.1.2
+      histoire:
+        specifier: 1.0.0-alpha.2
+        version: 1.0.0-alpha.2(@types/node@22.13.9)(bufferutil@4.0.9)(less@4.2.2)(terser@5.17.6)(utf-8-validate@5.0.10)(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      unocss:
+        specifier: ^66.1.0-beta.3
+        version: 66.1.0-beta.3(postcss@8.5.3)(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.2))
+      vite:
+        specifier: ^6.2.1
+        version: 6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/ui-transitions:
     dependencies:
@@ -1376,6 +1394,10 @@ packages:
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  '@akryum/tinypool@0.3.1':
+    resolution: {integrity: sha512-nznEC1ZA/m3hQDEnrGQ4c5gkaa9pcaVnw4LFJyzBAaR7E3nfiAPEHS3otnSafpZouVnoKeITl5D+2LsnwlnK8g==}
+    engines: {node: '>=14.0.0'}
 
   '@alvarosabu/utils@3.2.0':
     resolution: {integrity: sha512-aoGWRfaQjOo9TUwrBA6W0zwTHktgrXy69GIFNILT4gHsqscw6+X8P6uoSlZVQFr887SPm8x3aDin5EBVq8y4pw==}
@@ -2063,6 +2085,27 @@ packages:
 
   '@clack/prompts@0.10.0':
     resolution: {integrity: sha512-H3rCl6CwW1NdQt9rE3n373t7o5cthPv7yUoxF2ytZvyvlJv89C5RYMJu83Hed8ODgys5vpBU0GKxIRG83jd8NQ==}
+
+  '@codemirror/commands@6.8.0':
+    resolution: {integrity: sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==}
+
+  '@codemirror/lang-json@6.0.1':
+    resolution: {integrity: sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==}
+
+  '@codemirror/language@6.10.8':
+    resolution: {integrity: sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==}
+
+  '@codemirror/lint@6.8.4':
+    resolution: {integrity: sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==}
+
+  '@codemirror/state@6.5.2':
+    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+
+  '@codemirror/theme-one-dark@6.1.2':
+    resolution: {integrity: sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==}
+
+  '@codemirror/view@6.36.4':
+    resolution: {integrity: sha512-ZQ0V5ovw/miKEXTvjgzRyjnrk9TwriUB1k4R5p7uNnHR9Hus+D1SXHGdJshijEzPFjU25xea/7nhIeSqYFKdbA==}
 
   '@cryptography/aes@0.1.1':
     resolution: {integrity: sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==}
@@ -3022,6 +3065,26 @@ packages:
   '@guiiai/logg@1.0.7':
     resolution: {integrity: sha512-8pan2rLhgb4QrxP7+asK4uEuCQ9a9Zz+EcC0Qew4eQk5zTUck6b6Tru8lRrUrkYqIV8xCC9pGtgK3RsrOENsqw==}
 
+  '@histoire/app@1.0.0-alpha.2':
+    resolution: {integrity: sha512-sGQ470fHS965pSFVtALY3sRkgBDQXzhnjshmR9gzIcqs3ZBCW4N1nyA6t7r3X++1cvgJ16ctWKQl/lFERwQLgA==}
+
+  '@histoire/controls@1.0.0-alpha.2':
+    resolution: {integrity: sha512-05Oyb5PmYa7uYGss1mIwqH4qF1jqUs3iewuGAxVDOc5ERGwNQYm/pdiRWLSv8tYuCoYOn3N1wx3Gr5//F+cyTw==}
+
+  '@histoire/plugin-vue@1.0.0-alpha.2':
+    resolution: {integrity: sha512-MfXalw8Ld9wLVAmix311k8UoGm74xM988h7bFWgQipv+iu4LWjiXBD4hKThgrJh0siVCefAcOKdV91n71F1HHg==}
+    peerDependencies:
+      histoire: ^1.0.0-alpha.2
+      vue: ^3.2.47
+
+  '@histoire/shared@1.0.0-alpha.2':
+    resolution: {integrity: sha512-40suRsqX8sk9HFoN5u+ACYpIwp9Hzkgthf0NhXttUtUGU0dxTQU6JYC/mxJJhylTjbgQjY6UWF7kl+pwx32T1g==}
+    peerDependencies:
+      vite: ^6.0.1
+
+  '@histoire/vendors@1.0.0-alpha.2':
+    resolution: {integrity: sha512-5uef8/sfh7Pj2nHRX/Mp+u4t9fmZQIK2uyg7Ao/vKShzNdmZyiD4DNVRyXFhE3U67PrAbfcmy328gTC4YV/Seg==}
+
   '@huggingface/jinja@0.3.3':
     resolution: {integrity: sha512-vQQr2JyWvVFba3Lj9es4q9vCl1sAc74fdgnEMoX8qHrXtswap9ge9uO3ONDzQB0cQ0PUyaKY2N6HaVbTBvSXvw==}
     engines: {node: '>=18'}
@@ -3317,6 +3380,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@lezer/common@1.2.3':
+    resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
+
+  '@lezer/highlight@1.2.1':
+    resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.2':
+    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+
   '@malept/cross-spawn-promise@1.1.1':
     resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
     engines: {node: '>= 10'}
@@ -3324,6 +3399,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mdit-vue/plugin-component@2.1.3':
     resolution: {integrity: sha512-9AG17beCgpEw/4ldo/M6Y/1Rh4E1bqMmr/rCkWKmCAxy9tJz3lzY7HQJanyHMJufwsb3WL5Lp7Om/aPcQTZ9SA==}
@@ -4509,6 +4587,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -4529,6 +4610,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -5765,6 +5849,9 @@ packages:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   changelogen@0.5.7:
     resolution: {integrity: sha512-cTZXBcJMl3pudE40WENOakXkcVtrbBpbkmSkM20NdRiUqa4+VYRdXdEsgQ0BNQ6JBE2YymTNWtPKVF7UCTN5+g==}
     hasBin: true
@@ -5978,6 +6065,10 @@ packages:
   config-file-ts@0.2.6:
     resolution: {integrity: sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==}
 
+  connect@3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
+
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -6052,6 +6143,9 @@ packages:
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -6413,6 +6507,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diacritics@1.3.0:
+    resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -7202,6 +7299,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
@@ -7338,6 +7439,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
@@ -7576,6 +7681,12 @@ packages:
 
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+
+  histoire@1.0.0-alpha.2:
+    resolution: {integrity: sha512-W0u5svVoFq6cCoO7CwRMpqVecp260riENpFJEb2pLyurDBFNU4vVyskTnxm5MGwMf4+sjjWp5WXPBvJ22Mxglg==}
+    hasBin: true
+    peerDependencies:
+      vite: ^6.0.1
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -8058,6 +8169,9 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
+  launch-editor@2.10.0:
+    resolution: {integrity: sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -8276,8 +8390,23 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it-anchor@9.2.0:
+    resolution: {integrity: sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: '*'
+
   markdown-it-async@2.0.0:
     resolution: {integrity: sha512-jBthmQR5MwXR9Y8Y0teRoZAenaKQMdjuTfpbNARqMBSRPvyzyXCVduHZHakyyhL3ugIacCobXJrO07t277sIjw==}
+
+  markdown-it-attrs@4.3.1:
+    resolution: {integrity: sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      markdown-it: '>= 9.0.0'
+
+  markdown-it-emoji@3.0.0:
+    resolution: {integrity: sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==}
 
   markdown-it-link-attributes@4.0.1:
     resolution: {integrity: sha512-pg5OK0jPLg62H4k7M9mRJLT61gUp9nvG0XveKYHMOOluASo9OEF13WlXrpAp2aj35LbedAy3QOCgQCw0tkLKAQ==}
@@ -8884,6 +9013,10 @@ packages:
 
   ohash@2.0.5:
     resolution: {integrity: sha512-3k3APZwRRPYyohdIDmPTpe5i0AY5lm7gvu/Oip7tZrTaEGfSlKX+7kXUoWLd9sHX0GDRVwVvlW18yEcD7qS1zw==}
+
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -10005,6 +10138,10 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
   sanitize-filename@1.6.3:
     resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
 
@@ -10261,6 +10398,10 @@ packages:
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
 
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -10361,6 +10502,9 @@ packages:
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
+
+  style-mod@4.1.2:
+    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
 
   style-to-object@1.0.8:
     resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
@@ -11081,6 +11225,11 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0
 
+  vite-node@0.34.7:
+    resolution: {integrity: sha512-0Yzb96QzHmqIKIs/x2q/sqG750V/EF6yDkS2p1WjJc1W2bgRSuQjf5vB9HY8h2nVb5j4pO5paS5Npcv3s69YUg==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+
   vite-node@3.0.8:
     resolution: {integrity: sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -11135,6 +11284,37 @@ packages:
       vite: ^4.0.0 || ^5.0.0
       vue: ^3.2.4
       vue-router: ^4.0.11
+
+  vite@5.4.14:
+    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.2.1:
     resolution: {integrity: sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==}
@@ -11261,6 +11441,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -11585,6 +11768,8 @@ snapshots:
   '@11labs/client@0.0.7': {}
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
+
+  '@akryum/tinypool@0.3.1': {}
 
   '@alvarosabu/utils@3.2.0': {}
 
@@ -12568,6 +12753,50 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@codemirror/commands@6.8.0':
+    dependencies:
+      '@codemirror/language': 6.10.8
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.4
+      '@lezer/common': 1.2.3
+
+  '@codemirror/lang-json@6.0.1':
+    dependencies:
+      '@codemirror/language': 6.10.8
+      '@lezer/json': 1.0.3
+
+  '@codemirror/language@6.10.8':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.4
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+      style-mod: 4.1.2
+
+  '@codemirror/lint@6.8.4':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.4
+      crelt: 1.0.6
+
+  '@codemirror/state@6.5.2':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.2':
+    dependencies:
+      '@codemirror/language': 6.10.8
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.4
+      '@lezer/highlight': 1.2.1
+
+  '@codemirror/view@6.36.4':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      style-mod: 4.1.2
+      w3c-keyname: 2.2.8
+
   '@cryptography/aes@0.1.1': {}
 
   '@cspell/dict-ru_ru@2.2.4': {}
@@ -13288,6 +13517,56 @@ snapshots:
 
   '@guiiai/logg@1.0.7': {}
 
+  '@histoire/app@1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))':
+    dependencies:
+      '@histoire/controls': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/shared': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/vendors': 1.0.0-alpha.2
+      fuse.js: 7.1.0
+      shiki: 3.1.0
+    transitivePeerDependencies:
+      - vite
+
+  '@histoire/controls@1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))':
+    dependencies:
+      '@codemirror/commands': 6.8.0
+      '@codemirror/lang-json': 6.0.1
+      '@codemirror/language': 6.10.8
+      '@codemirror/lint': 6.8.4
+      '@codemirror/state': 6.5.2
+      '@codemirror/theme-one-dark': 6.1.2
+      '@codemirror/view': 6.36.4
+      '@histoire/shared': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/vendors': 1.0.0-alpha.2
+    transitivePeerDependencies:
+      - vite
+
+  '@histoire/plugin-vue@1.0.0-alpha.2(histoire@1.0.0-alpha.2(@types/node@22.13.9)(bufferutil@4.0.9)(less@4.2.2)(terser@5.17.6)(utf-8-validate@5.0.10)(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)))(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.2))':
+    dependencies:
+      '@histoire/controls': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/shared': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/vendors': 1.0.0-alpha.2
+      change-case: 5.4.4
+      globby: 14.0.2
+      histoire: 1.0.0-alpha.2(@types/node@22.13.9)(bufferutil@4.0.9)(less@4.2.2)(terser@5.17.6)(utf-8-validate@5.0.10)(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      launch-editor: 2.10.0
+      pathe: 1.1.2
+      vue: 3.5.13(typescript@5.8.2)
+    transitivePeerDependencies:
+      - vite
+
+  '@histoire/shared@1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))':
+    dependencies:
+      '@histoire/vendors': 1.0.0-alpha.2
+      '@types/fs-extra': 11.0.4
+      '@types/markdown-it': 14.1.2
+      chokidar: 4.0.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)
+
+  '@histoire/vendors@1.0.0-alpha.2': {}
+
   '@huggingface/jinja@0.3.3': {}
 
   '@huggingface/transformers@3.4.0':
@@ -13599,6 +13878,22 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@lezer/common@1.2.3': {}
+
+  '@lezer/highlight@1.2.1':
+    dependencies:
+      '@lezer/common': 1.2.3
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+
+  '@lezer/lr@1.4.2':
+    dependencies:
+      '@lezer/common': 1.2.3
+
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
       cross-spawn: 7.0.6
@@ -13611,6 +13906,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdit-vue/plugin-component@2.1.3':
     dependencies:
@@ -14592,8 +14889,7 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@sindresorhus/merge-streams@2.3.0':
-    optional: true
+  '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -14878,6 +15174,11 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.13.9
+
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 22.13.9
@@ -14895,6 +15196,10 @@ snapshots:
   '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.13.9
 
   '@types/keyv@3.1.4':
     dependencies:
@@ -16106,7 +16411,6 @@ snapshots:
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -16779,6 +17083,8 @@ snapshots:
 
   chalk@5.4.1: {}
 
+  change-case@5.4.4: {}
+
   changelogen@0.5.7(magicast@0.3.5):
     dependencies:
       c12: 1.11.2(magicast@0.3.5)
@@ -17009,6 +17315,15 @@ snapshots:
       glob: 10.4.5
       typescript: 5.8.2
 
+  connect@3.7.0:
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   consola@3.4.0: {}
 
   console-control-strings@1.1.0:
@@ -17071,6 +17386,8 @@ snapshots:
     dependencies:
       buffer: 5.7.1
     optional: true
+
+  crelt@1.0.6: {}
 
   cross-env@7.0.3:
     dependencies:
@@ -17172,7 +17489,6 @@ snapshots:
   cssstyle@4.1.0:
     dependencies:
       rrweb-cssom: 0.7.1
-    optional: true
 
   csstype@3.1.3: {}
 
@@ -17339,7 +17655,6 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-    optional: true
 
   date-fns@4.1.0: {}
 
@@ -17365,8 +17680,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.4.3:
-    optional: true
+  decimal.js@10.4.3: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -17436,6 +17750,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diacritics@1.3.0: {}
 
   diff@5.2.0: {}
 
@@ -18541,6 +18857,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.1.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
@@ -18681,6 +19009,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fuse.js@7.1.0: {}
 
   gauge@3.0.2:
     dependencies:
@@ -18824,7 +19154,6 @@ snapshots:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
-    optional: true
 
   globby@6.1.0:
     dependencies:
@@ -19105,6 +19434,52 @@ snapshots:
 
   hey-listen@1.0.8: {}
 
+  histoire@1.0.0-alpha.2(@types/node@22.13.9)(bufferutil@4.0.9)(less@4.2.2)(terser@5.17.6)(utf-8-validate@5.0.10)(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)):
+    dependencies:
+      '@akryum/tinypool': 0.3.1
+      '@histoire/app': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/controls': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/shared': 1.0.0-alpha.2(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0))
+      '@histoire/vendors': 1.0.0-alpha.2
+      '@types/markdown-it': 14.1.2
+      birpc: 0.2.19
+      change-case: 5.4.4
+      chokidar: 4.0.3
+      connect: 3.7.0
+      defu: 6.1.4
+      diacritics: 1.3.0
+      fs-extra: 11.2.0
+      globby: 14.0.2
+      gray-matter: 4.0.3
+      jiti: 2.4.2
+      jsdom: 25.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      markdown-it: 14.1.0
+      markdown-it-anchor: 9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
+      markdown-it-attrs: 4.3.1(markdown-it@14.1.0)
+      markdown-it-emoji: 3.0.0
+      micromatch: 4.0.8
+      mrmime: 2.0.1
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      sade: 1.8.1
+      shiki: 3.1.0
+      sirv: 3.0.1
+      vite: 6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 0.34.7(@types/node@22.13.9)(less@4.2.2)(terser@5.17.6)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - canvas
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - utf-8-validate
+
   hookable@5.5.3: {}
 
   hosted-git-info@4.1.0:
@@ -19118,7 +19493,6 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
-    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -19161,7 +19535,6 @@ snapshots:
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   http-response-object@3.0.2:
     dependencies:
@@ -19188,7 +19561,6 @@ snapshots:
       debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   human-signals@2.1.0: {}
 
@@ -19335,8 +19707,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -19464,7 +19835,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   jsesc@3.0.2: {}
 
@@ -19555,6 +19925,11 @@ snapshots:
     optional: true
 
   kolorist@1.8.0: {}
+
+  launch-editor@2.10.0:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.8.2
 
   lazy-val@1.0.5: {}
 
@@ -19800,10 +20175,21 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-it-anchor@9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.0
+
   markdown-it-async@2.0.0:
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.1.0
+
+  markdown-it-attrs@4.3.1(markdown-it@14.1.0):
+    dependencies:
+      markdown-it: 14.1.0
+
+  markdown-it-emoji@3.0.0: {}
 
   markdown-it-link-attributes@4.0.1: {}
 
@@ -20731,8 +21117,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nwsapi@2.2.12:
-    optional: true
+  nwsapi@2.2.12: {}
 
   nypm@0.3.12:
     dependencies:
@@ -20771,6 +21156,10 @@ snapshots:
   ohash@1.1.4: {}
 
   ohash@2.0.5: {}
+
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
 
   on-finished@2.4.1:
     dependencies:
@@ -21025,8 +21414,7 @@ snapshots:
 
   path-to-regexp@8.2.0: {}
 
-  path-type@5.0.0:
-    optional: true
+  path-type@5.0.0: {}
 
   pathe@1.1.2: {}
 
@@ -22157,8 +22545,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 8.2.0
 
-  rrweb-cssom@0.7.1:
-    optional: true
+  rrweb-cssom@0.7.1: {}
 
   run-applescript@7.0.0: {}
 
@@ -22173,6 +22560,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
   sanitize-filename@1.6.3:
     dependencies:
       truncate-utf8-bytes: 1.0.2
@@ -22182,7 +22573,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scslre@0.3.0:
     dependencies:
@@ -22363,8 +22753,7 @@ snapshots:
       arg: 5.0.2
       sax: 1.4.1
 
-  slash@5.1.0:
-    optional: true
+  slash@5.1.0: {}
 
   slashes@3.0.12: {}
 
@@ -22503,6 +22892,8 @@ snapshots:
 
   stats.js@0.17.0: {}
 
+  statuses@1.5.0: {}
+
   statuses@2.0.1: {}
 
   std-env@3.8.0: {}
@@ -22595,6 +22986,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  style-mod@4.1.2: {}
+
   style-to-object@1.0.8:
     dependencies:
       inline-style-parser: 0.2.4
@@ -22638,8 +23031,7 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   synckit@0.6.2:
     dependencies:
@@ -22792,13 +23184,11 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
-  tldts-core@6.1.61:
-    optional: true
+  tldts-core@6.1.61: {}
 
   tldts@6.1.61:
     dependencies:
       tldts-core: 6.1.61
-    optional: true
 
   tmp-promise@3.0.3:
     dependencies:
@@ -22828,7 +23218,6 @@ snapshots:
   tough-cookie@5.0.0:
     dependencies:
       tldts: 6.1.61
-    optional: true
 
   tr46@0.0.3: {}
 
@@ -22839,7 +23228,6 @@ snapshots:
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   trim-lines@3.0.1: {}
 
@@ -23569,6 +23957,25 @@ snapshots:
     dependencies:
       vite: 6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0)
 
+  vite-node@0.34.7(@types/node@22.13.9)(less@4.2.2)(terser@5.17.6):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      mlly: 1.7.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.14(@types/node@22.13.9)(less@4.2.2)(terser@5.17.6)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.0.8(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
@@ -23709,6 +24116,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite@5.4.14(@types/node@22.13.9)(less@4.2.2)(terser@5.17.6):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.3
+      rollup: 4.34.9
+    optionalDependencies:
+      '@types/node': 22.13.9
+      fsevents: 2.3.3
+      less: 4.2.2
+      terser: 5.17.6
+
   vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(less@4.2.2)(terser@5.17.6)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
@@ -23819,10 +24237,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
 
+  w3c-keyname@2.2.8: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
   wavefile@11.0.0: {}
 
@@ -23836,8 +24255,7 @@ snapshots:
 
   webidl-conversions@4.0.2: {}
 
-  webidl-conversions@7.0.0:
-    optional: true
+  webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -23855,16 +24273,13 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
-    optional: true
 
-  whatwg-mimetype@4.0.0:
-    optional: true
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.0.0:
     dependencies:
       tr46: 5.0.0
       webidl-conversions: 7.0.0
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -24064,13 +24479,11 @@ snapshots:
 
   xml-name-validator@4.0.0: {}
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
   xmlbuilder@15.1.1: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 


### PR DESCRIPTION
## Description

This pull request serves as the first PR to integrate Histoire into `@proj-airi/stage-ui`

Some idea: Maybe we should consider making UnoCSS config reusable between these stage- projects, as the config at stage-web and stage-tamagotchi are almost identical 

### Project structure

1. If a story is bound to a specific component, it can be placed beside the component in the `src` folder. e.g., `MyComponent.story.vue`
2. If a story is not bound to a specific component, then it should be placed in the `stories` folder. e.g., `MyStory.story.vue`

<img width="1698" alt="Screenshot 2025-03-12 at 3 45 32" src="https://github.com/user-attachments/assets/2dff6c8c-ce1d-4def-a209-a69d90ed7893" />

<img width="1698" alt="Screenshot 2025-03-12 at 3 45 40" src="https://github.com/user-attachments/assets/3f8da8b7-482e-4dd2-9a03-c751be2c6cac" />
