### PR TITLE
fix(ime): prevent message submission during IME input in chat areas

### DIFF
--- a/apps/stage-web/src/components/Layouts/InteractiveArea.vue
+++ b/apps/stage-web/src/components/Layouts/InteractiveArea.vue
@@ -17,6 +17,7 @@ const messageInput = ref('')
 const listening = ref(false)
 const tab = ref<'chat' | 'custom' | 'clothes'>('chat')
 const showMicrophoneSelect = ref(false)
+const isComposing = ref(false)
 
 const providersStore = useProvidersStore()
 const { activeProvider, activeModel } = storeToRefs(useConsciousnessStore())
@@ -46,7 +47,7 @@ const { transcribe: generate, terminate } = useWhisper(WhisperWorker, {
 })
 
 async function handleSend() {
-  if (!messageInput.value.trim()) {
+  if (!messageInput.value.trim() || isComposing.value) {
     return
   }
 
@@ -224,6 +225,8 @@ onAfterSend(async () => {
               'transition-colors-none placeholder:transition-colors-none': themeColorsHueDynamic,
             }"
             @submit="handleSend"
+            @compositionstart="isComposing = true"
+            @compositionend="isComposing = false"
           />
         </div>
       </div>

--- a/apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue
+++ b/apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue
@@ -12,6 +12,7 @@ import MobileChatHistory from '../Widgets/MobileChatHistory.vue'
 
 const messageInput = ref('')
 const listening = ref(false)
+const isComposing = ref(false)
 
 const providersStore = useProvidersStore()
 const { activeProvider, activeModel } = storeToRefs(useConsciousnessStore())
@@ -23,7 +24,7 @@ const { send, onAfterSend } = useChatStore()
 const { t } = useI18n()
 
 async function handleSend() {
-  if (!messageInput.value.trim()) {
+  if (!messageInput.value.trim() || isComposing.value) {
     return
   }
 
@@ -98,6 +99,8 @@ onMounted(() => {
           transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
           :class="{ 'transition-colors-none placeholder:transition-colors-none': themeColorsHueDynamic }"
           @submit="handleSend"
+          @compositionstart="isComposing = true"
+          @compositionend="isComposing = false"
         />
       </div>
     </div>


### PR DESCRIPTION
## Problem
When using Input Method Editors (IME) for languages like Chinese or Japanese, pressing Enter in chat input areas triggers both IME text confirmation and message submission. This makes it impossible to properly type text using IME.

## Solution
Add IME composition state detection in both InteractiveArea and MobileInteractiveArea components to prevent message submission while using IME input.

## Changes
- Add `isComposing` state to track IME input status
- Add `compositionstart` and `compositionend` event listeners
- Add IME state check in `handleSend` function 

## Files Changed
- `apps/stage-web/src/components/Layouts/InteractiveArea.vue`
- `apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue`
## Testing
I've prepared GIF recordings showing the behavior before and after the fix:
- Before:  ![a01acf2f4e1ed7a31f1d7f695b6e49ce](https://github.com/user-attachments/assets/247aa739-6041-488b-b68f-7b67b44c5d7f)
- After:  ![dacf6bdfe05cb4083ffe17b8cd13b2dd](https://github.com/user-attachments/assets/6361a8f4-ef75-446e-a02b-317c7bc472f9)

## Additional Notes
### Current Workaround
This PR implements a workaround in application components since i don't currently have access to modify the `@proj-airi/ui` package.

### Ideal Solution
The root cause of this issue is in the `BasicTextarea` component from `@proj-airi/ui` package. The ideal fix would be to modify the `onKeyDown` handler in `@proj-airi/ui/src/components/Form/Textarea/Basic.vue`:

```typescript
// Add IME composition state
const isComposing = ref(false)

function onKeyDown(e: KeyboardEvent) {
  if (e.code === 'Enter' && !e.shiftKey && !isComposing.value) {
    e.preventDefault()
    events('submit', input.value)
  }
}
```

```vue
<template>
  <textarea
    ref="textareaRef"
    v-model="input"
    :style="{ height: textareaHeight }"
    @keydown="onKeyDown"
    @compositionstart="isComposing = true"
    @compositionend="isComposing = false"
  />
</template>
```

This would properly handle IME input across all applications using the `BasicTextarea` component. However, since I couldn't locate the remote repository for `@proj-airi/ui`, I've implemented this workaround in  application components instead.


