### PR TITLE
update API key placeholder to 'GEMINI_API_KEY'

### DIFF
--- a/apps/stage-tamagotchi/src/pages/settings/providers/google-generative-ai.vue
+++ b/apps/stage-tamagotchi/src/pages/settings/providers/google-generative-ai.vue
@@ -89,7 +89,7 @@ function handleResetSettings() {
         <ProviderApiKeyInput
           v-model="apiKey"
           :provider-name="providerMetadata?.localizedName || 'Google'"
-          placeholder="sk-..."
+          placeholder="GEMINI_API_KEY"
         />
       </ProviderBasicSettings>
 

--- a/apps/stage-web/src/pages/settings/providers/google-generative-ai.vue
+++ b/apps/stage-web/src/pages/settings/providers/google-generative-ai.vue
@@ -89,7 +89,7 @@ function handleResetSettings() {
         <ProviderApiKeyInput
           v-model="apiKey"
           :provider-name="providerMetadata?.localizedName || 'Google'"
-          placeholder="sk-..."
+          placeholder="GEMINI_API_KEY"
         />
       </ProviderBasicSettings>
 


### PR DESCRIPTION

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Google Gemini API key doesn't start with `sk-`

## Linked Issues

<!-- Optional, if you have any -->

https://github.com/moeru-ai/airi/issues/176

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
