### PR TITLE
Fix for false positive API key detection

### DIFF
--- a/packages/stage-ui/src/components/Providers/ProviderApiKeyInput.story.vue
+++ b/packages/stage-ui/src/components/Providers/ProviderApiKeyInput.story.vue
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 import ProviderApiKeyInput from './ProviderApiKeyInput.vue'
 
 const apiKey = ref('')
-const filledApiKey = ref('sk-1234567890abcdefghijklmnopqrstuvwxyz')
+const filledApiKey = ref('sk-...')
 </script>
 
 <template>


### PR DESCRIPTION
## Description
As seen in https://github.com/moeru-ai/airi/pull/195#issuecomment-2949968140, this placeholder token is mistakenly interpreted as a true API key by Netlify. This PR tries to fix this issue, so Netlify can build without raising an error about an API key in the code.

## Additional context
Originally included in https://github.com/moeru-ai/airi/pull/195, but moved in a separate PR, as asked by https://github.com/moeru-ai/airi/pull/195#issuecomment-2956621208.