### PR TITLE
feat(state) speech support for player2

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -139,6 +139,7 @@ pnpm -F @proj-airi/stage-tamagotchi dev
 
 ## サポートされているLLM APIプロバイダー（[xsai](https://github.com/moeru-ai/xsai)によって提供）
 
+- [x] [Player2](https://player2.game/)
 - [x] [OpenRouter](https://openrouter.ai/)
 - [x] [vLLM](https://github.com/vllm-project/vllm)
 - [x] [SGLang](https://github.com/sgl-project/sglang)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ npx bumpp --no-commit --no-tag
 ```
 
 ## Supported the following LLM API Providers (powered by [xsai](https://github.com/moeru-ai/xsai))
-
+- [x] [Player2](https://player2.game/)
 - [x] [OpenRouter](https://openrouter.ai/)
 - [x] [vLLM](https://github.com/vllm-project/vllm)
 - [x] [SGLang](https://github.com/sgl-project/sglang)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,6 +137,7 @@ pnpm -F @proj-airi/stage-tamagotchi dev
 
 ## 原生支持的 LLM API 提供商列表（由 [xsai](https://github.com/moeru-ai/xsai) 驱动）
 
+- [x] [Player2](https://player2.game/)
 - [x] [OpenRouter](https://openrouter.ai/)
 - [x] [vLLM](https://github.com/vllm-project/vllm)
 - [x] [SGLang](https://github.com/sgl-project/sglang)

--- a/apps/stage-tamagotchi/src/pages/settings/modules/speech.vue
+++ b/apps/stage-tamagotchi/src/pages/settings/modules/speech.vue
@@ -98,7 +98,6 @@ async function generateTestSpeech() {
     if (audioUrl.value) {
       stopTestAudio()
     }
-
     const input = useSSML.value
       ? ssmlText.value
       : speechStore.generateSSML(testText.value, activeSpeechVoice.value, { ...providerConfig, pitch: pitch.value })

--- a/apps/stage-web/src/pages/settings/modules/speech.vue
+++ b/apps/stage-web/src/pages/settings/modules/speech.vue
@@ -101,7 +101,7 @@ async function generateTestSpeech() {
 
     const input = useSSML.value
       ? ssmlText.value
-      : speechStore.generateSSML(testText.value, activeSpeechVoice.value, { ...providerConfig, pitch: pitch.value })
+      : speechStore.supportsSSML ? speechStore.generateSSML(testText.value, activeSpeechVoice.value, { ...providerConfig, pitch: pitch.value }) : testText.value
 
     const response = await generateSpeech({
       ...provider.speech(activeSpeechModel.value, providerConfig),

--- a/apps/stage-web/src/pages/settings/providers/player2-speech.vue
+++ b/apps/stage-web/src/pages/settings/providers/player2-speech.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import type { SpeechProviderWithExtraOptions } from '@xsai-ext/shared-providers'
+import type { UnElevenLabsOptions } from 'unspeech'
+
+import {
+  SpeechPlayground,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useProvidersStore, useSpeechStore } from '@proj-airi/stage-ui/stores'
+import { FieldRange } from '@proj-airi/ui'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const providerId = 'player2-speech'
+const defaultModel = 'v1'
+
+const speedRatio = ref<number>(1.0)
+
+const speechStore = useSpeechStore()
+const providersStore = useProvidersStore()
+const { t } = useI18n()
+
+// Get available voices for ElevenLabs
+const availableVoices = computed(() => {
+  return speechStore.availableVoices[providerId] || []
+})
+
+// Generate speech with ElevenLabs-specific parameters
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean) {
+  const provider = providersStore.getProviderInstance(providerId) as SpeechProviderWithExtraOptions<string, UnElevenLabsOptions>
+  if (!provider) {
+    throw new Error('Failed to initialize speech provider')
+  }
+
+  // Get provider configuration
+  const providerConfig = providersStore.getProviderConfig(providerId)
+
+  // Get model from configuration or use default
+  const model = providerConfig.model as string | undefined || defaultModel
+
+  // ElevenLabs doesn't need SSML conversion, but if SSML is provided, use it directly
+  return await speechStore.speech(
+    provider,
+    model,
+    input,
+    voiceId,
+    {
+      ...providerConfig,
+    },
+  )
+}
+
+const hasPlayer2 = ref(true)
+
+onMounted(async () => {
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const providerMetadata = providersStore.getProviderMetadata(providerId)
+  if (await providerMetadata.validators.validateProviderConfig(providerConfig)) {
+    await speechStore.loadVoicesForProvider(providerId)
+  }
+  else {
+    console.error('Failed to validate provider config', providerConfig)
+  }
+  try {
+    const res = await fetch(`http://localhost:4315/v1/health`, {
+      method: 'GET',
+      headers: {
+        'player2-game-key': 'airi',
+      },
+    })
+    hasPlayer2.value = res.status === 200
+  }
+  catch (e) {
+    console.error(e)
+    hasPlayer2.value = false
+  }
+})
+
+watch(speedRatio, async () => {
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  providerConfig.speed = speedRatio.value
+})
+</script>
+
+<template>
+  <div v-if="!hasPlayer2" style="color: red; margin-bottom: 1rem;">
+    <div>
+      Please download and run the Player2 App:
+      <a href="https://player2.game" target="_blank" rel="noopener noreferrer">
+        https://player2.game
+      </a>
+
+      <div>
+        After downloading, if you still are having trouble, please reach out to us on Discord:
+        <a href="https://player2.game/discord" target="_blank" rel="noopener noreferrer">
+          https://player2.game/discord
+        </a>.
+      </div>
+    </div>
+  </div>
+  <SpeechProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+  >
+    <template #voice-settings>
+      <!-- Speed control - common to most providers -->
+      <FieldRange
+        v-model="speedRatio"
+        :label="t('settings.pages.providers.provider.common.fields.field.speed.label')"
+        :description="t('settings.pages.providers.provider.common.fields.field.speed.description')"
+        :min="0.5"
+        :max="5.0" :step="0.01"
+      />
+    </template>
+
+    <!-- Replace the default playground with our standalone component -->
+    <template #playground>
+      <SpeechPlayground
+        :available-voices="availableVoices"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="true"
+        default-text="Hello! This is a test of the Player 2 voice synthesis."
+      />
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+  meta:
+    layout: settings
+    stageTransition:
+      name: slide
+  </route>

--- a/apps/stage-web/src/pages/settings/providers/player2.vue
+++ b/apps/stage-web/src/pages/settings/providers/player2.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { RemovableRef } from '@vueuse/shared'
+
 import {
   ProviderBaseUrlInput,
   ProviderSettingsContainer,
@@ -13,14 +15,14 @@ import { useRouter } from 'vue-router'
 const { t } = useI18n()
 const router = useRouter()
 const providersStore = useProvidersStore()
-const { providers } = storeToRefs(providersStore)
+const { providers } = storeToRefs(providersStore) as { providers: RemovableRef<Record<string, any>> }
 
 // Get provider metadata
-const providerId = 'player2-api'
+const providerId = 'player2'
 const providerMetadata = computed(() => providersStore.getProviderMetadata(providerId))
 
 const baseUrl = computed({
-  get: () => providers.value[providerId]?.baseUrl as string || '',
+  get: () => providers.value[providerId]?.baseUrl || '',
   set: (value) => {
     if (!providers.value[providerId])
       providers.value[providerId] = {}
@@ -34,7 +36,7 @@ onMounted(() => {
   providersStore.initializeProvider(providerId)
 
   // Initialize refs with current values
-  baseUrl.value = providers.value[providerId]?.baseUrl as string || ''
+  baseUrl.value = providers.value[providerId]?.baseUrl || ''
 })
 
 // Watch settings and update the provider configuration

--- a/apps/stage-web/src/pages/settings/providers/player2.vue
+++ b/apps/stage-web/src/pages/settings/providers/player2.vue
@@ -8,7 +8,7 @@ import {
 } from '@proj-airi/stage-ui/components'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -30,13 +30,25 @@ const baseUrl = computed({
     providers.value[providerId].baseUrl = value
   },
 })
+const hasPlayer2 = ref(true)
 
-onMounted(() => {
-  // Initialize provider if it doesn't exist
+onMounted(async () => {
   providersStore.initializeProvider(providerId)
-
-  // Initialize refs with current values
   baseUrl.value = providers.value[providerId]?.baseUrl || ''
+
+  try {
+    const res = await fetch(`${baseUrl.value}health`, {
+      method: 'GET',
+      headers: {
+        'player2-game-key': 'airi',
+      },
+    })
+    hasPlayer2.value = res.status === 200
+  }
+  catch (e) {
+    console.error(e)
+    hasPlayer2.value = false
+  }
 })
 
 // Watch settings and update the provider configuration
@@ -55,8 +67,25 @@ function handleResetSettings() {
 </script>
 
 <template>
+  <div v-if="!hasPlayer2" style="color: red; margin-bottom: 1rem;">
+    <div>
+      Please download and run the Player2 App:
+      <a href="https://player2.game" target="_blank" rel="noopener noreferrer">
+        https://player2.game
+      </a>
+
+      <div>
+        After downloading, if you still are having trouble, please reach out to us on Discord:
+        <a href="https://player2.game/discord" target="_blank" rel="noopener noreferrer">
+          https://player2.game/discord
+        </a>.
+      </div>
+    </div>
+  </div>
+
   <ProviderSettingsLayout
-    :provider-name="providerMetadata?.localizedName" :provider-icon="providerMetadata?.icon"
+    :provider-name="providerMetadata?.localizedName"
+    :provider-icon="providerMetadata?.icon"
     :on-back="() => router.back()"
   >
     <ProviderSettingsContainer>

--- a/packages/stage-ui/src/stores/modules/consciousness.ts
+++ b/packages/stage-ui/src/stores/modules/consciousness.ts
@@ -64,7 +64,7 @@ export const useConsciousnessStore = defineStore('consciousness', () => {
     await loadModelsForProvider(newProvider)
     resetModelSelection()
 
-    if (newProvider === 'player2-api') {
+    if (newProvider === 'player2') {
       // Ping heal check every 60 seconds if Player2 is being used
       player2Interval = setInterval(() => {
         // eslint-disable-next-line no-console

--- a/packages/stage-ui/src/stores/modules/consciousness.ts
+++ b/packages/stage-ui/src/stores/modules/consciousness.ts
@@ -69,7 +69,13 @@ export const useConsciousnessStore = defineStore('consciousness', () => {
       player2Interval = setInterval(() => {
         // eslint-disable-next-line no-console
         console.log('Sending Player2 Health check if it is being used')
-        fetch('http://localhost:4315/v1/health').catch(() => {})
+        fetch(`localhost:4315/v1/health`, {
+          method: 'GET',
+          headers: {
+            'player2-game-key': 'airi',
+          },
+        })
+          .catch(() => {})
       }, 60_000)
     }
     else {

--- a/packages/stage-ui/src/stores/modules/speech.ts
+++ b/packages/stage-ui/src/stores/modules/speech.ts
@@ -73,7 +73,7 @@ export const useSpeechStore = defineStore('speech', () => {
 
   // Helper function to determine if a provider is a speech provider
   function isSpeechProvider(providerId: string): boolean {
-    return ['elevenlabs', 'microsoft-speech', 'azure-speech', 'google', 'amazon', 'alibaba-cloud-model-studio', 'volcengine'].includes(providerId)
+    return ['elevenlabs', 'microsoft-speech', 'azure-speech', 'google', 'amazon', 'alibaba-cloud-model-studio', 'volcengine', 'player2-speech'].includes(providerId)
   }
 
   async function loadVoicesForProvider(provider: string) {

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -128,6 +128,106 @@ export const useProvidersStore = defineStore('providers', () => {
 
   // Centralized provider metadata with provider factory functions
   const providerMetadata: Record<string, ProviderMetadata> = {
+    'player2': {
+      id: 'player2',
+      category: 'chat',
+      tasks: ['text-generation'],
+      nameKey: 'settings.pages.providers.provider.player2.title',
+      name: 'Player2 API',
+      descriptionKey: 'settings.pages.providers.provider.player2.description',
+      description: 'player2.game',
+      defaultOptions: {
+        baseUrl: 'http://localhost:4315/v1/',
+      },
+      createProvider: config => createPlayer2((config.baseUrl as string).trim(), 'airi'),
+      capabilities: {
+        listModels: async () => [
+          {
+            id: 'player2-model',
+            name: 'Player2 Model',
+            provider: 'player2',
+          },
+        ],
+      },
+      validators: {
+        validateProviderConfig: async (config: any) => {
+          return !!config.baseUrl
+        },
+      },
+    },
+    'player2-speech': {
+      id: 'player2-speech',
+      category: 'speech',
+      tasks: ['text-to-speech'],
+      nameKey: 'settings.pages.providers.provider.player2.title',
+      name: 'Player2 Speech',
+      descriptionKey: 'settings.pages.providers.provider.player2.description',
+      description: 'player2.game',
+      icon: 'i-lobe-icons:player2',
+      defaultOptions: {
+        baseUrl: 'http://localhost:4315/v1/',
+      },
+      createProvider: config => createPlayer2((config.baseUrl as string).trim(), 'airi'),
+      capabilities: {
+        listVoices: async () => {
+          return await fetch('http://localhost:4315/v1/tts/voices').then(res => res.json()).then(({ voices }) => (voices as { id: string, language: 'american_english' | 'british_english' | 'japanese' | 'mandarin_chinese' | 'spanish' | 'french' | 'hindi' | 'italian' | 'brazilian_portuguese', name: string, gender: string }[]).map(({ id, language, name, gender }) => (
+            {
+
+              id,
+              name,
+              provider: 'player2-speech',
+              gender,
+              languages: [{
+                american_english: {
+                  code: 'en',
+                  title: 'English',
+                },
+                british_english: {
+                  code: 'en',
+                  title: 'English',
+                },
+                japanese: {
+                  code: 'ja',
+                  title: 'Japanese',
+                },
+                mandarin_chinese: {
+                  code: 'zh',
+                  title: 'Chinese',
+                },
+                spanish: {
+                  code: 'es',
+                  title: 'Spanish',
+                },
+                french: {
+                  code: 'fr',
+                  title: 'French',
+                },
+                hindi: {
+                  code: 'hi',
+                  title: 'Hindi',
+                },
+
+                italian: {
+                  code: 'it',
+                  title: 'Italian',
+                },
+                brazilian_portuguese:
+                {
+                  code: 'pt',
+                  title: 'Portuguese',
+                },
+
+              }[language]],
+            }
+          )))
+        },
+      },
+      validators: {
+        validateProviderConfig: (config: any) => {
+          return !!config.baseUrl
+        },
+      },
+    },
     'openrouter-ai': {
       id: 'openrouter-ai',
       category: 'chat',
@@ -891,44 +991,7 @@ export const useProvidersStore = defineStore('providers', () => {
         },
       },
     },
-    'player2': {
-      id: 'player2',
-      category: 'chat',
-      tasks: ['text-generation'],
-      nameKey: 'settings.pages.providers.provider.player2.title',
-      name: 'Player2 API',
-      descriptionKey: 'settings.pages.providers.provider.player2.description',
-      description: 'player2.game',
-      defaultOptions: {
-        baseUrl: 'http://localhost:4315/v1/',
-      },
-      createProvider: (config) => {
-        return createPlayer2((config.baseUrl as string).trim())
-      },
-      capabilities: {
-        listModels: async () => [
-          {
-            id: 'player2-model',
-            name: 'Player2 Model',
-            provider: 'player2',
-          },
-        ],
-      },
-      validators: {
-        validateProviderConfig: (config) => {
-          const url: string = config.baseUrl ? config.baseUrl as string : 'http://localhost:4315/v1/'
-          // checks if health status is there, so it green if and only if you actually have the player2 app running
-          return fetch(`${url}health`, {
-            method: 'GET',
-            headers: {
-              'player2-game-key': 'airi',
-            },
-          })
-            .then(r => r.status === 200)
-            .catch(() => false)
-        },
-      },
-    },
+
     'cloudflare-workers-ai': {
       id: 'cloudflare-workers-ai',
       category: 'chat',

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -918,7 +918,14 @@ export const useProvidersStore = defineStore('providers', () => {
         validateProviderConfig: (config) => {
           const url: string = config.baseUrl ? config.baseUrl as string : 'http://localhost:4315/v1/'
           // checks if health status is there, so it green if and only if you actually have the player2 app running
-          return (fetch(`${url}health`).then(r => r.status === 200).catch(() => false))
+          return fetch(`${url}health`, {
+            method: 'GET',
+            headers: {
+              'player2-game-key': 'airi',
+            },
+          })
+            .then(r => r.status === 200)
+            .catch(() => false)
         },
       },
     },

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -891,8 +891,8 @@ export const useProvidersStore = defineStore('providers', () => {
         },
       },
     },
-    'player2-api': {
-      id: 'player2-api',
+    'player2': {
+      id: 'player2',
       category: 'chat',
       tasks: ['text-generation'],
       nameKey: 'settings.pages.providers.provider.player2.title',
@@ -910,7 +910,7 @@ export const useProvidersStore = defineStore('providers', () => {
           {
             id: 'player2-model',
             name: 'Player2 Model',
-            provider: 'player2-api',
+            provider: 'player2',
           },
         ],
       },


### PR DESCRIPTION
## Description
Adds speech support to player2. In order for this to work, still need to:

- (xsai) merge [this pr](https://github.com/moeru-ai/xsai/pull/167), then make release, then update version on airi
- (proj-airi/lobe-icons) merge [this pr](https://github.com/proj-airi/lobe-icons/pull/2), make release/update version on airi


For some reason speech.vue generated ssml by default, not sure if this was intentional but I made it do that iff the provider supports it 