### PR TITLE
fix(i18n): add MCP Server module title and description to en/zh-CN locales

### DIFF
--- a/apps/stage-tamagotchi/locales/en.yml
+++ b/apps/stage-tamagotchi/locales/en.yml
@@ -187,6 +187,9 @@ settings:
       gaming-minecraft:
         description: Playing Minecraft!
         title: Minecraft
+      mcp-server:
+        description: Connect and manage MCP server and tools
+        title: MCP Server
       hearing:
         description: Configure how speech recognition works
         title: Hearing

--- a/apps/stage-tamagotchi/locales/zh-CN.yml
+++ b/apps/stage-tamagotchi/locales/zh-CN.yml
@@ -226,6 +226,9 @@ settings:
       x:
         description: X / Twitter 的浏览和使用
         title: X / Twitter
+      mcp-server:
+        description: 连接和管理 MCP 服务器及工具
+        title: MCP 服务器
     providers:
       common:
         fields:

--- a/apps/stage-web/locales/en.yml
+++ b/apps/stage-web/locales/en.yml
@@ -240,6 +240,9 @@ settings:
       x:
         description: X / Twitter browsing and usage
         title: X / Twitter
+      mcp-server:
+        description: Connect and manage MCP server and tools
+        title: MCP Server
     providers:
       common:
         fields:

--- a/apps/stage-web/locales/zh-CN.yml
+++ b/apps/stage-web/locales/zh-CN.yml
@@ -226,6 +226,9 @@ settings:
       x:
         description: X / Twitter 的浏览和使用
         title: X / Twitter
+      mcp-server:
+        description: 连接和管理 MCP 服务器及工具
+        title: MCP 服务器
     providers:
       common:
         fields:


### PR DESCRIPTION
This PR adds missing i18n entries for the "MCP Server" module in both English and Chinese (en.yml, zh-CN.yml):
- Adds `title` and `description` fields under the modules section
- Ensures the settings/modules UI displays the MCP Server module correctly
- Follows the naming and description style of existing modules

![44edb7c494eadce7ebb89d62ceddcd3e](https://github.com/user-attachments/assets/09cecc20-3738-47d8-b77b-5329bb61ed9c)


Impact:
- UI only, no breaking changes
- Other locale files are not affected

Please help review, thanks!