### PR TITLE
install unplugin-unused as non-optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "unocss-preset-scrollbar": "^3.2.0",
     "unplugin-lightningcss": "^0.4.1",
     "unplugin-raw": "^0.5.0",
+    "unplugin-unused": "^0.5.1",
     "unplugin-vue": "^6.2.0",
     "vite": "^6.3.5",
     "vite-plugin-inspect": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       unplugin-raw:
         specifier: ^0.5.0
         version: 0.5.0
+      unplugin-unused:
+        specifier: ^0.5.1
+        version: 0.5.1
       unplugin-vue:
         specifier: ^6.2.0
         version: 6.2.0(@types/node@24.0.3)(jiti@2.4.2)(less@4.3.0)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(vue@3.5.17(typescript@5.8.3))(yaml@2.8.0)
@@ -23513,7 +23516,6 @@ snapshots:
       picocolors: 1.1.1
       pkg-types: 2.1.0
       unplugin: 2.3.5
-    optional: true
 
   unplugin-utils@0.2.4:
     dependencies:


### PR DESCRIPTION
## Description

This fixes `postinstall: @proj-airi/server-sdk:build:   ERROR  Error: Cannot find package 'unplugin-unused' imported from ...` when running `pnpm i` in a fresh clone.

## Linked Issues

## Additional context
