### PR TITLE
fix(settings): unify dark theme background color for content area and header

### DIFF
--- a/apps/stage-tamagotchi/src/layouts/settings.vue
+++ b/apps/stage-tamagotchi/src/layouts/settings.vue
@@ -138,6 +138,7 @@ const routeHeaderMetadata = computed(() => routeHeaderMetadataMap.value[route.pa
         <!-- Content -->
         <div flex="~ col" mx-auto max-w-screen-xl>
           <PageHeader
+            bg="bg-neutral-50 dark:bg-neutral-800"
             :title="routeHeaderMetadata?.title"
             :subtitle="routeHeaderMetadata?.subtitle"
             :disable-back-button="route.path === '/settings'"

--- a/apps/stage-tamagotchi/src/layouts/settings.vue
+++ b/apps/stage-tamagotchi/src/layouts/settings.vue
@@ -138,7 +138,7 @@ const routeHeaderMetadata = computed(() => routeHeaderMetadataMap.value[route.pa
         <!-- Content -->
         <div flex="~ col" mx-auto max-w-screen-xl>
           <PageHeader
-            bg="bg-neutral-50 dark:bg-neutral-800"
+            bg="neutral-50 dark:neutral-800"
             :title="routeHeaderMetadata?.title"
             :subtitle="routeHeaderMetadata?.subtitle"
             :disable-back-button="route.path === '/settings'"


### PR DESCRIPTION
## What’s Changed

- Unified the background color of the settings content area and PageHeader in dark mode to match the card  style for a more consistent visual experience.
- Fixed the issue where the PageHeader background color did not match the content/card area in dark theme.

## Visual Comparison

- Before
![c0b05fe92e56b6017841e8d0ee70bc82](https://github.com/user-attachments/assets/c4c71968-8f10-4f65-affe-089ca6ca03d5)

- After
![ae1222df69ab9c9313f1027fd1504479](https://github.com/user-attachments/assets/5468a7d9-c3e1-4544-ad70-39bb301c5c6d)


## Impact

- This change only affects the settings page in the desktop app (stage-tamagotchi) and does not impact other pages or features.