### PR TITLE
fix(stage-web): failed to launch when `localhost.crt` and `localhost.pem` is missing.

### DIFF
--- a/apps/stage-web/vite.config.ts
+++ b/apps/stage-web/vite.config.ts
@@ -64,7 +64,6 @@ export default defineConfig({
   },
 
   server: {
-    https: getHttps(),
   },
 
   plugins: [


### PR DESCRIPTION
## Description

`vite.config.ts` in `stage-web` requires `localhost.crt` and `localhost.pem` as the HTTPS cert of the dev server. It is undocumented.  
While it was starting, got a no such file error.
```
failed to load config from D:\airi\airi\apps\stage-web\vite.config.ts
error when starting dev server:
Error: ENOENT: no such file or directory, open 'D:\airi\airi\localhost.pem'     
```
Using HTTP should works as well.  
This PR makes it more robust and compatible.

## Linked Issues

<!-- Optional, if you have any -->

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
