### PR TITLE
fix(stage-ui): In the prod, the camera was not being set correct pos and target

### DIFF
--- a/packages/stage-ui/src/components/Scenarios/Settings/ModelSettings/VRM.vue
+++ b/packages/stage-ui/src/components/Scenarios/Settings/ModelSettings/VRM.vue
@@ -105,7 +105,7 @@ function urlUploadClick() {
       />
       <PropertyNumber
         v-model="cameraDistance"
-        :config="{ min: modelSize.z, max: modelSize.z * 20, step: modelSize.z / 100, label: t('settings.vrm.scale-and-position.camera-distance') }"
+        :config="{ min: modelSize.z, max: modelSize.z * 20, step: modelSize.z / 100, label: t('settings.vrm.scale-and-position.camera-distance'), formatValue: val => val?.toFixed(4) }"
         :label="t('settings.vrm.scale-and-position.camera-distance')"
       />
       <PropertyNumber

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -119,7 +119,9 @@ watch(cameraDistance, (newDistance) => {
       y: newPosition.y,
       z: newPosition.z,
     }
+    console.warn('camera setting complete: ', camera.value.position)
   }
+
   isUpdatingCamera = false
 })
 

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -52,10 +52,8 @@ watch(() => controlsRef.value?.controls, (ctrl) => {
     controlsReady.value = true
 })
 // If model is ready
-function handleLoadModelProgress(val: number) {
-  if (val === 100) {
-    modelReady.value = true
-  }
+function handleLoadModelProgress() {
+  modelReady.value = true
 }
 // Then start to set the camera postion and target
 watch(
@@ -150,7 +148,8 @@ defineExpose({
         :model="selectedModel"
         idle-animation="/assets/vrm/animations/idle_loop.vrma"
         :paused="false"
-        @load-model-progress="(val) => { emit('loadModelProgress', val); handleLoadModelProgress(val); }"
+        @load-model-progress="(val) => emit('loadModelProgress', val)"
+        @model-ready="handleLoadModelProgress"
         @error="(val) => emit('error', val)"
       />
     </TresCanvas>

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -48,6 +48,7 @@ watch(cameraFOV, (newFov) => {
 // })
 // If controls are ready
 watch(() => controlsRef.value?.controls, (ctrl) => {
+  console.warn('control ref is not undefined')
   if (ctrl)
     controlsReady.value = true
 })

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -2,7 +2,7 @@
 import { TresCanvas } from '@tresjs/core'
 import { useElementBounding } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { onMounted, ref, shallowRef, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 
 import * as THREE from 'three'
 
@@ -27,19 +27,10 @@ const modelRef = ref<InstanceType<typeof VRMModel>>()
 
 const camera = shallowRef(new THREE.PerspectiveCamera())
 const controlsRef = ref<InstanceType<typeof OrbitControls>>()
-
-onMounted(() => {
-  if (vrmContainerRef.value) {
-    camera.value.aspect = width.value / height.value
-    camera.value.fov = cameraFOV.value
-    camera.value.position.set(
-      cameraPosition.value.x,
-      cameraPosition.value.y,
-      cameraPosition.value.z,
-    )
-    camera.value.updateProjectionMatrix()
-  }
-})
+let isUpdatingCamera = true
+// manage the sequence of the camera and controls initialization
+const controlsReady = ref(false)
+const modelReady = ref(false)
 
 watch(cameraFOV, (newFov) => {
   if (camera.value) {
@@ -55,31 +46,46 @@ watch(cameraFOV, (newFov) => {
 //     camera.value.updateProjectionMatrix()
 //   }
 // })
+// If controls are ready
+watch(() => controlsRef.value?.controls, (ctrl) => {
+  if (ctrl)
+    controlsReady.value = true
+})
+// If model is ready
 function handleLoadModelProgress(val: number) {
-  if (val === 100 && camera.value && controlsRef.value && controlsRef.value.controls) {
-    // Set camera pos
-    camera.value.position.set(
-      cameraPosition.value.x,
-      cameraPosition.value.y,
-      cameraPosition.value.z,
-    )
-    camera.value.updateProjectionMatrix()
-
-    // Set camera target
-    controlsRef.value.controls.target.set(
-      modelOrigin.value.x,
-      modelOrigin.value.y,
-      modelOrigin.value.z,
-    )
-    controlsRef.value.controls.update()
+  if (val === 100) {
+    modelReady.value = true
   }
 }
+// Then start to set the camera postion and target
+watch(
+  [controlsReady, modelReady],
+  ([ctrlOk, modelOk]) => {
+    if (ctrlOk && modelOk && camera.value && controlsRef.value && controlsRef.value.controls) {
+      isUpdatingCamera = true
+      camera.value.aspect = width.value / height.value
+      camera.value.fov = cameraFOV.value
+      // Set camera position
+      camera.value.position.set(
+        cameraPosition.value.x,
+        cameraPosition.value.y,
+        cameraPosition.value.z,
+      )
+      camera.value.updateProjectionMatrix()
+      // Set camera target
+      controlsRef.value.setTarget(modelOrigin.value)
+      controlsRef.value.controls.update()
+      isUpdatingCamera = false
+    }
+  },
+)
 
 // Bidirectional watch between slider and OrbitControls
 watch(() => controlsRef.value?.getDistance(), (newDistance) => {
-  if (newDistance !== undefined) {
+  if (!isUpdatingCamera && newDistance !== undefined && camera.value) {
     // To avoid floating point inaccuracies causing a feedback loop with the other watcher,
     // we can check if the distance has changed significantly.
+    isUpdatingCamera = true
     if (Math.abs(cameraDistance.value - newDistance) > 1e-6) {
       cameraDistance.value = newDistance
       cameraPosition.value = {
@@ -88,10 +94,12 @@ watch(() => controlsRef.value?.getDistance(), (newDistance) => {
         z: camera.value.position.z,
       }
     }
+    isUpdatingCamera = false
   }
 })
 watch(cameraDistance, (newDistance) => {
-  if (camera.value && controlsRef.value && controlsRef.value.controls) {
+  if (!isUpdatingCamera && camera.value && controlsRef.value && controlsRef.value.controls) {
+    isUpdatingCamera = true
     const newPosition = new THREE.Vector3()
     const target = controlsRef.value.controls.target
     const direction = new THREE.Vector3().subVectors(camera.value.position, target).normalize()
@@ -108,6 +116,7 @@ watch(cameraDistance, (newDistance) => {
       z: newPosition.z,
     }
   }
+  isUpdatingCamera = false
 })
 
 defineExpose({
@@ -121,9 +130,9 @@ defineExpose({
   <div ref="vrmContainerRef" w="100%" h="100%">
     <TresCanvas v-if="camera" :camera="camera" :alpha="true" :antialias="true" :width="width" :height="height">
       <TresAxesHelper :size="1" />
+      <OrbitControls ref="controlsRef" />
       <TresDirectionalLight :color="0xFFFFFF" :intensity="1.8" :position="[1, 1, -10]" />
       <TresAmbientLight :color="0xFFFFFF" :intensity="1.2" />
-      <OrbitControls ref="controlsRef" />
       <VRMModel
         ref="modelRef"
         :key="selectedModel"

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -62,6 +62,10 @@ watch(
   [controlsReady, modelReady],
   ([ctrlOk, modelOk]) => {
     console.warn('start camera setting')
+    console.warn('ctr OK?', ctrlOk)
+    console.warn('model OK? ', modelOk)
+    console.warn('controlsRef is defined? ', controlsRef.value)
+    console.warn('controlsRef.value.controls is defined?', controlsRef)
     if (ctrlOk && modelOk && camera.value && controlsRef.value && controlsRef.value.controls) {
       isUpdatingCamera = true
       try {
@@ -76,7 +80,7 @@ watch(
         camera.value.updateProjectionMatrix()
         // Set camera target
         controlsRef.value.setTarget(modelOrigin.value)
-        controlsRef.value.controls.update()
+        // controlsRef.value.controls.update()
         console.warn('camera setting complete: ', camera.value.position)
       }
       finally {

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -75,9 +75,6 @@ watch(
         )
         camera.value.updateProjectionMatrix()
         controlsRef.value.controls.update()
-        console.warn('camera setting complete: ', camera.value.position)
-        console.warn('target set complete', controlsRef.value.controls.target)
-        console.warn('model origin: ', modelOrigin.value)
       }
       finally {
         isUpdatingCamera = false
@@ -86,10 +83,6 @@ watch(
     }
   },
 )
-
-watch(cameraPosition, (newpos) => {
-  console.warn('camera postion changed: ', newpos)
-})
 
 // Bidirectional watch between slider and OrbitControls
 watch(() => controlsRef.value?.getDistance(), (newDistance) => {

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -63,19 +63,23 @@ watch(
   ([ctrlOk, modelOk]) => {
     if (ctrlOk && modelOk && camera.value && controlsRef.value && controlsRef.value.controls) {
       isUpdatingCamera = true
-      camera.value.aspect = width.value / height.value
-      camera.value.fov = cameraFOV.value
-      // Set camera position
-      camera.value.position.set(
-        cameraPosition.value.x,
-        cameraPosition.value.y,
-        cameraPosition.value.z,
-      )
-      camera.value.updateProjectionMatrix()
-      // Set camera target
-      controlsRef.value.setTarget(modelOrigin.value)
-      controlsRef.value.controls.update()
-      isUpdatingCamera = false
+      try {
+        camera.value.aspect = width.value / height.value
+        camera.value.fov = cameraFOV.value
+        // Set camera position
+        camera.value.position.set(
+          cameraPosition.value.x,
+          cameraPosition.value.y,
+          cameraPosition.value.z,
+        )
+        camera.value.updateProjectionMatrix()
+        // Set camera target
+        controlsRef.value.setTarget(modelOrigin.value)
+        controlsRef.value.controls.update()
+      }
+      finally {
+        isUpdatingCamera = false
+      }
     }
   },
 )

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -76,6 +76,7 @@ watch(
         // Set camera target
         controlsRef.value.setTarget(modelOrigin.value)
         controlsRef.value.controls.update()
+        console.warn('camera setting complete: ', camera.value.position)
       }
       finally {
         isUpdatingCamera = false
@@ -119,7 +120,6 @@ watch(cameraDistance, (newDistance) => {
       y: newPosition.y,
       z: newPosition.z,
     }
-    console.warn('camera setting complete: ', camera.value.position)
   }
 
   isUpdatingCamera = false

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -48,7 +48,6 @@ watch(cameraFOV, (newFov) => {
 // })
 // If controls are ready
 watch(() => controlsRef.value?.controls, (ctrl) => {
-  console.warn('control ref is not undefined')
   if (ctrl)
     controlsReady.value = true
 })
@@ -62,6 +61,7 @@ function handleLoadModelProgress(val: number) {
 watch(
   [controlsReady, modelReady],
   ([ctrlOk, modelOk]) => {
+    console.warn('start camera setting')
     if (ctrlOk && modelOk && camera.value && controlsRef.value && controlsRef.value.controls) {
       isUpdatingCamera = true
       try {

--- a/packages/stage-ui/src/components/Scenes/VRM/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/Model.vue
@@ -44,7 +44,6 @@ const {
   cameraPosition,
   loadingModel,
   modelRotationY,
-  cameraDistance,
 } = storeToRefs(vrmStore)
 const vrmGroup = ref<Group>()
 
@@ -80,7 +79,7 @@ onMounted(async () => {
       y: vrmModelCenter.y + vrmInitialCameraOffset.y,
       z: vrmModelCenter.z + vrmInitialCameraOffset.z,
     }
-    cameraDistance.value = vrmInitialCameraOffset.length()
+    // cameraDistance.value = vrmInitialCameraOffset.length()
 
     // Set initial positions for model
     modelOrigin.value = {

--- a/packages/stage-ui/src/components/Scenes/VRM/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/Model.vue
@@ -43,6 +43,7 @@ const {
   cameraPosition,
   loadingModel,
   modelRotationY,
+  cameraDistance,
 } = storeToRefs(vrmStore)
 const vrmGroup = ref<Group>()
 
@@ -78,6 +79,7 @@ onMounted(async () => {
       y: vrmModelCenter.y + vrmInitialCameraOffset.y,
       z: vrmModelCenter.z + vrmInitialCameraOffset.z,
     }
+    cameraDistance.value = vrmInitialCameraOffset.length()
 
     // Set initial positions for model
     modelOrigin.value = {

--- a/packages/stage-ui/src/components/Scenes/VRM/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/Model.vue
@@ -135,14 +135,14 @@ onMounted(async () => {
         hipsTrack.values[1],
         hipsTrack.values[2],
       )
-      const delta = new Vector3().subVectors(animeHipPos, defaultHipPos)
+      const animeDelta = new Vector3().subVectors(animeHipPos, defaultHipPos)
 
       clip.tracks.forEach((track) => {
         if (track.name.endsWith('.position') && track instanceof VectorKeyframeTrack) {
           for (let i = 0; i < track.values.length; i += 3) {
-            track.values[i] -= delta.x
-            track.values[i + 1] -= delta.y
-            track.values[i + 2] -= delta.z
+            track.values[i] -= animeDelta.x
+            track.values[i + 1] -= animeDelta.y
+            track.values[i + 2] -= animeDelta.z
           }
         }
       })
@@ -204,6 +204,7 @@ defineExpose({
     vrmEmote.value?.setEmotionWithResetAfter(expression, 1000)
   },
   scene: computed(() => vrm.value?.scene),
+  lookAt: computed(() => vrm.value?.lookAt),
 })
 
 const { pause, resume } = useLoop()

--- a/packages/stage-ui/src/components/Scenes/VRM/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/Model.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'loadModelProgress', value: number): void
   (e: 'error', value: unknown): void
+  (e: 'modelReady'): void
 }>()
 
 let disposeBeforeRenderLoop: (() => void | undefined)
@@ -166,6 +167,7 @@ onMounted(async () => {
     vrm.value = _vrm
 
     loadingModel.value = false
+    emit('modelReady')
 
     disposeBeforeRenderLoop = onBeforeRender(({ delta }) => {
       vrmAnimationMixer.value?.update(delta)

--- a/packages/stage-ui/src/components/Scenes/VRM/OrbitControls.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/OrbitControls.vue
@@ -50,6 +50,12 @@ defineExpose({
   controls,
   getDistance: () => controls.value?.getDistance(),
   update: () => controls.value?.update(),
+  setTarget: (target: { x: number, y: number, z: number }) => {
+    if (controls.value) {
+      controls.value.target.set(target.x, target.y, target.z)
+      controls.value.update()
+    }
+  },
 })
 </script>
 


### PR DESCRIPTION
## Description

This is a possible fix. Try to enforce the camera position and target setting to be after the creation of Model and OrbitControls, such that these objects are not undefined.
 - Reset camera position and target of OrbitControls needs the information of the VRM model (Centre position & model size, etc), which will not be calculated after the loading of the Model.

## Linked Issues

If this can't fix it, then an issue to track it is needed.

## Additional context

None
