### PR TITLE
chore(vscode): disable rust-analyzer cache priming

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,5 +67,6 @@
     "editor.formatOnSave": true
   },
   "rust-analyzer.checkOnSave": true,
+  "rust-analyzer.cachePriming.enable": false, // Disable cache priming on workspace startup to save some memory while working on non-Rust tasks
   "vitest.disableWorkspaceWarning": true
 }


### PR DESCRIPTION
## Description

Setting `rust-analyzer.cachePriming.enable` to `false` in our shared `.vscode/settings.json` to disable rust-analyzer's cache priming feature on workspace startup. This would help save VSC memory consumption and reduce the laggy experience during startup, especially when the current window is not started to work on Rust-related tasks.

In the meantime, we can keep an eye on this official initiative: https://github.com/rust-lang/rust-analyzer/issues/17537

## Comparison

|Before|
|:-:|
|<img width="791" height="174" alt="Screenshot 2025-07-26 at 3 51 01" src="https://github.com/user-attachments/assets/348d1e2e-8e9e-4759-8697-829c9a85dce6" />|

|After ♻️  (~86% saved)|
|:-:|
|<img width="824" height="172" alt="Screenshot 2025-07-26 at 4 09 33" src="https://github.com/user-attachments/assets/ce54675b-4e3f-4f6f-a185-484ad9c4ff09" />|

## Concerns

### Will lazy-loading take long?

No. Caching will be started upon opening the first Rust file in the workspace, which takes only ~7 seconds to lazy-load on my side:

https://github.com/user-attachments/assets/635b039b-3666-4a1d-a8fa-e1acf5febc29

Therefore, don't worry about the waiting time!

### But tasks like `cargo metadata` and `cargo build` still run, right?

Yes, I consider this acceptable as the first-time setup takes a while, but that doesn't apply to future uses, which differ from the memory consumption case that matters on each startup.
