### PR TITLE
fix(stage-ui): clean up models on HMR

### DIFF
--- a/packages/stage-ui/src/components/Scenes/Live2D/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/Live2D/Model.vue
@@ -298,9 +298,13 @@ watchDebounced(loadingModel, (value) => {
 }, { debounce: 1000 })
 
 onMounted(updateDropShadowFilter)
-onUnmounted(() => {
+
+function componentCleanUp() {
   cancelAnimationFrame(dropShadowAnimationId.value)
   model.value && pixiApp.value?.stage.removeChild(model.value)
+}
+onUnmounted(() => {
+  componentCleanUp()
 })
 
 function listMotionGroups() {
@@ -311,6 +315,13 @@ defineExpose({
   setMotion,
   listMotionGroups,
 })
+
+if (import.meta.hot) {
+  // Ensure cleanup on HMR
+  import.meta.hot.dispose(() => {
+    componentCleanUp()
+  })
+}
 </script>
 
 <template>

--- a/packages/stage-ui/src/components/Scenes/VRM/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/Model.vue
@@ -217,13 +217,24 @@ watch(() => props.paused, (value) => {
   value ? pause() : resume()
 })
 
-onUnmounted(() => {
+function componentCleanUp() {
   disposeBeforeRenderLoop?.()
   if (vrm.value) {
     vrm.value.scene.removeFromParent()
     VRMUtils.deepDispose(vrm.value.scene)
   }
+}
+
+onUnmounted(() => {
+  componentCleanUp()
 })
+
+if (import.meta.hot) {
+  // Ensure cleanup on HMR
+  import.meta.hot.dispose(() => {
+    componentCleanUp()
+  })
+}
 </script>
 
 <template>


### PR DESCRIPTION
Cleaning up Live2D and VRM models on HMR as well. Although the `onUnmounted` hook should have been called on HMR, sometimes it doesn't (in our case). This may help prevent the models from being loaded and added to the scene multiple times without proper cleanup.