### PR TITLE
fix(docs): call writeHead before write and remove next()

### DIFF
--- a/docs/.vitepress/plugins/vite-frontmatter-assets.ts
+++ b/docs/.vitepress/plugins/vite-frontmatter-assets.ts
@@ -160,7 +160,7 @@ export function frontmatterAssets(): Plugin {
           'Content-Length': fileContent.length,
           'Cache-Control': 'public, max-age=31536000, immutable',
         })
-        res.write(fileContent)
+        res.end(fileContent)
         res.end()
       })
     },


### PR DESCRIPTION
Moving `writeHead` before `write` and removing the `next()` call to fix the following error while starting Vitepress:

```
node:_http_server:351
    throw new ERR_HTTP_HEADERS_SENT('write');
          ^

Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:351:11)
    at file:///.../docs/node_modules/.vite-temp/config.ts.timestamp-1753799242233-dd15bbae2280f.mjs:193:13 {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```