### PR TITLE
fix(docs): width not constraint for cover

### DIFF
--- a/docs/.vitepress/components/ParallaxCover.vue
+++ b/docs/.vitepress/components/ParallaxCover.vue
@@ -79,7 +79,7 @@ const maskImageURL = `url(${homeCover})`
 <template>
   <div
     :class="[
-      'relative left-1/2 -translate-x-1/2 max-w-none object-cover z-1',
+      'relative left-1/2 -translate-x-1/2 max-w-none z-1',
       'w-[160%] translate-y-[25%] -rotate-20 top-8rem',
       'md:w-[120%] md:translate-y-[20%] md:rotate-[-15deg] md:top-8dvh',
       'lg:w-[95%] lg:translate-y-[5%] lg:rotate-[-10deg] lg:top-32dvh',
@@ -87,7 +87,7 @@ const maskImageURL = `url(${homeCover})`
       '2xl:top-16dvh',
     ]"
   >
-    <img ref="surface" :src="homeCover" alt="Project AIRI Cover Image" class="w-full">
+    <img ref="surface" :src="homeCover" alt="Project AIRI Cover Image" class="w-full object-cover">
     <div ref="silhouettePink" class="silhouette absolute left-0 top-0 z--1 h-full w-full bg-[oklch(0.8105_0.1267_350.84)]" />
     <div ref="silhouettePurple" class="silhouette absolute left-0 top-0 z--2 h-full w-full bg-[oklch(0.5712_0.2396_278.59)]" />
   </div>


### PR DESCRIPTION
## Description

### Before

<img width="3008" height="1667" alt="image" src="https://github.com/user-attachments/assets/bf81c4e4-56e1-4200-b043-0f7008f53567" />

<img width="1485" height="934" alt="image" src="https://github.com/user-attachments/assets/b9d734ef-a1d1-4974-a68c-039790b0cca6" />

### After

<img width="3008" height="1667" alt="image" src="https://github.com/user-attachments/assets/ba2f8e35-7da1-4f43-9823-0d4a32aa5be9" />

<img width="1485" height="934" alt="image" src="https://github.com/user-attachments/assets/cc8578d1-44cf-4bf6-b325-4fea26b2438c" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

## Linked Issues

<!-- Optional, if you have any -->

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
