### PR TITLE
fix(stage-web): Now only the last AIRI's chat will be showing as 3 dots loading status.

### DIFF
--- a/apps/stage-web/src/components/Widgets/ChatHistory.vue
+++ b/apps/stage-web/src/components/Widgets/ChatHistory.vue
@@ -66,7 +66,7 @@ onTokenLiteral(async () => {
             <div>
               <span text-xs text="primary-400/90 dark:primary-600/90" font-normal class="inline <sm:hidden">{{ t('stage.chat.message.character-name.airi') }}</span>
             </div>
-            <div v-if="message.content && index === messages.length - 1" class="markdown-content break-words" text="xs primary-400">
+            <div v-if="message.content" class="markdown-content break-words" text="xs primary-400">
               <div v-for="(slice, sliceIndex) in message.slices" :key="sliceIndex">
                 <div v-if="slice.type === 'tool-call'">
                   <div
@@ -79,7 +79,7 @@ onTokenLiteral(async () => {
                 <div v-else v-html="process(slice.text)" />
               </div>
             </div>
-            <div v-else i-eos-icons:three-dots-loading />
+            <div v-else-if="index === messages.length - 1 && !message.content" i-eos-icons:three-dots-loading />
           </div>
         </div>
         <div v-else-if="message.role === 'user'" flex="~ row-reverse" ml="12">


### PR DESCRIPTION
## Description

Due to the incorrect v-if conditions, all the historical AIRI's chat will be shown as 3-dot loading. Now this condition has been fixed. All AIRI's chat history is visible now.

## Linked Issues

None

## Additional context

None
