### PR TITLE
feat(stage-ui): introduce helpers for stream and tts chunking

### DIFF
--- a/packages/stage-ui/src/utils/stream.ts
+++ b/packages/stage-ui/src/utils/stream.ts
@@ -4,11 +4,13 @@ export interface ControllableStream<R = any> {
 }
 
 export function createControllableStream<R = any>(): ControllableStream<R> {
-  let controller: ReadableStreamDefaultController<R>
+  // WHY!: ReadableStream.start is called synchronously and immediately
+  let controller!: ReadableStreamDefaultController<R>
+
   const stream = new ReadableStream<R>({
     start(ctrl) {
       controller = ctrl
     },
   })
-  return { stream, controller: controller! }
+  return { stream, controller }
 }

--- a/packages/stage-ui/src/utils/stream.ts
+++ b/packages/stage-ui/src/utils/stream.ts
@@ -1,0 +1,14 @@
+export interface ControllableStream<R = any> {
+  stream: ReadableStream<R>
+  controller: ReadableStreamDefaultController<R>
+}
+
+export function createControllableStream<R = any>(): ControllableStream<R> {
+  let controller: ReadableStreamDefaultController<R>
+  const stream = new ReadableStream<R>({
+    start(ctrl) {
+      controller = ctrl
+    },
+  })
+  return { stream, controller: controller! }
+}

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -1,5 +1,7 @@
 import type { ReaderLike } from 'clustr'
 
+import type { UseQueueReturn } from '../composables/queue'
+
 import { readGraphemeClusters } from 'clustr'
 
 // A special character to instruct the TTS pipeline to flush
@@ -142,5 +144,16 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
       words: chunkWordsCount + [...segmenter.segment(buffer)].filter(w => w.isWordLike).length,
       reason: 'flush',
     }
+  }
+}
+
+export async function chunkToTTSQueue(reader: ReaderLike, queue: UseQueueReturn<string>) {
+  try {
+    for await (const chunk of chunkTTSInput(reader)) {
+      await queue.add(chunk.text)
+    }
+  }
+  catch (e) {
+    console.error('Error chunking stream to TTS queue:', e)
   }
 }


### PR DESCRIPTION
## Description

As a follow-up to our [discussion](https://github.com/moeru-ai/airi/pull/330/files/7d973d5f9d38cbaa1c2bdd8c7d2c8745d7dea7b3#r2240268721), introducing a helper function `chunkToTTSQueue` to provide the reader to the TTS chunking processor and then pipe the chunks to the TTS queue, and a helper function `createControllableStream` to create externally controllable `ReadableStream`s at ease.