### PR TITLE
fix(stage-ui) TTS decimals are now retained, AIRI will no longer say "25" if it's "2.5"

### DIFF
--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -185,6 +185,8 @@ export const useChatStore = defineStore('chat', () => {
       }
 
       // Instruct the TTS pipeline to flush
+      // eslint-disable-next-line no-console
+      console.debug('message content:', messages.value)
       slicesQueue.add({ type: 'text', text: TTS_FLUSH_INSTRUCTION })
 
       await parser.end()

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -183,13 +183,10 @@ export const useChatStore = defineStore('chat', () => {
         })
         fullText += textPart
       }
+      await parser.end()
 
       // Instruct the TTS pipeline to flush
-      // eslint-disable-next-line no-console
-      console.debug('message content:', messages.value)
       slicesQueue.add({ type: 'text', text: TTS_FLUSH_INSTRUCTION })
-
-      await parser.end()
 
       for (const hook of onStreamEndHooks.value) {
         await hook()

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -169,6 +169,7 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
 export async function chunkToTTSQueue(reader: ReaderLike, queue: UseQueueReturn<string>) {
   try {
     for await (const chunk of chunkTTSInput(reader)) {
+      // TODO: remove later
       // eslint-disable-next-line no-console
       console.debug('chunk to be pushed: ', chunk)
       await queue.add(chunk.text)

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -82,8 +82,15 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
           if (previousValue !== undefined && /\d/.test(previousValue)) {
             const next = await iterator.next()
             if (!next.done && next.value && /\d/.test(next.value)) {
-              // This dot could be a decimal point, so we skip it
-              previousValue = next.value
+              // This dot could be a decimal point, so we skip it (don't fully skip! keep in tts input!)
+
+              // Kapapu: I think we need to remove the below line
+              // 1. Not sensible to let the previousValue to be the value of the next value
+              // 2. after the continue (jump to the bottom of the while loop), the previousValue will be reset to value, so this value assignment doesn't work at all
+              // previousValue = next.value
+
+              // If we don't append value ("." or ","), we will lose the decimal point, and 2.5 will become 25, which hugely impacted the tts...
+              buffer += value
               current = next
               continue
             }
@@ -133,10 +140,21 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
     }
 
     buffer += value
+    // eslint-disable-next-line no-console
+    console.debug('current buffer: ', buffer)
     previousValue = value
-    current = await iterator.next()
+    // For debugging why it stuck at "xxxx\u200B"
+    const next = await iterator.next()
+    // if (next.value ==='\u200B') {
+    //   console.debug("TTS_FLUSH get for the next value!")
+    // } else {
+    //   console.debug("the next value: ", next.value)
+    // }
+    current = next
   }
 
+  // eslint-disable-next-line no-console
+  console.debug('while loop ends, chunk/buffer:', chunk, buffer)
   if (chunk.length > 0 || buffer.length > 0) {
     const text = (chunk + buffer).trim()
     yield {
@@ -150,6 +168,8 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
 export async function chunkToTTSQueue(reader: ReaderLike, queue: UseQueueReturn<string>) {
   try {
     for await (const chunk of chunkTTSInput(reader)) {
+      // eslint-disable-next-line no-console
+      console.debug('chunk to be pushed: ', chunk)
       await queue.add(chunk.text)
     }
   }

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -140,6 +140,7 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
     }
 
     buffer += value
+    // TODO: remove later
     // eslint-disable-next-line no-console
     console.debug('current buffer: ', buffer)
     previousValue = value

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -84,7 +84,7 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
             if (!next.done && next.value && /\d/.test(next.value)) {
               // This dot could be a decimal point, so we skip it (don't fully skip! keep in tts input!)
 
-              // Kapapu: I think we need to remove the below line
+              // REVIEW: @Lilia-Chen I think we need to remove the below line
               // 1. Not sensible to let the previousValue to be the value of the next value
               // 2. after the continue (jump to the bottom of the while loop), the previousValue will be reset to value, so this value assignment doesn't work at all
               // previousValue = next.value

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -154,6 +154,7 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
     current = next
   }
 
+  // TODO: remove later
   // eslint-disable-next-line no-console
   console.debug('while loop ends, chunk/buffer:', chunk, buffer)
   if (chunk.length > 0 || buffer.length > 0) {


### PR DESCRIPTION
## Description

When reading the codes for the TTS generation, I realised that the current code will not keep the decimal itself in the tts input text:

```
if (flush || hard || soft) {
      switch (value) {
        case '.':
        case ',': {
          if (previousValue !== undefined && /\d/.test(previousValue)) {
            const next = await iterator.next()
            if (!next.done && next.value && /\d/.test(next.value)) {
              // This dot could be a decimal point, so we skip it
              previousValue = next.value
              current = next
              continue
            }
          }
        }
      }
```

<img width="2560" height="1392" alt="Screenshot 2025-07-31 212103" src="https://github.com/user-attachments/assets/0ae5e646-9628-4edb-92ed-91d1bd34b223" />

Moreover, the value assignment to previousValue and current is also a little bit confusing, so I re-write it.

## Linked Issues


## Additional context

Some other commented code is for debugging. I also realised that AIRI will stop talking if the last chunk ends with "a normal character (not hard not soft not flush) and a flush (\u200B)". The last sentence will not be pushed into ttsQueue until the next LLM API output arrived... I will open another issue to further discuss it.
