### PR TITLE
Chore(stage-ui): Queue.ts renaming, tts "..." recognition, and something relates to next and afterNext

### DIFF
--- a/packages/stage-ui/src/components/Scenes/Stage.vue
+++ b/packages/stage-ui/src/components/Scenes/Stage.vue
@@ -196,7 +196,7 @@ onBeforeSend(async () => {
 })
 
 onTokenLiteral(async (literal) => {
-  await messageContentQueue.add(literal)
+  await messageContentQueue.add(literal.replace(/\.{3}/g, '…'))
 })
 
 onTokenSpecial(async (special) => {

--- a/packages/stage-ui/src/composables/queue.ts
+++ b/packages/stage-ui/src/composables/queue.ts
@@ -22,7 +22,7 @@ export function useQueue<T>(options: {
 }) {
   const queue = ref<T[]>([]) as Ref<T[]>
   const isProcessing = ref(false)
-  const internalEventHandler: Events<T> = {
+  const internalEventListeners: Events<T> = {
     add: [],
     pick: [],
     processing: [],
@@ -30,26 +30,26 @@ export function useQueue<T>(options: {
     processed: [],
     done: [],
   }
-  const internalHandlerEventHandler: Record<string, Array<(...params: any[]) => void>> = {}
+  const internalHandlerEventListeners: Record<string, Array<(...params: any[]) => void>> = {}
 
-  function on<E extends keyof Events<T>>(eventName: E, handler: Events<T>[E][number]) {
-    internalEventHandler[eventName].push(handler as any)
+  function on<E extends keyof Events<T>>(eventName: E, Listener: Events<T>[E][number]) {
+    internalEventListeners[eventName].push(Listener as any)
   }
 
   function emit<E extends keyof Events<T>>(eventName: E, ...params: Parameters<Events<T>[E][number]>) {
-    const handlers = internalEventHandler[eventName] as Events<T>[E]
+    const handlers = internalEventListeners[eventName] as Events<T>[E]
     handlers.forEach((handler) => {
       (handler as any)(...params)
     })
   }
 
   function onHandlerEvent(eventName: string, handler: (...params: any[]) => void) {
-    internalHandlerEventHandler[eventName] = internalHandlerEventHandler[eventName] || []
-    internalHandlerEventHandler[eventName].push(handler)
+    internalHandlerEventListeners[eventName] = internalHandlerEventListeners[eventName] || []
+    internalHandlerEventListeners[eventName].push(handler)
   }
 
   function emitHandlerEvent(eventName: string, ...params: any[]) {
-    const handlers = internalHandlerEventHandler[eventName] || []
+    const handlers = internalHandlerEventListeners[eventName] || []
     handlers.forEach((handler) => {
       handler(...params)
     })
@@ -69,7 +69,8 @@ export function useQueue<T>(options: {
     return payload
   }
 
-  async function handleItem() {
+  // Listener for item add / enqueue event
+  async function addItemListener() {
     if (isProcessing.value)
       return
 
@@ -80,12 +81,19 @@ export function useQueue<T>(options: {
     isProcessing.value = true
 
     for (const handler of options.handlers) {
+      // If there is a need to register customised listener for processing event, then this line of code should be rewritten
+      // handlers as the input parameter is only designed for the add event
       emit('processing', payload, handler)
       try {
+        // Use handler to deal with the newly enqueued item
         const result = await handler({ data: payload, itemsToBeProcessed: () => queue.value.length, emit: emitHandlerEvent })
+        // If there is a need to register customised listener for processing event, then this line of code should be rewritten
+        // handlers as the input parameter is only designed for the add event
         emit('processed', payload, result, handler)
       }
       catch (err) {
+        // If there is a need to register customised listener for processing event, then this line of code should be rewritten
+        // handlers as the input parameter is only designed for the add event
         emit('error', payload, err as Error, handler)
         continue
       }
@@ -96,11 +104,13 @@ export function useQueue<T>(options: {
 
     // Process next item if any
     if (queue.value.length > 0)
-      handleItem()
+      addItemListener()
   }
 
-  on('add', handleItem)
-  on('done', handleItem)
+  on('add', addItemListener)
+  // Lilia: I'm not sure why do we need to register handleItem to 'done', if queue is not empty, addItemListner will continue to call addItemListner. Calling this function again when 'done' event is triggered will only lead to payload = undefined (since queue is already empty) and return
+  // Maybe leave 'done' event to be registered other customised listeners would be more reasonable
+  // on('done', addItemListener)
 
   return {
     add,

--- a/packages/stage-ui/src/composables/queue.ts
+++ b/packages/stage-ui/src/composables/queue.ts
@@ -8,7 +8,6 @@ export interface HandlerContext<T> {
   emit: (eventName: string, ...params: any[]) => void
 }
 
-// FIXME: should be exported?
 export interface Events<T> {
   add: Array<(payload: T) => void>
   pick: Array<(payload: T) => void>

--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -8,8 +8,8 @@ import { readGraphemeClusters } from 'clustr'
 export const TTS_FLUSH_INSTRUCTION = '\u200B'
 
 const keptPunctuations = new Set('?？!！')
-const hardPunctuations = new Set('.。?？!！…⋯～~「」\n\t\r')
-const softPunctuations = new Set(',，、–—:：;；《》')
+const hardPunctuations = new Set('.。?？!！…⋯～~\n\t\r')
+const softPunctuations = new Set(',，、–—:：;；《》「」')
 
 export interface TTSInputChunk {
   text: string
@@ -62,7 +62,7 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
   let current = await iterator.next()
 
   while (!current.done) {
-    const value = current.value
+    let value = current.value
 
     if (value.length > 1) {
       previousValue = value
@@ -74,13 +74,15 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
     const hard = hardPunctuations.has(value)
     const soft = softPunctuations.has(value)
     const kept = keptPunctuations.has(value)
+    let next: IteratorResult<string, any> | undefined
+    let afterNext: IteratorResult<string, any> | undefined
 
     if (flush || hard || soft) {
       switch (value) {
         case '.':
         case ',': {
           if (previousValue !== undefined && /\d/.test(previousValue)) {
-            const next = await iterator.next()
+            next = await iterator.next()
             if (!next.done && next.value && /\d/.test(next.value)) {
               // This dot could be a decimal point, so we skip it (don't fully skip! keep in tts input!)
 
@@ -93,6 +95,17 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
               buffer += value
               current = next
               continue
+            }
+          }
+          else if (value === '.') {
+            // trying catch '...' and turn it into U+2026
+            next = await iterator.next()
+            if (!next.done && next.value && next.value === '.') {
+              afterNext = await iterator.next()
+              // If this is a '...' repalce the current value
+              if (!afterNext.done && afterNext.value && afterNext.value === '.') {
+                value = '…'
+              }
             }
           }
         }
@@ -135,22 +148,40 @@ export async function* chunkTTSInput(input: string | ReaderLike, options?: TTSIn
       }
 
       previousValue = value
-      current = await iterator.next()
+      // If next had been read during decimal recognition or "..." recognition
+      if (next !== undefined) {
+        // If afterNext had also been read
+        if (afterNext !== undefined) {
+          // The only case that the program will come to this place is:
+          // "x..y" and y is not a "." so "..." is not recognised
+          // ".." is not a legal punctuation so ignored.
+          // The first "." had been consumed during hard flush
+          // next.value = second '.'
+          // afterNext.value = 'y', so we just need to care about 'y'
+          // In case 'y' is not just a useless blank. It's OK if 'y' is blank since we have `text = chunk.trim()`
+          current = afterNext
+          next = undefined
+          afterNext = undefined
+        }
+        else {
+          // Only next had been read
+          // This is the case where "x.y" and x is a number but y is not
+          // In case 'y' is not just a useless blank. It's OK if 'y' is blank since we have `text = chunk.trim()`
+          current = next
+          next = undefined
+        }
+      }
+      else {
+        // No next nor afterNext, so run `iterator.next()`
+        current = await iterator.next()
+      }
+      // No need to do anything with buffer, just jump to the next loop
       continue
     }
-
+    // If normal character enters, add it to the buffer and move to the next
     buffer += value
-    // TODO: remove later
-    // eslint-disable-next-line no-console
-    console.debug('current buffer: ', buffer)
     previousValue = value
-    // For debugging why it stuck at "xxxx\u200B"
-    const next = await iterator.next()
-    // if (next.value ==='\u200B') {
-    //   console.debug("TTS_FLUSH get for the next value!")
-    // } else {
-    //   console.debug("the next value: ", next.value)
-    // }
+    next = await iterator.next()
     current = next
   }
 


### PR DESCRIPTION
## Description

### 1 Queue.ts renaming
Following the design idea of EDA, I separated the naming of handlers and listeners. They are separate things and should not be called 'handlers' simultaneously. This change enhances the readability of the code.

### 2 Recognising "..." in tts
Based on the current mechanism of LLM message sending, receiving and parsing, all the literals are **single characters**, which means something like "..." will be enqueued as ".", "." and "." via 3 separate `onTokenLiteral` events. Therefore, according to the previous implementation, all the "..." will be directly recognised as ".", and the tts API will never get "..." to enhance its audio output quality.

Therefore, I added code to look for any other "."(s) after the existing ".". Once there are 3 sequential ".", the value will be changed into '…'. Now you can see ellipsis is also enqueued:
<img width="1270" height="724" alt="Screenshot 2025-08-06 230059" src="https://github.com/user-attachments/assets/f1538662-3f44-4c65-be55-d18833cb9afc" />

### 3 Something related to `next` and `afterNext`
After I completed part 2, I realised that `next` and `afterNext` were used to obtain the following characters from the stream. Since there is no going back for reading characters from a stream, we should be careful when the code is going to the next round of the loop. We can't just run `current = await iterator.next()` and just ignore the content we got in the `next` and `afterNext`.

For details, please refer to the changes I made. I also added a lot of comments to explain why I need to do that.

## Linked Issues

None

## Additional context

None
