### PR TITLE
fix(docs): correct AWS Claude documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ npx bumpp --no-commit --no-tag
 - [x] [OpenAI](https://platform.openai.com/docs/guides/gpt/chat-completions-api)
   - [ ] [Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference) (PR welcome)
 - [x] [Anthropic Claude](https://anthropic.com)
-  - [ ] [AWS Claude](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference) (PR welcome)
+  - [ ] [AWS Claude](https://docs.anthropic.com/en/api/claude-on-amazon-bedrock) (PR welcome)
 - [x] [DeepSeek](https://www.deepseek.com/)
 - [x] [Qwen](https://help.aliyun.com/document_detail/2400395.html)
 - [x] [xAI](https://x.ai/)


### PR DESCRIPTION
## Summary
- Fixed incorrect AWS Claude documentation link in README
- Changed from Microsoft Azure docs to proper Anthropic AWS Bedrock documentation

## Test plan
- [x] Verified the new link points to the correct Anthropic AWS Bedrock documentation
- [x] Confirmed the link is accessible and contains relevant AWS Claude information

🤖 Generated with [Claude Code](https://claude.ai/code)