### PR TITLE
feat: added debouncing for onboarding, fixed validation if the user i…

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -18,7 +18,7 @@ dialogs:
     baseUrlHelp: API endpoint URL (use default if unsure)
     accountId: Account ID
     validating: Validating configuration...
-    validationSuccess: Configuration is valid!
+    validationSuccess: Server has response, Configuration may valid.
     validationFailed: Configuration validation failed
     validationError: 'Validation error: {error}'
     skipForNow: Skip for now

--- a/packages/i18n/src/locales/es/settings.yaml
+++ b/packages/i18n/src/locales/es/settings.yaml
@@ -18,7 +18,6 @@ dialogs:
     baseUrlHelp: URL del endpoint de la API (usa el predeterminado si no estás seguro)
     accountId: ID de Cuenta
     validating: Validando configuración...
-    validationSuccess: ¡La configuración es válida!
     validationFailed: La validación de la configuración falló
     validationError: 'Error de validación: {error}'
     skipForNow: Omitir por ahora

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -16,7 +16,7 @@ dialogs:
     baseUrlHelp: API 端点 URL（如果不确定请使用默认值）
     accountId: 账户 ID
     validating: 正在验证配置...
-    validationSuccess: 配置有效！
+    validationSuccess: 初步测试服务器有响应，配置或许有效。
     validationFailed: 配置验证失败
     validationError: 验证错误：{error}
     skipForNow: 暂时跳过

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -48,6 +48,7 @@ import {
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { isAbsoluteUrl } from '../utils/string'
 import { models as elevenLabsModels } from './providers/elevenlabs/list-models'
 
 export interface ProviderMetadata {
@@ -159,6 +160,11 @@ export interface VoiceInfo {
 export const useProvidersStore = defineStore('providers', () => {
   const providerCredentials = useLocalStorage<Record<string, Record<string, unknown>>>('settings/credentials/providers', {})
   const { t } = useI18n()
+  const notBaseUrlError = computed(() => ({
+    errors: [new Error('Base URL is not absolute')],
+    reason: 'Base URL is not absolute. Check your input.',
+    valid: false,
+  }))
 
   // Helper function to fetch OpenRouter models manually
   async function fetchOpenRouterModels(config: Record<string, unknown>): Promise<ModelInfo[]> {
@@ -216,6 +222,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required'),
             !config.baseUrl && new Error('Base URL is required'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -494,6 +504,10 @@ export const useProvidersStore = defineStore('providers', () => {
             }
           }
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           // Check if the Ollama server is reachable
           return fetch(`${(config.baseUrl as string).trim()}models`, { headers: (config.headers as HeadersInit) || undefined })
             .then((response) => {
@@ -554,6 +568,10 @@ export const useProvidersStore = defineStore('providers', () => {
               reason: 'Base URL is required. Default to http://localhost:11434/v1/ for Ollama.',
               valid: false,
             }
+          }
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
           }
 
           // Check if the Ollama server is reachable
@@ -647,6 +665,10 @@ export const useProvidersStore = defineStore('providers', () => {
             }
           }
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           // Check if the vLLM is reachable
           return fetch(`${(config.baseUrl as string).trim()}models`, { headers: (config.headers as HeadersInit) || undefined })
             .then((response) => {
@@ -704,6 +726,10 @@ export const useProvidersStore = defineStore('providers', () => {
           const errors = [
             !config.baseUrl && new Error('Base URL is required. Default to https://api.openai.com/v1/ for official OpenAI API.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -818,6 +844,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required. Default to https://api.openai.com/v1/ for official OpenAI API.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -860,6 +890,10 @@ export const useProvidersStore = defineStore('providers', () => {
           const errors = [
             !config.baseUrl && new Error('Base URL is required. Default to https://api.openai.com/v1/ for official OpenAI API.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -992,6 +1026,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required. Default to https://api.anthropic.com/v1/ for official Claude API with OpenAI compatibility.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1036,6 +1074,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required. Default to https://generativelanguage.googleapis.com/v1beta/openai/ for official Google Gemini API with OpenAI compatibility.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1076,6 +1118,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1120,6 +1166,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1201,6 +1251,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1261,6 +1315,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1317,6 +1375,10 @@ export const useProvidersStore = defineStore('providers', () => {
           const errors = [
             !config.baseUrl && new Error('Base URL is required. Default to http://localhost:11996/tts for Index-TTS.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1386,6 +1448,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1447,6 +1513,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !((config.app as any)?.appId) && new Error('App ID is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1487,6 +1557,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1529,6 +1603,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1569,6 +1647,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1613,6 +1695,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1713,6 +1799,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1753,6 +1843,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
 
           return {
             errors,
@@ -1795,6 +1889,10 @@ export const useProvidersStore = defineStore('providers', () => {
             !config.baseUrl && new Error('Base URL is required.'),
           ].filter(Boolean)
 
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
+          }
+
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
@@ -1835,6 +1933,10 @@ export const useProvidersStore = defineStore('providers', () => {
               reason: 'Base URL is required. Default to http://localhost:4315/v1/',
               valid: false,
             }
+          }
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
           }
 
           // Check if the local running Player 2 is reachable
@@ -1940,6 +2042,10 @@ export const useProvidersStore = defineStore('providers', () => {
               reason: 'Base URL is required. Default to http://localhost:4315/v1/',
               valid: false,
             }
+          }
+
+          if (!isAbsoluteUrl(config.baseUrl as string)) {
+            return notBaseUrlError.value
           }
 
           return {

--- a/packages/stage-ui/src/utils/string.ts
+++ b/packages/stage-ui/src/utils/string.ts
@@ -1,0 +1,11 @@
+export function isAbsoluteUrl(url: string) {
+  try {
+    // This could be the most reliable way to check so using side-effect is acceptable
+    // eslint-disable-next-line no-new
+    new URL(url)
+    return true
+  }
+  catch {
+    return false
+  }
+}


### PR DESCRIPTION
…s not inputting url

## Description

- Added a 500ms debounce to onboarding api info validation, so user can know that "oh this configuration is still invalid".
- Added a url check for every validateProviderConfig except providers that does not check baseUrl, so "http:" will not pass validation.
- Modified statement of "success validation".

## Linked Issues

<!-- Optional, if you have any -->

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

## 描述

- 为 onboarding 界面的 api 信息验证部分添加了一个 500ms debounce，这样用户就能确认“即使我改了配置，这次的配置依然不能用”。
- 为每个 validateProviderConfig 添加了 url 检查，这样用户输入 "http:" 这样的 baseUrl 就无法通过检查了。
- 修改了验证成功的表述。

## 相关 issue

<!-- Optional, if you have any -->

## 额外上下文

<!-- e.g. is there anything you'd like reviewers to focus on? -->