### PR TITLE
fix(stage-ui): Ensure display model data consistency across windows

### DIFF
--- a/packages/stage-ui/src/stores/display-models.ts
+++ b/packages/stage-ui/src/stores/display-models.ts
@@ -73,7 +73,13 @@ export const useDisplayModelsStore = defineStore('display-models', () => {
 
   async function getDisplayModel(id: string) {
     await until(displayModelsFromIndexedDBLoading).toBe(false)
-    return await localforage.getItem<DisplayModelFile>(id)
+  const modelFromFile = await localforage.getItem<DisplayModelFile>(id)
+  if (modelFromFile) {
+    return modelFromFile
+  }
+
+  // Fallback to in-memory presets if not found in localforage
+  return displayModelsPresets.find(model => model.id === id)
   }
 
   async function addDisplayModel(format: DisplayModelFormat, file: File) {

--- a/packages/stage-ui/src/stores/display-models.ts
+++ b/packages/stage-ui/src/stores/display-models.ts
@@ -73,13 +73,13 @@ export const useDisplayModelsStore = defineStore('display-models', () => {
 
   async function getDisplayModel(id: string) {
     await until(displayModelsFromIndexedDBLoading).toBe(false)
-  const modelFromFile = await localforage.getItem<DisplayModelFile>(id)
-  if (modelFromFile) {
-    return modelFromFile
-  }
+    const modelFromFile = await localforage.getItem<DisplayModelFile>(id)
+    if (modelFromFile) {
+      return modelFromFile
+    }
 
-  // Fallback to in-memory presets if not found in localforage
-  return displayModelsPresets.find(model => model.id === id)
+    // Fallback to in-memory presets if not found in localforage
+    return displayModelsPresets.find(model => model.id === id)
   }
 
   async function addDisplayModel(format: DisplayModelFormat, file: File) {

--- a/packages/stage-ui/src/stores/display-models.ts
+++ b/packages/stage-ui/src/stores/display-models.ts
@@ -73,7 +73,7 @@ export const useDisplayModelsStore = defineStore('display-models', () => {
 
   async function getDisplayModel(id: string) {
     await until(displayModelsFromIndexedDBLoading).toBe(false)
-    return displayModels.value.find(model => model.id === id)
+    return await localforage.getItem<DisplayModelFile>(id)
   }
 
   async function addDisplayModel(format: DisplayModelFormat, file: File) {


### PR DESCRIPTION
#### Description

Fix Cant Pick newly uploaded model on tamagotchi due to inability to maintain model data list

#### Summary

This pull request modifies the `getDisplayModel` function in the `display-models` store to fetch data directly from `localforage` instead of relying on the in-memory `displayModels` ref.

#### Problem

When running the application in multiple windows, the `displayModels` ref can become stale. If a model is added in one window via `addDisplayModel`, other windows are not aware of this change, leading to data inconsistencies. When `getDisplayModel` is called in another window, it accesses the outdated in-memory cache and fails to find the newly added model.

#### Solution

The `getDisplayModel` function has been updated to bypass the in-memory cache and query `localforage` directly. This ensures that it always retrieves the most current model data from persistent storage, guaranteeing data consistency across all application windows.

#### My Comment

We can broadcast other window to update, or check model list version first, but the direct patch is to fetch it from browser index db, since getDisplayModel is only used once.