### PR TITLE
fix player2 healthcheck endpoints (#1)

### DIFF
--- a/apps/stage-tamagotchi/src/pages/settings/providers/player2-speech.vue
+++ b/apps/stage-tamagotchi/src/pages/settings/providers/player2-speech.vue
@@ -54,7 +54,7 @@ onMounted(async () => {
     console.error('Failed to validate provider config', providerConfig)
   }
   try {
-    const res = await fetch(`http://localhost:4315/v1/health`, {
+    const res = await fetch(`${providerConfig.baseUrl.endsWith('/') ? providerConfig.baseUrl.slice(0, -1) : providerConfig.baseUrl}/health`, {
       method: 'GET',
       headers: {
         'player2-game-key': 'airi',

--- a/apps/stage-web/src/pages/settings/providers/player2-speech.vue
+++ b/apps/stage-web/src/pages/settings/providers/player2-speech.vue
@@ -58,7 +58,7 @@ onMounted(async () => {
   }
 
   try {
-    const res = await fetch(`${providerConfig.baseUrl}/v1/health`, {
+    const res = await fetch(`${providerConfig.baseUrl.endsWith('/') ? providerConfig.baseUrl.slice(0, -1) : providerConfig.baseUrl}/health`, {
       method: 'GET',
       headers: {
         'player2-game-key': 'airi',

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2177,8 +2177,9 @@ export const useProvidersStore = defineStore('providers', () => {
       }),
       createProvider: async config => createPlayer2((config.baseUrl as string).trim(), 'airi'),
       capabilities: {
-        listVoices: async () => {
-          return await fetch('http://localhost:4315/v1/tts/voices').then(res => res.json()).then(({ voices }) => (voices as { id: string, language: 'american_english' | 'british_english' | 'japanese' | 'mandarin_chinese' | 'spanish' | 'french' | 'hindi' | 'italian' | 'brazilian_portuguese', name: string, gender: string }[]).map(({ id, language, name, gender }) => (
+        listVoices: async (config) => {
+          const baseUrl = (config.baseUrl as string).endsWith('/') ? (config.baseUrl as string).slice(0, -1) : config.baseUrl as string
+          return await fetch(`${baseUrl}/tts/voices`).then(res => res.json()).then(({ voices }) => (voices as { id: string, language: 'american_english' | 'british_english' | 'japanese' | 'mandarin_chinese' | 'spanish' | 'french' | 'hindi' | 'italian' | 'brazilian_portuguese', name: string, gender: string }[]).map(({ id, language, name, gender }) => (
             {
 
               id,


### PR DESCRIPTION
## Description

When configuring speech for player2 website says player2 is not running, while the actual tts call works:

<img width="1241" height="676" alt="Screenshot 2025-08-25 at 12 47 35" src="https://github.com/user-attachments/assets/3cf61c8d-36ac-437e-b443-ce4d474a1aa4" />


## Linked Issues

n/a

## Additional Context

the reason is hardcoded health-check urls, which this PR fixes
