### PR TITLE
Update VRM.vue

### DIFF
--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -15,9 +15,16 @@ import Environment from './VRM/Environment.vue'
 import { useVRM } from '../../stores/vrm'
 import { OrbitControls, VRMModel } from '../Scenes'
 
-const props = defineProps<{
-  modelSrc?: string
-}>()
+const props =  withDefaults(defineProps<{
+  modelSrc?: string;
+  showAxes?: boolean;
+  idleAnimation?: string;
+  paused?: boolean;
+}>(), { 
+  showAxes: false,
+  idleAnimation: '/assets/vrm/animations/idle_loop.vrma',
+  paused: false,
+ })
 
 const emit = defineEmits<{
   (e: 'loadModelProgress', value: number): void
@@ -303,13 +310,13 @@ defineExpose({
       <VRMModel
         ref="modelRef"
         :model-src="props.modelSrc"
-        idle-animation="/assets/vrm/animations/idle_loop.vrma"
-        :paused="false"
+        :idle-animation="props.idleAnimation"
+        :paused="props.paused"
         @load-model-progress="(val) => emit('loadModelProgress', val)"
         @model-ready="handleLoadModelProgress"
         @error="(val) => emit('error', val)"
       />
-      <TresAxesHelper :size="1" />
+      <TresAxesHelper :size="1" v-if="props.showAxes" />
     </TresCanvas>
   </div>
 </template>

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -16,9 +16,9 @@ import { useVRM } from '../../stores/vrm'
 import { OrbitControls, VRMModel } from '../Scenes'
 
 const props =  withDefaults(defineProps<{
-  modelSrc?: string;
-  showAxes?: boolean;
-  idleAnimation?: string;
+  modelSrc?: string
+  showAxes?: boolean
+  idleAnimation?: string
   paused?: boolean;
 }>(), { 
   showAxes: false,

--- a/packages/stage-ui/src/components/Scenes/VRM.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM.vue
@@ -19,7 +19,7 @@ const props =  withDefaults(defineProps<{
   modelSrc?: string
   showAxes?: boolean
   idleAnimation?: string
-  paused?: boolean;
+  paused?: boolean
 }>(), { 
   showAxes: false,
   idleAnimation: '/assets/vrm/animations/idle_loop.vrma',


### PR DESCRIPTION
fix(VRMViewer): respect parent showAxes prop for VRM axes display
- properly bind incoming showAxes prop
- render TresAxesHelper only when showAxes=true
- keep idleAnimation & paused defaults aligned with parent usage

## Description

I happened to notice that both the online and desktop versions display the VRM model with the coordinate axes still visible. After checking the source code, I found it’s a minor flaw in the way VRM.vue handles the props passed from its parent component.
