### PR TITLE
fix(stage-ui,stage-web): emit literals asap and show streaming messages

### DIFF
--- a/apps/stage-web/src/components/Widgets/ChatHistory.vue
+++ b/apps/stage-web/src/components/Widgets/ChatHistory.vue
@@ -8,7 +8,7 @@ import { useI18n } from 'vue-i18n'
 const chatHistoryRef = ref<HTMLDivElement>()
 
 const { t } = useI18n()
-const { messages, sending } = storeToRefs(useChatStore())
+const { messages, sending, streamingMessage } = storeToRefs(useChatStore())
 
 const { onBeforeMessageComposed, onTokenLiteral } = useChatStore()
 
@@ -102,6 +102,33 @@ onTokenLiteral(async () => {
             />
             <div v-else />
           </div>
+        </div>
+      </div>
+      <div v-if="sending" flex mr="12">
+        <div
+          flex="~ col" border="2 solid primary-200/50 dark:primary-500/50" shadow="md primary-200/50 dark:none" min-w-20
+          rounded-lg px-2 py-1 h="unset <sm:fit" bg="<md:primary-500/25"
+        >
+          <div>
+            <span text-xs text="primary-400/90 dark:primary-600/90" font-normal class="inline <sm:hidden">{{ t('stage.chat.message.character-name.airi') }}</span>
+          </div>
+          <div v-if="streamingMessage.content" class="break-words" text="xs primary-400">
+            <div v-for="(slice, sliceIndex) in streamingMessage.slices" :key="sliceIndex">
+              <div v-if="slice.type === 'tool-call'">
+                <div
+                  p="1" border="1 solid primary-200" rounded-lg m="y-1" bg="primary-100"
+                >
+                  Called: <code>{{ slice.toolCall.toolName }}</code>
+                </div>
+              </div>
+              <div v-else-if="slice.type === 'tool-call-result'" /> <!-- this line should be unreachable -->
+              <MarkdownRenderer
+                v-else
+                :content="slice.text"
+              />
+            </div>
+          </div>
+          <div v-else i-eos-icons:three-dots-loading />
         </div>
       </div>
     </div>

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -141,6 +141,7 @@ export const useChatStore = defineStore('chat', () => {
             await hook(special)
           }
         },
+        minLiteralEmitLength: 24, // Avoid emitting literals too fast. This is a magic number and can be changed later.
       })
 
       const toolCallQueue = useQueue<ChatSlices>({


### PR DESCRIPTION
* Move back to the FSM-style opening/closing tags scanner in `useLlmmarkerParser` to emit literals ASAP, otherwise they are only emitted when a complete tag is parsed
  * Time complexity should be linear
  * Pass all tests in `llmmarkerParser.test.ts`
  * Fix: Emit special tokens with the surrounding `<|` and `|>` to keep the behavior untouched
  * Fix: Do not emit a literal if it's part of an incomplete special tag
* Show the streaming message in the web chat history
