### PR TITLE
fix(stage-tamagotchi): fix first time initialization blank and an overlook

### DIFF
--- a/apps/stage-tamagotchi/src/bindings/tauri-plugins/window-pass-through-on-hover.ts
+++ b/apps/stage-tamagotchi/src/bindings/tauri-plugins/window-pass-through-on-hover.ts
@@ -4,40 +4,25 @@
 
 /** user-defined commands **/
 
-let passThroughEnabled = false;
 
 export const commands = {
-  async startPassThrough(): Promise<Result<null, string>> {
-    if (passThroughEnabled) {
-      return { status: 'ok', data: null };
-    }
+async startPassThrough() : Promise<Result<null, string>> {
     try {
-      passThroughEnabled = true;
-      return { status: 'ok', data: await TAURI_INVOKE('plugin:window-pass-through-on-hover|start_pass_through') };
-    }
-    catch (e) {
-      passThroughEnabled = false;
-      if (e instanceof Error)
-        throw e;
-      else return { status: 'error', error: e as any };
-    }
-  },
-  async stopPassThrough(): Promise<Result<null, string>> {
-    if (!passThroughEnabled) {
-      return { status: 'ok', data: null };
-    }
+    return { status: "ok", data: await TAURI_INVOKE("plugin:window-pass-through-on-hover|start_pass_through") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async stopPassThrough() : Promise<Result<null, string>> {
     try {
-      passThroughEnabled = false;
-      return { status: 'ok', data: await TAURI_INVOKE('plugin:window-pass-through-on-hover|stop_pass_through') };
-    }
-    catch (e) {
-      passThroughEnabled = true;
-      if (e instanceof Error)
-        throw e;
-      else return { status: 'error', error: e as any };
-    }
-  }
-};
+    return { status: "ok", data: await TAURI_INVOKE("plugin:window-pass-through-on-hover|stop_pass_through") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+}
+}
 
 /** user-defined events **/
 

--- a/apps/stage-tamagotchi/src/composables/tauri.ts
+++ b/apps/stage-tamagotchi/src/composables/tauri.ts
@@ -36,7 +36,7 @@ export interface WindowFrame {
 
 interface Events {
   'tauri://resize': unknown
-  'tauri://move': { payload: { x: number, y: number } }
+  'tauri://move': { x: number, y: number }
   'tauri://close-requested': unknown
   'tauri://destroyed': unknown
   'tauri://focus': unknown

--- a/apps/stage-tamagotchi/src/pages/index.vue
+++ b/apps/stage-tamagotchi/src/pages/index.vue
@@ -42,17 +42,21 @@ const windowY = ref(0)
 const isClickThrough = ref(false)
 const isPassingThrough = ref(false)
 const isOverUI = ref(false)
+const isFirstTime = ref(true)
 
 watchThrottled([mouseX, mouseY], async ([x, y]) => {
   const canvas = widgetStageRef.value?.canvasElement()
   if (!canvas)
     return
 
+  isFirstTime.value = false
+
   if (windowControlStore.controlMode === WindowControlMode.RESIZE || windowControlStore.controlMode === WindowControlMode.MOVE) {
     if (isPassingThrough.value) {
       passThroughCommands.stopPassThrough()
       isPassingThrough.value = false
     }
+
     return
   }
 
@@ -194,8 +198,8 @@ onMounted(async () => {
     windowY.value = pos.y
   }
   unListenFuncs.push(await listen('tauri://move', (event) => {
-    windowX.value = event.payload.payload.x
-    windowY.value = event.payload.payload.y
+    windowX.value = event.payload.x
+    windowY.value = event.payload.y
   }))
 
   await setupVADModel()
@@ -234,7 +238,7 @@ if (import.meta.hot) { // For better DX
 <template>
   <div
     :class="[modeIndicatorClass, {
-      'op-0': windowControlStore.isIgnoringMouseEvent && !isClickThrough,
+      'op-0': windowControlStore.isIgnoringMouseEvent && !isClickThrough && !isFirstTime,
       'pointer-events-none': !isClickThrough,
     }]"
     max-h="[100vh]"


### PR DESCRIPTION
#### Summary

This commit fixes an issue where the application window was blank on its first launch and corrects the data structure for the `tauri://move` event to handle window repositioning correctly.

#### Problem

1.  **Blank Window on First Load:** On initial startup, the main window was rendered with zero opacity, making it appear blank until the first mouse interaction.
2.  **Incorrect Event Payload:** The `tauri://move` event listener was attempting to access window coordinates from a nested `payload` object (`event.payload.payload.x`) that did not exist, causing errors when moving the window.

#### Solution

1.  A new `isFirstTime` reactive flag was added. The UI's opacity is now prevented from being set to zero on the initial render, ensuring content is visible immediately. The transparency logic is now only applied after the first mouse event.
2.  The type definition for the `tauri://move` event in [`apps/stage-tamagotchi/src/composables/tauri.ts`](apps/stage-tamagotchi/src/composables/tauri.ts:9) was corrected. The event listener in [`apps/stage-tamagotchi/src/pages/index.vue`](apps/stage-tamagotchi/src/pages/index.vue:198) was updated to access the coordinates directly from `event.payload`, aligning it with the actual data structure.

#### My comment

I remembered this is on yesterday commit, i guess i somehow undoing it