### PR TITLE
Fix: prevent module peer overwrite on re-announce

### DIFF
--- a/packages/server-runtime/src/index.ts
+++ b/packages/server-runtime/src/index.ts
@@ -98,7 +98,20 @@ function main() {
           const p = peers.get(peer.id)
           if (p) {
             unregisterModulePeer(p)
-            Object.assign(p, { authenticated: true, name: event.data.name })
+
+            const { name, index } = event.data as { name: string; index?: number }
+            if (!name || typeof name !== 'string') {
+              send(peer, { type: 'error', data: { message: "the field 'name' must be a non-empty string for event 'module:announce'" } })
+              return
+            }
+            if (typeof index !== 'undefined') {
+              if (typeof index !== 'number' || index < 0) {
+                send(peer, { type: 'error', data: { message: "the field 'index' must be a non-negative number for event 'module:announce'" } })
+                return
+              }
+            }
+            
+            Object.assign(p, { authenticated: true, name, index })
             registerModulePeer(p, p.name, p.index)
           }
           return


### PR DESCRIPTION
Fixed an issue where p.index was always undefined because event.data.index was never assigned, causing multiple modules with the same name but different indexes to overwrite each other in peersByModule.

Overall changes:
- Unregister the existing module peer before re-announcing
- Ensure peersByModule remains consistent on disconnect

## Description

This update prevents module peers from being incorrectly overwritten when they share the same name but have different indexes. It ensures proper peer lifecycle management by unregistering before re-announcing and cleaning up on disconnect.