### PR TITLE
Fix: prevent module peer overwrite on re-announce

### DIFF
--- a/packages/server-runtime/src/index.ts
+++ b/packages/server-runtime/src/index.ts
@@ -44,7 +44,7 @@ function main() {
   }
 
   function unregisterModulePeer(p: AuthenticatedPeer) {
-    if (!p.name) return
+if (!p.name) return;
     const group = peersByModule.get(p.name)
     if (group) {
       group.delete(p.index)


### PR DESCRIPTION
Fixed an issue where `p.index` was always undefined because `event.data.index` was never assigned, causing multiple modules with the same name but different indexes to overwrite each other in `peersByModule`.

**Changes**:
- Correctly assign event.data.index to p.index.
- Unregister the existing module peer before re-announcing.
- Ensure peersByModule remains consistent on disconnect.

**Description:**

This update prevents module peers from being overwritten when they share the same name but use different indexes. It improves peer lifecycle management by properly assigning indexes, unregistering before re-announcing, and ensuring cleanup on disconnect.