### PR TITLE
fix: TTS lags behind conversation

### DIFF
--- a/packages/stage-ui/src/components/Scenes/Stage.vue
+++ b/packages/stage-ui/src/components/Scenes/Stage.vue
@@ -74,11 +74,24 @@ vrmStore.onShouldUpdateView(async () => {
 const audioAnalyser = ref<AnalyserNode>()
 const nowSpeaking = ref(false)
 const lipSyncStarted = ref(false)
-
+let currentAudioSource: AudioBufferSourceNode | null = null
+  
 const audioQueue = useQueue<{ audioBuffer: AudioBuffer, text: string }>({
   handlers: [
     (ctx) => {
       return new Promise((resolve) => {
+        // Stop any currently playing audio
+        if (currentAudioSource) {
+          try { 
+            currentAudioSource.stop() 
+          } 
+          try {
+            currentAudioSource.stop()
+          }
+          catch {}
+          currentAudioSource.disconnect()
+          currentAudioSource = null
+        }
         // Create an AudioBufferSourceNode
         const source = audioContext.createBufferSource()
         source.buffer = ctx.data.audioBuffer


### PR DESCRIPTION
## Solved Issue https://github.com/moeru-ai/airi/issues/456
Old pull request (already closed) becuz my mistake...
 - https://github.com/moeru-ai/airi/pull/476

## Description
Um.. I did some search over all related files again and found currently, there is no logic in `Stage.vue` to stop or clear the `audioQueue` or `interrupt audio playback` when a new message is sent. This means if a user sends a new message while `TTS/audio` is still playing, the previous audio will continue, causing the lag and out-of-sync like issues https://github.com/moeru-ai/airi/issues/456 described.

## Linked Issues

Issue 456: 
- https://github.com/moeru-ai/airi/issues/456

## Additional Context
- Um... old branch is broken and was deleted. That's my mistake, yea so sorry. We can continue this issue on this pull request tysm.
- When a new message is composed `onBeforeMessageComposed`, stop any currently playing audio and clear the audioQueue to ensure only the new message is spoken.
