### PR TITLE
fix: remove duplicate pitch adjustment and replace hardcoded message

### DIFF
--- a/apps/stage-tamagotchi/src/pages/settings/modules/speech.vue
+++ b/apps/stage-tamagotchi/src/pages/settings/modules/speech.vue
@@ -359,10 +359,10 @@ function updateCustomModelName(value: string) {
           <!-- No voices available -->
           <Alert v-else type="warning">
             <template #title>
-              No voices available
+              {{ t('settings.pages.modules.speech.sections.section.provider-voice-selection.no_voices') }}
             </template>
             <template #content>
-              No voices were found for this provider. You can enter a custom voice name below.
+              {{ t('settings.pages.modules.speech.sections.section.provider-voice-selection.no_voices_description') }}
             </template>
           </Alert>
 
@@ -415,16 +415,6 @@ function updateCustomModelName(value: string) {
                   Multilingual v2
                 </option>
               </select>
-            </div>
-
-            <div flex="~ col gap-4">
-              <FieldRange
-                v-model="pitch"
-                label="Pitch"
-                description="Tune the pitch of the voice"
-                :min="-100" :max="100" :step="1"
-                :format-value="value => `${value}%`"
-              />
             </div>
           </div>
         </div>

--- a/apps/stage-web/src/pages/settings/modules/speech.vue
+++ b/apps/stage-web/src/pages/settings/modules/speech.vue
@@ -351,10 +351,10 @@ function updateCustomModelName(value: string) {
             class="mb-2"
           >
             <template #title>
-              No voices available
+              {{ t('settings.pages.modules.speech.sections.section.provider-voice-selection.no_voices') }}
             </template>
             <template #content>
-              No voices were found for this provider. You can enter a custom voice name below.
+              {{ t('settings.pages.modules.speech.sections.section.provider-voice-selection.no_voices_description') }}
             </template>
           </Alert>
 
@@ -407,16 +407,6 @@ function updateCustomModelName(value: string) {
                   Multilingual v2
                 </option>
               </select>
-            </div>
-
-            <div flex="~ col gap-4">
-              <FieldRange
-                v-model="pitch"
-                label="Pitch"
-                description="Tune the pitch of the voice"
-                :min="-100" :max="100" :step="1"
-                :format-value="value => `${value}%`"
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION


## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->
Updates the speech settings pages in both the Stage Tamagotchi and Stage Web apps to fix the duplicate pitch slider that was in the UI (one was inside the manual voice input div). Also replaced the hardcoded English strings with localization keys.

Localization improvements:

* Replaced hardcoded "No voices available" and its description with localized strings using the `t` function in both `apps/stage-tamagotchi/src/pages/settings/modules/speech.vue` and `apps/stage-web/src/pages/settings/modules/speech.vue`.

UI improvements:

* Removed the `FieldRange` duplicate pitch adjustment control from the speech settings UI in both `apps/stage-tamagotchi/src/pages/settings/modules/speech.vue` and `apps/stage-web/src/pages/settings/modules/speech.vue`. 