### PR TITLE
fix(chat): Handle IME composition in chat input

### DIFF
--- a/apps/stage-tamagotchi/src/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/components/InteractiveArea.vue
@@ -24,8 +24,14 @@ const { messages } = storeToRefs(useChatStore())
 const { t } = useI18n()
 const providersStore = useProvidersStore()
 const { activeModel, activeProvider } = storeToRefs(useConsciousnessStore())
+const isComposing = ref(false)
 
 async function handleSend() {
+  // IME problemma 你好airi
+  if (isComposing.value) {
+    return
+  }
+
   if (!messageInput.value.trim() && !attachments.value.length) {
     return
   }
@@ -39,6 +45,9 @@ async function handleSend() {
       providerConfig,
       attachments: attachmentsToSend,
     })
+
+    // clear after sending
+    messageInput.value = ''
   }
   catch (error) {
     messages.value.pop()
@@ -163,7 +172,9 @@ onMounted(() => {
       bg="primary-50 dark:primary-100" max-h="[10lh]" min-h="[1lh]"
       w-full shrink-0 resize-none overflow-y-scroll rounded-xl p-2 font-medium outline-none
       transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
-      @submit="handleSend"
+      @compositionstart="isComposing = true"
+      @compositionend="isComposing = false"
+      @keydown.enter.exact.prevent="handleSend"
       @paste-file="handleFilePaste"
     />
   </div>


### PR DESCRIPTION
#### Description

Fix: #507

### Summary:
This pull request addresses an issue with the chat input field where using an Input Method Editor (IME) would cause messages to be sent prematurely when the user confirms a composition.

### Problem:
When typing in languages that require an IME (e.g., Chinese, Japanese, Korean), pressing the Enter key to select a candidate from the composition list would also trigger the message submission event. This resulted in sending incomplete or unintended messages, providing a poor user experience for users of these languages.

### Solution:
- Introduced a `isComposing` reactive state to track whether an IME composition is currently active.
- Utilized the `@compositionstart` and `@compositionend` events on the textarea to toggle the `isComposing` state accordingly.
- Modified the `handleSend` function to prevent message submission if `isComposing` is `true`, ensuring the message is only sent when the user explicitly intends to.
- Changed the event listener from a generic `@submit` to a more specific `@keydown.enter.exact.prevent="handleSend"` to ensure only a direct press of the Enter key (without IME composition) triggers the send action.
- Added logic to clear the input field after a message is successfully sent, improving the chat flow.

### My comment:
I just tried IME Input 