### PR TITLE
fix(stage-web): support on pc submit with enter

### DIFF
--- a/apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue
+++ b/apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue
@@ -40,6 +40,16 @@ const { send, onAfterMessageComposed, discoverToolsCompatibility } = useChatStor
 const { messages } = storeToRefs(useChatStore())
 const { t } = useI18n()
 
+function isMobileDevice() {
+  return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+}
+
+async function handleSubmit() {
+  if (!isMobileDevice()) {
+    await handleSend()
+  }
+}
+
 async function handleSend() {
   if (!messageInput.value.trim() || isComposing.value) {
     return
@@ -160,7 +170,7 @@ onMounted(() => {
           transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
           :class="[themeColorsHueDynamic ? 'transition-colors-none placeholder:transition-colors-none' : '']"
           default-height="1lh"
-          @submit="() => {}"
+          @submit="handleSubmit"
           @compositionstart="isComposing = true"
           @compositionend="isComposing = false"
         />


### PR DESCRIPTION
## Description
This PR is to Enable Enter key submission for desktop users in MobileInteractiveArea component.
Desktop users in `MobileInteractiveArea.vue` component couldn't submit with Enter key. Mobile users continue to get new lines with Enter (no change)
## Linked Issues
none

## Additional Context
none