### PR TITLE
fix(stage-ui/VRM) Directional light setting results can be really applied and persist

### DIFF
--- a/packages/stage-ui/src/components/Scenes/VRM/Model.vue
+++ b/packages/stage-ui/src/components/Scenes/VRM/Model.vue
@@ -247,6 +247,9 @@ async function loadModel() {
               // --- Shader material, further IBL injection needed ---
               // disable envMap for NPR materials, envMap will be reassigned by default skybox
               // close tone mapping for NPR materials
+              // console.debug("Mat: ", mat)
+              // TODO: stylised shader injection
+              // Lilia: I plan to replce all injected shader code to be my own, so that it can always avoid double injection and unkown user upload VRM injected shader behaviour...
               if ('toneMapped' in mat)
                 mat.toneMapped = false
               if ('envMap' in mat && mat.envMap)

--- a/packages/stage-ui/src/stores/vrm.ts
+++ b/packages/stage-ui/src/stores/vrm.ts
@@ -40,7 +40,7 @@ export const useVRM = defineStore('vrm', () => {
   const cameraPosition = useLocalStorage('settings/vrm/camera-position', { x: 0, y: 0, z: -1 })
   const cameraDistance = useLocalStorage('settings/vrm/cameraDistance', 0)
 
-  const directionalLightPosition = useLocalStorage('settings/vrm/scenes/scene/directional-light/position', { x: 0, y: 0, z: -10 })
+  const directionalLightPosition = useLocalStorage('settings/vrm/scenes/scene/directional-light/position', { x: 0, y: 0, z: -1 })
   const directionalLightTarget = useLocalStorage('settings/vrm/scenes/scene/directional-light/target', { x: 0, y: 0, z: 0 })
   const directionalLightRotation = useLocalStorage('settings/vrm/scenes/scene/directional-light/rotation', { x: 0, y: 0, z: 0 })
   // TODO: Manual directional light intensity will not work for other


### PR DESCRIPTION
## Description

After [https://github.com/moeru-ai/airi/pull/554](https://github.com/moeru-ai/airi/pull/554), I realised that although the directional light can be adjusted in the setting page, it will still be reset due to Three.js's api mechanism...

The light instance's target must be correctly added to the scene so that the target change can be applied at the start when the light component was mounted...

## Linked Issues

none

## Additional Context

No idea why the API was designed like this...
