### PR TITLE
fix(stage-web): adjust padding in ChatHistory scrollbar

### DIFF
--- a/apps/stage-web/src/components/Layouts/InteractiveArea.vue
+++ b/apps/stage-web/src/components/Layouts/InteractiveArea.vue
@@ -144,7 +144,7 @@ onAfterMessageComposed(async () => {
         h-full w-full overflow-scroll rounded-xl
         bg="primary-50/50 dark:primary-950/70" backdrop-blur-md
       >
-        <ChatHistory h-full flex-1 p-4 w="full" max-h="<md:[60%]" />
+        <ChatHistory h-full flex-1 w="full" max-h="<md:[60%]" />
         <div h="<md:full" flex gap-2>
           <BasicTextarea
             v-model="messageInput"

--- a/apps/stage-web/src/components/Widgets/ChatHistory.vue
+++ b/apps/stage-web/src/components/Widgets/ChatHistory.vue
@@ -34,9 +34,9 @@ onTokenLiteral(async () => {
 </script>
 
 <template>
-  <div relative px="<sm:2" py="<sm:2" flex="~ col" rounded="lg" overflow-hidden>
+  <div py="<sm:2" flex="~ col" rounded="lg" relative overflow-hidden py-4>
     <div flex-1 /> <!-- spacer -->
-    <div ref="chatHistoryRef" v-auto-animate h-full w-full flex="~ col" overflow-scroll>
+    <div ref="chatHistoryRef" v-auto-animate px="<sm:2" flex="~ col" h-full w-full overflow-scroll px-4>
       <div flex-1 /> <!-- spacer -->
       <div v-for="(message, index) in messages" :key="index" mb-2>
         <div v-if="message.role === 'error'" flex mr="12">


### PR DESCRIPTION
Before:
<img width="1044" height="1656" alt="CleanShot 2025-09-06 at 22 27 50@2x" src="https://github.com/user-attachments/assets/51fb79ea-348d-4de8-9d48-0cc132bbbb15" />

After:
<img width="1048" height="1670" alt="CleanShot 2025-09-06 at 22 40 59@2x" src="https://github.com/user-attachments/assets/942b975d-0d93-4ac6-b3fb-601a461d248f" />
