### PR TITLE
fix(audio-recorder): resolve bugs and ensure proper recording behavior

### DIFF
--- a/packages/stage-ui/src/composables/audio/audio-recorder.ts
+++ b/packages/stage-ui/src/composables/audio/audio-recorder.ts
@@ -5,7 +5,9 @@ import { BufferTarget, MediaStreamAudioTrackSource, Output, QUALITY_MEDIUM, WavO
 import { ref, shallowRef, toRef } from 'vue'
 
 async function getMediaStreamTrack(stream: MediaStream) {
-  return stream.getAudioTracks()[0]
+  const tracks = stream.getAudioTracks()
+  if (!tracks.length) throw new Error("No audio tracks found in stream")
+  return tracks[0]
 }
 
 export function useAudioRecorder(
@@ -21,6 +23,10 @@ export function useAudioRecorder(
 
   function onStopRecord(callback: (recording: Blob | undefined) => Promise<void>) {
     onStopRecordHooks.value.push(callback)
+    // Return unsubscribe function to prevent memory leaks
+    return () => {
+      onStopRecordHooks.value = onStopRecordHooks.value.filter(h => h !== callback)
+    }
   }
 
   async function startRecord() {
@@ -42,14 +48,24 @@ export function useAudioRecorder(
       return
     }
 
-    await mediaOutput.value?.finalize()
-    const bufferTarget = mediaOutput.value?.target as BufferTarget | undefined
-    const buffer = bufferTarget!.buffer
-    const audioBlob = new Blob([buffer!], { type: mediaFormat.value })
+    await mediaOutput.value.finalize()
+    const bufferTarget = mediaOutput.value.target as BufferTarget | undefined
+    const buffer = bufferTarget?.buffer
+    const audioBlob = buffer ? new Blob([buffer], { type: mediaFormat.value }) : undefined
 
+    recording.value = audioBlob
+
+    // await hooks and catch errors
     for (const hook of onStopRecordHooks.value) {
-      hook(audioBlob)
+      try {
+        await hook(audioBlob)
+      }
+      catch (err) {
+        console.error("onStopRecord hook failed:", err)
+      }
     }
+
+    mediaOutput.value = undefined
 
     return audioBlob
   }


### PR DESCRIPTION
## Description

This PR fixes several issues in the `useAudioRecorder` composable to ensure proper and safe recording behavior:

- Updates the `recording` ref when recording stops so consumers can react to the latest recording.
- Awaits `onStopRecord` hooks and handles errors to prevent unhandled promise rejections.
- Adds safety checks for audio tracks and buffer to avoid runtime errors if a stream has no audio tracks.
- Cleans up `mediaOutput` after stopping to prevent double-finalize errors.
- Returns an unsubscribe function for `onStopRecord` hooks to prevent memory leaks when registering multiple hooks.

## Linked Issues

<!-- Optional, if you have any -->
Fixes potential runtime errors in audio recording composable (no specific issue linked).

## Additional Context
- Correctness of async hook handling (`onStopRecord`)  
- Safety checks for audio tracks and buffers  
- Proper cleanup of `mediaOutput` to prevent double-finalize
