### PR TITLE
fix(stage-ui): cosyvoice SSML support

### DIFF
--- a/packages/stage-ui/src/stores/modules/speech.ts
+++ b/packages/stage-ui/src/stores/modules/speech.ts
@@ -65,7 +65,11 @@ export const useSpeechStore = defineStore('speech', () => {
 
   const supportsSSML = computed(() => {
     // Currently only ElevenLabs and some other providers support SSML
-    return ['elevenlabs', 'microsoft-speech', 'azure-speech', 'google', 'alibaba-cloud-model-studio', 'volcengine'].includes(activeSpeechProvider.value)
+    // only part voices are support SSML in cosyvoice-v2 which is provided by alibaba
+    if (activeSpeechProvider.value === 'alibaba-cloud-model-studio' && activeSpeechModel.value === 'cosyvoice-v2') {
+      return true
+    }
+    return ['elevenlabs', 'microsoft-speech', 'azure-speech', 'google', 'volcengine'].includes(activeSpeechProvider.value)
   })
 
   async function loadVoicesForProvider(provider: string) {


### PR DESCRIPTION
## Description

This PR fix SSML support of cosyvoice-v1 return value is wrong.
Previous judgement about a speech model is supported SSML by provider. However cosyvoice-v1, a speech model which is provided by alibaba, is not supported SSML. So I add a special condition to solve it and not have influence on other provider models.

## Linked Issues
#567 
#570 
## Additional Context

[About alibaba provider model SSML support docs](https://help.aliyun.com/zh/model-studio/cosyvoice-websocket-api#e68ad1d2f7cwg)
You can search `SSML标记语言支持说明`
- For later `unspeech` package support cosyvoice-v2 models, we need to update code to verify whether the voice supported SSML because not every voice supports it.
