### PR TITLE
fix(providers): Improve OpenRouter validation and support key-less OpenAI-compatible services

### DIFF
--- a/apps/stage-tamagotchi-electron/src/renderer/pages/settings/providers/openai-compatible-audio-speech.vue
+++ b/apps/stage-tamagotchi-electron/src/renderer/pages/settings/providers/openai-compatible-audio-speech.vue
@@ -115,6 +115,7 @@ const {
       >
         <ProviderApiKeyInput
           v-model="apiKey"
+          :required="false"
           :provider-name="providerMetadata?.localizedName"
           placeholder="sk-..."
         />

--- a/apps/stage-tamagotchi/src/pages/settings/providers/openai-compatible-audio-speech.vue
+++ b/apps/stage-tamagotchi/src/pages/settings/providers/openai-compatible-audio-speech.vue
@@ -115,6 +115,7 @@ const {
       >
         <ProviderApiKeyInput
           v-model="apiKey"
+          :required="false"
           :provider-name="providerMetadata?.localizedName"
           placeholder="sk-..."
         />

--- a/apps/stage-web/src/pages/settings/providers/openai-compatible-audio-speech.vue
+++ b/apps/stage-web/src/pages/settings/providers/openai-compatible-audio-speech.vue
@@ -139,6 +139,7 @@ function handleResetSettings() {
       >
         <ProviderApiKeyInput
           v-model="apiKey"
+          :required="false"
           :provider-name="providerMetadata?.localizedName"
           placeholder="sk-..."
         />

--- a/apps/stage-web/src/pages/settings/providers/openai-compatible.vue
+++ b/apps/stage-web/src/pages/settings/providers/openai-compatible.vue
@@ -83,6 +83,7 @@ function handleResetSettings() {
       >
         <ProviderApiKeyInput
           v-model="apiKey"
+          :required="false"
           :provider-name="providerMetadata?.localizedName"
           placeholder="sk-..."
         />

--- a/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
+++ b/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
@@ -54,9 +54,6 @@ export function buildOpenAICompatibleProvider(
     validateProviderConfig: async (config: Record<string, unknown>) => {
       const errors: Error[] = []
 
-      if (!config.apiKey) {
-        errors.push(new Error('API key is required'))
-      }
       if (!config.baseUrl) {
         errors.push(new Error('Base URL is required'))
       }
@@ -83,7 +80,7 @@ export function buildOpenAICompatibleProvider(
 
       if (validationChecks.includes('health')) {
         try {
-          responseChat = await fetch(`${config.baseUrl as string}chat/completions`, { headers: { Authorization: `Bearer ${config.apiKey}`, ...additionalHeaders }, method: 'POST' })
+          responseChat = await fetch(`${config.baseUrl as string}chat/completions`, { headers: { Authorization: `Bearer ${config.apiKey}`, ...additionalHeaders }, method: 'POST', body: '{"model": "test"}' })
           responseModelList = await fetch(`${config.baseUrl as string}models`, { headers: { Authorization: `Bearer ${config.apiKey}`, ...additionalHeaders } })
 
           if (!([200, 400, 401].includes(responseChat.status) || [200, 400, 401].includes(responseModelList.status))) {
@@ -119,7 +116,7 @@ export function buildOpenAICompatibleProvider(
         try {
           let response = responseChat
           if (!response) {
-            response = await fetch(`${config.baseUrl as string}chat/completions`, { headers: { Authorization: `Bearer ${config.apiKey}`, ...additionalHeaders }, method: 'POST' })
+            response = await fetch(`${config.baseUrl as string}chat/completions`, { headers: { Authorization: `Bearer ${config.apiKey}`, ...additionalHeaders }, method: 'POST', body: '{"model": "test"}' })
           }
 
           if (!response.ok) {


### PR DESCRIPTION
#### Summary

This pull request introduces two key improvements for provider configuration: it adds a robust, custom validation mechanism for OpenRouter to prevent false positives with invalid API keys, and it makes the API key field optional for all OpenAI-compatible providers, enabling support for local models and other services that do not require an API key.