### PR TITLE
fix(uno): exclude node_modules from scan

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -174,9 +174,12 @@ export function sharedUnoConfig() {
           // the default
           /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
           // include js/ts files
-          '(components|src)/**/*.{js,ts,vue}',
-          '**/stage-ui/**/*.{vue,js,ts}',
-          '**/ui/**/*.{vue,js,ts}',
+          '(components|src)/**/*.{js,ts,vue}', // THIS CAN INCLUDE node_modules
+          '**/stage-ui/**/*.{vue,js,ts}', // THIS TOO
+          '**/ui/**/*.{vue,js,ts}', // THIS TOO
+        ],
+        exclude: [
+          /\/node_modules\//, // DO NOT SCAN THE BLACK HOLE
         ],
       },
     },


### PR DESCRIPTION
While running Histoire, it froze infinitely (or for a very long while). After profiling on the Node process, I realised that our previous UnoCSS config may also have included `**/node_modules/**` in the paths to scan, which is evil. 😈 

I hope this can help us save some time while developing.

<img width="968" height="622" alt="Screenshot 2025-09-13 at 3 56 31" src="https://github.com/user-attachments/assets/6b3cbb3c-5036-4f09-bd20-1d0f2b9a16ed" />

<img width="1333" height="291" alt="Screenshot 2025-09-13 at 3 56 05" src="https://github.com/user-attachments/assets/8f7182f2-5ce4-48fd-9b92-a33753abfa0b" />
