### PR TITLE
fix: Implement DPI Scaling Support

### DIFF
--- a/apps/stage-tamagotchi/src/composables/tauri.ts
+++ b/apps/stage-tamagotchi/src/composables/tauri.ts
@@ -216,8 +216,37 @@ export function useTauriDpi() {
     return new imported.LogicalPosition(x, y)
   }
 
+  async function getScaleFactor(): Promise<number> {
+    const imported = await tauriDpiApi.value
+    if (!imported) {
+      throw new Error('Tauri DPI API not available')
+    }
+
+    const monitor = await imported.currentMonitor()
+    return monitor?.scaleFactor ?? 1
+  }
+
+  async function convertPhysicalToLogical(physicalX: number, physicalY: number): Promise<{ x: number, y: number }> {
+    const scaleFactor = await getScaleFactor()
+    return {
+      x: physicalX / scaleFactor,
+      y: physicalY / scaleFactor,
+    }
+  }
+
+  async function convertLogicalToPhysical(logicalX: number, logicalY: number): Promise<{ x: number, y: number }> {
+    const scaleFactor = await getScaleFactor()
+    return {
+      x: logicalX * scaleFactor,
+      y: logicalY * scaleFactor,
+    }
+  }
+
   return {
     createLogicalPosition,
+    getScaleFactor,
+    convertPhysicalToLogical,
+    convertLogicalToPhysical,
   }
 }
 

--- a/apps/stage-tamagotchi/src/composables/use-rdev-mouse.ts
+++ b/apps/stage-tamagotchi/src/composables/use-rdev-mouse.ts
@@ -1,23 +1,58 @@
 import type { AiriTamagotchiEvents } from './tauri'
 
 import { createSharedComposable } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
-import { useTauriEvent } from './tauri'
+import { useTauriDpi, useTauriEvent } from './tauri'
 
 export const useRdevMouse = createSharedComposable(() => {
   const mouseX = ref(0)
   const mouseY = ref(0)
+  const logicalMouseX = ref(0)
+  const logicalMouseY = ref(0)
+  const scaleFactor = ref(1)
 
   const { listen } = useTauriEvent<AiriTamagotchiEvents>()
+  const { getScaleFactor } = useTauriDpi()
+
+  // Update scale factor when DPI changes
+  async function updateScaleFactor() {
+    try {
+      const newScaleFactor = await getScaleFactor()
+      console.warn(`[DPI Debug] Scale factor detected: ${newScaleFactor}`)
+      scaleFactor.value = newScaleFactor
+    }
+    catch (error) {
+      console.warn('Failed to get scale factor, using default 1.0:', error)
+      scaleFactor.value = 1
+    }
+  }
+
+  // Convert physical coordinates to logical coordinates
+  watch([mouseX, mouseY, scaleFactor], ([x, y, scale]) => {
+    logicalMouseX.value = x / scale
+    logicalMouseY.value = y / scale
+
+    // Debug logging every 100th mouse move to avoid spam
+    if (Math.floor(x) % 100 === 0) {
+      console.warn(`[DPI Debug] Physical: (${x}, ${y}) → Logical: (${logicalMouseX.value}, ${logicalMouseY.value}) | Scale: ${scale}`)
+    }
+  })
 
   async function setup() {
+    await updateScaleFactor()
+
     await listen('tauri-plugins:tauri-plugin-rdev:mousemove', (event) => {
       if (event.payload.event_type.MouseMove) {
         const { x, y } = event.payload.event_type.MouseMove
         mouseX.value = x
         mouseY.value = y
       }
+    })
+
+    // Listen for scale changes (when window moves between monitors with different DPI)
+    await listen('tauri://scale-change', () => {
+      updateScaleFactor()
     })
   }
 
@@ -26,5 +61,8 @@ export const useRdevMouse = createSharedComposable(() => {
   return {
     mouseX,
     mouseY,
+    logicalMouseX,
+    logicalMouseY,
+    scaleFactor,
   }
 })

--- a/apps/stage-tamagotchi/src/pages/index.vue
+++ b/apps/stage-tamagotchi/src/pages/index.vue
@@ -30,7 +30,7 @@ const windowControlStore = useWindowControlStore()
 const resourcesStore = useResourcesStore()
 const mcpStore = useMcpStore()
 const { getPosition } = useTauriWindow()
-const { mouseX, mouseY } = useRdevMouse()
+const { logicalMouseX, logicalMouseY } = useRdevMouse()
 
 const { listen } = useTauriEvent<AiriTamagotchiEvents>()
 const { invoke } = useTauriCore()
@@ -55,7 +55,7 @@ watch(shouldShowSetup, () => {
 }, { immediate: true })
 
 // Handle mouse pass-through based on WebGL pixel alpha.
-watchThrottled([mouseX, mouseY], ([x, y]) => {
+watchThrottled([logicalMouseX, logicalMouseY], ([x, y]) => {
   requestAnimationFrame(() => {
     const canvas = widgetStageRef.value?.canvasElement()
     if (!canvas)


### PR DESCRIPTION
## Description
This PR implements DPI-related functionality and applies code formatting to ensure consistency with project standards. The changes mainly affect three files:

**1. `apps/stage-tamagotchi/src/composables/tauri.ts`**

- Added `getScaleFactor()` to retrieve the current display’s scale factor.
    
- Added `convertPhysicalToLogical()` to convert physical coordinates to logical coordinates.
    
- Added `convertLogicalToPhysical()` to convert logical coordinates to physical coordinates.
    

**2. `apps/stage-tamagotchi/src/composables/use-rdev-mouse.ts`**

- Introduced Vue’s `watch` and the `useTauriDpi` composable.
    
- Added reactive references for logical coordinates: `logicalMouseX` and `logicalMouseY`.
    
- Added a reactive reference for `scaleFactor`.
    
- Implemented automatic conversion from physical to logical coordinates.
    
- Added listener for DPI scaling change events (`tauri://scale-change`).
    
- Added debug logs using `console.warn` for DPI tracking, following ESLint rules.
    

**3. `apps/stage-tamagotchi/src/pages/index.vue`**

- Updated mouse coordinate usage from physical (`mouseX`, `mouseY`) to logical (`logicalMouseX`, `logicalMouseY`).
    
- Updated relevant listeners to ensure consistent use of logical coordinates throughout the application.

These changes resolve inconsistencies in mouse coordinates across multiple monitors with different DPI settings, ensuring a 
consistent user experience. 

## Linked Issues

#596 