### PR TITLE
fix: update validation of novita-ai so it will be invalid without api key

### DIFF
--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -1427,7 +1427,7 @@ export const useProvidersStore = defineStore('providers', () => {
       description: 'novita.ai',
       defaultBaseUrl: 'https://api.novita.ai/openai/',
       creator: createNovita,
-      validation: ['health', 'model_list'],
+      validation: ['health', 'model_list', 'chat_completions'],
       iconColor: 'i-lobe-icons:novita',
     }),
     'fireworks-ai': buildOpenAICompatibleProvider({


### PR DESCRIPTION
## Description

On the settings/providers/novita-ai page, it showed "Configuration validation success" and on the settings/modules/consciousness, it showed the novita-ai is a available provider even without api key
This PR add chat_completions as one way to justify its validation. 

## Linked Issues

fixed #614 

## Additional Context

It still need to be tested since I don't want to buy some token to verify if it still works well with available api key
