### PR TITLE
fix(nix): run hash update actions sequentially

### DIFF
--- a/.github/workflows/update-nix-assets-hash.yaml
+++ b/.github/workflows/update-nix-assets-hash.yaml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: nix-update
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-nix-pnpm-deps-hash.yaml
+++ b/.github/workflows/update-nix-pnpm-deps-hash.yaml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: nix-update
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->

Fixes #604

> This means that there can be at most one running and one pending job in a concurrency group at any time. When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any existing pending job or workflow in the same concurrency group, if it exists, will be canceled and the new queued job or workflow will take its place.

We only have two update actions, so should be fine. With more than two we would have to rely on other methods 

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
