### PR TITLE
Feat/model category menu

### DIFF
--- a/packages/stage-ui/src/components/menu/CategoryMenu.vue
+++ b/packages/stage-ui/src/components/menu/CategoryMenu.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import {
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuRoot,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from 'reka-ui'
+import { onMounted, ref } from 'vue'
+
+// Define category group interface
+interface CategoryGroup {
+  id: string
+  name: string
+  options: { id: string, name: string }[]
+}
+
+// Define emits for parent communication
+const emit = defineEmits<{
+  (e: 'update:filter', filters: Record<string, string>): void
+}>()
+
+// Default category group
+const defaultGroups: CategoryGroup[] = [
+  {
+    id: 'price',
+    name: 'Pricing',
+    options: [
+      { id: 'free', name: 'Free' },
+      { id: 'paid', name: 'Paid' },
+    ],
+  },
+]
+
+// Reactive variable to store all groups (default + API loaded)
+const groups = ref<CategoryGroup[]>([...defaultGroups])
+
+// Currently selected filter options
+const selected = ref<Record<string, string>>({})
+
+// Simulated API request to fetch additional groups
+async function fetchGroupsFromAPI() {
+  // Example API response:
+  // [{ id:"type", name:"Model Type", options:[{id:"ai", name:"AI Model"}, {id:"cv", name:"Computer Vision"}] }]
+  const resp = await fetch('/api/model/categories')
+  const data: CategoryGroup[] = await resp.json()
+  groups.value = [...defaultGroups, ...data]
+}
+
+// Handle option selection
+function selectOption(groupId: string, optionId: string) {
+  selected.value[groupId] = optionId
+  // Emit event so the parent component can listen via @update:filter
+  emitFilter({ ...selected.value })
+}
+
+// Helper to emit filter updates
+function emitFilter(payload: Record<string, string>) {
+  emit('update:filter', payload)
+}
+
+// Fetch categories when component mounts
+onMounted(() => {
+  fetchGroupsFromAPI()
+})
+</script>
+
+<template>
+  <NavigationMenuRoot class="relative z-[1] w-full">
+    <NavigationMenuList class="flex list-none gap-2 border rounded-lg bg-white p-1 shadow-sm">
+      <!-- Loop through each category group -->
+      <NavigationMenuItem
+        v-for="group in groups"
+        :key="group.id"
+        class="min-w-[120px]"
+      >
+        <!-- Group trigger (button) -->
+        <NavigationMenuTrigger
+          class="text-grass11 group flex select-none items-center justify-between rounded-[4px] px-3 py-2 text-sm font-medium leading-none outline-none hover:bg-blue-100 focus:shadow-[0_0_0_2px] focus:shadow-blue-200"
+        >
+          {{ group.name }}
+        </NavigationMenuTrigger>
+
+        <!-- Dropdown content with options -->
+        <NavigationMenuContent class="absolute top-full z-50 mt-1 rounded-md bg-white p-2 shadow">
+          <ul class="flex flex-col gap-2">
+            <li
+              v-for="opt in group.options"
+              :key="opt.id"
+              class="cursor-pointer rounded px-2 py-1 hover:bg-blue-100"
+              :class="selected[group.id] === opt.id ? 'bg-blue-500 text-white' : ''"
+              @click="selectOption(group.id, opt.id)"
+            >
+              {{ opt.name }}
+            </li>
+          </ul>
+        </NavigationMenuContent>
+      </NavigationMenuItem>
+    </NavigationMenuList>
+
+    <NavigationMenuViewport />
+  </NavigationMenuRoot>
+</template>

--- a/packages/stage-ui/src/components/menu/RadioCardDetail.vue
+++ b/packages/stage-ui/src/components/menu/RadioCardDetail.vue
@@ -32,6 +32,37 @@ const isExpanded = ref(false)
 function toggleExpansion() {
   isExpanded.value = !isExpanded.value
 }
+
+const tooltipVisible = ref(false)
+const tooltipText = ref('')
+const tooltipX = ref(0)
+const tooltipY = ref(0)
+
+function isTextTruncated(el: HTMLElement) {
+  const hasLineClamp = window.getComputedStyle(el).webkitLineClamp !== 'none'
+
+  if (hasLineClamp) {
+    return el.scrollHeight > el.clientHeight
+  }
+  else {
+    return el.scrollWidth > el.clientWidth
+  }
+}
+
+function showTooltip(event: MouseEvent) {
+  const el = event.currentTarget as HTMLElement
+  if (isTextTruncated(el)) {
+    tooltipText.value = el.textContent || ''
+    const rect = el.getBoundingClientRect()
+    tooltipX.value = rect.left - rect.width * 1.5
+    tooltipY.value = rect.top - 150
+    tooltipVisible.value = true
+  }
+}
+
+function hideTooltip() {
+  tooltipVisible.value = false
+}
 </script>
 
 <template>
@@ -86,6 +117,8 @@ function toggleExpansion() {
               ? 'text-neutral-700 dark:text-neutral-300'
               : 'text-neutral-700 dark:text-neutral-400',
           ]"
+          @mouseenter="showTooltip"
+          @mouseleave="hideTooltip"
         >
           {{ title }}
         </span>
@@ -151,6 +184,13 @@ function toggleExpansion() {
       </div>
     </div>
   </label>
+  <div
+    v-if="tooltipVisible"
+    class="absolute z-50 whitespace-nowrap rounded bg-white px-2 py-1 text-xs text-black dark:bg-black dark:text-white"
+    :style="{ left: `${tooltipX}px`, top: `${tooltipY}px`, transform: 'translateX(-50%)' }"
+  >
+    {{ tooltipText }}
+  </div>
 </template>
 
 <style scoped>

--- a/packages/stage-ui/src/components/menu/RadioCardManySelect.vue
+++ b/packages/stage-ui/src/components/menu/RadioCardManySelect.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 
 import Alert from '../misc/Alert.vue'
+import CategoryMenu from './CategoryMenu.vue'
 import RadioCardDetail from './RadioCardDetail.vue'
 
 interface Item {
@@ -48,6 +49,7 @@ const searchQuery = defineModel<string>('searchQuery')
 
 const isListExpanded = ref(false)
 const customValue = ref('')
+const categoryFilters = ref<Record<string, string>>({})
 
 const filteredItems = computed(() => {
   if (!searchQuery.value)
@@ -63,6 +65,12 @@ const filteredItems = computed(() => {
 function updateCustomValue(value: string) {
   customValue.value = value
   emit('update:customValue', value)
+}
+
+function updateCategoryFilters(filters: Record<string, string>) {
+  categoryFilters.value = filters
+  // Here you can add logic to filter items based on category filters
+  // For example: further filter filteredItems
 }
 </script>
 
@@ -82,6 +90,11 @@ function updateCustomValue(value: string) {
         bg="white dark:neutral-900"
         :placeholder="searchPlaceholder"
       >
+    </div>
+
+    <!-- Category filter menu -->
+    <div class="mt-4">
+      <CategoryMenu @update:filter="updateCategoryFilters" />
     </div>
 
     <!-- Items list with search results info -->


### PR DESCRIPTION
## Description

1. Added tooltips to the model selection interface. When a model name is abbreviated, hovering the cursor over it displays the full name.
2. Implemented a basic filter component and its invocation method, enabling model filtering and configuration of filter categories (not fully implemented; specific approach to be discussed).
3. Tips: If the filtering feature is too experimental, I can submit a PR containing only feature 1 for merging. Apologies in advance if my code is messy as a beginner.

1.为模型选择界面添加了tooltip在模型省略名称时可以通过悬浮光标在名称上显示全名
2.添加了一个基础的筛选组件和调用，提供模型的筛选和筛选分类的设置（未完全实现，具体方式有待讨论）
Tips：如果筛选功能过于实验性的话我可以提交一份只有功能1的PR来提供merge，初学者如果写的很烂我很抱歉

## Linked Issues

#478 

## Additional Context
To enable filtered selection, we'd need to add a conditional check to `const filteredItems`. This shouldn't be too difficult. However, I might need some guidance on how to retrieve model information. Since that project is written in Rust, I'll need to find time to figure it out. Thanks for your help.

如果要能实现分类选择的话，应该需要对const filteredItems 添加一个条件判断，这应该不是很难，还是麻烦可能得给点指导关于如何获取模型信息，那个项目是rust写的我可能还得抽空寻思一下，麻烦各位了。

Lately I've been dealing with some stuff, so my writing efficiency has been pretty low. Some parts might be a bit rushed—feel free to point out any issues, just don't yell at me, lol.

由于最近有些事要处理，我这写的效率属实低了点，有些地方估计也挺着急，有问题可以告诉我，别骂我就成XD
