### PR TITLE
fix(openai-compatible-builder): ignore embed & gemini-2.5-pro model

### DIFF
--- a/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
+++ b/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
@@ -126,6 +126,8 @@ export function buildOpenAICompatibleProvider(
             [
               // exclude embedding models
               'embed',
+              // exclude tts models, specifically for OpenAI
+              'tts',
               // bypass gemini pro quota
               // TODO: more elegant solution
               'gemini-2.5-pro',


### PR DESCRIPTION
fix #649 

<img width="1458" height="1064" alt="image" src="https://github.com/user-attachments/assets/aa3c6b73-ce38-4392-b2cb-058d3036bf28" />
