### PR TITLE
fix(ui): align `ColorHueRange` model binding

### DIFF
--- a/packages/ui/src/components/Form/Range/ColorHueRange.vue
+++ b/packages/ui/src/components/Form/Range/ColorHueRange.vue
@@ -1,18 +1,27 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 const props = defineProps<{
   disabled?: boolean
   class?: string
 }>()
 
-const colorValue = defineModel<string>('colorValue', {
-  type: String,
-  default: '',
+const modelValue = defineModel<number>({ required: true })
+
+const sliderValue = computed({
+  get: () => modelValue.value,
+  set: (value: number) => {
+    if (Number.isNaN(value))
+      return
+
+    modelValue.value = value
+  },
 })
 </script>
 
 <template>
   <input
-    v-model="colorValue"
+    v-model.number="sliderValue"
     type="range" min="0" max="360" step="0.01"
     class="color-hue-range"
     transition="all ease-in-out duration-250"


### PR DESCRIPTION
## Description

把模型切回默认的 modelValue 并用一个 computed 做双向绑定, 读写都走同一条通道, 初始化滑条 thumb 就不会一直跑到默认中点

https://github.com/user-attachments/assets/a9a91556-1226-46fc-b8e0-16d97695b826


https://github.com/user-attachments/assets/39d2664f-35b8-46bc-8035-1ce7f76202d4

