### PR TITLE
fix(stage-ui): fix the anthropic validation failure due to not able to fetch models list

### DIFF
--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -955,6 +955,12 @@ export const useProvidersStore = defineStore('providers', () => {
         'anthropic-dangerous-direct-browser-access': 'true',
       },
       capabilities: {
+        // This is a hardcoded list of Anthropic models to work around issues with
+        // fetching the model list directly from their API via browser.
+        // See: https://github.com/moeru-ai/airi/issues/729
+        // This list should be periodically updated based on Anthropic's official documentation:
+        // https://docs.anthropic.com/en/docs/models-overview
+        // Some legacy models are not listed here.
         listModels: async () => {
           return [{
             id: 'claude-haiku-4-5-20251001',

--- a/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
+++ b/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
@@ -171,6 +171,9 @@ export function buildOpenAICompatibleProvider(
           try {
             if (capabilities?.listModels) {
               const models = await capabilities.listModels(config)
+              if (models.length <= 0) {
+                throw new Error('No models returned from capabilities.listModels')
+              }
               return models[0].id
             }
           }


### PR DESCRIPTION
## Description

Fix the anthropic validation failure due to not able to fetch models list, by using local model lists (or anthropic models cannot be used even after deleting validations).

## Linked Issues

fix #729 

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I tested it by manually going through the onboarding process and chatting with AIRI, since test files are lacking.

<img width="2066" height="1137" alt="image" src="https://github.com/user-attachments/assets/1a5f79a8-e201-45df-83fa-b1570f66f38a" />



