### PR TITLE
fix(tamagotchi): Windows tray icon rendering

### DIFF
--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -58,7 +58,9 @@ function setupTray(params: {
   captionWindow: ReturnType<typeof setupCaptionWindowManager>
 }): void {
   once(() => {
-    const appTray = new Tray(nativeImage.createFromPath(macOSTrayIcon).resize({ width: 16 }))
+    const trayImage = nativeImage.createFromPath(isMacOS ? macOSTrayIcon : icon).resize({ width: 16 })
+    trayImage.setTemplateImage(isMacOS)
+    const appTray = new Tray(trayImage)
     onAppBeforeQuit(() => appTray.destroy())
 
     const contextMenu = Menu.buildFromTemplate([


### PR DESCRIPTION
## Description

Switched the tray setup to pick a platform-appropriate asset before creating the Tray instance so Windows now receives the full-color app icon instead of the monochrome macOS-only asset, preventing the all-black rendering.

<img width="69" height="47" alt="image" src="https://github.com/user-attachments/assets/985cb64c-d68b-4bbc-b843-e9b6a031e238" />

## Linked Issues
https://github.com/moeru-ai/airi/issues/725
