### PR TITLE
feat(stage-tamagotchi): wayland support

### DIFF
--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -52,6 +52,11 @@ if (isLinux) {
   app.commandLine.appendSwitch('enable-unsafe-webgpu')
   app.commandLine.appendSwitch('enable-features', 'Vulkan')
 
+  // NOTICE: we need UseOzonePlatform, WaylandWindowDecorations for working on Wayland.
+  // Partially related to https://github.com/electron/electron/issues/41551, since X11 is deprecating now, 
+  // we can safely remove the feature flags for Electron once they made it default supported.
+  // Fixes: https://github.com/moeru-ai/airi/issues/757
+  // Ref: https://github.com/mmaura/poe2linuxcompanion/blob/90664607a147ea5ccea28df6139bd95fb0ebab0e/electron/main/index.ts#L28-L46
   if (env.XDG_SESSION_TYPE === 'wayland') {
     app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal')
 


### PR DESCRIPTION
## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->
airi used to fail to render anything in wayland session

adding `--enable-features=UseOzonePlatform` command option to electron seems to be working, and i copied rest of options from [here](https://github.com/mmaura/poe2linuxcompanion/blob/90664607a147ea5ccea28df6139bd95fb0ebab0e/electron/main/index.ts#L28-L46).

## Linked Issues

<!-- Optional, if you have any -->
https://github.com/moeru-ai/airi/issues/757

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
