### PR TITLE
fix(ui): fix file change reactive trigger in BasicInputFile

### DIFF
--- a/packages/ui/src/components/Form/Input/BasicInputFile.vue
+++ b/packages/ui/src/components/Form/Input/BasicInputFile.vue
@@ -17,15 +17,16 @@ const isDragging = ref(false)
 const isDraggingDebounced = useDebounce(isDragging, 150)
 
 function handleFileChange(e: Event) {
-  files.value = []
-
   const input = e.target as HTMLInputElement
   if (!input.files)
     return
 
-  for (let i = 0; i < input.files?.length; i++) {
-    files.value.push(input.files[i])
+  const newFiles: File[] = []
+  for (let i = 0; i < input.files.length; i++) {
+    newFiles.push(input.files[i])
   }
+
+  files.value = newFiles
 
   if (files.value && files.value.length > 0) {
     firstFile.value = files.value[0]


### PR DESCRIPTION
## 描述
在 使用 /devtools/background-removal 时遇到文件无法上传问题

`packages/ui/src/components/Form/Input/BasicInputFile.vue` 在这个文件下
files.value.push 无法触发响应式更新 改为push完后再一次性赋值