### PR TITLE
fix(stage-tamagotchi): try to fix #770 macOS crashes with Team ID mismatch check

### DIFF
--- a/apps/stage-tamagotchi/electron-builder.yml
+++ b/apps/stage-tamagotchi/electron-builder.yml
@@ -42,7 +42,10 @@ mac:
   extendInfo:
     - NSMicrophoneUsageDescription: 'AIRI requires microphone access for voice interaction'
     - NSCameraUsageDescription: 'AIRI requires camera access for vision understanding'
+  # If still fails, check:
+  # https://github.com/electron-userland/electron-builder/issues/3989#issuecomment-557013674
   notarize: false
+  hardenedRuntime: false
   executableName: airi
 dmg:
   artifactName: ${productName}-${version}-darwin-${arch}.${ext}


### PR DESCRIPTION
## Description

Fix #770 

## Linked Issues

Related to #503, #38

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
