### PR TITLE
fix(stage-ui): AIRI in full resolution! fixed pixi.js resolution issue

### DIFF
--- a/packages/stage-ui/src/components/scenes/live2d/Canvas.vue
+++ b/packages/stage-ui/src/components/scenes/live2d/Canvas.vue
@@ -35,7 +35,11 @@ async function initLive2DPixiStage(parent: HTMLDivElement) {
     height: props.height * props.resolution,
     backgroundAlpha: 0,
     preserveDrawingBuffer: true,
+    autoDensity: false,
+    resolution: 1,
   })
+
+  pixiApp.value.stage.scale.set(props.resolution)
 
   pixiAppCanvas.value = pixiApp.value.view
 
@@ -54,19 +58,15 @@ async function initLive2DPixiStage(parent: HTMLDivElement) {
 function handleResize() {
   if (pixiApp.value) {
     // Update the internal rendering resolution
-    pixiApp.value.renderer.resize(props.width, props.height)
+    pixiApp.value.renderer.resize(props.width * props.resolution, props.height * props.resolution)
+    pixiApp.value.stage.scale.set(props.resolution)
   }
 
   // The CSS styles handle the display size, so we don't need to manually set view dimensions
 }
 
 watch([() => props.width, () => props.height], () => handleResize())
-watch(() => props.resolution, (newScale) => {
-  if (pixiApp.value && newScale) {
-    pixiApp.value.renderer.resolution = newScale
-    handleResize() // Refresh the renderer
-  }
-})
+watch(() => props.resolution, () => handleResize())
 
 onMounted(async () => containerRef.value && await initLive2DPixiStage(containerRef.value))
 onUnmounted(() => pixiApp.value?.destroy())


### PR DESCRIPTION
No more blurry live2d models on HDPI screens!

<img width="2844" height="1491" alt="image" src="https://github.com/user-attachments/assets/78749627-6499-42f5-913d-1fe52dd57b21" />
<img width="2839" height="1502" alt="image" src="https://github.com/user-attachments/assets/53610cd5-e52f-4d73-8de6-6c1105f5731b" />


Yes it also works on tamagotchi

<img width="546" height="592" alt="Screenshot 2025-12-17 at 10 12 21 AM" src="https://github.com/user-attachments/assets/f2109197-3425-458b-b562-addc3e788047" />

