### PR TITLE
fix(stage-ui) patch ModelSettings.validateFiles to support utf-8

### DIFF
--- a/packages/stage-ui/src/utils/live2d-zip-loader.ts
+++ b/packages/stage-ui/src/utils/live2d-zip-loader.ts
@@ -4,6 +4,7 @@ import JSZip from 'jszip'
 
 import { Cubism4ModelSettings, ModelSettings as ModelSettingsClass, ZipLoader } from 'pixi-live2d-display/cubism4'
 
+// TODO: this is a bit hacky, do we have other choice?
 // NOTICE: Patch to handle UTF-8 encoded file paths in model settings
 const originalValidateFiles = ModelSettingsClass.prototype.validateFiles
 ModelSettingsClass.prototype.validateFiles = function (files: string[]): string[] {


### PR DESCRIPTION
Closes #742 