### PR TITLE
feat(stage-ui,i18n): added Japanese as language option

### DIFF
--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -2,6 +2,7 @@ export const all = {
   'en': 'English',
   'es': 'Español',
   'fr': 'Français',
+  'ja': '日本語',
   'ru': 'Русский',
   'vi': 'Tiếng Việt',
   'zh-Hans': '简体中文',

--- a/packages/stage-ui/src/stores/settings.ts
+++ b/packages/stage-ui/src/stores/settings.ts
@@ -28,6 +28,8 @@ const languageRemap: Record<string, string> = {
   'ru-RU': 'ru',
   'fr': 'fr',
   'fr-FR': 'fr',
+  'ja': 'ja',
+  'ja-JP': 'ja',
 }
 
 export const DEFAULT_THEME_COLORS_HUE = 220.44


### PR DESCRIPTION
## Description

This PR adds Japanese as a selectable language option in the application's language settings.
While Japanese was already added to the Crowdin project, the language selection option was missing from the app's settings screen. As a result, users were unable to switch the app language to Japanese. This PR resolves that issue.

## Additional Context

Running `pnpm lint && pnpm typecheck` revealed some pre-existing lint errors (such as formatting issues in `Cargo.toml` and warnings in `llm.ts`), but these are unrelated to the changes in this PR and have not been addressed here. (It's also possible that these errors are specific to my local environment setup.)
