### PR TITLE
fix(stage-ui): preserve default capabilities in openai-compatible-builder

### DIFF
--- a/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
+++ b/packages/stage-ui/src/stores/providers/openai-compatible-builder.ts
@@ -71,7 +71,7 @@ export function buildOpenAICompatibleProvider(
     ...rest
   } = options
 
-  const finalCapabilities = capabilities || {
+  const defaultCapabilities = {
     listModels: async (config: Record<string, unknown>) => {
       // Safer casting of apiKey/baseUrl (prevents .trim() crash if not a string)
       const apiKey = normalizeString(config.apiKey)
@@ -106,6 +106,11 @@ export function buildOpenAICompatibleProvider(
         } satisfies ModelInfo
       })
     },
+  }
+
+  const finalCapabilities = {
+    ...defaultCapabilities,
+    ...capabilities,
   }
 
   const finalValidators = validators || {


### PR DESCRIPTION
## Description
This PR fixes an issue where the `listModels` capability was incorrectly overwritten when the `openai-compatible-audio-speech` provider supplied its own `listVoices` capability. This resulted in an empty model selection list in the UI as the default model fetching logic was lost.

## Changes
- Updated `buildOpenAICompatibleProvider` function.
- The builder now performs a shallow merge of the provided `capabilities` with the default capabilities (which includes `listModels`).
- This ensures that default functionalities are preserved unless explicitly overridden by the specific provider.

## Tests
I have verified the fix with the following test case to ensure that both default and provided capabilities coexist:

```typescript
it('should merge default capabilities (listModels) with provided capabilities (listVoices)', () => {
  const providerMetadata = buildOpenAICompatibleProvider({
    // ... config
    capabilities: {
      listVoices: async () => [],
    }
  })

  // Both should be present
  expect(providerMetadata.capabilities).toHaveProperty('listVoices')
  expect(providerMetadata.capabilities).toHaveProperty('listModels')
})