### PR TITLE
fix(stage-layout): missing back button

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/layouts/settings.vue
+++ b/apps/stage-tamagotchi/src/renderer/layouts/settings.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { isStageTamagotchi } from '@proj-airi/stage-shared'
 import { PageHeader } from '@proj-airi/stage-ui/components'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { storeToRefs } from 'pinia'
@@ -164,7 +165,7 @@ const routeHeaderMetadata = computed(() => {
           <PageHeader
             :title="routeHeaderMetadata?.title"
             :subtitle="routeHeaderMetadata?.subtitle"
-            :disable-back-button="route.path === '/settings'"
+            :disable-back-button="isStageTamagotchi() && route.path === '/settings'"
             px-4
           />
           <div min-h-0 flex-1 px-4>


### PR DESCRIPTION
## Description

https://discord.com/channels/1345828247744680047/1352220885762703388/1460622112082493481

> I noticed while testing the application on iOS using xcode that it's difficult to navigate from the settings back to the main app screen. However, when you navigate into one of the sub settings screens there's a back icon that appears next to the title of the setting. 

> Should we implement a back button that returns you to the main screen when you're done in setting? A '<' character next to the settings header?

cc @leaft 

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
