### PR TITLE
fix(stage-ui): update connection icon to use correct variant

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/settings/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/index.vue
@@ -63,7 +63,7 @@ const settings = computed(() => [
   {
     title: t('settings.pages.connection.title'),
     description: t('settings.pages.connection.description'),
-    icon: 'i-solar:route-bold-duotone',
+    icon: 'i-solar:wi-fi-router-bold-duotone',
     to: '/settings/connection',
   },
   {

--- a/packages/stage-pages/src/pages/settings/index.vue
+++ b/packages/stage-pages/src/pages/settings/index.vue
@@ -72,7 +72,7 @@ const settings = computed(() => [
   {
     title: t('settings.pages.connection.title'),
     description: t('settings.pages.connection.description'),
-    icon: 'i-solar:route-bold-duotone',
+    icon: 'i-solar:wi-fi-router-bold-duotone',
     to: '/settings/connection',
   },
   {


### PR DESCRIPTION
## Description

Fix connection icon error. Maybe [ `route-bold-duotone`](https://icones.js.org/collection/solar?s=rout-bold-duotone&icon=solar:route-bold-duotone)  ? @LemonNekoGH  

## Linked Issues

https://github.com/moeru-ai/airi/issues/960

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
