### PR TITLE
fix(stage-ui): combobox z-order

### DIFF
--- a/packages/ui/src/components/form/combobox/combobox.vue
+++ b/packages/ui/src/components/form/combobox/combobox.vue
@@ -28,9 +28,6 @@ function toDisplayValue(value: T): string {
   const option = props.options.flatMap(group => group.children).find(option => option?.value === value)
   return option ? option.label : props.placeholder || ''
 }
-
-// Keep popover above modal overlays (dialogs use z-9999)
-const COMBOBOX_PORTAL_Z = 'z-[12000]'
 </script>
 
 <template>


### PR DESCRIPTION
## Description
ComboboxContent using z-150 while the dialog overlay/content run at z-9999, so the picker was rendered underneath and unclickable.
<img width="473" height="612" alt="image" src="https://github.com/user-attachments/assets/0310f91a-ab0f-46ce-adb6-75657b3427f5" />

<img width="589" height="614" alt="image" src="https://github.com/user-attachments/assets/a096abc6-c95a-4fb9-bb6a-5371e63b730f" />

