### PR TITLE
fix(stage-ui-live2d): remove scale override to allow proper Live2D scale

### DIFF
--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -46,7 +46,7 @@ const componentStateModel = defineModel<'pending' | 'loading' | 'mounted'>('mode
 const live2dCanvasRef = ref<InstanceType<typeof Live2DCanvas>>()
 
 const live2d = useLive2d()
-const { scale, position } = storeToRefs(live2d)
+const { position } = storeToRefs(live2d)
 
 watch([componentStateModel, componentStateCanvas], () => {
   componentState.value = (componentStateModel.value === 'mounted' && componentStateCanvas.value === 'mounted')


### PR DESCRIPTION
## Description

Fix Live2D scaling not responding to store updates by removing scale destructuring in Live2D.vue.

## Additional Context

Minimal change: removed unnecessary destructuring to restore reactive scale behavior.
