### PR TITLE
feat: allow nix package version to be read from package.json

### DIFF
--- a/nix/common.nix
+++ b/nix/common.nix
@@ -11,7 +11,7 @@
 
 stdenvNoCC.mkDerivation (final: {
   pname = "airi";
-  version = "0.8.0-alpha.6";
+  version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
 
   src = ../.;
 


### PR DESCRIPTION
## Description

The version string for the nix package hasn't been updated for long enough. Here I make it be read from package.json so as to not keep track of it in two places.

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
