### PR TITLE
fix(stage-ui): fix chat spinner and potential API error

### DIFF
--- a/packages/stage-ui/src/components/scenarios/chat/history.vue
+++ b/packages/stage-ui/src/components/scenarios/chat/history.vue
@@ -63,7 +63,7 @@ const renderMessages = computed<ChatHistoryItem[]>(() => {
   if (!streamTs)
     return props.messages
 
-  const hasStreamAlready = streamTs && props.messages.some(msg => msg?.createdAt === streamTs)
+  const hasStreamAlready = streamTs && props.messages.some(msg => msg?.role === 'assistant' && msg?.createdAt === streamTs)
   if (hasStreamAlready)
     return props.messages
 

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -246,7 +246,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       })
 
       let newMessages = sessionMessagesForSend.map((msg) => {
-        const { context: _context, ...withoutContext } = msg
+        const { context: _context, id: _id, ...withoutContext } = msg
         const rawMessage = toRaw(withoutContext)
 
         if (rawMessage.role === 'assistant') {


### PR DESCRIPTION
user message shares the same timestamp as the assistant message, resulting in the spinner getting deduped

strip the unnecessary local id on API call to prevent issues with providers like openrouter