### PR TITLE
fix(stage-ui): auto-mark player2 provider as added when valid

### DIFF
--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2215,7 +2215,7 @@ export const useProvidersStore = defineStore('providers', () => {
     if (providerRuntimeState.value[providerId]) {
       providerRuntimeState.value[providerId].isConfigured = validationResult.valid
       // Auto-mark Web Speech API as added if valid and available
-      if (validationResult.valid && (providerId === 'browser-web-speech-api' || providerId === 'player2')) {
+      if (validationResult.valid && ['browser-web-speech-api', 'player2'].includes(providerId)) {
         markProviderAdded(providerId)
       }
     }


### PR DESCRIPTION
Player2 doesn't really require an API key. It's kinda annoying having to type something in the key field just to make AIRI recognize it as a valid provider.

This might not be the most ideal way to do it, but it's simple enough