### PR TITLE
fix(nix): nix workflows are more resilient

### DIFF
--- a/.github/workflows/update-nix-assets-hash.yaml
+++ b/.github/workflows/update-nix-assets-hash.yaml
@@ -41,3 +41,4 @@ jobs:
         with:
           commit_message: 'chore(nix): update assets hash'
           commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          pull: '--rebase --autostash'

--- a/.github/workflows/update-nix-pnpm-deps-hash.yaml
+++ b/.github/workflows/update-nix-pnpm-deps-hash.yaml
@@ -40,3 +40,4 @@ jobs:
         with:
           commit_message: 'chore(nix): update pnpmDeps hash'
           commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          pull: '--rebase --autostash'


### PR DESCRIPTION
## Description

Sometimes the nix hash update workflows run in parallel: both commit, one pushes, the other tries to push and runs into a problem: it doesn't have the latest commit (needs to pull again) and the workflow errors without updating the hash. Here I give a fix to that problem.

