### PR TITLE
fix(stage-layouts): HeaderLink component no longer makes entire Header clickable

### DIFF
--- a/packages/stage-layouts/src/components/Layouts/HeaderLink.vue
+++ b/packages/stage-layouts/src/components/Layouts/HeaderLink.vue
@@ -10,8 +10,8 @@ const { isDark: dark } = useTheme()
 
 <template>
   <RouterLink
-    to="/" flex="~" items-center
-    gap-2 px-2 text-nowrap text-2xl outline-none
+    to="/" flex="~"
+    w-max items-center gap-2 px-2 text-nowrap text-2xl outline-none
   >
     <template v-if="dark">
       <img :src="LogoDark" h-8 w-8 class="theme-colored">


### PR DESCRIPTION
# Summary

The `stage-web` uses the `Header` component. On the settings page the entire header is clickable and redirects to the main page (`/`) - users can click on the AIRI button, but they can also click wherever on the wide invisible box and it results in the same effect. This PR fixes this bug by limiting the clickable area to the width of the `HeaderLink` component.

## Linked Issues

Resolves: #1031 

## Extra notes regarding tests

I tried to add tests to check if clicking outside the AIRI logo triggers a page redirect (in `stage-layout`, using Vitest + Playwright), but I ran into constant errors such as:
`Failed to resolve import "~build/time" from "../stage-ui/src/composables/use-build-info.ts"`
and some issues related to Cubism (when I tried to add those tests in `stage-web` and merge the config from vite.config.ts).

It seems that when running tests in browser mode (vitest.config.ts → test → browser), the `@proj-airi/ui` module cannot be mocked with vi.mock(). As far as I understand, vite tries to resolve and bundle the module before the tests run, which causes the `~build/*` alias errors (maybe it would work with proper resolve.alias). Because of this, the tests fail before any mocks can work.

The reason for using browser mode was to test how the CSS is rendered, since it is a bug in the styles that cannot be detected in the default Node environment. I didn't want to simply check the presence of `width: max-content` in test, but rather to check it if clicking works. However, because of these module issues, I wasn’t able to make this work.

I think that the easiest way to test this behavior to prevent regressions would be with e2e tests

Here's the approach that I used:
```sh
cd packages/stage-layout
# added "@vitest/browser-playwright": "catalog:vitest" to dev dependencies in package.json
pnpm install --workspace-root=false
pnpm add -D @vitejs/plugin-vue@^6.0.3 @vue/test-utils
```
config was similar to this:
```ts
import { playwright } from '@vitest/browser-playwright'
// […]
test: {
    globals: true,
    browser: {
      enabled: true,
      provider: playwright(),
      instances: [
        { browser: 'chromium' },
      ],
      headless: false,
    },
    include: ['**/*.test.{ts,js}'],
}
```
