### PR TITLE
fix(stage-ui): hardcode Perplexity models and disable dynamic listing

### DIFF
--- a/packages/stage-ui/src/libs/providers/providers/perplexity-ai/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/perplexity-ai/index.ts
@@ -1,3 +1,5 @@
+import type { ModelInfo } from '../../types'
+
 import { createPerplexity } from '@xsai-ext/providers/create'
 import { z } from 'zod'
 
@@ -45,9 +47,43 @@ export const providerPerplexityAI = defineProvider<PerplexityConfig>({
   validationRequiredWhen(config) {
     return !!config.apiKey?.trim()
   },
+  extraMethods: {
+    async listModels() {
+      return [
+        {
+          id: 'sonar',
+          name: 'Sonar',
+          provider: 'perplexity-ai',
+          description: 'Lightweight, cost-effective search model with grounding.',
+          contextLength: 127072,
+        },
+        {
+          id: 'sonar-pro',
+          name: 'Sonar Pro',
+          provider: 'perplexity-ai',
+          description: 'Advanced search offering with grounding, supporting complex queries and follow-ups.',
+          contextLength: 200000,
+        },
+        {
+          id: 'sonar-reasoning-pro',
+          name: 'Sonar Reasoning Pro',
+          provider: 'perplexity-ai',
+          description: 'Precise reasoning offering with Chain of Thought (CoT).',
+          contextLength: 127072,
+        },
+        {
+          id: 'sonar-deep-research',
+          name: 'Sonar Deep Research',
+          provider: 'perplexity-ai',
+          description: 'Expert-level research model conducting exhaustive searches and generating comprehensive reports.',
+          contextLength: 200000,
+        },
+      ] satisfies ModelInfo[]
+    },
+  },
   validators: {
     ...createOpenAICompatibleValidators({
-      checks: ['connectivity', 'model_list'],
+      checks: ['connectivity'],
     }),
   },
 })

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -1985,7 +1985,39 @@ export const useProvidersStore = defineStore('providers', () => {
       description: 'perplexity.ai',
       defaultBaseUrl: 'https://api.perplexity.ai/',
       creator: createPerplexity,
-      validation: ['health', 'model_list'],
+      validation: ['health'],
+      capabilities: {
+        listModels: async () => [
+          {
+            id: 'sonar',
+            name: 'Sonar',
+            provider: 'perplexity-ai',
+            description: 'Lightweight, cost-effective search model with grounding.',
+            contextLength: 127072,
+          },
+          {
+            id: 'sonar-pro',
+            name: 'Sonar Pro',
+            provider: 'perplexity-ai',
+            description: 'Advanced search offering with grounding, supporting complex queries and follow-ups.',
+            contextLength: 200000,
+          },
+          {
+            id: 'sonar-reasoning-pro',
+            name: 'Sonar Reasoning Pro',
+            provider: 'perplexity-ai',
+            description: 'Precise reasoning offering with Chain of Thought (CoT).',
+            contextLength: 127072,
+          },
+          {
+            id: 'sonar-deep-research',
+            name: 'Sonar Deep Research',
+            provider: 'perplexity-ai',
+            description: 'Expert-level research model conducting exhaustive searches and generating comprehensive reports.',
+            contextLength: 200000,
+          },
+        ] satisfies ModelInfo[],
+      },
     }),
     'mistral-ai': buildOpenAICompatibleProvider({
       id: 'mistral-ai',


### PR DESCRIPTION
Perplexity doesn't support model listing 


1. Removing the `model_list` validation check, as Perplexity does not support a standard `/models` endpoint compatible with the validator.
2. Hardcoding the list of supported Sonar models (`sonar`, `sonar-pro`, `sonar-reasoning-pro`, `sonar-deep-research`) in the provider capabilities.
3. Ensuring `sonar` is the first model in the list so it is used for connectivity health checks.
