### PR TITLE
fix(nix): Pull before push in workflows

### DIFF
--- a/.github/workflows/update-nix-assets-hash.yaml
+++ b/.github/workflows/update-nix-assets-hash.yaml
@@ -37,8 +37,10 @@ jobs:
       - name: Update Hash
         run: nix/update-assets-hash.sh
 
+      - name: Pull with rebase
+        run: git pull --rebase --autostash
+
       - uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: 'chore(nix): update assets hash'
           commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          pull: '--rebase --autostash'

--- a/.github/workflows/update-nix-pnpm-deps-hash.yaml
+++ b/.github/workflows/update-nix-pnpm-deps-hash.yaml
@@ -36,8 +36,10 @@ jobs:
       - name: Update Hash
         run: nix/update-pnpm-deps-hash.sh
 
+      - name: Pull with rebase
+        run: git pull --rebase --autostash
+
       - uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: 'chore(nix): update pnpmDeps hash'
           commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          pull: '--rebase --autostash'


### PR DESCRIPTION
This removes the faulty push: key in the in git-auto-commit-action and replaces it with a manual pull with rebase and autostash. See failing job https://github.com/moeru-ai/airi/actions/runs/22438275987/job/64974489450