### PR TITLE
fix(stage-ui): add bottom padding to settings data and ripple-grid layouts

### DIFF
--- a/packages/stage-pages/src/pages/settings/data/index.vue
+++ b/packages/stage-pages/src/pages/settings/data/index.vue
@@ -86,7 +86,7 @@ async function handleImport(event: Event) {
 </script>
 
 <template>
-  <div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-4 pb-4">
     <div class="border-2 border-neutral-200/50 rounded-xl bg-white/70 p-4 shadow-sm dark:border-neutral-800/60 dark:bg-neutral-900/60">
       <div class="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
         <div class="flex flex-col gap-1 md:max-w-[560px]">

--- a/packages/stage-ui/src/components/layouts/ripple-grid/index.vue
+++ b/packages/stage-ui/src/components/layouts/ripple-grid/index.vue
@@ -93,7 +93,7 @@ function handleItemClick(item: TItem, globalIndex: number) {
       </div>
 
       <div
-        class="grid gap-4"
+        class="grid gap-4 pb-4"
         :style="{
           gridTemplateColumns: `repeat(${currentCols}, minmax(0, 1fr))`,
         }"


### PR DESCRIPTION
Adds pb-4 bottom padding to packages/stage-pages/src/pages/settings/data/index.vue and packages/stage-ui/src/components/layouts/ripple-grid/index.vue to improve spacing under content.