### PR TITLE
fix(stage-ui): respect SSML toggle in test synthesis

### DIFF
--- a/packages/stage-pages/src/pages/settings/modules/speech.vue
+++ b/packages/stage-pages/src/pages/settings/modules/speech.vue
@@ -168,7 +168,9 @@ async function generateTestSpeech() {
 
     const input = useSSML.value
       ? ssmlText.value
-      : speechStore.supportsSSML ? speechStore.generateSSML(testText.value, voice, { ...providerConfig, pitch: pitch.value }) : testText.value
+      : ssmlEnabled.value && speechStore.supportsSSML
+        ? speechStore.generateSSML(testText.value, voice, { ...providerConfig, pitch: pitch.value })
+        : testText.value
 
     const response = await generateSpeech({
       ...provider.speech(model, providerConfig),


### PR DESCRIPTION
## Summary
- fix speech test synthesis input selection to honor the `Enable SSML` toggle
- only auto-generate SSML when `ssmlEnabled` is true and the provider supports SSML
- keep custom SSML mode behavior unchanged

Fixes #1059

## Testing
- `pnpm exec moeru-lint --fix packages/stage-pages/src/pages/settings/modules/speech.vue`
- `pnpm -F @proj-airi/stage-pages typecheck`
- `pnpm test:run -- packages/stage-ui/src/stores/modules/speech.test.ts`
