### PR TITLE
chore: align Novita default OpenAI-compatible endpoint

### DIFF
--- a/packages/stage-ui/src/libs/providers/providers/novita-ai/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/novita-ai/index.ts
@@ -10,7 +10,7 @@ const novitaConfigSchema = z.object({
   baseUrl: z
     .string('Base URL')
     .optional()
-    .default('https://api.novita.ai/openai/'),
+    .default('https://api.novita.ai/openai'),
 })
 
 type NovitaConfig = z.input<typeof novitaConfigSchema>


### PR DESCRIPTION
## Summary
- update Novita provider default base URL to https://api.novita.ai/openai
- keep provider behavior unchanged (builder normalizes trailing slash when needed)

## Testing
- not run (configuration default string update only)