### PR TITLE
chore(i18n): make dev tools name consistent

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -814,7 +814,7 @@ pages:
                 title: Markdown Stress
                 description: Stress markdown parsing and rendering with heavy chat payloads
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys Tool
                 description: Test shortcuts
               audio-record:
                 title: Audio Record

--- a/packages/i18n/src/locales/en/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/en/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: useWindowMouse
+            title: useWindowMouse Tool
             description: Test the Electron window cursor position
 devtools:
   title: Developer

--- a/packages/i18n/src/locales/es/settings.yaml
+++ b/packages/i18n/src/locales/es/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown Stress
                 description: Stress markdown parsing and rendering with heavy chat payloads
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys Tool
                 description: Test shortcuts
               audio-record:
                 title: Audio Record

--- a/packages/i18n/src/locales/es/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/es/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: Usa el ratón de Windows
+            title: Herramienta useWindowMouse
             description: Evalúa la posición del cursor de la ventana de Electron
 devtools:
   title: Desarrollador

--- a/packages/i18n/src/locales/fr/settings.yaml
+++ b/packages/i18n/src/locales/fr/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown Stress
                 description: Stress markdown parsing and rendering with heavy chat payloads
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys Tool
                 description: Test shortcuts
               audio-record:
                 title: Audio Record

--- a/packages/i18n/src/locales/fr/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/fr/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: useWindowMouse
+            title: useWindowMouse Tool
             description: Test the Electron window cursor position
 devtools:
   title: Developer

--- a/packages/i18n/src/locales/ja/settings.yaml
+++ b/packages/i18n/src/locales/ja/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown ストレス
                 description: 大量のチャットデータを含むMarkdownの解析とレンダリング負荷のテスト
               use-magic-keys:
-                title: マジックキーを使用
+                title: useMagicKeys ツール
                 description: ショートカットをテスト
               audio-record:
                 title: オーディオ録音

--- a/packages/i18n/src/locales/ja/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ja/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: ウィンドウマウスの使用
+            title: useWindowMouse ツール
             description: Electronウィンドウのカーソル位置をテストします
 devtools:
   title: 開発者

--- a/packages/i18n/src/locales/ko/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ko/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: 창 마우스 사용
+            title: useWindowMouse 도구
             description: Electron 창 커서 위치 테스트
 devtools:
   title: 개발자 옵션

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown Stress
                 description: Stress markdown parsing and rendering with heavy chat payloads
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys Tool
                 description: Test shortcuts
               audio-record:
                 title: Audio Record

--- a/packages/i18n/src/locales/ru/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ru/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: useWindowMouse
+            title: useWindowMouse Tool
             description: Test the Electron window cursor position
 devtools:
   title: Developer

--- a/packages/i18n/src/locales/vi/settings.yaml
+++ b/packages/i18n/src/locales/vi/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown Stress
                 description: Stress markdown parsing and rendering with heavy chat payloads
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys Tool
                 description: Test shortcuts
               audio-record:
                 title: Audio Record

--- a/packages/i18n/src/locales/vi/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/vi/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: useWindowMouse
+            title: useWindowMouse Tool
             description: Test the Electron window cursor position
 devtools:
   title: Developer

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown Stress
                 description: 用大量聊天负载来测试 Markdown 的解析和渲染能力
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys 工具
                 description: 测试快捷键
               audio-record:
                 title: 音频录制

--- a/packages/i18n/src/locales/zh-Hans/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: useWindowMouse
+            title: useWindowMouse 工具
             description: 测试 Electron 窗口鼠标位置
 devtools:
   title: 开发者选项

--- a/packages/i18n/src/locales/zh-Hant/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/settings.yaml
@@ -787,7 +787,7 @@ pages:
                 title: Markdown Stress
                 description: Stress markdown parsing and rendering with heavy chat payloads
               use-magic-keys:
-                title: useMagicKeys
+                title: useMagicKeys 工具
                 description: 測試快捷鍵
               audio-record:
                 title: Audio Record

--- a/packages/i18n/src/locales/zh-Hant/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/tamagotchi/settings.yaml
@@ -25,7 +25,7 @@ pages:
       sections:
         section:
           use-window-mouse:
-            title: 使用WindowMouse
+            title: useWindowMouse 工具
             description: 測試 Electron 視窗滑鼠游標位置
 devtools:
   title: 開發者


### PR DESCRIPTION
## Summary
Add 'Tool' wording to the useMagicKeys and useWindowMouse titles so they clearly advertise the dev tools

## Testing
- Not Run (not requested)
