### PR TITLE
fix(stage-ui): add listModels capability to Deepgram TTS provider

### DIFF
--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -953,6 +953,34 @@ export const useProvidersStore = defineStore('providers', () => {
         return provider
       },
       capabilities: {
+        listModels: async () => {
+          return [
+            {
+              id: 'aura-2',
+              name: 'Aura 2',
+              provider: 'deepgram-tts',
+              description: 'Latest generation Aura model',
+              contextLength: 0,
+              deprecated: false,
+            },
+            {
+              id: 'aura-1',
+              name: 'Aura 1',
+              provider: 'deepgram-tts',
+              description: 'First generation Aura model',
+              contextLength: 0,
+              deprecated: false,
+            },
+            {
+              id: 'aura',
+              name: 'Aura (Legacy)',
+              provider: 'deepgram-tts',
+              description: 'Original Aura model',
+              contextLength: 0,
+              deprecated: true,
+            },
+          ]
+        },
         listVoices: async (config) => {
           const provider = createUnDeepgram((config.apiKey as string).trim(), (config.baseUrl as string).trim()) as VoiceProviderWithExtraOptions<UnDeepgramOptions>
 


### PR DESCRIPTION
## Problem
The Deepgram TTS provider is missing the `listModels` capability, causing an empty model dropdown in the UI. Users cannot select a model or use the provider at all.

## Root Cause
In `packages/stage-ui/src/stores/providers.ts`, the Deepgram provider's `capabilities` only defines `listVoices` but not `listModels`. The UI checks for `listModels` to populate the model selector.

## Fix
Add `listModels` to the Deepgram provider capabilities, returning the three available Aura model generations:
- **Aura 2** — latest generation
- **Aura 1** — first generation
- **Aura (Legacy)** — original model (marked deprecated)

This follows the same pattern used by the Microsoft Speech provider.

## Testing
1. Go to Settings → Modules → Speech
2. Select Deepgram provider
3. Model dropdown now shows 3 models
4. Select model + voice → speech generation works

Closes #1056