### PR TITLE
fix: keep page header fixed while scrolling

### DIFF
--- a/packages/stage-ui/src/components/layouts/page-header.vue
+++ b/packages/stage-ui/src/components/layouts/page-header.vue
@@ -59,7 +59,7 @@ watch([() => props.title, () => props.subtitle, route], async () => {
       right: 'env(safe-area-inset-right, 0px)',
       left: 'env(safe-area-inset-left, 0px)',
     }"
-    sticky inset-x-0 top-0 z-99 w-full pb-6 pt-10
+    fixed inset-x-0 top-0 z-99 w-full pb-6 pt-10
     flex="~ row items-center gap-2"
     bg="$bg-color"
   >


### PR DESCRIPTION
## Description

This PR improves the user experience on settings pages, such as the Providers page, by changing the header positioning from sticky to fixed.

What this PR solves:
On smaller viewports or narrow screens, the long list of provider settings required significant upward scrolling just to reach the "Back" button. While sticky was a step in the right direction, switching to fixed ensures the header stays strictly at the top of the viewport, providing a consistent navigation anchor regardless of the container's layout or scroll depth.

Key Changes:
Updated header positioning class from sticky to fixed.

## Additional Context

The shift to fixed positioning guarantees that the "Back" button is always accessible, significantly reducing the "interaction cost" for mobile users who no longer need to scroll through a long list of providers to navigate away.