### PR TITLE
fix(stage-ui): prevent onboard model list overflow under collapse button

### DIFF
--- a/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-model-selection.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-model-selection.vue
@@ -50,7 +50,7 @@ const {
         :custom-input-placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.custom_model_placeholder')"
         :expand-button-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.expand')"
         :collapse-button-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.collapse')"
-        list-class="max-h-[calc(100dvh-17rem)] sm:max-h-120"
+        list-class="max-h-[calc(100dvh-17rem)] sm:max-h-120 overflow-y-auto"
       />
 
       <Alert v-else type="error">


### PR DESCRIPTION
## Description

When many models are available in the onboarding model selection step, the list could overflow visually beneath the collapse button.

<img width="1052" height="1140" alt="ScreenShot_2026-03-03_105118_090" src="https://github.com/user-attachments/assets/a1dbc679-2065-4170-a498-9c2514283d78" />

This was caused by the missing `overflow-y-auto` on the list container.

### Change

Added `overflow-y-auto` to the `list-class `prop.

The change is scoped to this dialog via the `list-class` prop to avoid affecting other usages of `RadioCardManySelect`.

### Result

<img width="1005" height="1089" alt="ScreenShot_2026-03-03_105132_336" src="https://github.com/user-attachments/assets/c9b3bc28-a7ff-481a-b52b-a49872ce7c03" />
