### PR TITLE
feat(tamagotchi): add reset main window position to system tray

### DIFF
--- a/apps/stage-tamagotchi/src/main/tray/index.ts
+++ b/apps/stage-tamagotchi/src/main/tray/index.ts
@@ -37,7 +37,7 @@ export function setupTray(params: {
       { label: 'Show', click: () => toggleWindowShow(params.mainWindow) },
       { type: 'separator' },
       {
-        label: 'Reset main window',
+        label: 'Center and Reset Size',
         click: () => {
           params.mainWindow.setSize(450, 600)
           params.mainWindow.center()


### PR DESCRIPTION
## Description

sometimes the window gets stuck and you cannot click on the move button to drag the window, so it might be beneficial to add a system tray option to force reset the window when stuck. 

## Linked Issues

https://github.com/moeru-ai/airi/issues/1087

## Additional Context

