### PR TITLE
fix(stage-tamagotchi): improve controls island tooltip placement

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/control-button-tooltip.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/control-button-tooltip.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 import { TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
+
+const { side = 'top' } = defineProps<{
+  side?: 'top' | 'right' | 'bottom' | 'left'
+}>()
 </script>
 
 <template>
@@ -20,7 +24,7 @@ import { TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from 're
             'rounded-lg backdrop-blur-md',
             'text-xs',
           ]"
-          side="left"
+          :side="side"
           :side-offset="4"
         >
           <slot name="tooltip" />

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -179,7 +179,7 @@ function refreshWindow() {
 
       <!-- Main Controls -->
       <div flex flex-col gap-1>
-        <ControlButtonTooltip>
+        <ControlButtonTooltip side="left">
           <ControlButton :button-style="adjustStyleClasses.button" @click="expanded = !expanded">
             <div
 
@@ -194,7 +194,7 @@ function refreshWindow() {
           </template>
         </ControlButtonTooltip>
 
-        <ControlButtonTooltip>
+        <ControlButtonTooltip side="left">
           <ControlButton :button-style="adjustStyleClasses.button" cursor-move :class="{ 'drag-region': isLinux }" @mousedown="startDraggingWindow?.()">
             <div i-ph:arrows-out-cardinal :class="adjustStyleClasses.icon" text="neutral-800 dark:neutral-300" />
           </ControlButton>


### PR DESCRIPTION
Move expanded drawer tooltips to the top to avoid blocking other items
Set default tooltip placement to 'top' in ControlButtonTooltip
Keep main controls tooltips on the left
Refactor ControlButtonTooltip to use reactive props destructuring

<img width="332" height="600" alt="image" src="https://github.com/user-attachments/assets/66c7b7e8-e2c1-48c3-8f0d-84324924e828" />
