### PR TITLE
fix(stage-ui): guard against undefined voices in ElevenLabs listVoices

### DIFF
--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -917,6 +917,10 @@ export const useProvidersStore = defineStore('providers', () => {
             ...provider.voice(),
           })
 
+          if (!voices || !Array.isArray(voices)) {
+            return []
+          }
+
           // Find indices of Aria and Bill
           const ariaIndex = voices.findIndex(voice => voice.name.includes('Aria'))
           const billIndex = voices.findIndex(voice => voice.name.includes('Bill'))


### PR DESCRIPTION
## Summary

Fix the `Cannot read properties of undefined (reading 'findIndex')` error in ElevenLabs Voice Configuration.

## Problem

When configuring AIRI's speech module with ElevenLabs, the Voice Configuration section displays an error because `listVoices()` from the unspeech library can return `undefined` when:
- The API key is invalid
- The ElevenLabs service is unreachable
- The proxy endpoint returns an unexpected response

The code at `providers.ts` then tries to call `voices.findIndex(...)` on the undefined value, causing a TypeError.

## Fix

Added a guard check after the `listVoices()` call that returns an empty array if the response is `undefined` or not an array. This prevents the crash and allows the UI to gracefully show an empty voice list.

Closes #1095