### PR TITLE
fix(ui): raise ComboboxContent z-index above Dialog overlay

### DIFF
--- a/packages/ui/src/components/form/combobox/combobox.vue
+++ b/packages/ui/src/components/form/combobox/combobox.vue
@@ -71,9 +71,11 @@ function toDisplayValue(value: T): string {
         :side-offset="4"
         :avoid-collisions="true"
         :class="[
-          // NOTICE: DrawerContent is z-[1000], here we choose `1010`
-          // Read more at: https://github.com/moeru-ai/airi/blob/0fddd043f2b213f441f3998c52dca1d24acb8405/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue#L62C8-L62C21
-          'z-[1010]',
+          // NOTICE: DialogContent/DialogOverlay use z-[9999], and DrawerContent uses z-[1000].
+          // ComboboxContent must render above these layers so that dropdowns inside
+          // Dialog/Drawer are not hidden behind the overlay or dismissed unexpectedly.
+          // Read more at: https://github.com/moeru-ai/airi/issues/1136
+          'z-[10010]',
           'w-full min-w-[160px] overflow-hidden rounded-xl shadow-sm border will-change-[opacity,transform]',
           'data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade',
           'bg-white dark:bg-neutral-900',


### PR DESCRIPTION
## Summary

Fix dropdown in modal/popup closing unexpectedly when hovering over select options.

## Problem

The `ComboboxContent` (dropdown menu) was rendered at `z-[1010]` via `ComboboxPortal`, while `DialogContent` and `DialogOverlay` use `z-[9999]`. When a Combobox/Select is placed inside a Dialog, the dropdown portal renders behind the dialog overlay, causing:
- Dropdown options to be hidden behind the dialog overlay
- Mouse events on options being intercepted by the dialog's `DismissableLayer`
- The dialog closing unexpectedly when trying to select dropdown options

## Fix

Raised the `ComboboxContent` z-index from `z-[1010]` to `z-[10010]` to ensure dropdown options always render above all dialog/drawer layers (which max out at `z-[9999]`).

Closes #1136