### PR TITLE
fix(stage-ui): auto-mark provider as added after successful validation on settings page

### DIFF
--- a/packages/stage-ui/src/composables/use-provider-validation.ts
+++ b/packages/stage-ui/src/composables/use-provider-validation.ts
@@ -73,6 +73,14 @@ export function useProviderValidation(providerId: string) {
 
       if (!isValid.value)
         finalValidationMessage = validationResult.reason
+
+      // When a provider validates successfully on its settings page,
+      // mark it as added so it appears in the model selector (e.g. Consciousness module).
+      // This fixes providers like LM Studio that use default config and may not
+      // need an API key, yet should be selectable after successful validation.
+      if (isValid.value) {
+        providersStore.markProviderAdded(providerId)
+      }
     }
     catch (error) {
       isValid.value = false


### PR DESCRIPTION
## Summary

Fix LM Studio (and similar local providers) not showing up in the Consciousness module's model selector after successful configuration.

## Problem

When a user configures LM Studio:
1. Navigates to Settings > Providers > Chat > LM Studio
2. The server is detected as **up and running** (validation succeeds)
3. Goes to Settings > Modules > Consciousness
4. **LM Studio does not appear** in the provider list

This happens because the provider is never explicitly marked as 'added' via `markProviderAdded()`. The `persistedChatProvidersMetadata` computed property requires either:
- `addedProviders[id] === true` (never set for LM Studio)
- `isProviderConfigDirty(id)` to be true (returns false when config matches defaults)

LM Studio uses default config (`http://localhost:1234/v1/`) and doesn't require an API key, so neither condition is met even though the provider validates successfully.

## Fix

In `useProviderValidation` composable (used by provider settings pages), when validation succeeds, automatically call `providersStore.markProviderAdded(providerId)` to ensure the provider appears in the model selector.

This is scoped to the settings page context (user has explicitly visited the provider configuration), so it won't cause unwanted providers to appear in the UI.

Closes #1081