### PR TITLE
feat(stage-pages): add manual model input fallback when model list fails to load

### DIFF
--- a/packages/stage-pages/src/pages/settings/modules/consciousness.vue
+++ b/packages/stage-pages/src/pages/settings/modules/consciousness.vue
@@ -165,6 +165,18 @@ function handleDeleteProvider(providerId: string) {
           :error="activeProviderModelError"
         />
 
+        <!-- Manual model input fallback when model list fails to load -->
+        <div v-if="activeProviderModelError" class="mt-2">
+          <label class="mb-1 block text-sm font-medium">
+            {{ t('settings.pages.modules.consciousness.sections.section.provider-model-selection.manual_model_name') }}
+          </label>
+          <input
+            v-model="activeModel" type="text"
+            class="w-full border border-neutral-300 rounded bg-white px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+            :placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.manual_model_placeholder')"
+          >
+        </div>
+
         <!-- No models available -->
         <Alert
           v-else-if="providerModels.length === 0 && !isLoadingActiveProviderModels"


### PR DESCRIPTION
## Summary

Add a fallback text input for manual model name entry when the `/v1/models` endpoint fails.

## Problem

When using the OpenAI Compatible provider with services like MiniMax (`api.minimax.io`), the `/v1/models` endpoint returns a `404` error. In this case, the Consciousness module's model selection only shows an error message with no way to manually specify a model name/ID.

## Fix

Added a manual text input field below the error container in the Consciousness module's model selection section. When model list fetching fails, users can now type their desired model name/ID (e.g., `MiniMax-M2.5`) directly.

The implementation reuses existing i18n keys (`manual_model_name` and `manual_model_placeholder`) for consistency with the existing manual input shown for providers that don't support model listing.

Closes #1058