### PR TITLE
feat: add provider configuration export/import

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -199,7 +199,9 @@ pages:
         reset: Reset module settings
       providers:
         title: Providers
-        description: Reset all provider settings and credentials.
+        description: Export or import provider configurations and credentials.
+        export: Export providers
+        import: Import providers
         reset: Reset provider settings
       danger:
         title: Danger zone
@@ -223,6 +225,9 @@ pages:
       models_deleted: Models deleted.
       modules_reset: Module settings reset.
       providers_reset: Provider settings reset.
+      providers_exported: Provider configurations exported.
+      providers_imported: Provider configurations imported.
+      providers_import_error: Failed to import provider configurations. Please check the file format.
       all_deleted: All local data deleted.
       desktop_reset: Desktop data reset.
   models:

--- a/packages/stage-pages/src/pages/settings/data/index.vue
+++ b/packages/stage-pages/src/pages/settings/data/index.vue
@@ -13,6 +13,8 @@ const {
   deleteAllChatSessions,
   exportChatSessions,
   importChatSessions,
+  exportProviderConfigurations,
+  importProviderConfigurations,
   deleteAllData,
   resetDesktopApplicationState,
 } = useDataMaintenance()
@@ -21,6 +23,7 @@ const statusMessage = ref('')
 const statusTone = ref<'neutral' | 'success' | 'error'>('neutral')
 const importError = ref('')
 const importFileInput = ref<HTMLInputElement>()
+const providerImportFileInput = ref<HTMLInputElement>()
 const isDesktop = computed(() => isStageTamagotchi())
 
 function setStatus(message: string, tone: 'neutral' | 'success' | 'error' = 'success') {
@@ -83,6 +86,48 @@ async function handleImport(event: Event) {
     target.value = ''
   }
 }
+
+function triggerProviderExport() {
+  try {
+    const blob = exportProviderConfigurations()
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `airi-provider-configurations-${new Date().toISOString()}.json`
+    anchor.click()
+    URL.revokeObjectURL(url)
+    setStatus(t('settings.pages.data.status.providers_exported'))
+  }
+  catch (error) {
+    console.error(error)
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+function triggerProviderImportPicker() {
+  importError.value = ''
+  providerImportFileInput.value?.click()
+}
+
+function handleProviderImport(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file)
+    return
+
+  file.text().then((raw) => {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    importProviderConfigurations(parsed)
+    setStatus(t('settings.pages.data.status.providers_imported'))
+    importError.value = ''
+  }).catch((error) => {
+    console.error(error)
+    importError.value = t('settings.pages.data.status.providers_import_error')
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }).finally(() => {
+    target.value = ''
+  })
+}
 </script>
 
 <template>
@@ -124,6 +169,30 @@ async function handleImport(event: Event) {
       <p v-if="importError" class="text-sm text-red-500">
         {{ importError }}
       </p>
+    </div>
+
+    <div class="border-2 border-neutral-200/50 rounded-xl bg-white/70 p-4 shadow-sm dark:border-neutral-800/60 dark:bg-neutral-900/60">
+      <div class="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+        <div class="flex flex-col gap-1 md:max-w-[560px]">
+          <div class="text-lg font-medium">
+            {{ t('settings.pages.data.sections.providers.title') }}
+          </div>
+          <p class="text-sm text-neutral-600 dark:text-neutral-400">
+            {{ t('settings.pages.data.sections.providers.description') }}
+          </p>
+        </div>
+        <div class="flex flex-col items-start gap-2 sm:items-end">
+          <div class="flex flex-wrap gap-2">
+            <Button variant="secondary" @click="triggerProviderExport">
+              {{ t('settings.pages.data.sections.providers.export') }}
+            </Button>
+            <Button variant="primary" @click="triggerProviderImportPicker">
+              {{ t('settings.pages.data.sections.providers.import') }}
+            </Button>
+          </div>
+        </div>
+      </div>
+      <input ref="providerImportFileInput" type="file" accept="application/json" class="hidden" @change="handleProviderImport">
     </div>
 
     <div class="border-2 border-neutral-200/50 rounded-xl bg-white/70 p-4 shadow-sm dark:border-neutral-800/60 dark:bg-neutral-900/60">

--- a/packages/stage-ui/src/composables/use-data-maintenance.ts
+++ b/packages/stage-ui/src/composables/use-data-maintenance.ts
@@ -68,6 +68,45 @@ export function useDataMaintenance() {
     return new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
   }
 
+  function exportProviderConfigurations() {
+    const configs = providersStore.providers
+    const added = providersStore.addedProviders
+    const data = {
+      format: 'provider-configurations:v1',
+      exportedAt: new Date().toISOString(),
+      providers: configs,
+      addedProviders: added,
+    }
+    return new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  }
+
+  function isProviderConfigPayload(payload: unknown): payload is { format: string, providers: Record<string, Record<string, unknown>>, addedProviders: Record<string, boolean> } {
+    if (!payload || typeof payload !== 'object')
+      return false
+    return (payload as { format?: string }).format === 'provider-configurations:v1'
+      && typeof (payload as any).providers === 'object'
+  }
+
+  function importProviderConfigurations(payload: Record<string, unknown>) {
+    if (!isProviderConfigPayload(payload))
+      throw new Error('Invalid provider configuration export format')
+
+    const currentProviders = providersStore.providers
+    for (const [id, config] of Object.entries(payload.providers)) {
+      if (config && typeof config === 'object') {
+        currentProviders[id] = config
+      }
+    }
+
+    if (payload.addedProviders) {
+      for (const [id, added] of Object.entries(payload.addedProviders)) {
+        if (added) {
+          providersStore.markProviderAdded(id)
+        }
+      }
+    }
+  }
+
   function isChatSessionsPayload(payload: unknown): payload is ChatSessionsExport {
     if (!payload || typeof payload !== 'object')
       return false
@@ -112,6 +151,8 @@ export function useDataMaintenance() {
     deleteAllChatSessions,
     exportChatSessions,
     importChatSessions,
+    exportProviderConfigurations,
+    importProviderConfigurations,
     deleteAllData,
     resetDesktopApplicationState,
   }


### PR DESCRIPTION
## Summary

Adds the ability to export and import provider configurations (API keys, endpoints, settings) from the Data settings page. This addresses Issue #973.

## Changes

- **\packages/stage-ui/src/composables/use-data-maintenance.ts\**: Added \exportProviderConfigurations()\ and \importProviderConfigurations()\ functions with format validation (\provider-configurations:v1\)
- **\packages/stage-pages/src/pages/settings/data/index.vue\**: Added a new provider configurations card section with Export and Import buttons, following the established chat sessions pattern
- **\packages/i18n/src/locales/en/settings.yaml\**: Added i18n keys for export/import labels and status messages

## How it works

- **Export**: Creates a JSON blob containing all provider credentials and added-provider flags, triggering a file download
- **Import**: Opens a file picker, validates the JSON format, and merges provider configurations into the current state (marks imported providers as added)
- Export format includes a version identifier (\provider-configurations:v1\) for future compatibility

## Testing

- Verified no TypeScript errors
- UI follows the established pattern from chat sessions export/import

Closes #973