### PR TITLE
feat: add anti-aliasing support for 3D models

### DIFF
--- a/packages/stage-ui-three/src/components/ThreeScene.vue
+++ b/packages/stage-ui-three/src/components/ThreeScene.vue
@@ -91,6 +91,8 @@ const {
   envSelect,
   skyBoxSrc,
   skyBoxIntensity,
+  renderScale,
+  multisampling,
 } = storeToRefs(modelStore)
 
 const modelRef = ref<InstanceType<typeof VRMModel>>()
@@ -314,6 +316,7 @@ defineExpose({
         v-show="true"
         :camera="camera"
         :antialias="true"
+        :dpr="renderScale"
         :width="width"
         :height="height"
         :tone-mapping="ACESFilmicToneMapping"
@@ -361,7 +364,7 @@ defineExpose({
           cast-shadow
         />
         <Suspense>
-          <EffectComposerPmndrs>
+          <EffectComposerPmndrs :multisampling="multisampling">
             <HueSaturationPmndrs v-bind="effectProps" />
           </EffectComposerPmndrs>
         </Suspense>

--- a/packages/stage-ui-three/src/stores/model-store.ts
+++ b/packages/stage-ui-three/src/stores/model-store.ts
@@ -139,6 +139,10 @@ export const useModelStore = defineStore('modelStore', () => {
   const ambientLightColor = useLocalStorage('settings/stage-ui-three/scenes/scene/ambient-light/color', '#FFFFFF')
   const ambientLightIntensity = useLocalStorage('settings/stage-ui-three/scenes/scene/ambient-light/intensity', 0.6)
 
+  // Rendering quality
+  const renderScale = useLocalStorage('settings/stage-ui-three/renderScale', Math.min(window.devicePixelRatio, 2))
+  const multisampling = useLocalStorage('settings/stage-ui-three/multisampling', 4)
+
   // environment related setting
   const envSelect = useLocalStorage('settings/stage-ui-three/envEnabled', 'hemisphere' as 'hemisphere' | 'skyBox')
   const skyBoxSrc = useLocalStorage('settings/stage-ui-three/skyBoxUrl', defaultSkyBoxSrc)
@@ -173,6 +177,9 @@ export const useModelStore = defineStore('modelStore', () => {
     lookAtTarget,
     trackingMode,
     eyeHeight,
+    renderScale,
+    multisampling,
+
     envSelect,
     skyBoxSrc,
     skyBoxIntensity,


### PR DESCRIPTION
## Summary

Adds configurable anti-aliasing for 3D VRM models to fix aliased/jagged rendering on both 1080p and 4K displays. Addresses #1138.

## Changes

### Supersampling via Device Pixel Ratio (ThreeScene.vue)
- Added `:dpr="renderScale"` prop to TresCanvas, which renders at a higher resolution and downscales — the most effective anti-aliasing approach
- Defaults to `window.devicePixelRatio` (capped at 2x) so HiDPI/4K displays render at native resolution instead of being upscaled from 1x

### MSAA via EffectComposer (ThreeScene.vue)
- Added `:multisampling="multisampling"` prop to EffectComposerPmndrs for hardware MSAA within the post-processing pipeline
- Defaults to 4 samples (a good balance between quality and performance)

### Configurable Settings (model-store.ts)
- `renderScale`: Pixel ratio multiplier (persisted to localStorage, default: `Math.min(devicePixelRatio, 2)`)
- `multisampling`: MSAA sample count (persisted to localStorage, default: 4)
- Both settings can be adjusted for performance tuning (lower values for weaker GPUs)

## Why this approach

Per the issue, the user explicitly requested effective AA like MSAA/TAA or supersampling, not SMAA. This implementation provides:
1. **Supersampling** via `dpr` — renders at higher resolution, most effective for fine geometry
2. **MSAA** via `multisampling` on the EffectComposer — hardware-accelerated edge smoothing
3. Both settings are configurable and persisted, so users can balance quality vs performance

Closes #1138
