### PR TITLE
fix(telegram-bot): guard structured message fallback

### DIFF
--- a/services/telegram-bot/src/bots/telegram/agent/actions/send-message.test.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/send-message.test.ts
@@ -33,6 +33,18 @@ describe('parseMayStructuredMessage', () => {
     expect(result).toMatchObject({ messages: ['Hello, world!', 'Hello, world!'], reply_to_message_id: '1234567890' })
   })
 
+  it('should fall back to the original text when structured output omits messages', () => {
+    const text = '{"reply_to_message_id":"1234567890"}'
+    const result = parseMayStructuredMessage(text)
+    expect(result).toMatchObject({ messages: [text], reply_to_message_id: '1234567890' })
+  })
+
+  it('should fall back to the original text when structured output uses a non-array messages field', () => {
+    const text = '{"messages":"Hello, world!"}'
+    const result = parseMayStructuredMessage(text)
+    expect(result).toMatchObject({ messages: [text], reply_to_message_id: undefined })
+  })
+
   it('should return an array of messages from multi-line elements of input', () => {
     const result = parseMayStructuredMessage(`{"messages": [
 "Hello,

--- a/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
@@ -25,10 +25,19 @@ export function parseMayStructuredMessage(responseText: string) {
   if (result) {
     logger.withField('text', JSON.stringify(responseText)).withField('result', result).log('Multiple messages detected')
 
-    const parsedResponse = parse(result?.[0]) as ({ messages?: string[], reply_to_message_id?: string } | undefined)
-    parsedResponse.messages = parsedResponse.messages?.filter(message => message.trim() !== '')
+    const parsedResponse = parse(result[0]) as ({ messages?: unknown, reply_to_message_id?: unknown } | undefined)
+    const messages = Array.isArray(parsedResponse?.messages)
+      ? parsedResponse.messages.filter((message): message is string => typeof message === 'string' && message.trim() !== '')
+      : []
+    const replyToMessageId = typeof parsedResponse?.reply_to_message_id === 'string'
+      ? parsedResponse.reply_to_message_id
+      : undefined
 
-    return parsedResponse
+    if (messages.length > 0) {
+      return { messages, reply_to_message_id: replyToMessageId }
+    }
+
+    return { messages: [responseText], reply_to_message_id: replyToMessageId }
   }
 
   return { messages: [responseText], reply_to_message_id: undefined }


### PR DESCRIPTION
## Summary
- treat brace-wrapped Telegram agent output without a valid `messages` array as plain-text fallback instead of returning a shape that can break `sendMessage()`
- preserve `reply_to_message_id` when it is still usable while falling back to the original text
- add regression coverage for missing/non-array `messages` payloads

## Testing
- `pnpm exec vitest run src/bots/telegram/agent/actions/send-message.test.ts --config vitest.config.ts`
- `pnpm -F @proj-airi/telegram-bot typecheck` *(still fails on the pre-existing `services/telegram-bot/src/utils/velin.ts` type mismatch unrelated to this patch)*