### PR TITLE
fix(ci): with outputHashAlgo to output non-empty output

### DIFF
--- a/nix/common.nix
+++ b/nix/common.nix
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation (final: {
     '';
 
     outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
     outputHash = builtins.readFile ./assets-hash.txt;
   };
 


### PR DESCRIPTION
Fixes #1180. Nix 2.94+ (Lix) requires an explicit hash algorithm when outputHash is empty. Added outputHashAlgo = "sha256" to match the hash format used in pnpm-deps-hash.txt.