### PR TITLE
feat(tamagotchi): Add model selection and custom Voice ID support for Alibaba Bailian

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/speech/alibaba-cloud-model-studio.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/alibaba-cloud-model-studio.vue
@@ -8,13 +8,21 @@ import {
 } from '@proj-airi/stage-ui/components'
 import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
-import { FieldRange } from '@proj-airi/ui'
+import { FieldInput, FieldRange, FieldSelect } from '@proj-airi/ui'
+import { useDebounceFn } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const providerId = 'alibaba-cloud-model-studio'
 const defaultModel = 'cosyvoice-v1'
+
+// 可选模型列表
+const modelOptions = [
+  { value: 'cosyvoice-v1', label: 'CosyVoice v1' },
+  { value: 'cosyvoice-v2', label: 'CosyVoice v2' },
+  { value: 'cosyvoice-v3-flash', label: 'CosyVoice v3 Flash（支持复刻声音）' },
+]
 
 // Default voice settings specific to ElevenLabs
 const defaultVoiceSettings = {
@@ -30,15 +38,34 @@ const providersStore = useProvidersStore()
 const { providers } = storeToRefs(providersStore)
 const { t } = useI18n()
 
+// 模型选择
+const selectedModel = ref<string>(defaultModel)
+
+// 自定义声音 ID（用于阿里百炼复刻声音）
+const customVoiceId = ref<string>('')
+
+// 当用户修改自定义声音 ID 时，保存到 provider config 并刷新声音列表
+const debouncedSaveCustomVoiceId = useDebounceFn(async () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+
+  providers.value[providerId].customVoiceId = customVoiceId.value.trim()
+  await speechStore.loadVoicesForProvider(providerId)
+}, 800)
+
+watch(customVoiceId, () => {
+  debouncedSaveCustomVoiceId()
+})
+
 // Check if API key is configured
 const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 
-// Get available voices for ElevenLabs
+// Get available voices
 const availableVoices = computed(() => {
   return speechStore.availableVoices[providerId] || []
 })
 
-// Generate speech with ElevenLabs-specific parameters
+// Generate speech
 async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean) {
   const provider = await providersStore.getProviderInstance(providerId) as SpeechProviderWithExtraOptions<string, UnElevenLabsOptions>
   if (!provider) {
@@ -48,10 +75,9 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
   // Get provider configuration
   const providerConfig = providersStore.getProviderConfig(providerId)
 
-  // Get model from configuration or use default
-  const model = providerConfig.model as string | undefined || defaultModel
+  // 使用用户选择的模型
+  const model = selectedModel.value || defaultModel
 
-  // ElevenLabs doesn't need SSML conversion, but if SSML is provided, use it directly
   return await speechStore.speech(
     provider,
     model,
@@ -64,8 +90,20 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
   )
 }
 
+// 当用户修改模型时，保存到 provider config
+watch(selectedModel, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+
+  providers.value[providerId].model = selectedModel.value
+})
+
 onMounted(async () => {
+  // 初始化时从 provider config 读取已保存的模型和自定义声音 ID
   const providerConfig = providersStore.getProviderConfig(providerId)
+  selectedModel.value = (providerConfig.model as string) || defaultModel
+  customVoiceId.value = (providerConfig.customVoiceId as string) || ''
+
   const providerMetadata = providersStore.getProviderMetadata(providerId)
   if (await providerMetadata.validators.validateProviderConfig(providerConfig)) {
     await speechStore.loadVoicesForProvider(providerId)
@@ -110,9 +148,26 @@ watch(providers, async () => {
     :default-model="defaultModel"
     :additional-settings="defaultVoiceSettings"
   >
-    <!-- Voice settings specific to ElevenLabs -->
+    <!-- Voice settings -->
     <template #voice-settings>
       <div flex="~ col gap-4">
+        <!-- 模型选择 -->
+        <FieldSelect
+          v-model="selectedModel"
+          :options="modelOptions"
+          label="模型"
+          description="选择语音合成模型。使用复刻声音时，必须选择与创建声音时相同的模型。"
+          layout="horizontal"
+        />
+
+        <!-- 自定义声音 ID 输入框（用于阿里百炼复刻声音） -->
+        <FieldInput
+          v-model="customVoiceId"
+          label="自定义声音 ID"
+          description="填入阿里百炼复刻声音的 voice ID，例如 cosyvoice-v3-flash-bailian-xxxx。填入后会自动出现在声音选择列表中。"
+          placeholder="cosyvoice-v3-flash-bailian-..."
+        />
+
         <!-- Pitch control - common to most providers -->
         <FieldRange
           v-model="pitch"
@@ -148,7 +203,7 @@ watch(providers, async () => {
         :available-voices="availableVoices"
         :generate-speech="handleGenerateSpeech"
         :api-key-configured="apiKeyConfigured"
-        default-text="Hello! This is a test of the ElevenLabs voice synthesis."
+        default-text="你好！这是阿里百炼语音合成的测试。"
       />
     </template>
   </SpeechProviderSettings>

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -299,6 +299,30 @@ const speechPipeline = createSpeechPipeline<AudioBuffer>({
       }
     }
 
+    // 阿里百炼：优先使用 provider config 中的模型和自定义声音 ID
+    if (activeSpeechProvider.value === 'alibaba-cloud-model-studio') {
+      // 优先使用设置页面中选择的模型
+      if (providerConfig?.model) {
+        model = providerConfig.model as string
+      }
+
+      // 当未选择声音但配置了自定义声音 ID 时，使用自定义声音 ID
+      if (!voice) {
+        const customVoiceId = providerConfig?.customVoiceId as string | undefined
+        if (customVoiceId?.trim()) {
+          voice = {
+            id: customVoiceId.trim(),
+            name: `自定义声音 (${customVoiceId.trim()})`,
+            description: customVoiceId.trim(),
+            previewURL: '',
+            languages: [{ code: 'zh-CN', title: '中文' }],
+            provider: activeSpeechProvider.value,
+            gender: 'neutral',
+          }
+        }
+      }
+    }
+
     if (!model || !voice)
       return null
 

--- a/packages/stage-ui/src/stores/modules/speech.ts
+++ b/packages/stage-ui/src/stores/modules/speech.ts
@@ -271,6 +271,12 @@ export const useSpeechStore = defineStore('speech', () => {
       hasVoice ||= !!providerConfig?.voice
     }
 
+    // 阿里百炼：自定义声音 ID 也视为有效 voice 配置
+    if (activeSpeechProvider.value === 'alibaba-cloud-model-studio') {
+      const providerConfig = providersStore.getProviderConfig(activeSpeechProvider.value)
+      hasVoice ||= !!providerConfig?.customVoiceId
+    }
+
     return hasModel && hasVoice
   })
 

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -1224,23 +1224,44 @@ export const useProvidersStore = defineStore('providers', () => {
       createProvider: async config => createUnAlibabaCloud((config.apiKey as string).trim(), (config.baseUrl as string).trim()),
       capabilities: {
         listVoices: async (config) => {
-          const provider = createUnAlibabaCloud((config.apiKey as string).trim(), (config.baseUrl as string).trim()) as VoiceProviderWithExtraOptions<UnAlibabaCloudOptions>
-
-          const voices = await listVoices({
-            ...provider.voice(),
-          })
-
-          return voices.map((voice) => {
-            return {
-              id: voice.id,
-              name: voice.name,
+          // 如果用户配置了自定义声音 ID（用于复刻声音），将其作为可选声音添加到列表开头
+          const customVoices: VoiceInfo[] = []
+          const customVoiceId = config.customVoiceId as string | undefined
+          if (customVoiceId?.trim()) {
+            customVoices.push({
+              id: customVoiceId.trim(),
+              name: `自定义声音 (${customVoiceId.trim()})`,
               provider: 'alibaba-cloud-model-studio',
-              compatibleModels: voice.compatible_models,
-              previewURL: voice.preview_audio_url,
-              languages: voice.languages,
-              gender: voice.labels?.gender,
-            }
-          })
+              languages: [{ code: 'zh-CN', title: '中文' }],
+              gender: 'neutral',
+            })
+          }
+
+          try {
+            const provider = createUnAlibabaCloud((config.apiKey as string).trim(), (config.baseUrl as string).trim()) as VoiceProviderWithExtraOptions<UnAlibabaCloudOptions>
+
+            const voices = await listVoices({
+              ...provider.voice(),
+            })
+
+            const apiVoices = voices.map((voice) => {
+              return {
+                id: voice.id,
+                name: voice.name,
+                provider: 'alibaba-cloud-model-studio',
+                compatibleModels: voice.compatible_models,
+                previewURL: voice.preview_audio_url,
+                languages: voice.languages,
+                gender: voice.labels?.gender,
+              }
+            })
+
+            return [...customVoices, ...apiVoices]
+          }
+          catch {
+            // 即使 API 获取声音列表失败，仍然返回自定义声音
+            return customVoices
+          }
         },
         listModels: async () => {
           return [
@@ -1257,6 +1278,14 @@ export const useProvidersStore = defineStore('providers', () => {
               name: 'CosyVoice (New)',
               provider: 'alibaba-cloud-model-studio',
               description: '',
+              contextLength: 0,
+              deprecated: false,
+            },
+            {
+              id: 'cosyvoice-v3-flash',
+              name: 'CosyVoice v3 Flash',
+              provider: 'alibaba-cloud-model-studio',
+              description: '支持自定义复刻声音的快速语音合成模型',
               contextLength: 0,
               deprecated: false,
             },


### PR DESCRIPTION
## Description

This PR enhances the **Alibaba Bailian (DashScope)** TTS integration within the Speech module.

Previously, the integration relied on default settings. I have added new UI controls and logic to allow for more granular configuration, specifically for voice cloning scenarios.

**Key Changes:**
- **Model Selection:** Added a dropdown/input to select the specific model version (e.g., `cosyvoice-v1`).
- **Custom Voice ID:** Added an input field for users to provide a custom Voice ID.
- **Backend Logic:** Updated the API request payload to include the user-defined `model` and `voice_id`.

**Why:**
This feature enables users to use their own **cloned voices (Voice Replication)** generated on the Alibaba platform directly within Airi, rather than being restricted to the preset system voices.

## Additional Context

**Screenshots:**
<img width="995" height="988" alt="image" src="https://github.com/user-attachments/assets/546cf2e2-f0d0-4a66-b5c6-1295e8234094" />
<img width="1012" height="564" alt="image" src="https://github.com/user-attachments/assets/0bced8d3-6dbc-4e65-914b-6aa05f894f22" />


**Testing:**
- Verified that the custom Voice ID is correctly passed to the Alibaba Bailian API.
- Tested with a custom-cloned voice model, and the audio output matches the expected voice.