### PR TITLE
fix(stage-pages): add missing local provider settings routes

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue
@@ -24,6 +24,7 @@ const speechStore = useSpeechStore()
 const providersStore = useProvidersStore()
 const { providers } = storeToRefs(providersStore)
 const { t } = useI18n()
+providersStore.initializeProvider(providerId)
 
 const speed = ref<number>(
   (providers.value[providerId] as any)?.voiceSettings?.speed
@@ -34,8 +35,6 @@ const speed = ref<number>(
 const model = computed({
   get: () => providers.value[providerId]?.model as string | undefined || defaultModel,
   set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
     providers.value[providerId].model = value
   },
 })
@@ -43,8 +42,6 @@ const model = computed({
 const voice = computed({
   get: () => providers.value[providerId]?.voice || 'alloy',
   set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
     providers.value[providerId].voice = value
   },
 })
@@ -73,29 +70,11 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 }
 
 onMounted(async () => {
-  providersStore.initializeProvider(providerId)
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-
   await providersStore.fetchModelsForProvider(providerId)
 })
 
 watch(speed, () => {
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
   providers.value[providerId].speed = speed.value
-})
-
-watch(model, () => {
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-  providers.value[providerId].model = model.value
-})
-
-watch(voice, () => {
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-  providers.value[providerId].voice = voice.value
 })
 </script>
 

--- a/packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue
@@ -48,8 +48,14 @@ const voice = computed({
 
 const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
 const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+const baseUrl = computed(() => (providers.value[providerId]?.baseUrl as string | undefined)?.trim() || '')
+const isProviderConfigured = computed(() => !!baseUrl.value)
 
 async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  if (!baseUrl.value) {
+    throw new Error('Base URL is required. Configure your local endpoint in Advanced settings first.')
+  }
+
   const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
   if (!provider)
     throw new Error('Failed to initialize speech provider')
@@ -70,7 +76,9 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 }
 
 onMounted(async () => {
-  await providersStore.fetchModelsForProvider(providerId)
+  if (baseUrl.value) {
+    await providersStore.fetchModelsForProvider(providerId)
+  }
 })
 
 watch(speed, () => {
@@ -117,7 +125,7 @@ watch(speed, () => {
         v-model:model-value="model"
         v-model:voice="voice as any"
         :generate-speech="handleGenerateSpeech"
-        :api-key-configured="true"
+        :api-key-configured="isProviderConfigured"
         default-text="Hello! This is a test of the local speech provider."
       />
     </template>

--- a/packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import type { SpeechProvider } from '@xsai-ext/providers/utils'
+
+import {
+  SpeechPlaygroundOpenAICompatible,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import {
+  FieldInput,
+  FieldRange,
+  FieldSelect,
+} from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const providerId = 'app-local-audio-speech'
+const defaultModel = 'tts-1'
+const defaultSpeed = 1.0
+
+const speechStore = useSpeechStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore)
+const { t } = useI18n()
+
+const speed = ref<number>(
+  (providers.value[providerId] as any)?.voiceSettings?.speed
+  || (providers.value[providerId] as any)?.speed
+  || defaultSpeed,
+)
+
+const model = computed({
+  get: () => providers.value[providerId]?.model as string | undefined || defaultModel,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].model = value
+  },
+})
+
+const voice = computed({
+  get: () => providers.value[providerId]?.voice || 'alloy',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].voice = value
+  },
+})
+
+const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
+const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize speech provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = modelId || model.value || defaultModel
+
+  return speechStore.speech(
+    provider,
+    modelToUse,
+    input,
+    voiceId || (voice.value as string),
+    {
+      ...providerConfig,
+      speed: speed.value,
+    },
+  )
+}
+
+onMounted(async () => {
+  providersStore.initializeProvider(providerId)
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+
+  await providersStore.fetchModelsForProvider(providerId)
+})
+
+watch(speed, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  providers.value[providerId].speed = speed.value
+})
+
+watch(model, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  providers.value[providerId].model = model.value
+})
+
+watch(voice, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  providers.value[providerId].voice = voice.value
+})
+</script>
+
+<template>
+  <SpeechProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+    :additional-settings="{ speed: defaultSpeed }"
+    placeholder="Not required for local provider"
+  >
+    <template #voice-settings>
+      <FieldSelect
+        v-if="providerModels.length > 0"
+        v-model="model"
+        label="Model"
+        description="Select the speech model to use"
+        :options="providerModels.map(m => ({ value: m.id, label: m.name }))"
+        :disabled="isLoadingModels"
+        placeholder="Select a model..."
+      />
+      <FieldInput
+        v-else
+        v-model="model"
+        label="Model"
+        description="Enter the local speech model name"
+        placeholder="tts-1"
+      />
+      <FieldRange
+        v-model="speed"
+        :label="t('settings.pages.providers.provider.common.fields.field.speed.label')"
+        :description="t('settings.pages.providers.provider.common.fields.field.speed.description')"
+        :min="0.5"
+        :max="2.0"
+        :step="0.01"
+      />
+    </template>
+
+    <template #playground>
+      <SpeechPlaygroundOpenAICompatible
+        v-model:model-value="model"
+        v-model:voice="voice as any"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="true"
+        default-text="Hello! This is a test of the local speech provider."
+      />
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue
@@ -24,6 +24,7 @@ const speechStore = useSpeechStore()
 const providersStore = useProvidersStore()
 const { providers } = storeToRefs(providersStore)
 const { t } = useI18n()
+providersStore.initializeProvider(providerId)
 
 const speed = ref<number>(
   (providers.value[providerId] as any)?.voiceSettings?.speed
@@ -34,8 +35,6 @@ const speed = ref<number>(
 const model = computed({
   get: () => providers.value[providerId]?.model as string | undefined || defaultModel,
   set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
     providers.value[providerId].model = value
   },
 })
@@ -43,8 +42,6 @@ const model = computed({
 const voice = computed({
   get: () => providers.value[providerId]?.voice || 'alloy',
   set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
     providers.value[providerId].voice = value
   },
 })
@@ -73,29 +70,11 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 }
 
 onMounted(async () => {
-  providersStore.initializeProvider(providerId)
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-
   await providersStore.fetchModelsForProvider(providerId)
 })
 
 watch(speed, () => {
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
   providers.value[providerId].speed = speed.value
-})
-
-watch(model, () => {
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-  providers.value[providerId].model = model.value
-})
-
-watch(voice, () => {
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-  providers.value[providerId].voice = voice.value
 })
 </script>
 

--- a/packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import type { SpeechProvider } from '@xsai-ext/providers/utils'
+
+import {
+  SpeechPlaygroundOpenAICompatible,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import {
+  FieldInput,
+  FieldRange,
+  FieldSelect,
+} from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const providerId = 'browser-local-audio-speech'
+const defaultModel = 'tts-1'
+const defaultSpeed = 1.0
+
+const speechStore = useSpeechStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore)
+const { t } = useI18n()
+
+const speed = ref<number>(
+  (providers.value[providerId] as any)?.voiceSettings?.speed
+  || (providers.value[providerId] as any)?.speed
+  || defaultSpeed,
+)
+
+const model = computed({
+  get: () => providers.value[providerId]?.model as string | undefined || defaultModel,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].model = value
+  },
+})
+
+const voice = computed({
+  get: () => providers.value[providerId]?.voice || 'alloy',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].voice = value
+  },
+})
+
+const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
+const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize speech provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = modelId || model.value || defaultModel
+
+  return speechStore.speech(
+    provider,
+    modelToUse,
+    input,
+    voiceId || (voice.value as string),
+    {
+      ...providerConfig,
+      speed: speed.value,
+    },
+  )
+}
+
+onMounted(async () => {
+  providersStore.initializeProvider(providerId)
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+
+  await providersStore.fetchModelsForProvider(providerId)
+})
+
+watch(speed, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  providers.value[providerId].speed = speed.value
+})
+
+watch(model, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  providers.value[providerId].model = model.value
+})
+
+watch(voice, () => {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  providers.value[providerId].voice = voice.value
+})
+</script>
+
+<template>
+  <SpeechProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+    :additional-settings="{ speed: defaultSpeed }"
+    placeholder="Not required for local provider"
+  >
+    <template #voice-settings>
+      <FieldSelect
+        v-if="providerModels.length > 0"
+        v-model="model"
+        label="Model"
+        description="Select the speech model to use"
+        :options="providerModels.map(m => ({ value: m.id, label: m.name }))"
+        :disabled="isLoadingModels"
+        placeholder="Select a model..."
+      />
+      <FieldInput
+        v-else
+        v-model="model"
+        label="Model"
+        description="Enter the local speech model name"
+        placeholder="tts-1"
+      />
+      <FieldRange
+        v-model="speed"
+        :label="t('settings.pages.providers.provider.common.fields.field.speed.label')"
+        :description="t('settings.pages.providers.provider.common.fields.field.speed.description')"
+        :min="0.5"
+        :max="2.0"
+        :step="0.01"
+      />
+    </template>
+
+    <template #playground>
+      <SpeechPlaygroundOpenAICompatible
+        v-model:model-value="model"
+        v-model:voice="voice as any"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="true"
+        default-text="Hello! This is a test of the local speech provider."
+      />
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue
@@ -48,8 +48,14 @@ const voice = computed({
 
 const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
 const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+const baseUrl = computed(() => (providers.value[providerId]?.baseUrl as string | undefined)?.trim() || '')
+const isProviderConfigured = computed(() => !!baseUrl.value)
 
 async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  if (!baseUrl.value) {
+    throw new Error('Base URL is required. Configure your local endpoint in Advanced settings first.')
+  }
+
   const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
   if (!provider)
     throw new Error('Failed to initialize speech provider')
@@ -70,7 +76,9 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 }
 
 onMounted(async () => {
-  await providersStore.fetchModelsForProvider(providerId)
+  if (baseUrl.value) {
+    await providersStore.fetchModelsForProvider(providerId)
+  }
 })
 
 watch(speed, () => {
@@ -117,7 +125,7 @@ watch(speed, () => {
         v-model:model-value="model"
         v-model:voice="voice as any"
         :generate-speech="handleGenerateSpeech"
-        :api-key-configured="true"
+        :api-key-configured="isProviderConfigured"
         default-text="Hello! This is a test of the local speech provider."
       />
     </template>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue
@@ -32,8 +32,14 @@ const model = computed({
 
 const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
 const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+const baseUrl = computed(() => (providers.value[providerId]?.baseUrl as string | undefined)?.trim() || '')
+const isProviderConfigured = computed(() => !!baseUrl.value)
 
 async function handleGenerateTranscription(file: File) {
+  if (!baseUrl.value) {
+    throw new Error('Base URL is required. Configure your local endpoint in Advanced settings first.')
+  }
+
   const provider = await providersStore.getProviderInstance<TranscriptionProviderWithExtraOptions<string, any>>(providerId)
   if (!provider)
     throw new Error('Failed to initialize transcription provider')
@@ -51,7 +57,9 @@ async function handleGenerateTranscription(file: File) {
 }
 
 onMounted(async () => {
-  await providersStore.fetchModelsForProvider(providerId)
+  if (baseUrl.value) {
+    await providersStore.fetchModelsForProvider(providerId)
+  }
 })
 </script>
 
@@ -83,7 +91,7 @@ onMounted(async () => {
     <template #playground>
       <TranscriptionPlayground
         :generate-transcription="handleGenerateTranscription"
-        :api-key-configured="true"
+        :api-key-configured="isProviderConfigured"
       />
     </template>
   </TranscriptionProviderSettings>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import type { RemovableRef } from '@vueuse/core'
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import {
+  TranscriptionPlayground,
+  TranscriptionProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import {
+  FieldInput,
+  FieldSelect,
+} from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, watch } from 'vue'
+
+const providerId = 'app-local-audio-transcription'
+const defaultModel = 'whisper-1'
+
+const hearingStore = useHearingStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore) as { providers: RemovableRef<Record<string, any>> }
+
+const model = computed({
+  get: () => providers.value[providerId]?.model || defaultModel,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].model = value
+  },
+})
+
+const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
+const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+
+async function handleGenerateTranscription(file: File) {
+  const provider = await providersStore.getProviderInstance<TranscriptionProviderWithExtraOptions<string, any>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize transcription provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = providerConfig.model as string | undefined || model.value || defaultModel
+
+  return hearingStore.transcription(
+    providerId,
+    provider,
+    modelToUse,
+    file,
+    'json',
+  )
+}
+
+onMounted(async () => {
+  providersStore.initializeProvider(providerId)
+  await providersStore.fetchModelsForProvider(providerId)
+})
+
+watch(model, () => {
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  providerConfig.model = model.value
+})
+</script>
+
+<template>
+  <TranscriptionProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+    placeholder="Not required for local provider"
+  >
+    <template #basic-settings>
+      <FieldSelect
+        v-if="providerModels.length > 0"
+        v-model="model"
+        label="Model"
+        description="Select the transcription model to use"
+        :options="providerModels.map(m => ({ value: m.id, label: m.name }))"
+        :disabled="isLoadingModels"
+        placeholder="Select a model..."
+      />
+      <FieldInput
+        v-else
+        v-model="model"
+        label="Model"
+        description="Enter the local transcription model name"
+        placeholder="whisper-1"
+      />
+    </template>
+
+    <template #playground>
+      <TranscriptionPlayground
+        :generate-transcription="handleGenerateTranscription"
+        :api-key-configured="true"
+      />
+    </template>
+  </TranscriptionProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue
@@ -13,7 +13,7 @@ import {
   FieldSelect,
 } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted } from 'vue'
 
 const providerId = 'app-local-audio-transcription'
 const defaultModel = 'whisper-1'
@@ -21,12 +21,11 @@ const defaultModel = 'whisper-1'
 const hearingStore = useHearingStore()
 const providersStore = useProvidersStore()
 const { providers } = storeToRefs(providersStore) as { providers: RemovableRef<Record<string, any>> }
+providersStore.initializeProvider(providerId)
 
 const model = computed({
   get: () => providers.value[providerId]?.model || defaultModel,
   set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
     providers.value[providerId].model = value
   },
 })
@@ -52,13 +51,7 @@ async function handleGenerateTranscription(file: File) {
 }
 
 onMounted(async () => {
-  providersStore.initializeProvider(providerId)
   await providersStore.fetchModelsForProvider(providerId)
-})
-
-watch(model, () => {
-  const providerConfig = providersStore.getProviderConfig(providerId)
-  providerConfig.model = model.value
 })
 </script>
 

--- a/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import type { RemovableRef } from '@vueuse/core'
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import {
+  TranscriptionPlayground,
+  TranscriptionProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import {
+  FieldInput,
+  FieldSelect,
+} from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, watch } from 'vue'
+
+const providerId = 'browser-local-audio-transcription'
+const defaultModel = 'whisper-1'
+
+const hearingStore = useHearingStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore) as { providers: RemovableRef<Record<string, any>> }
+
+const model = computed({
+  get: () => providers.value[providerId]?.model || defaultModel,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].model = value
+  },
+})
+
+const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
+const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+
+async function handleGenerateTranscription(file: File) {
+  const provider = await providersStore.getProviderInstance<TranscriptionProviderWithExtraOptions<string, any>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize transcription provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = providerConfig.model as string | undefined || model.value || defaultModel
+
+  return hearingStore.transcription(
+    providerId,
+    provider,
+    modelToUse,
+    file,
+    'json',
+  )
+}
+
+onMounted(async () => {
+  providersStore.initializeProvider(providerId)
+  await providersStore.fetchModelsForProvider(providerId)
+})
+
+watch(model, () => {
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  providerConfig.model = model.value
+})
+</script>
+
+<template>
+  <TranscriptionProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+    placeholder="Not required for local provider"
+  >
+    <template #basic-settings>
+      <FieldSelect
+        v-if="providerModels.length > 0"
+        v-model="model"
+        label="Model"
+        description="Select the transcription model to use"
+        :options="providerModels.map(m => ({ value: m.id, label: m.name }))"
+        :disabled="isLoadingModels"
+        placeholder="Select a model..."
+      />
+      <FieldInput
+        v-else
+        v-model="model"
+        label="Model"
+        description="Enter the local transcription model name"
+        placeholder="whisper-1"
+      />
+    </template>
+
+    <template #playground>
+      <TranscriptionPlayground
+        :generate-transcription="handleGenerateTranscription"
+        :api-key-configured="true"
+      />
+    </template>
+  </TranscriptionProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
@@ -32,8 +32,14 @@ const model = computed({
 
 const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
 const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
+const baseUrl = computed(() => (providers.value[providerId]?.baseUrl as string | undefined)?.trim() || '')
+const isProviderConfigured = computed(() => !!baseUrl.value)
 
 async function handleGenerateTranscription(file: File) {
+  if (!baseUrl.value) {
+    throw new Error('Base URL is required. Configure your local endpoint in Advanced settings first.')
+  }
+
   const provider = await providersStore.getProviderInstance<TranscriptionProviderWithExtraOptions<string, any>>(providerId)
   if (!provider)
     throw new Error('Failed to initialize transcription provider')
@@ -51,7 +57,9 @@ async function handleGenerateTranscription(file: File) {
 }
 
 onMounted(async () => {
-  await providersStore.fetchModelsForProvider(providerId)
+  if (baseUrl.value) {
+    await providersStore.fetchModelsForProvider(providerId)
+  }
 })
 </script>
 
@@ -83,7 +91,7 @@ onMounted(async () => {
     <template #playground>
       <TranscriptionPlayground
         :generate-transcription="handleGenerateTranscription"
-        :api-key-configured="true"
+        :api-key-configured="isProviderConfigured"
       />
     </template>
   </TranscriptionProviderSettings>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
@@ -13,7 +13,7 @@ import {
   FieldSelect,
 } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted } from 'vue'
 
 const providerId = 'browser-local-audio-transcription'
 const defaultModel = 'whisper-1'
@@ -21,12 +21,11 @@ const defaultModel = 'whisper-1'
 const hearingStore = useHearingStore()
 const providersStore = useProvidersStore()
 const { providers } = storeToRefs(providersStore) as { providers: RemovableRef<Record<string, any>> }
+providersStore.initializeProvider(providerId)
 
 const model = computed({
   get: () => providers.value[providerId]?.model || defaultModel,
   set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
     providers.value[providerId].model = value
   },
 })
@@ -52,13 +51,7 @@ async function handleGenerateTranscription(file: File) {
 }
 
 onMounted(async () => {
-  providersStore.initializeProvider(providerId)
   await providersStore.fetchModelsForProvider(providerId)
-})
-
-watch(model, () => {
-  const providerConfig = providersStore.getProviderConfig(providerId)
-  providerConfig.model = model.value
 })
 </script>
 


### PR DESCRIPTION
## Description

Fixes a routing gap behind issue #1073 where selecting local transcription/speech provider settings could fall through to the wildcard page (`Where are we?`) instead of opening a real settings page.

### What changed

- Added missing local provider settings pages in `stage-pages`:
  - `packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue`
  - `packages/stage-pages/src/pages/settings/providers/transcription/app-local-audio-transcription.vue`
  - `packages/stage-pages/src/pages/settings/providers/speech/browser-local-audio-speech.vue`
  - `packages/stage-pages/src/pages/settings/providers/speech/app-local-audio-speech.vue`
- Reused existing provider settings/playground components with provider-specific IDs.
- Kept patch scope minimal: route-page completion only, no provider core logic changes.

### Why this fixes it

The providers were already registered in `providers.ts`, but corresponding settings route files were missing in `stage-pages`, causing the app to hit the catch-all fallback page. Adding these files makes the routes resolvable.

## Linked Issues

Fixes #1073

## Additional Context

### Validation performed

- Targeted lint on changed files passed:
  - `corepack pnpm -C <repo> exec eslint <4 changed files>`
- Confirmed all 4 route files now exist and map to local provider settings pages.

### Reviewer test plan

1. Start app (`dev:web` or `dev:tamagotchi`).
2. Open:
   - `/settings/providers/transcription/browser-local-audio-transcription`
   - `/settings/providers/transcription/app-local-audio-transcription`
   - `/settings/providers/speech/browser-local-audio-speech`
   - `/settings/providers/speech/app-local-audio-speech`
3. Confirm pages render settings UI (not `Where are we?` fallback).
4. Run a quick playground interaction on one transcription page and one speech page.