### PR TITLE
feat(stage-tamagotchi): enable click-through on transparent canvas ar…

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -112,14 +112,12 @@ watch([isOutsideFor250Ms, isAroundWindowBorderFor250Ms, isOutsideWindow, isTrans
   }
   else {
     const fadeEnabled = fadeOnHoverEnabled.value
-    // Otherwise allow click-through while we fade UI based on transparency (when enabled)
-    isIgnoringMouseEvents.value = fadeEnabled
+    const shouldIgnore = fadeEnabled ? true : isTransparent.value
+
+    isIgnoringMouseEvents.value = shouldIgnore
     shouldFadeOnCursorWithin.value = fadeEnabled && !isOutsideWindow.value && !isTransparent.value
-    setIgnoreMouseEvents([fadeEnabled, { forward: true }])
-    if (fadeEnabled)
-      resume()
-    else
-      pause()
+    setIgnoreMouseEvents([shouldIgnore, { forward: true }])
+    resume()
   }
 })
 


### PR DESCRIPTION
## Description

This PR addresses an issue where transparent areas of the Canvas layer prevented pointer events from passing through. Although visually transparent, these regions still captured mouse interactions, which created misleading behavior during desktop presentation and interaction.

To improve usability and interaction clarity:

- Transparent Canvas regions are now configured to allow click-through behavior.
- Underlying interactive elements remain accessible even when covered by visually transparent UI layers.
- This prevents visual misinterpretation during desktop display where elements appear clickable but were previously blocked by the Canvas layer.

Overall, this change aligns visual transparency with actual interaction behavior and improves the overall desktop interaction experience.

## Linked Issues

N/A

## Additional Context

Reviewers may want to verify pointer event behavior on transparent Canvas regions and ensure underlying interaction areas remain fully functional.