### PR TITLE
feat(stage-tamagotchi): add always-on-top toggle IPC API

### DIFF
--- a/apps/stage-tamagotchi/src/main/windows/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/main/index.ts
@@ -143,18 +143,17 @@ export async function setupMainWindow(params: {
   // https://github.com/electron/electron/issues/10078#issuecomment-3410164802
   // https://stackoverflow.com/questions/39835282/set-browserwindow-always-on-top-even-other-app-is-in-fullscreen-electron-mac
   // Always on top - can be toggled via IPC
-  let alwaysOnTopEnabled = true // default enabled
-  window.setAlwaysOnTop(alwaysOnTopEnabled, 'screen-saver', 1)
+  // BrowserWindow is the single source of truth (no separate state variable)
+  window.setAlwaysOnTop(true, 'screen-saver', 1)
 
   // IPC handler for toggling always-on-top
   ipcMain.handle('window:set-always-on-top', (_event, enabled: boolean) => {
-    alwaysOnTopEnabled = enabled
     window.setAlwaysOnTop(enabled, 'screen-saver', 1)
     return enabled
   })
 
   ipcMain.handle('window:get-always-on-top', () => {
-    return alwaysOnTopEnabled
+    return window.isAlwaysOnTop()
   })
   window.setFullScreenable(false)
   window.setVisibleOnAllWorkspaces(true)

--- a/apps/stage-tamagotchi/src/preload/shared.ts
+++ b/apps/stage-tamagotchi/src/preload/shared.ts
@@ -5,8 +5,13 @@ import { contextIsolated, platform } from 'node:process'
 import { electronAPI } from '@electron-toolkit/preload'
 import { contextBridge, ipcRenderer } from 'electron'
 
-// Always-on-top window controls
-export const alwaysOnTopAPI = {
+// Always-on-top window controls API interface
+export interface AlwaysOnTopAPI {
+  set: (enabled: boolean) => Promise<boolean>
+  get: () => Promise<boolean>
+}
+
+export const alwaysOnTopAPI: AlwaysOnTopAPI = {
   set: (enabled: boolean) => ipcRenderer.invoke('window:set-always-on-top', enabled),
   get: () => ipcRenderer.invoke('window:get-always-on-top'),
 }


### PR DESCRIPTION
Implements #1159

## Changes
Added IPC API for toggling always-on-top mode:

### Main Process
- `window:set-always-on-top(enabled)` - Toggle always-on-top
- `window:get-always-on-top()` - Get current state

### Preload
- `window.alwaysOnTop.set(enabled)` - Set mode
- `window.alwaysOnTop.get()` - Get mode

## Default
Enabled (current behavior preserved)

## Usage
```typescript
// Renderer process
const enabled = await window.alwaysOnTop.get()
await window.alwaysOnTop.set(false) // Disable always-on-top
```

Note: UI toggle button can be added separately.