### PR TITLE
fix(discord): prevent VoiceManager memory leaks on join/leave cycles

### DIFF
--- a/services/discord-bot/src/bots/discord/commands/summon.ts
+++ b/services/discord-bot/src/bots/discord/commands/summon.ts
@@ -318,18 +318,18 @@ export class VoiceManager extends EventEmitter {
 
   leaveChannel(channel: BaseGuildVoiceChannel) {
     const connection = this.connections.get(channel.id)
-    const listeners = this.connectionListeners.get(channel.id)
-
-    if (connection && listeners) {
-      // Remove event listeners to prevent memory leaks
-      connection.off('stateChange', listeners.stateChange)
-      connection.off('error', listeners.error)
-      connection.receiver.speaking.off('start', listeners.speakingStart)
-      connection.receiver.speaking.off('end', listeners.speakingEnd)
-      this.connectionListeners.delete(channel.id)
-    }
 
     if (connection) {
+      // Remove event listeners to prevent memory leaks
+      const listeners = this.connectionListeners.get(channel.id)
+      if (listeners) {
+        connection.off('stateChange', listeners.stateChange)
+        connection.off('error', listeners.error)
+        connection.receiver.speaking.off('start', listeners.speakingStart)
+        connection.receiver.speaking.off('end', listeners.speakingEnd)
+        this.connectionListeners.delete(channel.id)
+      }
+
       connection.destroy()
       this.connections.delete(channel.id)
     }


### PR DESCRIPTION
Fixes #1202

## Problems

### 1. Event Listener Leaks
4 event listeners added on every join, never removed:
- `connection.on('stateChange', ...)`
- `connection.on('error', ...)`
- `connection.receiver.speaking.on('start', ...)`
- `connection.receiver.speaking.on('end', ...)`

Each join/leave cycle accumulates 4 more listeners → `MaxListenersExceeded` → OOM

### 2. Undefined State Access
`debouncedProcessTranscription` crashes when `userStates.get(userId)` returns undefined

## Fixes

1. **Added `connectionListeners` Map** - Track all listener references
2. **Save listeners on join** - Store references for later cleanup
3. **Remove listeners on leave** - Call `off()` before `destroy()`
4. **Added undefined check** - Prevent crash on timing edge case

## Impact
- ✅ No more memory growth on repeated join/leave
- ✅ No more MaxListenersExceeded warnings
- ✅ Prevents OOM on busy servers
- ✅ Fixes potential crash

## Testing
- Long-running bot with frequent join/leave cycles
- Monitor memory usage - should remain stable
- No MaxListenersExceeded warnings