### PR TITLE
fix(stage-ui): reset always-on-top via manual reset

### DIFF
--- a/packages/stage-ui/src/stores/settings/controls-island.ts
+++ b/packages/stage-ui/src/stores/settings/controls-island.ts
@@ -8,7 +8,7 @@ export const useSettingsControlsIsland = defineStore('settings-controls-island',
 
   function resetState() {
     allowVisibleOnAllWorkspaces.reset()
-    alwaysOnTop.value = true
+    alwaysOnTop.reset()
     controlsIslandIconSize.reset()
   }
 


### PR DESCRIPTION
## Summary
- use alwaysOnTop.reset() in settings reset flow
- align controls-island reset behavior with other manual-reset settings stores

## Validation
- pnpm -F @proj-airi/stage-ui typecheck
- pnpm lint:fix *(fails due existing unrelated repo-wide lint issues)*