### PR TITLE
fix(stage-pocket): use system mkcert to work around feaxios download crash

### DIFF
--- a/apps/stage-pocket/vite.config.ts
+++ b/apps/stage-pocket/vite.config.ts
@@ -97,7 +97,8 @@ export default defineConfig({
   plugins: [
     ...isEnvTruthy(process.env.VITE_SKIP_MKCERT ?? '') ? [] : [mkcert((() => {
       // Workaround: plugin's bundled downloader has a feaxios bug, prefer system mkcert
-      try { return { mkcertPath: execSync('which mkcert', { stdio: 'pipe' }).toString().trim() } }
+      const command = process.platform === 'win32' ? 'where' : 'which'
+      try { return { mkcertPath: execSync(`${command} mkcert`, { stdio: 'pipe' }).toString().trim().split(/\r?\n/)[0] } }
       catch { return {} }
     })())],
 


### PR DESCRIPTION
## Summary

When `vite-plugin-mkcert` attempts to download the mkcert binary on startup, it crashes with:

```
AxiosError: res[(options.responseType || "text")] is not a function
```

The root cause is a bug in `feaxios` (the fetch-based axios wrapper used by the plugin): it calls `res["arraybuffer"]()` but the Fetch API method is `res.arrayBuffer()` (camelCase). This causes any binary download to fail.

This commit works around the issue by preferring the system-installed `mkcert` binary (via `which mkcert`), bypassing the plugin's built-in downloader entirely. If no system mkcert is found, it falls back to the default plugin behavior.

## Upstream

- **feaxios fix**: https://github.com/divyam234/feaxios/pull/5
- **vite-plugin-mkcert issue**: https://github.com/liuweiGL/vite-plugin-mkcert/issues/118