### PR TITLE
feat(stage-tamagotchi): add top drag area to move window

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -333,24 +333,6 @@ watch([stream, () => vadLoaded.value], async ([s, loaded]) => {
     relative z-2 h-full overflow-hidden rounded-xl
     transition="opacity duration-500 ease-in-out"
   >
-    <!-- Drag area at top to move window -->
-    <Transition
-      enter-active-class="transition-opacity duration-250 ease-in-out"
-      enter-from-class="opacity-50"
-      enter-to-class="opacity-100"
-      leave-active-class="transition-opacity duration-250 ease-in-out"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-50"
-    >
-      <div v-if="showDragHint && !isLoading" class="pointer-events-none absolute left-0 top-0 z-10 h-12 w-full">
-        <div
-          :class="[
-            'b-primary/50',
-            'h-full w-full animate-flash animate-duration-3s animate-count-infinite b-t-4 rounded-t-2xl',
-          ]"
-        />
-      </div>
-    </Transition>
     <div
       v-show="!isLoading"
       absolute left-0 top-0 z-10 h-12 w-full


### PR DESCRIPTION
## Description

Added a draggable area at the top of the window to allow users to move the entire application window by dragging.

## Key Changes

- Added a **48px height draggable area** at the top of the window
- Shows a **flashing border hint** on mouse hover
- Supports **Windows/macOS** (via `startDraggingWindow` API)
- Supports **Linux** (via `drag-region` CSS class)

## User Experience

- Border hint appears when hovering over the top area
- Flash animation matches the existing window border hint style
- Dragging the area moves the entire application window

## Linked Issues
When resizing the window from the edges, the drag button and setting button may occasionally be shifted outside the visible screen area.
<img width="938" height="761" alt="issue1" src="https://github.com/user-attachments/assets/c40af300-2bc1-4c6c-993d-3b18e37b5e31" />

The window can be moved back into the visible screen area by dragging it from the top draggable area.


## Additional Context

The implementation follows the existing **window border hint styling** to maintain UI consistency.  
Linux systems use the `drag-region` CSS class as an alternative due to Electron API limitations.