### PR TITLE
fix(stage-ui): prevent tooltip from blocking button interaction

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/control-button-tooltip.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/control-button-tooltip.vue
@@ -22,7 +22,7 @@ const { side = 'top' } = defineProps<{
             'bg-neutral-50/80 dark:bg-neutral-800/70',
             'w-fit flex items-center self-end justify-center px-1.5 py-1',
             'rounded-lg backdrop-blur-md',
-            'text-xs',
+            'text-xs pointer-events-none',
           ]"
           :side="side"
           :side-offset="4"


### PR DESCRIPTION
## Summary

Closes #1236 — Tooltip overlays no longer intercept mouse events or block adjacent button interactions.

### Problem

On the Stage interface, hovering over a control button (e.g. microphone) shows a tooltip. When the cursor moves off the button onto the tooltip, the tooltip stays open because it captures `mouseenter` events. This also blocks interaction with buttons positioned behind the tooltip.

### Fix

Add `pointer-events-none` (UnoCSS utility) to the `TooltipContent` element so the tooltip is purely visual and does not intercept any mouse events.

### Changes

| File | Change |
|------|--------|
| `apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/control-button-tooltip.vue` | Add `pointer-events-none` class to `TooltipContent` |

One-line change, zero risk.