### PR TITLE
fix(stage-tamagotchi): patch startup and onboarding regressions

### DIFF
--- a/apps/stage-tamagotchi/electron-builder.config.ts
+++ b/apps/stage-tamagotchi/electron-builder.config.ts
@@ -75,6 +75,13 @@ export default {
     '!**/node_modules/**/{CHANGELOG.md,README.md,README,readme.md,readme}',
     '!**/node_modules/**/{.turbo,test,src,__tests__,tests,example,examples}',
     '**/node_modules/debug/**/*',
+    // NOTICE: h3@2.x resolves rou3 at runtime from its distributed ESM entry.
+    // Electron Builder misses this transitive dependency in the packaged app under pnpm,
+    // which makes released Windows builds fail at startup with:
+    // `Cannot find package 'rou3' imported from ...\\node_modules\\h3\\dist\\*.mjs`.
+    // Keep h3/rou3 explicitly included until upstream packaging reliably preserves them.
+    '**/node_modules/h3/**/*',
+    '**/node_modules/rou3/**/*',
     '**/node_modules/superjson/**/*',
     '!electron.vite.config.{js,ts,mjs,cjs}',
     '!vite.config.{js,ts,mjs,cjs}',

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -104,8 +104,22 @@ function removeAttachment(index: number) {
 }
 
 watch([activeProvider, activeModel], async () => {
-  if (activeProvider.value && activeModel.value) {
-    await discoverToolsCompatibility(activeModel.value, await providersStore.getProviderInstance<ChatProvider>(activeProvider.value), [])
+  if (!activeProvider.value || !activeModel.value) {
+    return
+  }
+
+  try {
+    await discoverToolsCompatibility(
+      activeModel.value,
+      await providersStore.getProviderInstance<ChatProvider>(activeProvider.value),
+      [],
+    )
+  }
+  catch (error) {
+    // NOTICE: Capability discovery is a best-effort warm-up. Some providers/models
+    // can fail this probe during onboarding completion, and letting that rejection
+    // escape can take down the stage renderer right after setup.
+    console.error('[InteractiveArea] Failed to discover tools compatibility:', error)
   }
 }, { immediate: true })
 

--- a/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-model-selection.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-model-selection.vue
@@ -26,7 +26,7 @@ const {
 </script>
 
 <template>
-  <div h-full flex flex-col gap-4>
+  <div h-full min-h-0 flex flex-col gap-4>
     <div sticky top-0 z-100 flex flex-shrink-0 items-center gap-2>
       <button outline-none @click="props.onPrevious">
         <div i-solar:alt-arrow-left-line-duotone h-5 w-5 />
@@ -38,7 +38,7 @@ const {
     </div>
 
     <!-- Using the new RadioCardManySelect component -->
-    <div flex flex-1 flex-col gap-4>
+    <div min-h-0 flex flex-1 flex-col gap-4>
       <Alert
         v-if="providerModels.length === 0 && !isLoadingActiveProviderModels"
         type="error"
@@ -53,30 +53,40 @@ const {
         </template>
       </Alert>
 
-      <RadioCardManySelect
-        v-model="activeModel"
-        v-model:search-query="modelSearchQuery"
-        :items="providerModels.toSorted((a, b) => a.id === activeModel ? -1 : b.id === activeModel ? 1 : 0)"
-        :searchable="true"
-        :allow-custom="true"
-        :search-placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.search_placeholder')"
-        :search-no-results-title="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.no_search_results')"
-        :search-no-results-description="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.no_search_results_description', { query: modelSearchQuery })"
-        :search-results-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.search_results', { count: '{count}', total: '{total}' })"
-        :custom-input-placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.custom_model_placeholder')"
-        :expand-button-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.expand')"
-        :collapse-button-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.collapse')"
-        list-class="max-h-[calc(100dvh-17rem)] sm:max-h-120 overflow-y-auto"
-      />
+      <div min-h-0 flex-1>
+        <RadioCardManySelect
+          v-model="activeModel"
+          v-model:search-query="modelSearchQuery"
+          :items="providerModels.toSorted((a, b) => a.id === activeModel ? -1 : b.id === activeModel ? 1 : 0)"
+          :searchable="true"
+          :allow-custom="true"
+          :search-placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.search_placeholder')"
+          :search-no-results-title="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.no_search_results')"
+          :search-no-results-description="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.no_search_results_description', { query: modelSearchQuery })"
+          :search-results-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.search_results', { count: '{count}', total: '{total}' })"
+          :custom-input-placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.custom_model_placeholder')"
+          :expand-button-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.expand')"
+          :collapse-button-text="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.collapse')"
+          list-class="max-h-[calc(100dvh-20rem)] sm:max-h-100 overflow-y-auto"
+        />
+      </div>
     </div>
 
     <!-- Action Buttons -->
-    <Button
-      variant="primary"
-      :disabled="!activeModel"
-      :loading="isLoadingActiveProviderModels"
-      :label="t('settings.dialogs.onboarding.saveAndContinue')"
-      @click="props.onNext"
-    />
+    <div
+      :class="[
+        'sticky bottom-0 z-20 -mx-3 px-3 pt-3 pb-2',
+        'bg-gradient-to-t from-white via-white to-white/85',
+        'dark:from-[#0f0f0f] dark:via-[#0f0f0f] dark:to-[#0f0f0f]/85',
+      ]"
+    >
+      <Button
+        variant="primary"
+        :disabled="!activeModel"
+        :loading="isLoadingActiveProviderModels"
+        :label="t('settings.dialogs.onboarding.saveAndContinue')"
+        @click="props.onNext"
+      />
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Fixes [#1249](https://github.com/moeru-ai/airi/issues/1249) and also addresses two related onboarding regressions in `stage-tamagotchi`.

Changes included:
- include `h3` and `rou3` explicitly in the packaged desktop app so Windows release builds no longer fail at startup with `ERR_MODULE_NOT_FOUND`
- keep onboarding model selection usable when the model list is expanded by preventing the sticky action button from being pushed out of view
- make post-onboarding tool compatibility discovery best-effort so a failed probe does not take down the renderer right after setup

## Details

### Desktop startup packaging
Recent Windows release builds can fail during startup with an error like:

`Cannot find package 'rou3' imported from ...\\node_modules\\h3\\dist\\*.mjs`

This happens because `h3` resolves `rou3` at runtime, but the packaged app did not reliably include that dependency under the current Electron Builder + pnpm setup.

This PR explicitly includes both `h3` and `rou3` in the desktop package.

### Onboarding model selection layout
When the onboarding model selector is expanded, the `Save and Continue` button can be pushed out of view.

This PR keeps the list area shrinkable/scrollable and pins the action button in a sticky bottom section so the flow stays usable.

### Renderer stability after onboarding
After selecting a model, the renderer may immediately run a compatibility discovery probe.

This PR wraps that probe in error handling so provider/model-specific probe failures do not crash the stage renderer.

## Testing

Tested locally with:
- `pnpm lint:fix`
- `pnpm typecheck`
- desktop packaging with `electron-builder --dir`
- launching the unpacked Windows app and confirming it stays alive
- manually verifying the onboarding model selection layout

## Notes

`pnpm lint:fix` and `pnpm typecheck` still report unrelated existing issues in the current repository state, including:
- `packages/server-runtime`
- `services/minecraft`

These failures were not introduced by this PR.
