### PR TITLE
chore(ci): added Scoop bucket manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@
   </a>
 </p>
 
+> [!TIP]
+> On Windows, you can also install AIRI with [Scoop](https://scoop.sh/):
+>
+> ```powershell
+> scoop bucket add airi https://github.com/moeru-ai/airi
+> scoop install airi/airi
+> ```
+
 <p align="center">
   <a href="https://www.producthunt.com/products/airi?embed=true&utm_source=badge-featured&utm_medium=badge&utm_source=badge-airi" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=993524&theme=neutral&t=1752696535380" alt="AIRI - A&#0032;container&#0032;of&#0032;cyber&#0032;living&#0032;souls&#0044;&#0032;re&#0045;creation&#0032;of&#0032;Neuro&#0045;sama | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
   <a href="https://trendshift.io/repositories/14636" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14636" alt="moeru-ai%2Fairi | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>

--- a/bucket/airi.json
+++ b/bucket/airi.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.9.0-alpha.12",
+  "description": "A self-hosted AI companion desktop app with voice chat and game integrations",
+  "homepage": "https://airi.moeru.ai/",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/moeru-ai/airi/releases/download/v0.9.0-alpha.12/AIRI-0.9.0-alpha.12-windows-x64-setup.exe#/dl.7z",
+      "hash": "cf4698c7c483ce58e81e05b08a5015a753243e79c54aa2e4baec81c92041e5a7"
+    }
+  },
+  "extract_dir": "$PLUGINSDIR",
+  "pre_install": [
+    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+    "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse"
+  ],
+  "shortcuts": [
+    [
+      "airi.exe",
+      "AIRI"
+    ]
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/moeru-ai/airi/releases/download/v$version/AIRI-$version-windows-x64-setup.exe#/dl.7z"
+      }
+    },
+    "hash": {
+      "url": "$baseurl/latest.yml",
+      "regex": "sha512:\\s$base64"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Scoop bucket manifest for the Windows desktop release
- extract the packaged Electron app from the NSIS installer using the standard Scoop `#/dl.7z` pattern
- document the Scoop install flow in the main README

## Testing
- `python3 -m json.tool bucket/airi.json >/dev/null`

Closes #1210