### PR TITLE
fix: bundle rou3 for Windows desktop runtime

### DIFF
--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -115,6 +115,7 @@
     "reka-ui": "^2.8.2",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "rou3": "^0.7.12",
     "shiki": "^3.23.0",
     "splitpanes": "catalog:",
     "std-env": "^4.0.0-rc.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,6 +1139,9 @@ importers:
       h3:
         specifier: ^2.0.1-rc.14
         version: 2.0.1-rc.14(crossws@0.4.4(srvx@0.11.8(patch_hash=c761d25a70e22a0925c88fe91a9dd1c3153dd341d8fd4f260166678156c4df2d)))
+      rou3:
+        specifier: ^0.7.12
+        version: 0.7.12
       injeca:
         specifier: 'catalog:'
         version: 0.1.8(@guiiai/logg@1.2.11)(error-stack-parser@2.1.4)(nanoid@5.1.6)


### PR DESCRIPTION
## Description

Adds `rou3` as an explicit Stage Tamagotchi runtime dependency so the packaged desktop app ships the router module that `h3` expects at runtime. This targets the Alpha 12 Windows launch failure where the app errors on missing package `rou3`.

## Linked Issues

Closes #1249

## Additional Context

Verification:
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @proj-airi/stage-tamagotchi exec node --input-type=module -e "await import('h3'); await import('rou3'); console.log('resolved runtime deps for stage-tamagotchi')"`

I also tried `typecheck:node`, but the current branch has unrelated pre-existing workspace resolution/type errors in Stage Tamagotchi, so I did not include that as a blocker for this packaging-only fix.