### PR TITLE
feat: port scrolllock microphone toggle service

### DIFF
--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -171,7 +171,11 @@ app.whenReady().then(async () => {
 
   injeca.invoke({
     dependsOn: { mainWindow, tray, serverChannel, pluginHost, mcpStdioManager, onboardingWindow: onboardingWindowManager },
-    callback: noop,
+    callback: (deps) => {
+      import('./services/shortcuts/mic-toggle').then((m) => {
+        m.setupMicToggleShortcut(deps.mainWindow)
+      })
+    },
   })
 
   injeca.start().catch(err => console.error(err))

--- a/apps/stage-tamagotchi/src/main/services/shortcuts/mic-toggle.ts
+++ b/apps/stage-tamagotchi/src/main/services/shortcuts/mic-toggle.ts
@@ -1,0 +1,74 @@
+import type { BrowserWindow } from 'electron'
+
+import { spawn } from 'node:child_process'
+
+import { ipcMain } from 'electron'
+
+let powershellProcess: ReturnType<typeof spawn> | null = null
+let currentMicState = false
+let currentLEDState = false
+
+export function setupMicToggleShortcut(mainWindow: BrowserWindow) {
+  // 1. Start PowerShell script to monitor Scroll Lock LED state
+  const psScript = `
+    Add-Type -AssemblyName System.Windows.Forms
+    $state = [System.Windows.Forms.Control]::IsKeyLocked('Scroll')
+    Write-Host "SCROLLLOCK_STATE:$state"
+    while ($true) {
+      Start-Sleep -Milliseconds 100
+      $newState = [System.Windows.Forms.Control]::IsKeyLocked('Scroll')
+      if ($newState -ne $state) {
+        $state = $newState
+        Write-Host "SCROLLLOCK_STATE:$state"
+      }
+    }
+  `
+
+  powershellProcess = spawn('powershell', ['-NoProfile', '-NonInteractive', '-Command', psScript], {
+    windowsHide: true,
+  })
+
+  powershellProcess.stdout?.on('data', (data) => {
+    const output = data.toString()
+    if (output.includes('SCROLLLOCK_STATE:True')) {
+      currentLEDState = true
+      // If the user hit the key, the LED is now True. If the mic is off, turn it on.
+      if (!currentMicState) {
+        mainWindow.webContents.send('toggle-mic-from-shortcut')
+      }
+    }
+    else if (output.includes('SCROLLLOCK_STATE:False')) {
+      currentLEDState = false
+      // If the user hit the key, the LED is now False. If the mic is on, turn it off.
+      if (currentMicState) {
+        mainWindow.webContents.send('toggle-mic-from-shortcut')
+      }
+    }
+  })
+
+  // 2. Listen to renderer state changes for the mic
+  // If the user clicks the UI button, we need to sync the LED to match the new mic state.
+  ipcMain.on('mic-state-changed', (_event, micEnabled: boolean, deviceName?: string) => {
+    console.log(`[Mic Toggle] State changed: ${micEnabled ? 'ENABLED' : 'DISABLED'} | Device: ${deviceName || 'Unknown'}`)
+    currentMicState = micEnabled
+    if (micEnabled !== currentLEDState) {
+      // Toggle the Scroll Lock LED via SendKeys
+      // This will trigger the PS script to see a state change, which emits SCROLLLOCK_STATE
+      // but since micEnabled will match currentLEDState after, it won't trigger another toggle.
+      const syncScript = `
+        $wsh = New-Object -ComObject WScript.Shell
+        $wsh.SendKeys('{SCROLLLOCK}')
+      `
+      spawn('powershell', ['-NoProfile', '-NonInteractive', '-Command', syncScript], {
+        windowsHide: true,
+      })
+    }
+  })
+}
+
+export function cleanupMicToggleShortcut() {
+  if (powershellProcess) {
+    powershellProcess.kill()
+    powershellProcess = null
+  }
+}

--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -292,6 +292,10 @@ function stopAudioInteraction() {
 }
 
 watch(enabled, async (val) => {
+  if (window.electron?.ipcRenderer) {
+    window.electron.ipcRenderer.send('mic-state-changed', val, settingsAudioDeviceStore.selectedAudioInputLabel)
+  }
+
   console.info('[Main Page] Audio enabled changed:', val, 'stream available:', !!stream.value)
   if (val) {
     await askPermission()
@@ -310,6 +314,13 @@ watch([() => onboardingStore.shouldShowSetup], ([shouldShowSetup]) => {
 
 onMounted(() => {
   onboardingStore.initializeSetupCheck()
+
+  if (window.electron?.ipcRenderer) {
+    window.electron.ipcRenderer.on('toggle-mic-from-shortcut', () => {
+      console.info('[Main Page] Toggling mic from shortcut')
+      settingsAudioDeviceStore.enabled = !settingsAudioDeviceStore.enabled
+    })
+  }
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
### [Port] ScrollLock Microphone Toggle

This PR introduces hardware-based microphone toggling using the Scroll Lock LED state.

#### Key Changes
- **Service Layer:** Created `mic-toggle.ts` which uses a PowerShell script to monitor the Scroll Lock LED state.
- - **Main Process Integration:** Integrated the service into the Electron main process for system-wide monitoring.
- - **Renderer Integration:** Updated the main UI (`index.vue`) to listen for `toggle-mic-from-shortcut` IPC events and update the microphone state accordingly.