### PR TITLE
fix(stage-ui): keep nested reasoning out of speech

### DIFF
--- a/packages/stage-ui/src/composables/response-categoriser.test.ts
+++ b/packages/stage-ui/src/composables/response-categoriser.test.ts
@@ -88,18 +88,9 @@ describe('createStreamingCategorizer', () => {
     categorizer.consume(text)
     const result = categorizer.end()
 
-    // Both tags should be extracted
     expect(result.segments.length).toBeGreaterThan(0)
-    // Speech should exclude tag content
-    // Note: rehype handles nested tags by extracting both, but the speech extraction
-    // may include text between nested tags or closing tag text
-    // The important thing is that the main tag content (inner, outer text) is in reasoning
-    expect(result.speech).toContain('Start')
-    expect(result.speech).toContain('end')
-    // Tag content should be in reasoning, not speech
+    expect(result.speech).toBe('Start end')
     expect(result.reasoning).toContain('inner')
-    // The exact speech format may vary with nested tags, but should not contain the main tag content
-    expect(result.speech).not.toContain('inner')
   })
 
   it('should correctly identify speech positions with isSpeechAt', () => {

--- a/packages/stage-ui/src/composables/response-categoriser.ts
+++ b/packages/stage-ui/src/composables/response-categoriser.ts
@@ -179,7 +179,7 @@ export function categorizeResponse(
         speechParts.push(text)
       }
     }
-    lastEnd = segment.endIndex
+    lastEnd = Math.max(lastEnd, segment.endIndex)
   }
 
   // Add remaining text after last segment


### PR DESCRIPTION
## Summary

- stop nested reasoning tags from rewinding the speech cursor in `categorizeResponse()`, which could leak tagged content back into the speech/TTS channel
- tighten the nested-tag regression in `response-categoriser.test.ts` to assert the exact speech contract (`Start end`)
- keep the patch isolated to `packages/stage-ui`, separate from the already-open AIRI plugin-sdk and other stage-ui lines

## Validation

- `pnpm -F @proj-airi/stage-ui exec vitest run src/composables/response-categoriser.test.ts`
- `pnpm -F @proj-airi/stage-ui typecheck`
- `pnpm lint:fix -- packages/stage-ui/src/composables/response-categoriser.ts packages/stage-ui/src/composables/response-categoriser.test.ts` *(root lint still reports unrelated pre-existing monorepo errors outside the touched files)*