### PR TITLE
fix(plugin-sdk): preserve absolute plugin entrypoints

### DIFF
--- a/packages/plugin-sdk/src/plugin-host/core.test.ts
+++ b/packages/plugin-sdk/src/plugin-host/core.test.ts
@@ -116,6 +116,22 @@ describe('for FileSystemPluginHost', () => {
     })).toBe('/tmp/plugin/electron-entry.ts')
   })
 
+  it('should preserve absolute runtime entrypoints', () => {
+    const host = new FileSystemLoader()
+
+    expect(host.resolveEntrypointFor({
+      apiVersion: 'v1',
+      kind: 'manifest.plugin.airi.moeru.ai',
+      name: 'test-plugin',
+      entrypoints: {
+        node: '/opt/plugins/entry.ts',
+      },
+    }, {
+      cwd: '/tmp/plugin',
+      runtime: 'node',
+    })).toBe('/opt/plugins/entry.ts')
+  })
+
   it('should throw deterministic error when no runtime entrypoint exists', () => {
     const host = new FileSystemLoader()
 

--- a/packages/plugin-sdk/src/plugin-host/core.ts
+++ b/packages/plugin-sdk/src/plugin-host/core.ts
@@ -13,7 +13,7 @@ import type { CapabilityDescriptor } from '../plugin/apis/protocol'
 import type { Plugin } from '../plugin/shared'
 import type { PluginTransport } from './transports'
 
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import { cwd } from 'node:process'
 
 import { defineInvokeHandler } from '@moeru/eventa'
@@ -1080,7 +1080,7 @@ export class FileSystemLoader {
       )
     }
 
-    return join(root, entrypoint)
+    return isAbsolute(entrypoint) ? entrypoint : join(root, entrypoint)
   }
 
   /**


### PR DESCRIPTION
## Summary

- preserve absolute manifest entrypoints in `FileSystemLoader.resolveEntrypointFor()` instead of joining them back onto the current working directory
- add a focused plugin-host regression that proves absolute runtime entrypoints stay absolute
- keep the patch isolated to `packages/plugin-sdk`, away from the active stage-ui AIRI PR lines

## Validation

- `pnpm -F @proj-airi/plugin-sdk exec vitest run src/plugin-host/core.test.ts`
- `pnpm -F @proj-airi/plugin-sdk typecheck`
- `pnpm lint:fix -- packages/plugin-sdk/src/plugin-host/core.ts packages/plugin-sdk/src/plugin-host/core.test.ts` *(still reports unrelated pre-existing monorepo lint errors elsewhere, but the touched package tests/typecheck pass)*