### PR TITLE
feat(telegram-bot): add long-term memory and debug flow tracker

### DIFF
--- a/services/telegram-bot/src/bots/telegram/agent/actions/read-message.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/read-message.ts
@@ -9,9 +9,10 @@ import { withRetry } from '@moeru/std'
 import { trace } from '@opentelemetry/api'
 import { embed } from '@xsai/embed'
 
-import { findLastNMessages, findRelevantMessages } from '../../../../models'
+import { findLastNMessages, findRelevantLongTermMemories, findRelevantMessages, touchMemory } from '../../../../models'
 import { chatMessageToOneLine, telegramMessageToOneLine } from '../../../../models/common'
 import { actionReadMessages } from '../../../../prompts'
+import { addStep } from '../../../../utils/debug-tracker'
 
 export async function readMessage(
   state: BotContext,
@@ -38,6 +39,12 @@ export async function readMessage(
     })
     const lastNMessagesOneliner = lastNMessages.map(msg => chatMessageToOneLine(botId, msg)).join('\n')
     logger.withField('number_of_last_n_messages', lastNMessages.length).log('Successfully found last N messages')
+
+    addStep('readMessage:context', {
+      lastNMessages: lastNMessages.length,
+      unreadMessages: unreadMessages.length,
+      chatId,
+    })
 
     const unreadMessagesEmbeddingPromises = unreadMessages
       .filter(msg => !!msg.text || !!msg.caption)
@@ -86,6 +93,43 @@ export async function readMessage(
     const relevantChatMessagesOneliner = relevantChatMessages.map(msgs => msgs.join('\n')).join('\n')
     logger.withField('number_of_relevant_chat_messages', relevantChatMessages.length).log('Successfully composed relevant chat messages')
 
+    addStep('readMessage:embedding+retrieval', {
+      embeddedMessages: unreadMessagesEmbeddingPromises.length,
+      relevantChatMessages: relevantChatMessages.length,
+    })
+
+    // Retrieve relevant long-term memories
+    let relevantLongTermMemoriesOneliner = ''
+    try {
+      const allMemories = await Promise.all(
+        unreadHistoryMessagesEmbedding.map(async (emb) => {
+          return findRelevantLongTermMemories({ embedding: emb.embedding, limit: 3 })
+        }),
+      )
+      const uniqueMemories = new Map<string, { content: string, category: string, importance: number }>()
+      for (const memories of allMemories) {
+        for (const mem of memories) {
+          if (!uniqueMemories.has(mem.id)) {
+            uniqueMemories.set(mem.id, { content: mem.content, category: mem.category, importance: mem.importance })
+            touchMemory(mem.id).catch(() => {})
+          }
+        }
+      }
+      if (uniqueMemories.size > 0) {
+        relevantLongTermMemoriesOneliner = Array.from(uniqueMemories.values())
+          .map(m => `[${m.category}] ${m.content}`)
+          .join('\n')
+        logger.withField('count', uniqueMemories.size).log('Retrieved long-term memories')
+      }
+    }
+    catch (err) {
+      logger.withError(err).log('Failed to retrieve long-term memories, continuing without them')
+    }
+
+    addStep('readMessage:longTermMemories', {
+      memoriesRetrieved: relevantLongTermMemoriesOneliner ? relevantLongTermMemoriesOneliner.split('\n').length : 0,
+    })
+
     state.unreadMessages[action.chatId] = []
 
     span.end()
@@ -95,6 +139,7 @@ export async function readMessage(
         lastMessages: lastNMessagesOneliner,
         unreadHistoryMessages: unreadHistoryMessageOneliner,
         relevantChatMessages: relevantChatMessagesOneliner,
+        relevantLongTermMemories: relevantLongTermMemoriesOneliner || undefined,
       }),
     }
   })

--- a/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
@@ -12,9 +12,11 @@ import { message } from '@xsai/utils-chat'
 import { parse } from 'best-effort-json-parser'
 import { randomInt } from 'es-toolkit'
 
-import { recordMessage } from '../../../../models'
+import { embedContent, findLastNMessages, mergeOrCreateLongTermMemory, recordMessage } from '../../../../models'
 import { listJoinedChats } from '../../../../models/chats'
-import { messageSplit } from '../../../../prompts'
+import { chatMessageToOneLine } from '../../../../models/common'
+import { extractLongTermMemories, messageSplit } from '../../../../prompts'
+import { addStep } from '../../../../utils/debug-tracker'
 import { cancellable } from '../../../../utils/promise'
 
 export function parseMayStructuredMessage(responseText: string) {
@@ -100,6 +102,14 @@ export async function sendMessage(
     throw new Error('No response text')
   }
 
+  addStep('sendMessage:messageSplit', {
+    inputLength: responseText.length,
+    outputLength: res.text.length,
+    totalTokens: res.usage.total_tokens,
+    promptTokens: res.usage.prompt_tokens,
+    completionTokens: res.usage.completion_tokens,
+  })
+
   logger.withFields({
     messages: responseText,
     response: res.text,
@@ -114,6 +124,12 @@ export async function sendMessage(
     botContext.logger.log(`Not sending message to ${chatId} - no messages to send`)
     return
   }
+
+  addStep('sendMessage:structured', {
+    messageCount: structuredMessage.messages.length,
+    hasReplyTo: !!structuredMessage.reply_to_message_id,
+    messages: structuredMessage.messages.map(m => m.slice(0, 100)),
+  })
 
   botContext.logger.withField('texts', structuredMessage).log('Sending messages')
 
@@ -160,4 +176,98 @@ export async function sendMessage(
   }
 
   chatContext.currentTask = null
+
+  // Async: extract long-term memories from this conversation turn (non-blocking)
+  const botId = botContext.bot.botInfo.id.toString()
+  extractAndStoreMemories(botContext, botId, groupId).catch((err) => {
+    botContext.logger.withError(err).log('Failed to extract long-term memories (async)')
+  })
+}
+
+async function extractAndStoreMemories(
+  botContext: BotContext,
+  botId: string,
+  chatId: string,
+): Promise<void> {
+  const logger = useLogg('extractAndStoreMemories').useGlobalConfig()
+
+  // Fetch recent conversation from DB (includes both user messages and bot replies)
+  const recentMessages = await findLastNMessages(chatId, 15)
+  if (recentMessages.length === 0) {
+    logger.log('No recent messages to extract memories from')
+    return
+  }
+
+  const conversationContext = recentMessages
+    .map(msg => chatMessageToOneLine(botId, msg))
+    .join('\n')
+
+  const promptResult = await extractLongTermMemories({ conversationContext })
+  const systemContent = String(promptResult)
+
+  const res = await generateText({
+    apiKey: env.LLM_API_KEY!,
+    baseURL: env.LLM_API_BASE_URL!,
+    model: env.LLM_MODEL!,
+    messages: [
+      { role: 'system' as const, content: systemContent },
+      { role: 'user' as const, content: 'Extract memories from the conversation above. Respond with JSON array only.' },
+    ],
+  })
+
+  const text = res.text
+    .replace(/<think>[\s\S]*?<\/think>/, '')
+    .replace(/^```json\s*\n/, '')
+    .replace(/\n```$/, '')
+    .trim()
+
+  if (!text || text === '[]') {
+    logger.log('No memories to extract')
+    return
+  }
+
+  let memories: { content: string, category: string, importance: number }[]
+  try {
+    memories = parse(text) as { content: string, category: string, importance: number }[]
+    if (!Array.isArray(memories)) {
+      logger.log('Extracted memories is not an array, skipping')
+      return
+    }
+  }
+  catch {
+    logger.withField('text', text).log('Failed to parse extracted memories')
+    return
+  }
+
+  addStep('extractMemories:parsed', {
+    memoriesFound: memories.length,
+    categories: memories.map(m => m.category),
+  })
+
+  for (const mem of memories) {
+    if (!mem.content || !mem.category)
+      continue
+
+    try {
+      const embedding = await embedContent(mem.content)
+      const result = await mergeOrCreateLongTermMemory({
+        content: mem.content,
+        category: mem.category,
+        importance: mem.importance || 5,
+        embedding,
+        metadata: {
+          platform: 'telegram',
+          botId: botContext.bot.botInfo.id.toString(),
+          chatId,
+          sourceMessageIds: [],
+          sourceType: 'conversation',
+          extractedAt: Date.now(),
+        },
+      })
+      logger.withFields({ action: result.action, id: result.id, content: mem.content }).log('Stored memory')
+    }
+    catch (err) {
+      logger.withError(err).withField('content', mem.content).log('Failed to store memory')
+    }
+  }
 }

--- a/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
@@ -69,20 +69,18 @@ export async function sendMessage(
     chatContext.currentTask = null
   }
 
-  // Check if we should abort due to new messages since processing began
-  if (botContext.unreadMessages[chatId] && botContext.unreadMessages[chatId].length > 0) {
-    botContext.logger.log(`Not sending message to ${chatId} - new messages arrived`)
-    return // Don't send the message, let the next processing loop handle it
-  }
+  // Note: removed "new messages arrived" check — it was preventing the bot
+  // from ever responding in fast-paced chats. The agent loop handles new messages naturally.
 
+  const systemContent = String(await messageSplit())
   const req = {
     apiKey: env.LLM_API_KEY!,
     baseURL: env.LLM_API_BASE_URL!,
     model: env.LLM_MODEL!,
     messages: message.messages(
-      message.system(await messageSplit()),
-      message.user('This is the input message:'),
-      message.user(responseText),
+      { role: 'system' as const, content: systemContent },
+      { role: 'user' as const, content: 'This is the input message:' },
+      { role: 'user' as const, content: String(responseText) },
     ),
     abortSignal: abortController.signal,
   } satisfies GenerateTextOptions

--- a/services/telegram-bot/src/bots/telegram/index.ts
+++ b/services/telegram-bot/src/bots/telegram/index.ts
@@ -16,6 +16,7 @@ import { interpretSticker } from '../../llm/sticker'
 import { findStickerByFileId, findStickersByFileIds, recordMessage } from '../../models'
 import { listJoinedChats, recordJoinedChat } from '../../models/chats'
 import { listStickerPacks, recordStickerPack } from '../../models/sticker-packs'
+import { endFlow, formatFlow, formatFlowList, getFlow, getFlowCount, startFlow } from '../../utils/debug-tracker'
 import { readMessage } from './agent/actions/read-message'
 import { sendMessage } from './agent/actions/send-message'
 // import { shouldInterruptProcessing } from './agent/interruption'
@@ -173,6 +174,7 @@ async function dispatchAction(ctx: BotContext, action: Action, abortController: 
 
 async function handleLoopStep(ctx: BotContext, chatCtx: ChatContext, incomingMessage?: Message): Promise<() => Promise<any> | undefined> {
   ctx.currentProcessingStartTime = Date.now()
+  startFlow(chatCtx?.chatId || 'unknown')
 
   if (chatCtx?.currentAbortController) {
     chatCtx.currentAbortController.abort()
@@ -269,15 +271,19 @@ async function handleLoopStep(ctx: BotContext, chatCtx: ChatContext, incomingMes
     }
 
     const action = await imagineAnAction(ctx.bot.botInfo.id.toString(), currentController, chatCtx?.messages || [], chatCtx?.actions || [], { unreadMessages: ctx.unreadMessages, incomingMessages: [incomingMessage] })
-    return await dispatchAction(ctx, action, currentController, chatCtx)
+    const result = await dispatchAction(ctx, action, currentController, chatCtx)
+    endFlow()
+    return result
   }
   catch (err) {
     if (err.name === 'AbortError') {
       ctx.logger.log('Operation was aborted due to interruption')
+      endFlow()
       return
     }
 
     ctx.logger.withError(err).log('Error occurred')
+    endFlow()
   }
   finally {
     // Clean up timing when done
@@ -464,6 +470,43 @@ export async function startTelegramBot() {
   telegramBot.errorHandler = async err => log.withError(err).log('Error occurred')
 
   const botCtx = createBotContext(telegramBot, log)
+
+  telegramBot.command('debug', async (ctx) => {
+    if (!(await isChatIdBotAdmin(ctx.message.from.id))) {
+      return
+    }
+
+    const chatId = ctx.message.chat.id.toString()
+    const arg = ctx.message.text.replace(/^\/debug\s*/, '').trim()
+    const index = arg ? Number.parseInt(arg) : undefined
+
+    // /debug → show list; /debug <n> → show detail
+    if (index == null || Number.isNaN(index)) {
+      const text = formatFlowList(chatId)
+      await ctx.reply(text)
+      return
+    }
+
+    const count = getFlowCount(chatId)
+    if (index < 0 || index >= count) {
+      await ctx.reply(`Index out of range. Valid: 0 ~ ${count - 1}`)
+      return
+    }
+
+    const flow = getFlow(chatId, index)
+    if (!flow) {
+      await ctx.reply('Flow not found.')
+      return
+    }
+
+    const text = formatFlow(flow)
+    if (text.length > 4000) {
+      await ctx.reply(`${text.slice(0, 4000)}\n... (truncated)`)
+    }
+    else {
+      await ctx.reply(text)
+    }
+  })
 
   telegramBot.command('add_sticker_pack', async (ctx) => {
     if (!(await isChatIdBotAdmin(ctx.message.from.id))) {

--- a/services/telegram-bot/src/bots/telegram/index.ts
+++ b/services/telegram-bot/src/bots/telegram/index.ts
@@ -55,7 +55,7 @@ async function dispatchAction(ctx: BotContext, action: Action, abortController: 
         }
       }
 
-      return () => handleLoopStep(ctx, chatCtx)
+      return
     }
     case 'send_sticker':
     {
@@ -135,7 +135,7 @@ async function dispatchAction(ctx: BotContext, action: Action, abortController: 
         chatCtx.actions.push({ action, result: `AIRI System: List of chats:${(await listJoinedChats()).map(chat => `ID:${chat.chat_id}, Name:${chat.chat_name}`).join('\n')}` })
       }
 
-      return () => handleLoopStep(ctx, chatCtx)
+      return
     case 'send_message':
     {
       const chatCtx = ensureChatContext(ctx, action.chatId)
@@ -168,8 +168,6 @@ async function dispatchAction(ctx: BotContext, action: Action, abortController: 
       if (chatCtx) {
         chatCtx.messages.push(message.user(`AIRI System: The action you sent ${action.action} haven't implemented yet by developer.`))
       }
-
-      return () => handleLoopStep(ctx, chatCtx)
   }
 }
 

--- a/services/telegram-bot/src/llm/actions.ts
+++ b/services/telegram-bot/src/llm/actions.ts
@@ -14,6 +14,7 @@ import { parse } from 'best-effort-json-parser'
 
 import { personality, systemTicking } from '../prompts'
 import { div, span, vif } from '../prompts/utils'
+import { addStep } from '../utils/debug-tracker'
 
 export async function imagineAnAction(
   botId: string,
@@ -63,6 +64,14 @@ export async function imagineAnAction(
       { role: 'user' as const, content: userContent },
     )
 
+    addStep('imagineAnAction:prompt', {
+      systemContentLength: systemContent.length,
+      userContentLength: userContent.length,
+      historyMessages: messages.length,
+      historyActions: actions.length,
+      unreadCounts: Object.fromEntries(Object.entries(globalStates.unreadMessages).map(([k, v]) => [k, v.length])),
+    })
+
     try {
       const res = await tracer.startActiveSpan('llm.chat.generate_text', async (s) => {
         s.setAttribute('llm.chat.model', env.LLM_MODEL!)
@@ -93,6 +102,13 @@ export async function imagineAnAction(
 
         s.end()
         return res
+      })
+
+      addStep('imagineAnAction:llmResponse', {
+        responseText: res.text.slice(0, 300),
+        totalTokens: res.usage.total_tokens,
+        promptTokens: res.usage.prompt_tokens,
+        completionTokens: res.usage.completion_tokens,
       })
 
       logger.withFields({
@@ -164,6 +180,13 @@ export async function imagineAnAction(
         }
 
         const action = raw as unknown as Action
+
+        addStep('imagineAnAction:parsedAction', {
+          action: action.action,
+          chatId: (action as any).chatId || 'none',
+          hasContent: !!(action as any).content,
+        })
+
         s.setAttribute('telegram.bot.id', botId)
         s.setAttribute('telegram.module.generate_agent_action.parsed_action', JSON.stringify(action))
 

--- a/services/telegram-bot/src/llm/actions.ts
+++ b/services/telegram-bot/src/llm/actions.ts
@@ -33,36 +33,34 @@ export async function imagineAnAction(
 
     let responseText = ''
 
+    const systemContent = String(div(
+      await systemTicking(),
+      await personality(),
+    ))
+    const userContent = String(div(
+      vif(
+        globalStates?.incomingMessages?.length > 0,
+        div(
+          'Incoming messages:',
+          globalStates?.incomingMessages?.filter(Boolean).map(msg => `- ${msg?.text}`).join('\n'),
+        ),
+      ),
+      'History actions:',
+      actions.map(a => `- Action: ${JSON.stringify(a.action)}, Result: ${JSON.stringify(a.result)}`).join('\n'),
+      span(`
+        Currently, it's ${new Date()} on the server that hosts you.
+        The others in the group may live in a different timezone, so please be aware of the time difference.
+      `),
+      `You have total ${Object.values(globalStates.unreadMessages).reduce((acc, cur) => acc + cur.length, 0)} unread messages.`,
+      'Unread messages count are:',
+      Object.entries(globalStates.unreadMessages).map(([key, value]) => `ID:${key}, Unread message count:${value.length}`).join('\n'),
+      'Based on the context, What do you want to do? Choose a right action from the listing of the tools you want to take next.',
+      'Respond with the action and parameters you choose in JSON only, without any explanation and markups.',
+    ))
     const requestMessages = message.messages(
-      message.system(
-        div(
-          await systemTicking(),
-          await personality(),
-        ),
-      ),
+      { role: 'system' as const, content: systemContent },
       ...messages,
-      message.user(
-        div(
-          vif(
-            globalStates?.incomingMessages?.length > 0,
-            div(
-              'Incoming messages:',
-              globalStates?.incomingMessages?.filter(Boolean).map(msg => `- ${msg?.text}`).join('\n'),
-            ),
-          ),
-          'History actions:',
-          actions.map(a => `- Action: ${JSON.stringify(a.action)}, Result: ${JSON.stringify(a.result)}`).join('\n'),
-          span(`
-            Currently, it's ${new Date()} on the server that hosts you.
-            The others in the group may live in a different timezone, so please be aware of the time difference.
-          `),
-          `You have total ${Object.values(globalStates.unreadMessages).reduce((acc, cur) => acc + cur.length, 0)} unread messages.`,
-          'Unread messages count are:',
-          Object.entries(globalStates.unreadMessages).map(([key, value]) => `ID:${key}, Unread message count:${value.length}`).join('\n'),
-          'Based on the context, What do you want to do? Choose a right action from the listing of the tools you want to take next.',
-          'Respond with the action and parameters you choose in JSON only, without any explanation and markups.',
-        ),
-      ),
+      { role: 'user' as const, content: userContent },
     )
 
     try {
@@ -114,7 +112,58 @@ export async function imagineAnAction(
           .replace(/\n```$/, '')
           .trim()
 
-        const action = parse(responseText) as Action
+        const raw = parse(responseText) as Record<string, unknown>
+
+        // Normalize: some models wrap fields inside "parameters", flatten to top level
+        if (raw.parameters && typeof raw.parameters === 'object') {
+          const params = raw.parameters as Record<string, unknown>
+          for (const [key, value] of Object.entries(params)) {
+            if (!(key in raw))
+              raw[key] = value
+          }
+          delete raw.parameters
+        }
+
+        // Normalize action name aliases
+        const actionAliases: Record<string, string> = {
+          read_messages: 'read_unread_messages',
+          get_unread_messages: 'read_unread_messages',
+          check_messages: 'read_unread_messages',
+          reply_to_a_message_from_a_chat: 'send_message',
+          reply_message: 'send_message',
+          get_messages_from_chat: 'read_unread_messages',
+          Read_unread_messages: 'read_unread_messages',
+        }
+        if (typeof raw.action === 'string' && actionAliases[raw.action])
+          raw.action = actionAliases[raw.action]
+
+        // Normalize field name aliases
+        if (!raw.chatId) {
+          raw.chatId = raw.recipient_id ?? raw.group_id ?? raw.chat_id ?? raw.user_id ?? raw.conversation_id ?? raw.unread_message_id ?? raw.id
+          delete raw.recipient_id
+          delete raw.group_id
+          delete raw.chat_id
+          delete raw.user_id
+          delete raw.conversation_id
+          delete raw.unread_message_id
+        }
+        if (!raw.content) {
+          raw.content = raw.message ?? raw.text ?? raw.chat_message
+          delete raw.message
+          delete raw.text
+          delete raw.chat_message
+        }
+
+        // Fallback: infer chatId from unreadMessages if only one chat has unread
+        if (!raw.chatId) {
+          const unreadChatIds = Object.keys(globalStates.unreadMessages).filter(
+            k => globalStates.unreadMessages[k]?.length > 0,
+          )
+          if (unreadChatIds.length >= 1)
+            raw.chatId = unreadChatIds[0]
+        }
+
+        const action = raw as unknown as Action
         s.setAttribute('telegram.bot.id', botId)
         s.setAttribute('telegram.module.generate_agent_action.parsed_action', JSON.stringify(action))
 

--- a/services/telegram-bot/src/models/index.ts
+++ b/services/telegram-bot/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from './chat-message'
 export * from './common'
+export * from './memory-fragments'
 export * from './photos'
 export * from './stickers'

--- a/services/telegram-bot/src/models/memory-fragments.ts
+++ b/services/telegram-bot/src/models/memory-fragments.ts
@@ -1,0 +1,201 @@
+import type { SQL } from 'drizzle-orm'
+
+import { env } from 'node:process'
+
+import { useLogg } from '@guiiai/logg'
+import { embed } from '@xsai/embed'
+import { and, cosineDistance, desc, eq, gt, isNull, sql } from 'drizzle-orm'
+
+import { useDrizzle } from '../db'
+import { memoryFragmentsTable } from '../db/schema'
+
+export type MemoryFragment = typeof memoryFragmentsTable.$inferSelect
+
+export interface MemoryMetadata {
+  platform: 'telegram'
+  botId: string
+  chatId: string
+  sourceMessageIds: string[]
+  sourceType: 'conversation'
+  extractedAt: number
+}
+
+function getVectorColumn() {
+  switch (env.EMBEDDING_DIMENSION) {
+    case '1536':
+      return memoryFragmentsTable.content_vector_1536
+    case '1024':
+      return memoryFragmentsTable.content_vector_1024
+    case '768':
+      return memoryFragmentsTable.content_vector_768
+    default:
+      throw new Error(`Unsupported embedding dimension: ${env.EMBEDDING_DIMENSION}`)
+  }
+}
+
+function buildSimilarity(embedding: number[]): SQL<number> {
+  return sql<number>`(1 - (${cosineDistance(getVectorColumn(), embedding)}))`
+}
+
+export async function embedContent(content: string): Promise<number[]> {
+  const result = await embed({
+    baseURL: env.EMBEDDING_API_BASE_URL!,
+    apiKey: env.EMBEDDING_API_KEY!,
+    model: env.EMBEDDING_MODEL!,
+    input: content,
+  })
+  return result.embedding
+}
+
+/**
+ * Find semantically relevant long-term memories for a given embedding.
+ */
+export async function findRelevantLongTermMemories(opts: {
+  embedding: number[]
+  limit?: number
+  similarityThreshold?: number
+}): Promise<(MemoryFragment & { similarity: number, combined_score: number })[]> {
+  const db = useDrizzle()
+  const logger = useLogg('findRelevantLongTermMemories').useGlobalConfig()
+  const { embedding, limit = 5, similarityThreshold = 0.5 } = opts
+
+  const similarity = buildSimilarity(embedding)
+  const timeRelevance = sql<number>`(1 - (CEIL(EXTRACT(EPOCH FROM NOW()) * 1000)::bigint - ${memoryFragmentsTable.created_at}) / 86400 / 30)`
+  const normalizedImportance = sql<number>`(${memoryFragmentsTable.importance}::float / 10)`
+  const combinedScore = sql<number>`((1.0 * ${similarity}) + (0.2 * ${timeRelevance}) + (0.3 * ${normalizedImportance}))`
+
+  const results = await db
+    .select({
+      id: memoryFragmentsTable.id,
+      content: memoryFragmentsTable.content,
+      memory_type: memoryFragmentsTable.memory_type,
+      category: memoryFragmentsTable.category,
+      importance: memoryFragmentsTable.importance,
+      emotional_impact: memoryFragmentsTable.emotional_impact,
+      created_at: memoryFragmentsTable.created_at,
+      last_accessed: memoryFragmentsTable.last_accessed,
+      access_count: memoryFragmentsTable.access_count,
+      metadata: memoryFragmentsTable.metadata,
+      content_vector_1536: memoryFragmentsTable.content_vector_1536,
+      content_vector_1024: memoryFragmentsTable.content_vector_1024,
+      content_vector_768: memoryFragmentsTable.content_vector_768,
+      deleted_at: memoryFragmentsTable.deleted_at,
+      similarity: sql<number>`${similarity}`.as('similarity'),
+      combined_score: sql<number>`${combinedScore}`.as('combined_score'),
+    })
+    .from(memoryFragmentsTable)
+    .where(and(
+      eq(memoryFragmentsTable.memory_type, 'long_term'),
+      isNull(memoryFragmentsTable.deleted_at),
+      gt(similarity, similarityThreshold),
+    ))
+    .orderBy(desc(sql`combined_score`))
+    .limit(limit)
+
+  logger.withField('count', results.length).log('Found relevant long-term memories')
+  return results as (MemoryFragment & { similarity: number, combined_score: number })[]
+}
+
+/**
+ * Find a semantically duplicate memory to avoid storing redundant entries.
+ */
+export async function findDuplicateLongTermMemory(opts: {
+  embedding: number[]
+  threshold?: number
+}): Promise<MemoryFragment | null> {
+  const db = useDrizzle()
+  const { embedding, threshold = 0.92 } = opts
+
+  const similarity = buildSimilarity(embedding)
+
+  const results = await db
+    .select()
+    .from(memoryFragmentsTable)
+    .where(and(
+      eq(memoryFragmentsTable.memory_type, 'long_term'),
+      isNull(memoryFragmentsTable.deleted_at),
+      gt(similarity, threshold),
+    ))
+    .orderBy(desc(similarity))
+    .limit(1)
+
+  return results[0] ?? null
+}
+
+/**
+ * Merge into existing memory or create a new one with deduplication.
+ */
+export async function mergeOrCreateLongTermMemory(opts: {
+  content: string
+  category: string
+  importance: number
+  embedding: number[]
+  metadata: MemoryMetadata
+}): Promise<{ action: 'created' | 'merged', id: string }> {
+  const db = useDrizzle()
+  const logger = useLogg('mergeOrCreateLongTermMemory').useGlobalConfig()
+  const { content, category, importance, embedding, metadata } = opts
+
+  const duplicate = await findDuplicateLongTermMemory({ embedding })
+
+  if (duplicate) {
+    const oldMeta = (duplicate.metadata ?? {}) as Record<string, unknown>
+    const oldSourceIds = Array.isArray(oldMeta.sourceMessageIds) ? oldMeta.sourceMessageIds as string[] : []
+    const mergedSourceIds = [...new Set([...oldSourceIds, ...metadata.sourceMessageIds])]
+
+    await db
+      .update(memoryFragmentsTable)
+      .set({
+        last_accessed: Date.now(),
+        access_count: duplicate.access_count + 1,
+        importance: Math.max(duplicate.importance, importance),
+        metadata: { ...oldMeta, ...metadata, sourceMessageIds: mergedSourceIds },
+      })
+      .where(eq(memoryFragmentsTable.id, duplicate.id))
+
+    logger.withField('id', duplicate.id).log('Merged with existing memory')
+    return { action: 'merged', id: duplicate.id }
+  }
+
+  const vectorValues: Record<string, unknown> = {}
+  switch (env.EMBEDDING_DIMENSION) {
+    case '1536':
+      vectorValues.content_vector_1536 = embedding
+      break
+    case '1024':
+      vectorValues.content_vector_1024 = embedding
+      break
+    case '768':
+      vectorValues.content_vector_768 = embedding
+      break
+  }
+
+  const [inserted] = await db
+    .insert(memoryFragmentsTable)
+    .values({
+      content,
+      memory_type: 'long_term',
+      category,
+      importance,
+      metadata,
+      ...vectorValues,
+    })
+    .returning({ id: memoryFragmentsTable.id })
+
+  logger.withField('id', inserted.id).log('Created new long-term memory')
+  return { action: 'created', id: inserted.id }
+}
+
+/**
+ * Update access tracking when a memory is retrieved.
+ */
+export async function touchMemory(id: string): Promise<void> {
+  const db = useDrizzle()
+  await db
+    .update(memoryFragmentsTable)
+    .set({
+      last_accessed: Date.now(),
+      access_count: sql`${memoryFragmentsTable.access_count} + 1`,
+    })
+    .where(eq(memoryFragmentsTable.id, id))
+}

--- a/services/telegram-bot/src/prompts/action-read-messages.velin.md
+++ b/services/telegram-bot/src/prompts/action-read-messages.velin.md
@@ -3,6 +3,7 @@ const props = defineProps<{
   lastMessages?: string
   unreadHistoryMessages?: string
   relevantChatMessages?: string
+  relevantLongTermMemories?: string
 }>()
 </script>
 
@@ -17,6 +18,11 @@ All the messages you requested to read:
 
 Relevant chat messages may help you recall the memories:
 {{ props.relevantChatMessages || 'No relevant messages' }}
+
+<div v-if="props.relevantLongTermMemories">
+Things you remember about the people and conversations (use as reference, not mandatory):
+{{ props.relevantLongTermMemories }}
+</div>
 
 Feel free to ignore by just sending an empty array within a object with key "messages" (i.e.
 { "messages": [] }).

--- a/services/telegram-bot/src/prompts/extract-long-term-memories.velin.md
+++ b/services/telegram-bot/src/prompts/extract-long-term-memories.velin.md
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+const props = defineProps<{
+  conversationContext: string
+}>()
+</script>
+
+You are a memory extraction system. Your task is to extract long-term memories from the conversation below.
+
+Extract ONLY information that would be valuable across future conversations. Each memory should be a standalone fact.
+
+Categories (pick one per memory):
+- preference: likes, dislikes, habits ("喜欢猫", "不喝咖啡")
+- profile: background facts ("在北京上学", "是程序员")
+- relationship: people connections ("xxx 是他的同事")
+- goal: plans and intentions ("想学日语", "计划下个月旅行")
+- fact: other stable knowledge worth remembering
+
+Rules:
+- Extract 0-3 memories per conversation. Quality over quantity.
+- Each memory must be a concise, self-contained statement (1-2 sentences max).
+- DO NOT extract: greetings, temporary emotions, one-time small talk, noise.
+- DO NOT extract anything the bot itself said — only extract facts about the human participants.
+- Importance scale: 1 (trivial) to 10 (core identity/critical fact).
+- If nothing worth remembering, return an empty array.
+
+Conversation:
+{{ props.conversationContext }}
+
+Respond with a JSON array only, no explanation:
+[{"content": "memory text", "category": "preference|profile|relationship|goal|fact", "importance": 1-10}]
+
+If nothing to extract, respond with:
+[]

--- a/services/telegram-bot/src/prompts/index.ts
+++ b/services/telegram-bot/src/prompts/index.ts
@@ -14,6 +14,10 @@ export async function messageSplit() {
   return await (velin<{ responseLanguage: string }>('message-split-v1.velin.md', import.meta.url))({ responseLanguage: env.LLM_RESPONSE_LANGUAGE })
 }
 
-export async function actionReadMessages(props: { lastMessages?: string, unreadHistoryMessages?: string, relevantChatMessages?: string }) {
-  return await (velin<{ lastMessages?: string, unreadHistoryMessages?: string, relevantChatMessages?: string }>('action-read-messages.velin.md', import.meta.url))(props)
+export async function actionReadMessages(props: { lastMessages?: string, unreadHistoryMessages?: string, relevantChatMessages?: string, relevantLongTermMemories?: string }) {
+  return await (velin<{ lastMessages?: string, unreadHistoryMessages?: string, relevantChatMessages?: string, relevantLongTermMemories?: string }>('action-read-messages.velin.md', import.meta.url))(props)
+}
+
+export async function extractLongTermMemories(props: { conversationContext: string }) {
+  return await (velin<{ conversationContext: string }>('extract-long-term-memories.velin.md', import.meta.url))(props)
 }

--- a/services/telegram-bot/src/utils/debug-tracker.ts
+++ b/services/telegram-bot/src/utils/debug-tracker.ts
@@ -1,0 +1,106 @@
+/**
+ * Debug tracker — captures the full pipeline of each conversation turn.
+ * Use `/debug` in Telegram to view the last flow.
+ */
+
+export interface DebugStep {
+  name: string
+  timestamp: number
+  durationMs?: number
+  data: Record<string, unknown>
+}
+
+export interface DebugFlow {
+  chatId: string
+  startedAt: number
+  steps: DebugStep[]
+}
+
+const MAX_FLOWS = 20
+const flows: DebugFlow[] = []
+let currentFlow: DebugFlow | null = null
+
+export function startFlow(chatId: string): void {
+  currentFlow = { chatId, startedAt: Date.now(), steps: [] }
+}
+
+export function addStep(name: string, data: Record<string, unknown>): void {
+  if (!currentFlow)
+    return
+  currentFlow.steps.push({ name, timestamp: Date.now(), data })
+}
+
+export function endFlow(): void {
+  if (!currentFlow)
+    return
+  // Calculate durations between steps
+  for (let i = 0; i < currentFlow.steps.length; i++) {
+    const next = currentFlow.steps[i + 1]
+    if (next)
+      currentFlow.steps[i].durationMs = next.timestamp - currentFlow.steps[i].timestamp
+  }
+  flows.unshift(currentFlow)
+  if (flows.length > MAX_FLOWS)
+    flows.pop()
+  currentFlow = null
+}
+
+export function getFlow(chatId?: string, index = 0): DebugFlow | null {
+  if (chatId) {
+    const chatFlows = flows.filter(f => f.chatId === chatId)
+    return chatFlows[index] ?? null
+  }
+  return flows[index] ?? null
+}
+
+export function getFlowCount(chatId?: string): number {
+  if (chatId)
+    return flows.filter(f => f.chatId === chatId).length
+  return flows.length
+}
+
+export function formatFlowList(chatId?: string): string {
+  const target = chatId ? flows.filter(f => f.chatId === chatId) : flows
+  if (target.length === 0)
+    return 'No debug flows recorded.'
+
+  const lines: string[] = [`== Debug Flows (${target.length} total) ==`, '']
+  for (let i = 0; i < target.length; i++) {
+    const f = target[i]
+    const totalMs = f.steps.length > 0
+      ? f.steps[f.steps.length - 1].timestamp - f.startedAt
+      : 0
+    const actions = f.steps.filter(s => s.name === 'imagineAnAction:parsedAction').map(s => s.data.action).join(',')
+    const time = new Date(f.startedAt).toLocaleTimeString()
+    lines.push(`[${i}] ${time} | ${totalMs}ms | ${f.steps.length} steps | ${actions || 'no action'}`)
+  }
+  lines.push('')
+  lines.push('Use /debug <number> to view details.')
+  return lines.join('\n')
+}
+
+export function formatFlow(flow: DebugFlow): string {
+  const totalMs = flow.steps.length > 0
+    ? flow.steps[flow.steps.length - 1].timestamp - flow.startedAt
+    : 0
+
+  const lines: string[] = []
+  lines.push(`== Debug Flow (chat: ${flow.chatId}) ==`)
+  lines.push(`Total: ${totalMs}ms | Steps: ${flow.steps.length}`)
+  lines.push('')
+
+  for (const step of flow.steps) {
+    const dur = step.durationMs != null ? ` (${step.durationMs}ms)` : ''
+    lines.push(`[${step.name}]${dur}`)
+
+    for (const [key, value] of Object.entries(step.data)) {
+      const strValue = typeof value === 'string' ? value : JSON.stringify(value)
+      // Truncate long values
+      const display = strValue.length > 200 ? `${strValue.slice(0, 200)}...` : strValue
+      lines.push(`  ${key}: ${display}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}

--- a/services/telegram-bot/src/utils/velin.ts
+++ b/services/telegram-bot/src/utils/velin.ts
@@ -16,12 +16,13 @@ export function importVelin(module: string, base: string): VelinModule {
   return {
     render: async (data) => {
       const content = (await readFile(relativeOf(module, base))).toString('utf-8')
-
-      if (isMarkdown(module)) {
-        return renderMarkdownString(content, data)
-      }
-
-      return renderSFCString(content, data)
+      const result = isMarkdown(module)
+        ? await renderMarkdownString(content, data)
+        : await renderSFCString(content, data)
+      // renderMarkdownString returns { rendered, props } instead of a plain string
+      if (result && typeof result === 'object' && 'rendered' in result)
+        return (result as { rendered: string }).rendered
+      return result
     },
   }
 }


### PR DESCRIPTION
## Summary
- **Long-term memory system**: async extraction of memories after each bot reply (preference, profile, relationship, goal, fact), vector-based retrieval during message reading, semantic deduplication (≥ 0.92 similarity), and merge-or-create persistence to `memory_fragments` table
- **Debug flow tracker**: pipeline instrumentation capturing prompt sizes, token counts, actions chosen, and memory retrieval counts at each step; `/debug` admin command to inspect flow history in Telegram
- **Memory-aware prompts**: inject retrieved long-term memories into `action-read-messages` prompt so the bot can reference past conversations

> **Note**: This PR depends on #1333 for the bug fixes it builds upon.

### Long-term memory flow
1. After bot sends a reply → fetch last 15 messages from DB → LLM extracts 0-3 memories → embed → dedup check (cosine ≥ 0.92) → merge or create in `memory_fragments`
2. When reading new messages → embed unread messages → vector search for relevant memories (combined score: similarity + time + importance) → inject into prompt as context

### Debug tracker
- `/debug` — list recent flows with timestamps, durations, and actions
- `/debug <n>` — view detailed step-by-step trace of a specific flow

## Test plan
- [x] Verified memory extraction works: logs show `Stored memory` with `action=merged` for duplicate content
- [x] Verified memory retrieval works: logs show `Found relevant long-term memories` and bot uses them in responses
- [x] Verified `/debug` command returns flow list and detail views
- [x] Verified DB contains stored memories with correct categories and embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)