### PR TITLE
fix(stage-ui): fix hash scroll on SPA navigation to providers page

### DIFF
--- a/packages/stage-layouts/src/layouts/settings.vue
+++ b/packages/stage-layouts/src/layouts/settings.vue
@@ -94,7 +94,7 @@ onMounted(() => updateThemeColor())
         :subtitle="routeHeaderMetadata?.subtitle"
         :disable-back-button="route.path === '/settings'"
       />
-      <div relative min-h-0 flex-1 overflow-y-auto scrollbar-none>
+      <div id="settings-scroll-container" relative min-h-0 flex-1 overflow-y-auto scrollbar-none>
         <RouterView />
       </div>
     </div>

--- a/packages/stage-pages/src/pages/settings/providers/index.vue
+++ b/packages/stage-pages/src/pages/settings/providers/index.vue
@@ -62,6 +62,7 @@ useScrollToHash(() => route.hash, {
   behavior: 'smooth', // smooth scroll animation
   maxRetries: 15, // retry if target element isn't ready
   retryDelay: 150, // wait between retries
+  scrollContainer: '#settings-scroll-container',
 })
 </script>
 


### PR DESCRIPTION
The settings layout uses a scrollable div with overflow-y-auto, not window. useScrollToHash was scrolling window which had no effect on SPA navigation. Point it at the actual scroll container instead.
