### PR TITLE
fix(stage-ui): use nullish coalescing for errorMessageFrom fallback

### DIFF
--- a/packages/stage-ui/src/composables/use-provider-validation.ts
+++ b/packages/stage-ui/src/composables/use-provider-validation.ts
@@ -152,7 +152,7 @@ export function useProviderValidation(providerId: string) {
     }
     catch (error) {
       manualTestPassed.value = false
-      manualTestMessage.value = errorMessageFrom(error)
+      manualTestMessage.value = errorMessageFrom(error) ?? 'Unknown error'
     }
     finally {
       isManualTesting.value = false

--- a/packages/stage-ui/src/libs/providers/validators/run.ts
+++ b/packages/stage-ui/src/libs/providers/validators/run.ts
@@ -138,7 +138,7 @@ export async function validateProvider(
     }
     catch (error) {
       step.status = 'invalid'
-      step.reason = errorMessageFrom(error) || 'Unknown error'
+      step.reason = errorMessageFrom(error) ?? 'Unknown error'
       onValidatorError?.({ kind: 'config', index, step, error })
       return { valid: false, reason: step.reason }
     }
@@ -158,13 +158,13 @@ export async function validateProvider(
 
   let providerInstance: ProviderInstance
   try {
-    providerInstance = await definition.createProvider(config as any)
+    providerInstance = await definition.createProvider(config)
   }
   catch (error) {
     for (let i = 0; i < providerValidators.length; i++) {
       const step = steps[providerStepOffset + i]
       step.status = 'invalid'
-      step.reason = errorMessageFrom(error)
+      step.reason = errorMessageFrom(error) ?? 'Unknown error'
     }
     return steps
   }
@@ -175,14 +175,14 @@ export async function validateProvider(
     step.reason = ''
     onValidatorStart?.({ kind: 'provider', index, step })
     try {
-      const result = await validatorDefinition.validator(config, providerInstance as any, providerExtra as any, runContext)
+      const result = await validatorDefinition.validator(config, providerInstance, providerExtra as any, runContext)
       step.status = result.valid ? 'valid' : 'invalid'
       step.reason = result.valid ? '' : result.reason
       onValidatorSuccess?.({ kind: 'provider', index, step, result })
     }
     catch (error) {
       step.status = 'invalid'
-      step.reason = errorMessageFrom(error)
+      step.reason = errorMessageFrom(error) ?? 'Unknown error'
       onValidatorError?.({ kind: 'provider', index, step, error })
     }
   }))
@@ -212,14 +212,14 @@ export async function validateProviderManual(
 
   let providerInstance: ProviderInstance
   try {
-    providerInstance = await definition.createProvider(config as any)
+    providerInstance = await definition.createProvider(config)
   }
   catch (error) {
     return manualProviderValidators.map(v => ({
       id: v.id,
       label: v.name,
       status: 'invalid' as ProviderValidationStepStatus,
-      reason: errorMessageFrom(error),
+      reason: errorMessageFrom(error) ?? 'Unknown error',
       kind: 'provider' as ProviderValidationStepKind,
     }))
   }
@@ -238,14 +238,14 @@ export async function validateProviderManual(
     step.reason = ''
     onValidatorStart?.({ kind: 'provider', index, step })
     try {
-      const result = await validatorDefinition.validator(config, providerInstance as any, providerExtra as any, runContext)
+      const result = await validatorDefinition.validator(config, providerInstance, providerExtra as any, runContext)
       step.status = result.valid ? 'valid' : 'invalid'
       step.reason = result.valid ? '' : result.reason
       onValidatorSuccess?.({ kind: 'provider', index, step, result })
     }
     catch (error) {
       step.status = 'invalid'
-      step.reason = errorMessageFrom(error)
+      step.reason = errorMessageFrom(error) ?? 'Unknown error'
       onValidatorError?.({ kind: 'provider', index, step, error })
     }
   }))


### PR DESCRIPTION
## Summary

`errorMessageFrom` returns `string | undefined`, but `ProviderValidationStep.reason` and related fields require `string`. This caused typecheck failures across `packages/stage-ui`.

## Changes

- Replace bare `errorMessageFrom(error)` assignments with `errorMessageFrom(error) ?? 'Unknown error'`
- Replace the existing `|| 'Unknown error'` pattern with `??` to avoid incorrectly swallowing valid empty strings

### Affected files
- `packages/stage-ui/src/libs/providers/validators/run.ts` — 5 sites
- `packages/stage-ui/src/composables/use-provider-validation.ts` — 1 site

## Testing

```
pnpm typecheck
```

All 41 packages pass with no errors.

Co-authored-by: GitHub Copilot <copilot@github.com>
