### PR TITLE
fix(stage-pages): use placeholderLocalized from provider config for API key input

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/chat/[providerId].vue
+++ b/packages/stage-pages/src/pages/settings/providers/chat/[providerId].vue
@@ -11,6 +11,7 @@ import {
   ProviderValidationAlerts,
 } from '@proj-airi/stage-ui/components'
 import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { getDefinedProvider } from '@proj-airi/stage-ui/libs'
 import { useConsciousnessStore } from '@proj-airi/stage-ui/stores/modules/consciousness'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { storeToRefs } from 'pinia'
@@ -60,6 +61,21 @@ const {
   runManualTest,
 } = useProviderValidation(providerId)
 
+const apiKeyPlaceholder = computed(() => {
+  const definition = getDefinedProvider(providerId)
+  if (!definition?.createProviderConfig)
+    return 'sk-...'
+
+  const schema = definition.createProviderConfig({ t }) as any
+  const shape = typeof schema?.shape === 'function' ? schema.shape() : schema?.shape
+  const apiKeySchema = shape?.apiKey
+  if (!apiKeySchema)
+    return 'sk-...'
+
+  const meta = typeof apiKeySchema.meta === 'function' ? apiKeySchema.meta() : undefined
+  return typeof meta?.placeholderLocalized === 'string' ? meta.placeholderLocalized : 'sk-...'
+})
+
 function goToModelSelection() {
   activeProvider.value = providerId
   router.push('/settings/modules/consciousness')
@@ -81,7 +97,7 @@ function goToModelSelection() {
         <ProviderApiKeyInput
           v-model="apiKey"
           :provider-name="providerMetadata?.localizedName"
-          placeholder="sk-..."
+          :placeholder="apiKeyPlaceholder"
         />
       </ProviderBasicSettings>
 

--- a/packages/stage-pages/src/pages/settings/providers/speech/openai-compatible-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/openai-compatible-audio-speech.vue
@@ -7,6 +7,7 @@ import {
   SpeechProviderSettings,
 } from '@proj-airi/stage-ui/components'
 import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { getDefinedProvider } from '@proj-airi/stage-ui/libs'
 import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { FieldInput, FieldRange } from '@proj-airi/ui'
@@ -155,6 +156,21 @@ const {
   validationMessage,
   forceValid,
 } = useProviderValidation(providerId)
+
+const apiKeyPlaceholder = computed(() => {
+  const definition = getDefinedProvider(providerId)
+  if (!definition?.createProviderConfig)
+    return 'sk-...'
+
+  const schema = definition.createProviderConfig({ t }) as any
+  const shape = typeof schema?.shape === 'function' ? schema.shape() : schema?.shape
+  const apiKeySchema = shape?.apiKey
+  if (!apiKeySchema)
+    return 'sk-...'
+
+  const meta = typeof apiKeySchema.meta === 'function' ? apiKeySchema.meta() : undefined
+  return typeof meta?.placeholderLocalized === 'string' ? meta.placeholderLocalized : 'sk-...'
+})
 </script>
 
 <template>
@@ -162,7 +178,7 @@ const {
     :provider-id="providerId"
     :default-model="defaultModel"
     :additional-settings="defaultVoiceSettings"
-    placeholder="sk-..."
+    :placeholder="apiKeyPlaceholder"
   >
     <!-- Voice settings specific to OpenAI Compatible -->
     <template #voice-settings>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/comet-api-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/comet-api-transcription.vue
@@ -13,6 +13,7 @@ import {
   TranscriptionPlayground,
 } from '@proj-airi/stage-ui/components'
 import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { getDefinedProvider } from '@proj-airi/stage-ui/libs'
 import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { FieldInput } from '@proj-airi/ui'
@@ -81,6 +82,21 @@ const {
   handleResetSettings,
   forceValid,
 } = useProviderValidation(providerId)
+
+const apiKeyPlaceholder = computed(() => {
+  const definition = getDefinedProvider(providerId)
+  if (!definition?.createProviderConfig)
+    return 'sk-...'
+
+  const schema = definition.createProviderConfig({ t }) as any
+  const shape = typeof schema?.shape === 'function' ? schema.shape() : schema?.shape
+  const apiKeySchema = shape?.apiKey
+  if (!apiKeySchema)
+    return 'sk-...'
+
+  const meta = typeof apiKeySchema.meta === 'function' ? apiKeySchema.meta() : undefined
+  return typeof meta?.placeholderLocalized === 'string' ? meta.placeholderLocalized : 'sk-...'
+})
 </script>
 
 <template>
@@ -98,7 +114,7 @@ const {
         <ProviderApiKeyInput
           v-model="apiKey"
           :provider-name="providerMetadata?.localizedName"
-          placeholder="sk-..."
+          :placeholder="apiKeyPlaceholder"
         />
         <FieldInput
           v-model="model"

--- a/packages/stage-pages/src/pages/settings/providers/transcription/openai-compatible-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/openai-compatible-audio-transcription.vue
@@ -13,6 +13,7 @@ import {
   TranscriptionPlayground,
 } from '@proj-airi/stage-ui/components'
 import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { getDefinedProvider } from '@proj-airi/stage-ui/libs'
 import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { FieldInput, FieldSelect } from '@proj-airi/ui'
@@ -109,6 +110,21 @@ const {
   forceValid,
 } = useProviderValidation(providerId)
 
+const apiKeyPlaceholder = computed(() => {
+  const definition = getDefinedProvider(providerId)
+  if (!definition?.createProviderConfig)
+    return 'sk-...'
+
+  const schema = definition.createProviderConfig({ t }) as any
+  const shape = typeof schema?.shape === 'function' ? schema.shape() : schema?.shape
+  const apiKeySchema = shape?.apiKey
+  if (!apiKeySchema)
+    return 'sk-...'
+
+  const meta = typeof apiKeySchema.meta === 'function' ? apiKeySchema.meta() : undefined
+  return typeof meta?.placeholderLocalized === 'string' ? meta.placeholderLocalized : 'sk-...'
+})
+
 // Expand Advanced section if there's a base URL validation error
 const shouldExpandAdvanced = computed(() => {
   if (!validationMessage.value)
@@ -195,7 +211,7 @@ watch(model, () => {
           <ProviderApiKeyInput
             v-model="apiKey"
             :provider-name="providerMetadata?.localizedName"
-            placeholder="sk-..."
+            :placeholder="apiKeyPlaceholder"
           />
           <!-- Model selection: Use dropdown if models are available, otherwise use text input -->
           <FieldSelect


### PR DESCRIPTION
## Description

The v1 provider settings pages hardcode `placeholder="sk-..."` for API key inputs. Each provider already defines a `placeholderLocalized` value in its `createProviderConfig` schema metadata, and the v2 settings page already uses it correctly. This PR brings the v1 pages in line with the v2 pattern.

**What changed:**
- `[providerId].vue` (chat providers) now reads `placeholderLocalized` from the provider's schema metadata
- `comet-api-transcription.vue` and `openai-compatible-audio-transcription.vue` (transcription providers) get the same fix
- `openai-compatible-audio-speech.vue` (speech provider) also updated
- All four pages fall back to `'sk-...'` when no provider-specific placeholder is defined

## Linked Issues

Fixes #1379

## Additional Context

- References the v2 implementation at `packages/stage-pages/src/pages/v2/settings/providers/edit/[providerId]/index.vue` (line 108)
- Uses `getDefinedProvider` from `@proj-airi/stage-ui/libs` to access the provider schema
- Provider configs like xAI define `placeholderLocalized` via i18n keys (e.g., `settings.pages.providers.catalog.edit.config.common.fields.field.api-key.placeholder`)

This contribution was developed with AI assistance (Claude Code).