### PR TITLE
fix(bucket): fix scoop manifest decompress error for NSIS installer

### DIFF
--- a/bucket/airi.json
+++ b/bucket/airi.json
@@ -9,10 +9,9 @@
       "hash": "cf4698c7c483ce58e81e05b08a5015a753243e79c54aa2e4baec81c92041e5a7"
     }
   },
-  "extract_dir": "$PLUGINSDIR",
   "pre_install": [
     "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-    "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse"
+    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\", \"$dir\\`$R1\", \"$dir\\Uninstall*\", \"$dir\\nsProcess*\" -Force -Recurse -ErrorAction SilentlyContinue"
   ],
   "shortcuts": [
     [


### PR DESCRIPTION
## Description

`scoop install airi/airi` fails with a `DirectoryNotFoundException` because the `extract_dir: "$PLUGINSDIR"` field causes path resolution issues. The `$` prefix in `$PLUGINSDIR` conflicts with PowerShell variable interpolation in scoop's internal path handling, causing the extraction log file path to fail.

**What changed:**
- Removed `extract_dir` field from the scoop manifest
- The `pre_install` script now handles the full extraction path using backtick-escaped `$PLUGINSDIR` (`` `$PLUGINSDIR ``), which PowerShell correctly treats as a literal `$`
- Added cleanup of NSIS artifacts (`$PLUGINSDIR`, `$R0`, `$R1`, `Uninstall*`, `nsProcess*`) with `-ErrorAction SilentlyContinue` for robustness

**Error from issue:**
```
Exception calling "AppendAllText" with "2" argument(s): "Could not find a part of the path
'C:\Users\bucker\scoop\apps\airi\0.9.0-alpha.12\$PLUGINSDIR\7zip.log'."
```

## Linked Issues

Fixes #1367

## Additional Context

- The `#/dl.7z` URL suffix tells scoop to treat the NSIS `.exe` as a `.7z` archive
- NSIS installers contain a `$PLUGINSDIR` folder with `app-64.7z` holding the actual Electron app
- Testing was done via manifest structure analysis. I don't have a Windows environment to verify end-to-end, but the pattern matches working scoop manifests for other electron-builder NSIS apps.

This contribution was developed with AI assistance (Claude Code).