### PR TITLE
fix: harden minecraft js planner sandbox

### DIFF
--- a/services/minecraft/src/cognitive/conscious/js-planner.test.ts
+++ b/services/minecraft/src/cognitive/conscious/js-planner.test.ts
@@ -235,6 +235,36 @@ describe('javaScriptPlanner', () => {
     await expect(planner.evaluate('while (true) {}', actions, globals, executeAction)).rejects.toThrow(/Script execution timed out/i)
   })
 
+  it('blocks vm escape attempts through the sandbox global constructor chain', async () => {
+    const planner = new JavaScriptPlanner()
+    const executeAction = vi.fn(async action => `ok:${action.tool}`)
+
+    const planned = await planner.evaluate('return globalThis.constructor?.constructor?.("return process")()?.version ?? "blocked"', actions, globals, executeAction)
+    expect(planned.returnValue).toBe(`'blocked'`)
+    expect(planned.actions).toHaveLength(0)
+  })
+
+  it('blocks eval and Function constructor code generation inside the sandbox', async () => {
+    const planner = new JavaScriptPlanner()
+    const executeAction = vi.fn(async action => `ok:${action.tool}`)
+
+    await expect(planner.evaluate('return eval("1 + 1")', actions, globals, executeAction)).rejects.toThrow(/Code generation from strings disallowed/i)
+    await expect(planner.evaluate('return Function("return 1")()', actions, globals, executeAction)).rejects.toThrow(/Code generation from strings disallowed/i)
+  })
+
+  it('keeps action tool bindings immutable inside the sandbox', async () => {
+    const planner = new JavaScriptPlanner()
+    const executeAction = vi.fn(async action => `ok:${action.tool}`)
+
+    const planned = await planner.evaluate(`
+      chat = async () => ({ ok: true, result: "shadowed" })
+      await chat("hello")
+    `, actions, globals, executeAction)
+
+    expect(executeAction).toHaveBeenCalledOnce()
+    expect(planned.actions[0]?.action).toEqual({ tool: 'chat', params: { message: 'hello' } })
+  })
+
   it('supports expectation guardrails on structured action telemetry', async () => {
     const planner = new JavaScriptPlanner()
     const executeAction = vi.fn(async () => ({

--- a/services/minecraft/src/cognitive/conscious/js-planner.ts
+++ b/services/minecraft/src/cognitive/conscious/js-planner.ts
@@ -107,11 +107,21 @@ interface DescribeGlobalsOptions {
   includeBuiltins?: boolean
 }
 
+const SANDBOX_LOCKDOWN_SOURCE = `
+Object.setPrototypeOf(globalThis, null)
+`
+
 export function extractJavaScriptCandidate(input: string): string {
   const trimmed = input.trim()
-  const fenced = trimmed.match(/^```(?:js|javascript|ts|typescript)?[^\S\r\n]*\r?\n?([\s\S]*?)\r?\n?```$/i)
-  if (fenced?.[1])
-    return fenced[1].trim()
+  if (trimmed.startsWith('```') && trimmed.endsWith('```')) {
+    const firstNewline = trimmed.indexOf('\n')
+    if (firstNewline >= 0) {
+      const fenceHeader = trimmed.slice(3, firstNewline).trim().toLowerCase()
+      const isJavaScriptFence = fenceHeader.length === 0 || ['js', 'javascript', 'ts', 'typescript'].includes(fenceHeader)
+      if (isJavaScriptFence)
+        return trimmed.slice(firstNewline + 1, -3).trim()
+    }
+  }
 
   return trimmed
 }
@@ -119,6 +129,7 @@ export function extractJavaScriptCandidate(input: string): string {
 export class JavaScriptPlanner {
   private readonly context: vm.Context
   private activeRun: ActivePlannerRun | null = null
+  private readonly installedActionToolNames = new Set<string>()
   private readonly maxActionsPerTurn: number
   private readonly sandbox: Record<string, unknown>
   private readonly timeoutMs: number
@@ -126,8 +137,14 @@ export class JavaScriptPlanner {
   constructor(options: JavaScriptPlannerOptions = {}) {
     this.timeoutMs = options.timeoutMs ?? 750
     this.maxActionsPerTurn = options.maxActionsPerTurn ?? 5
-    this.sandbox = {}
-    this.context = vm.createContext(this.sandbox)
+    this.sandbox = Object.create(null) as Record<string, unknown>
+    this.context = vm.createContext(this.sandbox, {
+      codeGeneration: {
+        strings: false,
+        wasm: false,
+      },
+    })
+    this.lockDownSandbox()
     this.installBuiltins()
   }
 
@@ -426,14 +443,14 @@ export class JavaScriptPlanner {
 
   private installActionTools(availableActions: Action[]): void {
     for (const action of availableActions) {
-      const existing = Object.getOwnPropertyDescriptor(this.sandbox, action.name)
-      if (existing && existing.configurable === false)
+      if (this.installedActionToolNames.has(action.name))
         continue
 
-      this.defineUpdatableGlobal(action.name, async (...args: unknown[]) => {
-        const params = this.mapArgsToParams(action, args)
+      this.defineGlobalTool(action.name, async (...args: unknown[]) => {
+        const params = this.mapArgsToParams(action.name, args)
         return this.runAction(action.name, params)
       })
+      this.installedActionToolNames.add(action.name)
     }
   }
 
@@ -484,7 +501,11 @@ export class JavaScriptPlanner {
     }
   }
 
-  private mapArgsToParams(action: Action, args: unknown[]): Record<string, unknown> {
+  private mapArgsToParams(toolName: string, args: unknown[]): Record<string, unknown> {
+    const action = this.activeRun?.actionsByName.get(toolName)
+    if (!action)
+      return {}
+
     const shape = action.schema.shape as Record<string, unknown>
     const keys = Object.keys(shape)
 
@@ -614,18 +635,6 @@ export class JavaScriptPlanner {
     })
   }
 
-  // NOTICE: Action tools must be updatable because the set of available actions
-  // can change at runtime. Unlike builtins (which are immutable), action tool
-  // globals use configurable: true so they can be redefined on each evaluate().
-  private defineUpdatableGlobal(name: string, value: unknown): void {
-    Object.defineProperty(this.sandbox, name, {
-      value,
-      configurable: true,
-      enumerable: true,
-      writable: false,
-    })
-  }
-
   private previewValue(value: unknown): string {
     if (value === null)
       return 'null'
@@ -636,5 +645,14 @@ export class JavaScriptPlanner {
 
     const rendered = inspect(value, { depth: 1, breakLength: 120 })
     return rendered.length > 120 ? `${rendered.slice(0, 117)}...` : rendered
+  }
+
+  private lockDownSandbox(): void {
+    // NOTICE: The planner context intentionally disables runtime code generation
+    // and severs the global object's prototype chain to block common vm escapes
+    // such as `globalThis.constructor.constructor("return process")()`.
+    new vm.Script(SANDBOX_LOCKDOWN_SOURCE).runInContext(this.context, {
+      timeout: this.timeoutMs,
+    })
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent VM escape vectors and runtime code-generation RCE from planner scripts by hardening the sandbox used by the in-game JavaScript planner. 
- Ensure planner tool globals cannot be shadowed by user scripts while preserving per-run schema validation and runtime behavior.

### Description
- Replace the mutable plain object sandbox with a null-prototype sandbox and create the VM context with `codeGeneration: { strings: false, wasm: false }`, then run a small lockdown script (`Object.setPrototypeOf(globalThis, null)`) to sever global prototype escape paths in `services/minecraft/src/cognitive/conscious/js-planner.ts`.
- Make action tool bindings installed once (tracked with `installedActionToolNames`) and immutable in the sandbox, and change argument-to-params mapping to resolve schemas from the active run at call time, preventing in-sandbox shadowing while keeping validation intact.
- Replace the fragile fenced-code regex extraction with a linear parser path to avoid regex backtracking issues in `extractJavaScriptCandidate`.
- Add regression tests in `services/minecraft/src/cognitive/conscious/js-planner.test.ts` to assert blocking of `globalThis.constructor` escapes, rejection of `eval`/`Function` code generation, and immutability of action tool bindings.

### Testing
- Ran linter: `pnpm exec eslint services/minecraft/src/cognitive/conscious/js-planner.ts services/minecraft/src/cognitive/conscious/js-planner.test.ts` and addressed issues; linter reports clean for the modified files.
- Unit tests: `pnpm exec vitest run -c vitest.config.ts src/cognitive/conscious/js-planner.test.ts` (from `services/minecraft`) executed and `24` tests passed.
- Live verification: booted a local vanilla Minecraft `1.20.4` server and ran a small live test connecting a `Mineflayer` bot that exercised `query.self()`, `query.snapshot()` and `chat("sandbox-live-check")`; the bot connected and the planner executed the tool call and observed echoed chat as expected.
- Typecheck: `pnpm -F @proj-airi/minecraft-bot typecheck` still fails due to pre-existing `Bot.pathfinder` typing issues unrelated to this change set (left unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba1b809d608329b432de9d32e981ee)