### PR TITLE
fix(server-runtime): use constant-time comparison for auth token

### DIFF
--- a/packages/server-runtime/src/index.ts
+++ b/packages/server-runtime/src/index.ts
@@ -30,15 +30,25 @@ import {
   matchesDestinations,
 } from './middlewares'
 
-/** Constant-time string comparison that prevents timing attacks (CWE-208). */
+/**
+ * Constant-time string comparison that prevents timing attacks (CWE-208).
+ *
+ * @param {string} a - the first string to compare
+ * @param {string} b - the expected value (e.g., the real secret)
+ * @returns {boolean} `true` if the strings are equal, `false` otherwise
+ */
 function timingSafeCompare(a: string, b: string): boolean {
   const bufA = Buffer.from(a)
   const bufB = Buffer.from(b)
   if (bufA.length !== bufB.length) {
     // Compare against itself to keep constant time, then return false
     timingSafeEqual(bufA, bufA)
+    // To prevent leaking length information, we perform a dummy comparison on the
+    // expected value, making the execution time dependent on its length.
+    timingSafeEqual(bufB, bufB)
     return false
   }
+
   return timingSafeEqual(bufA, bufB)
 }
 


### PR DESCRIPTION
## Summary

- Replace direct string comparison (`!==`) with `crypto.timingSafeEqual()` in the WebSocket authentication handler to prevent timing-based side-channel attacks ([CWE-208](https://cwe.mitre.org/data/definitions/208.html))
- Add a `timingSafeCompare` helper that handles variable-length strings safely (compares against itself on length mismatch to avoid leaking length information)
- Add `import { timingSafeEqual } from 'node:crypto'`

Fixes #1444

## Details

The `event.data.token !== authToken` comparison in `packages/server-runtime/src/index.ts` (line 342) exits early on the first mismatched byte. An attacker observing response latency can incrementally guess the token character by character.

`crypto.timingSafeEqual()` always compares all bytes in constant time, eliminating the timing oracle.

## Test plan

- [ ] Verify WebSocket authentication still works with correct token
- [ ] Verify authentication is rejected with incorrect token
- [ ] Verify server works without auth token configured (no-auth mode)
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*