### PR TITLE
fix(docs): fix Try Live button opening 404 in VitePress SPA router

### DIFF
--- a/docs/.vitepress/components/HomeButton.vue
+++ b/docs/.vitepress/components/HomeButton.vue
@@ -8,6 +8,7 @@ defineProps<{
 
 <template>
   <a
+    :target="item.target"
     :href="item.link"
     :class="[
       'rounded-xl px-3 py-2 lg:px-5 lg:py-3 font-extrabold outline-none backdrop-blur-md active:scale-95 focus:outline-none text-nowrap text-sm md:text-base',

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -213,6 +213,7 @@ export default defineConfig<ThemeConfig>({
               text: 'Try Live',
               link: webLive,
               primary: true,
+              target: '_self',
             },
             {
               text: 'Download',
@@ -353,6 +354,7 @@ export default defineConfig<ThemeConfig>({
               text: '网页版',
               link: webLive,
               primary: true,
+              target: '_self',
             },
             {
               text: '下载',
@@ -493,6 +495,7 @@ export default defineConfig<ThemeConfig>({
               text: 'ライブ版を試す',
               link: webLive,
               primary: true,
+              target: '_self',
             },
             {
               text: 'ダウンロード',
@@ -513,7 +516,6 @@ export default defineConfig<ThemeConfig>({
       { icon: 'discord', link: discord },
       { icon: 'github', link: github },
     ],
-
     search: {
       provider: 'local',
     },

--- a/docs/.vitepress/theme/config.ts
+++ b/docs/.vitepress/theme/config.ts
@@ -12,6 +12,7 @@ export interface ButtonItem {
   text?: string
   link?: string
   primary?: boolean
+  target?: string
 }
 
 export type ThemeConfig = DefaultTheme.Config & ExtraThemeConfig


### PR DESCRIPTION
## Summary

VitePress intercepts clicks on `<a>` elements without an explicit `target` attribute and routes them through Vue Router. The **Try Live** button links to the external URL `https://airi.moeru.ai/`, which is not a VitePress route, causing a 404.

## Changes

- Added `target?: string` field to the `ButtonItem` interface in `theme/config.ts`
- Set `target: '_self'` on all locales' **Try Live** button configs (EN, ZH, JA) in `config.ts`
- Fixed `HomeButton.vue` to bind `:target="item.target"` on the `<a>` element

## How it fixes the issue

Setting `target="_self"` signals to VitePress/Vue Router to skip client-side navigation and let the browser perform a standard navigation to the URL, preventing the 404.
