### PR TITLE
fix(stage-layouts): align web chat tools discovery with Tamagotchi (immediate watch)）

### DIFF
--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -134,7 +134,7 @@ watch([activeProvider, activeModel], async () => {
   if (activeProvider.value && activeModel.value) {
     await discoverToolsCompatibility(activeModel.value, await providersStore.getProviderInstance<ChatProvider>(activeProvider.value), [])
   }
-})
+}, { immediate: true })
 
 onUnmounted(() => {
   teardownAnalyzer()

--- a/packages/stage-layouts/src/components/Widgets/ChatArea.vue
+++ b/packages/stage-layouts/src/components/Widgets/ChatArea.vue
@@ -138,7 +138,7 @@ watch([activeProvider, activeModel], async () => {
   if (activeProvider.value && activeModel.value) {
     await discoverToolsCompatibility(activeModel.value, await providersStore.getProviderInstance<ChatProvider>(activeProvider.value), [])
   }
-})
+}, { immediate: true })
 
 onAfterMessageComposed(async () => {
 })


### PR DESCRIPTION
## Description

Web chat (`ChatArea` / `MobileInteractiveArea`) watched `activeProvider` + `activeModel` **without** `{ immediate: true }`, so `discoverToolsCompatibility` only ran **after** the user changed provider or model. Until then, `toolsCompatibility` had no entry and `llm.stream` sent **`tools: undefined`**—no MCP/debug/extra tools on the first messages.

Tamagotchi’s `InteractiveArea.vue` already used `{ immediate: true }`, so behavior differed. This PR adds `{ immediate: true }` to both web components so discovery runs on mount when provider/model are already set.

## Linked Issues

N/A

## Additional Context

Small, `stage-layouts` only.
