### PR TITLE
fix(stage-ui): bind cursor floating css vars

### DIFF
--- a/packages/stage-ui/src/components/physics/cursor-floating.vue
+++ b/packages/stage-ui/src/components/physics/cursor-floating.vue
@@ -13,8 +13,10 @@ const props = withDefaults(defineProps<Props>(), {
 
 const cardRef = ref<HTMLElement | null>(null)
 const transformStyle = ref('')
-const gradientPosition = ref('50% 50%')
-const sparklePosition = ref('50% 50%')
+const cardPositionX = ref('50%')
+const cardPositionY = ref('50%')
+const sparklePositionX = ref('50%')
+const sparklePositionY = ref('50%')
 const sparkleOpacity = ref(0.5)
 
 function handleMouseMove(event: MouseEvent) {
@@ -50,15 +52,19 @@ function handleMouseMove(event: MouseEvent) {
 
   // Update style values
   transformStyle.value = `perspective(1200px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) scale3d(${1 + 0.015 * props.intensity}, ${1 + 0.015 * props.intensity}, ${1 + 0.015 * props.intensity})`
-  gradientPosition.value = `${leftPos}% ${topPos}%`
-  sparklePosition.value = `${sparkleX}% ${sparkleY}%`
+  cardPositionX.value = `${leftPos}%`
+  cardPositionY.value = `${topPos}%`
+  sparklePositionX.value = `${sparkleX}%`
+  sparklePositionY.value = `${sparkleY}%`
   sparkleOpacity.value = opacity
 }
 
 function resetCard() {
   transformStyle.value = 'perspective(1200px) rotateX(0deg) rotateY(0deg) scale3d(1, 1, 1)'
-  gradientPosition.value = '50% 50%'
-  sparklePosition.value = '50% 50%'
+  cardPositionX.value = '50%'
+  cardPositionY.value = '50%'
+  sparklePositionX.value = '50%'
+  sparklePositionY.value = '50%'
   sparkleOpacity.value = 0.5
 }
 
@@ -75,10 +81,10 @@ onMounted(() => {
     :style="{
       'transform': transformStyle,
       '--effect-intensity': intensity,
-      '--card-position-x': gradientPosition.split(' ')[0],
-      '--card-position-y': gradientPosition.split(' ')[1],
-      '--sparkle-position-x': sparklePosition.split(' ')[0],
-      '--sparkle-position-y': sparklePosition.split(' ')[1],
+      '--card-position-x': cardPositionX,
+      '--card-position-y': cardPositionY,
+      '--sparkle-position-x': sparklePositionX,
+      '--sparkle-position-y': sparklePositionY,
       '--sparkle-opacity': sparkleOpacity,
     }"
     @mousemove="handleMouseMove"


### PR DESCRIPTION
## Summary
- bind the computed cursor and sparkle CSS variables in `cursor-floating.vue` so the pseudo-element hover effects actually follow the pointer
- keep the fix scoped to the component and verify it against the existing `cursor-floating.story.vue` surface

## Testing
- packages/stage-ui/src/components/physics/cursor-floating.story.vue (verification surface)
- packages/stage-ui/src/components/physics/cursor-floating.vue
- packages/stage-ui: `./node_modules/.bin/histoire build` (completed with existing global setup warnings but produced the story build output)
- packages/stage-ui: `./node_modules/.bin/vue-tsc --noEmit` is currently blocked by pre-existing workspace dependency resolution issues outside the touched file
- LSP diagnostics on `cursor-floating.vue` are clean