### PR TITLE
fix(docs): links to other doc pages

### DIFF
--- a/docs/content/en/docs/overview/index.md
+++ b/docs/content/en/docs/overview/index.md
@@ -95,4 +95,4 @@ of tokens for running AIRI.
 
 For guides that help you understand how to contribute to this project, please refer to [Contributing](../contributing/) page.
 
-For references Contributing help you design and improve the UI of Project AIRI, please refer to [Design Guidelines](../contributing/design-guidelines/resources) page.
+For references to help you design and improve the UI of Project AIRI, please refer to [Design Guidelines](../contributing/design-guidelines/resources) page.


### PR DESCRIPTION
## Description

Some links point to 404 page. Fix the links to correct pages.

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
