### PR TITLE
fix(ui): forward default slot in InputFile to BasicInputFile

### DIFF
--- a/packages/ui/src/components/form/input/input-file.vue
+++ b/packages/ui/src/components/form/input/input-file.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
+import { useSlots } from 'vue'
+
 import BasicInputFile from './basic-input-file.vue'
 
 defineProps<{
   accept?: string
   multiple?: boolean
 }>()
+
+const slots = useSlots()
 </script>
 
 <template>
@@ -28,7 +32,9 @@ defineProps<{
     :multiple="multiple"
   >
     <template #default="{ isDragging }">
+      <slot v-if="slots.default" :is-dragging="isDragging" />
       <div
+        v-else
         class="flex flex-col items-center"
         :class="[
           isDragging ? 'text-primary-500 dark:text-primary-400' : 'text-neutral-400 dark:text-neutral-500',


### PR DESCRIPTION
## Summary

- `InputFile` was ignoring any `default` slot passed by consumers and always rendering its own hardcoded English strings ("Upload", "Release to upload", "Click or drag and drop a file here")
- Pages that already provide a localized `<template #default>` (e.g. `packages/stage-pages/src/pages/settings/airi-card/index.vue`) never had their content rendered — the slot was silently dropped
- Fix: use `useSlots()` to detect whether a consumer has passed a default slot; if so, forward it (along with `isDragging`) to `BasicInputFile`; otherwise fall back to the built-in English UI so existing usages remain unaffected

## Test plan

- [x] Open the AIRI card settings page — the upload area should now show the localized text from `airi-card/index.vue` instead of "Upload"
- [x] Verify drag-and-drop state (`isDragging`) is correctly forwarded to the consumer slot
- [x] Verify pages that do **not** pass a custom slot still render the default fallback UI