### PR TITLE
fix(stage-tamagotchi): autoUpdater should have channel selected

### DIFF
--- a/apps/stage-tamagotchi/src/main/services/electron/auto-updater.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/auto-updater.ts
@@ -4,7 +4,7 @@ import type { UpdateInfo } from 'electron-updater'
 
 import type { AutoUpdaterState } from '../../../shared/eventa'
 
-import process from 'node:process'
+import { arch } from 'node:process'
 
 import electronUpdater from 'electron-updater'
 
@@ -64,7 +64,7 @@ export function setupAutoUpdater(): AutoUpdater {
 
   // Fix: explicitly map base channel to architecture to resolve 404 targets.
   // electron-updater natively appends OS suffixes (-mac.yml, -linux.yml) automatically.
-  autoUpdater.channel = process.arch === 'arm64' ? 'latest-arm64' : 'latest-x64'
+  autoUpdater.channel = arch === 'arm64' ? 'latest-arm64' : 'latest-x64'
 
   function broadcast(next: AutoUpdaterState) {
     state = next


### PR DESCRIPTION
## Description

When launching the app, the main process crashes immediately with `SyntaxError: The requested module 'vue' does not provide an export named 'computed'`. This prevents the application from opening.

## Linked Issues
#1428 (for updater issue)

## Additional Context
(Launch issues Patch)
The Electron main process runs in Node's ESM context and something interacts with `vue`. Since Vue's default Node.js file path resolves to its CommonJS build wrapper, Node's ES Module loader cannot statically detect or extract its named exports (like `computed`, `ref`, etc.), leading to the crash.

Added `vue` to `externalizeDeps.exclude` inside the main process configuration within `electron.vite.config.ts`. By bundling `vue` into the main process output rather than leaving it as an external runtime require, we bypass Node's CJS-ESM module parsing bug entirely and safely resolve the reactivity methods during compilation.

(Updater patch) the updater portion detects the device architecture before checking for updates, since latest.yml doesnt exist so it should pull the correct version with the full yml naming schemes.