### PR TITLE
fix(stage-layouts): clear voice auto-send input before ingest resolves

### DIFF
--- a/packages/stage-layouts/src/components/Widgets/ChatArea.vue
+++ b/packages/stage-layouts/src/components/Widgets/ChatArea.vue
@@ -97,8 +97,9 @@ async function debouncedAutoSend(text: string) {
       }
       catch (err) {
         console.error('[ChatArea] Auto-send error:', err)
-        messageInput.value = textToSend
-        pendingAutoSendText.value = textToSend
+        // Preserve any transcription that arrived while ingest was in flight (see PR review).
+        messageInput.value = [textToSend, messageInput.value.trim()].filter(Boolean).join(' ')
+        pendingAutoSendText.value = [textToSend, pendingAutoSendText.value.trim()].filter(Boolean).join(' ')
       }
     }
     autoSendTimeout = undefined


### PR DESCRIPTION
## Description

### Bug
With streaming transcription (e.g. Alibaba Cloud NLS) and voice auto-send enabled in the stage chat (ChatArea), if the user spoke again while the assistant reply was still streaming, the next recognized sentence was appended to the previous message in the input (and could be sent as one combined user message). Waiting until the assistant finished speaking avoided the issue. OpenAI-compatible transcription paths did not show the same behavior in our checks.
<img width="1170" height="1765" alt="PixPin_2026-03-28_20-48-33" src="https://github.com/user-attachments/assets/0af58a0b-958a-45f3-bb96-bea0b9cfaff5" />

### Cause
ingest() only resolves after the full assistant turn completes. Auto-send previously cleared messageInput and pendingAutoSendText after await ingest(), so new SentenceEnd callbacks kept appending to text that was already committed logically but still present in the UI/buffer.

### Fix
Clear messageInput and pendingAutoSendText before await ingest(), matching the manual send path (clear first, then send). On failure, restore both from the captured textToSend.

### Follow-up
Early clear means the textarea can stay empty until the next transcript delta while a turn is in flight. A small UX improvement later (e.g. a short “sent” / “queued” hint) would make that less confusing; treating as a separate polish item.

## Linked Issues

N/A

## Additional Context

Suggested test: NLS + auto-send → send one utterance → speak again before the assistant finishes → confirm the second message is not merged with the first.
