### PR TITLE
typo(i18n): correct xsai-transformers URL typo in Japanese locale

### DIFF
--- a/packages/i18n/src/locales/ja/settings.yaml
+++ b/packages/i18n/src/locales/ja/settings.yaml
@@ -601,16 +601,16 @@ pages:
     provider:
       app-local-audio-transcription:
         title: アプリ (ローカル)
-        description: https://github.com/moeru-ai/xsai-transforers
+        description: https://github.com/moeru-ai/xsai-transformers
       app-local-audio-speech:
         title: アプリ (ローカル)
-        description: https://github.com/moeru-ai/xsai-transforers
+        description: https://github.com/moeru-ai/xsai-transformers
       browser-local-audio-transcription:
         title: ブラウザ (ローカル)
-        description: https://github.com/moeru-ai/xsai-transforers
+        description: https://github.com/moeru-ai/xsai-transformers
       browser-local-audio-speech:
         title: ブラウザ (ローカル)
-        description: https://github.com/moeru-ai/xsai-transforers
+        description: https://github.com/moeru-ai/xsai-transformers
       alibaba-cloud-model-studio:
         description: bailian.console.aliyun.com
         title: Alibaba Cloud Model Studio


### PR DESCRIPTION
## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->

<img width="1170" height="280" alt="image" src="https://github.com/user-attachments/assets/6e4191ac-09f9-427e-816b-66ac0bb88b84" />

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I tested it's fixed with this PR

<img width="1178" height="276" alt="image" src="https://github.com/user-attachments/assets/c5c460a5-db48-413d-976c-d8b9cdd3c07a" />
