### PR TITLE
Add adjustable Live2D render resolution scaling in settings

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -127,6 +127,9 @@ live2d:
     description: Limit rendering frame rate
     options:
       unlimited: ∞
+  resolution-scaling:
+    title: Rendering Resolution Scale
+    description: Adjust Live2D render resolution scaling (base 2x)
 microphone: Microphone
 models: Model
 pages:

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -120,6 +120,9 @@ live2d:
     description: 限制渲染帧率
     options:
       unlimited: '∞'
+  resolution-scaling:
+    title: 渲染分辨率缩放
+    description: 调整 Live2D 渲染分辨率缩放（基础为 2x）
 microphone: 麦克风
 models: 模型
 pages:

--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Screen } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import Live2DCanvas from './live2d/Canvas.vue'
 import Live2DModel from './live2d/Model.vue'
@@ -28,6 +28,7 @@ withDefaults(defineProps<{
   live2dExpressionEnabled?: boolean
   live2dShadowEnabled?: boolean
   live2dMaxFps?: number
+  live2dResolutionScaling?: number
 }>(), {
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
@@ -41,6 +42,7 @@ withDefaults(defineProps<{
   live2dExpressionEnabled: true,
   live2dShadowEnabled: true,
   live2dMaxFps: 0,
+  live2dResolutionScaling: 1,
 })
 
 const componentState = defineModel<'pending' | 'loading' | 'mounted'>('state', { default: 'pending' })
@@ -51,6 +53,7 @@ const live2dCanvasRef = ref<InstanceType<typeof Live2DCanvas>>()
 
 const live2d = useLive2d()
 const { position } = storeToRefs(live2d)
+const live2dCanvasResolution = computed(() => Math.max(0.5, props.live2dResolutionScaling) * 2)
 
 watch([componentStateModel, componentStateCanvas], () => {
   componentState.value = (componentStateModel.value === 'mounted' && componentStateCanvas.value === 'mounted')
@@ -73,7 +76,7 @@ defineExpose({
       v-model:state="componentStateCanvas"
       :width="width"
       :height="height"
-      :resolution="2"
+      :resolution="live2dCanvasResolution"
       :max-fps="live2dMaxFps"
       max-h="100dvh"
     >

--- a/packages/stage-ui/src/components/scenarios/settings/model-settings/live2d.vue
+++ b/packages/stage-ui/src/components/scenarios/settings/model-settings/live2d.vue
@@ -34,6 +34,7 @@ const {
   live2dExpressionEnabled,
   live2dShadowEnabled,
   live2dMaxFps,
+  live2dResolutionScaling,
 } = storeToRefs(settings)
 
 const live2d = useLive2d()
@@ -337,6 +338,35 @@ function handleMotionSelect(selectedMotionPath: string | number | undefined) {
         <SelectTab v-model="live2dMaxFps" :options="fpsOptions" size="sm" :class="['shrink-0']" />
       </div>
     </label>
+
+    <FieldRange
+      v-model="live2dResolutionScaling"
+      as="div"
+      :min="0.5"
+      :max="2"
+      :step="0.05"
+      :label="t('settings.live2d.resolution-scaling.title')"
+    >
+      <template #label>
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex-1">
+            <div class="text-sm font-medium">
+              {{ t('settings.live2d.resolution-scaling.title') }}
+            </div>
+            <div class="text-xs text-neutral-500 dark:text-neutral-400">
+              {{ t('settings.live2d.resolution-scaling.description') }}
+            </div>
+          </div>
+          <button
+            class="px-2 text-xs outline-none"
+            title="Reset value to default"
+            @click="() => live2dResolutionScaling = 1"
+          >
+            <div class="i-solar:forward-linear transform-scale-x--100 text-neutral-500 dark:text-neutral-400" />
+          </button>
+        </div>
+      </template>
+    </FieldRange>
 
     <div mt-4 flex items-center justify-between>
       <span text-sm text-neutral-600 dark:text-neutral-400>Auto Blink</span>

--- a/packages/stage-ui/src/components/scenarios/settings/model-settings/preview-stage.vue
+++ b/packages/stage-ui/src/components/scenarios/settings/model-settings/preview-stage.vue
@@ -43,6 +43,7 @@ const {
   live2dForceAutoBlinkEnabled,
   live2dShadowEnabled,
   live2dMaxFps,
+  live2dResolutionScaling,
 } = storeToRefs(settingsStore)
 const { scale: live2dScale } = storeToRefs(live2dStore)
 const { sceneMutationLocked, scenePhase } = storeToRefs(modelStore)
@@ -136,6 +137,7 @@ defineExpose({
         :live2d-force-auto-blink-enabled="live2dForceAutoBlinkEnabled"
         :live2d-shadow-enabled="live2dShadowEnabled"
         :live2d-max-fps="live2dMaxFps"
+        :live2d-resolution-scaling="live2dResolutionScaling"
       />
     </div>
   </template>

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -68,6 +68,7 @@ const {
   live2dExpressionEnabled,
   live2dShadowEnabled,
   live2dMaxFps,
+  live2dResolutionScaling,
 } = storeToRefs(settingsStore)
 const { mouthOpenSize } = storeToRefs(useSpeakingStore())
 const { audioContext } = useAudioContext()
@@ -588,6 +589,7 @@ defineExpose({
         :live2d-expression-enabled="live2dExpressionEnabled"
         :live2d-shadow-enabled="live2dShadowEnabled"
         :live2d-max-fps="live2dMaxFps"
+        :live2d-resolution-scaling="live2dResolutionScaling"
       />
       <ThreeScene
         v-if="stageModelRenderer === 'vrm' && showStage"

--- a/packages/stage-ui/src/stores/settings/index.ts
+++ b/packages/stage-ui/src/stores/settings/index.ts
@@ -74,6 +74,7 @@ export const useSettings = defineStore('settings', () => {
     live2dExpressionEnabled: live2dRefs.live2dExpressionEnabled,
     live2dShadowEnabled: live2dRefs.live2dShadowEnabled,
     live2dMaxFps: live2dRefs.live2dMaxFps,
+    live2dResolutionScaling: live2dRefs.live2dResolutionScaling,
 
     // Theme settings
     themeColorsHue: themeRefs.themeColorsHue,

--- a/packages/stage-ui/src/stores/settings/live2d.ts
+++ b/packages/stage-ui/src/stores/settings/live2d.ts
@@ -27,6 +27,7 @@ export const useSettingsLive2d = defineStore('settings-live2d', () => {
   const live2dExpressionEnabled = useLocalStorageManualReset<boolean>('settings/live2d/expression-enabled', false)
   const live2dShadowEnabled = useLocalStorageManualReset<boolean>('settings/live2d/shadow-enabled', true)
   const live2dMaxFps = useLocalStorageManualReset<number>('settings/live2d/max-fps', 0)
+  const live2dResolutionScaling = useLocalStorageManualReset<number>('settings/live2d/resolution-scaling', 1)
 
   function resetState() {
     live2dDisableFocus.reset()
@@ -36,6 +37,7 @@ export const useSettingsLive2d = defineStore('settings-live2d', () => {
     live2dExpressionEnabled.reset()
     live2dShadowEnabled.reset()
     live2dMaxFps.reset()
+    live2dResolutionScaling.reset()
   }
 
   return {
@@ -46,6 +48,7 @@ export const useSettingsLive2d = defineStore('settings-live2d', () => {
     live2dExpressionEnabled,
     live2dShadowEnabled,
     live2dMaxFps,
+    live2dResolutionScaling,
     resetState,
   }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13346,9 +13346,6 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
@@ -20144,7 +20141,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.12.2
-      jose: 6.1.3
+      jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -27988,8 +27985,6 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.6.1: {}
-
-  jose@6.1.3: {}
 
   jose@6.2.2: {}
 


### PR DESCRIPTION
### Motivation
- Allow users to trade off Live2D rendering quality and performance by exposing a simple resolution scaling control in the settings UI.
- Make the scaling persistent and flow through preview and main stage so the change affects all Live2D render surfaces consistently.

### Description
- Add a persisted setting `live2dResolutionScaling` (key `settings/live2d/resolution-scaling`, default `1`) to the Live2D settings store via `useSettingsLive2d` and expose it through the unified `useSettings` facade.
- Add a new slider (`FieldRange`) in the Live2D settings page `packages/stage-ui/src/components/scenarios/settings/model-settings/live2d.vue` with range `0.5..2`, step `0.05`, and a reset-to-default button wired to the new setting.
- Thread the new setting through the preview and main stage by passing `:live2d-resolution-scaling` into `Live2DScene` from `preview-stage.vue` and `Stage.vue` so both preview and runtime use the same value.
- Make `stage-ui-live2d/src/components/scenes/Live2D.vue` compute `live2dCanvasResolution` as `Math.max(0.5, props.live2dResolutionScaling) * 2` and pass it to `Live2DCanvas` via the `:resolution` prop so canvas resolution scales from the previous 2x baseline.
- Add i18n keys `settings.live2d.resolution-scaling.{title,description}` to English and Simplified Chinese locales for the new control.

### Testing
- Ran `pnpm lint:fix` in this environment but it failed because the `moeru-lint` command is not available here (lint step could not complete).
- Ran `pnpm typecheck` but it failed in this environment due to missing `vue-tsc` in multiple workspaces, so full type checks did not complete.
- No unit tests were added or modified as part of this change; please run targeted Vitest runs and project typechecks locally or in CI (for example `pnpm -F @proj-airi/stage-ui exec vitest run` and `pnpm -F @proj-airi/stage-ui typecheck`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea495a95c8329aaadcc44c54de18b)