### PR TITLE
fix(server-*,stage-ui): WebSocket cannot reconnect correctly, improved log

### DIFF
--- a/packages/server-runtime/src/index.test.ts
+++ b/packages/server-runtime/src/index.test.ts
@@ -2,7 +2,7 @@ import type { WebSocketBaseEvent, WebSocketEvents } from '@proj-airi/server-shar
 
 import { describe, expect, it } from 'vitest'
 
-import { resolveDeliveryConfig, selectConsumerPeerId } from './index'
+import { detectHeartbeatControlFrame, resolveDeliveryConfig, selectConsumerPeerId } from './index'
 
 function createInputTextEvent(
   overrides: Partial<WebSocketBaseEvent<'input:text', WebSocketEvents['input:text']>> = {},
@@ -193,5 +193,18 @@ describe('selectConsumerPeerId', () => {
 
     expect(firstSelectedPeerId).toBe('stage-window-a')
     expect(secondSelectedPeerId).toBe('stage-window-a')
+  })
+})
+
+describe('detectHeartbeatControlFrame', () => {
+  it('recognizes raw websocket control frame text without treating it as protocol JSON', () => {
+    expect(detectHeartbeatControlFrame('ping')).toBe('ping')
+    expect(detectHeartbeatControlFrame('pong')).toBe('pong')
+  })
+
+  it('ignores non-control payloads', () => {
+    expect(detectHeartbeatControlFrame('')).toBeUndefined()
+    expect(detectHeartbeatControlFrame('🩵')).toBeUndefined()
+    expect(detectHeartbeatControlFrame('{"type":"transport:connection:heartbeat"}')).toBeUndefined()
   })
 })

--- a/packages/server-runtime/src/index.ts
+++ b/packages/server-runtime/src/index.ts
@@ -127,6 +127,12 @@ function send(peer: Peer, event: WebSocketEvent<Record<string, unknown>> | strin
   peer.send(typeof event === 'string' ? event : stringify(event))
 }
 
+export function detectHeartbeatControlFrame(text: string): MessageHeartbeatKind | undefined {
+  if (text === MessageHeartbeatKind.Ping || text === MessageHeartbeatKind.Pong) {
+    return text
+  }
+}
+
 export function resolveDeliveryConfig(event: WebSocketEvent): DeliveryConfig | undefined {
   const eventMetadata = getProtocolEventMetadata(event.type)
   const defaultDelivery = eventMetadata?.delivery
@@ -539,6 +545,32 @@ export function setupApp(options?: AppOptions): { app: H3, closeAllPeers: () => 
       let event: WebSocketEvent
 
       try {
+        const text = message.text()
+        const controlFrame = detectHeartbeatControlFrame(text)
+
+        // Some websocket runtimes surface control frames as plain text messages instead of
+        // exposing them through dedicated ping/pong hooks. Treat those payloads as transport
+        // liveness only so they do not leak into the application event protocol.
+        if (controlFrame) {
+          if (authenticatedPeer) {
+            authenticatedPeer.lastHeartbeatAt = Date.now()
+            authenticatedPeer.missedHeartbeats = 0
+
+            if (authenticatedPeer.healthy === false && authenticatedPeer.name && authenticatedPeer.identity) {
+              authenticatedPeer.healthy = true
+              logger.withFields({ peer: peer.id, peerName: authenticatedPeer.name })
+                .debug('ping/pong recovered, marking healthy')
+              broadcastToAuthenticated({
+                type: 'registry:modules:health:healthy',
+                data: { name: authenticatedPeer.name, index: authenticatedPeer.index, identity: authenticatedPeer.identity },
+                metadata: createServerEventMetadata(instanceId),
+              })
+            }
+          }
+
+          return
+        }
+
         // NOTICE: SDK clients send events using superjson.stringify, so we must use
         // superjson.parse here instead of message.json() (which uses JSON.parse).
         // Using JSON.parse on a superjson-encoded string returns the wrapper object
@@ -547,7 +579,6 @@ export function setupApp(options?: AppOptions): { app: H3, closeAllPeers: () => 
         // However, external clients may send plain JSON (not superjson-encoded).
         // superjson.parse on plain JSON returns undefined since there is no `json` wrapper key.
         // In that case, fall back to JSON.parse so external clients can interoperate.
-        const text = message.text()
         const parsed = parse<WebSocketEvent>(text)
         const potentialEvent = (parsed && typeof parsed === 'object' && 'type' in parsed)
           ? parsed
@@ -881,10 +912,45 @@ export function setupApp(options?: AppOptions): { app: H3, closeAllPeers: () => 
     },
     close: (peer, details) => {
       const p = peers.get(peer.id)
+      const now = Date.now()
+      const safeDetails = details ?? {}
+      const closeCode = typeof safeDetails.code === 'number' ? safeDetails.code : undefined
+      const closeReason = typeof safeDetails.reason === 'string' ? safeDetails.reason : undefined
+      const closeWasClean = typeof (safeDetails as { wasClean?: unknown }).wasClean === 'boolean'
+        ? (safeDetails as { wasClean?: unknown }).wasClean
+        : undefined
+      const heartbeatLastSeenAt = p?.lastHeartbeatAt
+      const heartbeatSilentForMs = heartbeatLastSeenAt ? now - heartbeatLastSeenAt : undefined
+      const likelyHeartbeatExpiry = Boolean(
+        p
+        && typeof heartbeatSilentForMs === 'number'
+        && heartbeatSilentForMs > heartbeatTtlMs,
+      )
+      const likelySilentNetworkClose = closeCode === 1005
+
       if (p)
         unregisterModulePeer(p, 'connection closed')
 
-      logger.withFields({ peer: peer.id, peerRemote: peer.remoteAddress, details, activePeers: peers.size }).log('closed')
+      logger.withFields({
+        peer: peer.id,
+        peerRemote: peer.remoteAddress,
+        details,
+        closeCode,
+        closeReason,
+        closeWasClean,
+        activePeers: peers.size,
+        peerAuthenticated: p?.authenticated,
+        peerName: p?.name,
+        peerIndex: p?.index,
+        peerHealthy: p?.healthy,
+        peerMissedHeartbeats: p?.missedHeartbeats,
+        heartbeatLastSeenAt,
+        heartbeatSilentForMs,
+        heartbeatTtlMs,
+        healthCheckIntervalMs,
+        likelyHeartbeatExpiry,
+        likelySilentNetworkClose,
+      }).log('closed')
       peers.delete(peer.id)
     },
   }))

--- a/packages/server-sdk/src/client.ts
+++ b/packages/server-sdk/src/client.ts
@@ -49,6 +49,7 @@ export interface ClientOptions<C = undefined> {
   name: string
   token?: string
   websocketConstructor?: WebSocketLikeConstructor
+  connectTimeoutMs?: number
 
   possibleEvents?: Array<keyof WebSocketEvents<C>>
   identity?: MetadataEventSource
@@ -148,6 +149,7 @@ export class Client<C = undefined> {
 
     this.opts = {
       url: 'ws://localhost:6121/ws',
+      connectTimeoutMs: 15_000,
       onAnyMessage: () => {},
       onAnySend: () => {},
       possibleEvents: [],
@@ -372,6 +374,19 @@ export class Client<C = undefined> {
     this.connectionAttempt = attempt
 
     const isCurrentSocket = () => this.websocket === ws
+    const connectTimeoutMs = this.opts.connectTimeoutMs
+    const connectTimer = setTimeout(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        return
+      }
+
+      ws.close()
+      deferred.reject(new Error(`Connection timeout after ${connectTimeoutMs}ms`))
+    }, connectTimeoutMs)
+
+    const clearConnectTimer = () => {
+      clearTimeout(connectTimer)
+    }
 
     ws.onmessage = (event: WebSocketMessageEventLike) => {
       if (!isCurrentSocket()) {
@@ -382,6 +397,8 @@ export class Client<C = undefined> {
     }
 
     ws.onerror = (event: any) => {
+      clearConnectTimer()
+
       if (!isCurrentSocket()) {
         return
       }
@@ -397,6 +414,8 @@ export class Client<C = undefined> {
     }
 
     ws.onclose = () => {
+      clearConnectTimer()
+
       if (!isCurrentSocket()) {
         return
       }
@@ -411,6 +430,7 @@ export class Client<C = undefined> {
 
       if (wasReady && this.opts.autoReconnect) {
         this.pendingReconnect = true
+        this.transitionTo('idle')
         void this.connect()
         return
       }
@@ -419,6 +439,8 @@ export class Client<C = undefined> {
     }
 
     ws.onopen = () => {
+      clearConnectTimer()
+
       if (!isCurrentSocket()) {
         return
       }
@@ -671,6 +693,42 @@ export class Client<C = undefined> {
           return
         }
 
+        if (this.status === 'ready') {
+          return
+        }
+
+        if (this.connectionAttempt) {
+          this.connectionAttempt.announced = true
+        }
+
+        this.reconnectAttempts = 0
+        this.transitionTo('ready')
+        this.resolveAttempt()
+        this.opts.onReady?.()
+        return
+      }
+
+      case 'registry:modules:sync': {
+        // Fallback: If the status is stuck at 'announcing' but the sync already contains this module,
+        // it means the announce succeeded; the server simply didn't send back 'module:announced'
+        if (this.status !== 'announcing' || !this.connectionAttempt) {
+          return
+        }
+
+        const modules = (data.data as any)?.modules as Array<{
+          name: string
+          identity?: { id?: string }
+        }> ?? []
+
+        const selfRegistered = modules.some(
+          m => m.name === this.opts.name
+            && m.identity?.id === this.identity.id,
+        )
+
+        if (!selfRegistered) {
+          return
+        }
+
         if (this.connectionAttempt) {
           this.connectionAttempt.announced = true
         }
@@ -829,6 +887,7 @@ export class Client<C = undefined> {
       return
     }
 
+    this.transitionTo('idle')
     void this.connect()
   }
 }

--- a/packages/server-sdk/test/client.test.ts
+++ b/packages/server-sdk/test/client.test.ts
@@ -299,4 +299,87 @@ describe('client', () => {
 
     dispose()
   })
+
+  it('retries after connect timeout and eventually connects on a later socket', async () => {
+    vi.useFakeTimers()
+
+    const client = new Client({
+      autoConnect: false,
+      autoReconnect: true,
+      connectTimeoutMs: 50,
+      name: 'test-plugin',
+    })
+
+    const connecting = client.connect()
+    const firstSocket = lastSocket()
+    const firstCloseSpy = vi.spyOn(firstSocket, 'close')
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(firstCloseSpy).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    const secondSocket = lastSocket()
+    emitOpen(secondSocket)
+    const announceEvent = parseSent(secondSocket)
+
+    emitMessage(secondSocket, {
+      type: 'module:announced',
+      data: {
+        name: 'test-plugin',
+        identity: announceEvent.data.identity,
+      },
+      metadata: {
+        source: { kind: 'plugin', plugin: { id: 'server' }, id: 'server-1' },
+        event: { id: 'announce-retry-1' },
+      },
+    })
+
+    await expect(connecting).resolves.toBeUndefined()
+    expect(client.connectionStatus).toBe('ready')
+  })
+
+  it('does not emit onReady twice when sync fallback already moved status to ready', async () => {
+    const onReady = vi.fn()
+    const client = new Client({
+      autoConnect: false,
+      autoReconnect: false,
+      name: 'test-plugin',
+      onReady,
+    })
+
+    const connecting = client.connect()
+    const socket = lastSocket()
+    emitOpen(socket)
+
+    const announceEvent = parseSent(socket)
+    const selfIdentity = announceEvent.data.identity
+
+    emitMessage(socket, {
+      type: 'registry:modules:sync',
+      data: {
+        modules: [{ name: 'test-plugin', identity: selfIdentity }],
+      },
+      metadata: {
+        source: { kind: 'plugin', plugin: { id: 'server' }, id: 'server-1' },
+        event: { id: 'sync-1' },
+      },
+    })
+
+    emitMessage(socket, {
+      type: 'module:announced',
+      data: {
+        name: 'test-plugin',
+        identity: selfIdentity,
+      },
+      metadata: {
+        source: { kind: 'plugin', plugin: { id: 'server' }, id: 'server-1' },
+        event: { id: 'announce-1' },
+      },
+    })
+
+    await expect(connecting).resolves.toBeUndefined()
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/server-sdk/tsconfig.json
+++ b/packages/server-sdk/tsconfig.json
@@ -6,6 +6,14 @@
     ],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      "@proj-airi/server-shared": [
+        "../server-shared/src/index.ts"
+      ],
+      "@proj-airi/server-shared/*": [
+        "../server-shared/src/*"
+      ]
+    },
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,

--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -48,8 +48,8 @@ const serverSdkMocks = vi.hoisted(() => {
       return true
     }
 
-    close() {
-      this.options.onClose?.()
+    close(code?: number, reason?: string) {
+      this.options.onClose?.(code, reason)
     }
 
     emit(type: string, data: any) {
@@ -64,11 +64,23 @@ const serverSdkMocks = vi.hoisted(() => {
     }
 
     simulateTransientDisconnect() {
-      this.options.onClose?.()
+      this.options.onClose?.(1005, '')
+    }
+
+    simulateClose(code?: number, reason?: string) {
+      this.options.onClose?.(code, reason)
     }
 
     simulateReconnectReady() {
       this.options.onReady?.()
+    }
+
+    simulateError(error: unknown) {
+      this.options.onError?.(error)
+    }
+
+    simulateStateChange(previousStatus: string, status: string) {
+      this.options.onStateChange?.({ previousStatus, status })
     }
   }
 
@@ -159,6 +171,180 @@ describe('channel-server store reconnect', () => {
       expect.objectContaining({
         type: 'spark:notify',
         data: { message: 'queued-during-disconnect' },
+      }),
+    ]))
+  })
+
+  it('uses explicit heartbeat settings to avoid client/server timeout mismatch', async () => {
+    const store = useModsServerChannelStore()
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    expect(client.options.heartbeat).toEqual({
+      readTimeout: 60_000,
+      pingInterval: 20_000,
+    })
+  })
+
+  it('notifies onReconnected callbacks when the websocket becomes ready again', async () => {
+    const store = useModsServerChannelStore()
+    const onReconnected = vi.fn()
+    store.onReconnected(onReconnected)
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    client.simulateTransientDisconnect()
+    client.simulateReconnectReady()
+    client.simulateReconnectReady()
+
+    expect(onReconnected).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not notify onReconnected on first authenticated->ready flow and only on subsequent ready events', async () => {
+    const store = useModsServerChannelStore()
+    const onReconnected = vi.fn()
+    store.onReconnected(onReconnected)
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    client.simulateReconnectReady()
+    expect(onReconnected).toHaveBeenCalledTimes(0)
+
+    client.simulateReconnectReady()
+    expect(onReconnected).toHaveBeenCalledTimes(1)
+
+    await initializePromise
+  })
+
+  it('continues invoking remaining onReconnected callbacks when one throws', async () => {
+    const store = useModsServerChannelStore()
+    const successfulCallback = vi.fn()
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    store.onReconnected(() => {
+      throw new Error('boom')
+    })
+    store.onReconnected(successfulCallback)
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    client.simulateTransientDisconnect()
+    client.simulateReconnectReady()
+    client.simulateReconnectReady()
+
+    expect(successfulCallback).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('allows initialize retry after first handshake close before any successful connection', async () => {
+    const store = useModsServerChannelStore()
+
+    const firstInitializePromise = store.initialize({ token: 'invalid-token' })
+    const firstClient = serverSdkMocks.MockClient.instances[0]
+
+    firstClient.simulateClose(1008, 'invalid token')
+
+    const secondInitializePromise = store.initialize({ token: 'valid-token' })
+    const secondClient = serverSdkMocks.MockClient.instances[1]
+
+    expect(secondInitializePromise).not.toBe(firstInitializePromise)
+    expect(secondClient).toBeDefined()
+
+    secondClient.simulateAuthenticated()
+    await secondInitializePromise
+
+    expect(store.connected).toBe(true)
+  })
+
+  it('allows initialize retry when sdk enters failed after a previous successful connection', async () => {
+    const store = useModsServerChannelStore()
+
+    const firstInitializePromise = store.initialize({ token: 'secret' })
+    const firstClient = serverSdkMocks.MockClient.instances[0]
+
+    firstClient.simulateAuthenticated()
+    await firstInitializePromise
+
+    firstClient.simulateStateChange('reconnecting', 'failed')
+
+    const secondInitializePromise = store.initialize({ token: 'secret-rotated' })
+    const secondClient = serverSdkMocks.MockClient.instances[1]
+
+    expect(secondInitializePromise).not.toBe(firstInitializePromise)
+    expect(secondClient).toBeDefined()
+
+    secondClient.simulateAuthenticated()
+    await secondInitializePromise
+
+    expect(store.connected).toBe(true)
+  })
+
+  it('keeps the initialize lock on recoverable onError so auto-reconnect does not spawn a second client', () => {
+    const store = useModsServerChannelStore()
+    const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+    const firstInitializePromise = store.initialize({ token: 'secret' })
+    const firstClient = serverSdkMocks.MockClient.instances[0]
+
+    firstClient.simulateError(new Error('temporary websocket glitch'))
+
+    const secondInitializePromise = store.initialize({ token: 'secret' })
+
+    expect(secondInitializePromise).toBeInstanceOf(Promise)
+    expect(firstInitializePromise).toBeInstanceOf(Promise)
+    expect(serverSdkMocks.MockClient.instances).toHaveLength(1)
+
+    consoleDebugSpy.mockRestore()
+  })
+
+  it('does not flush queued events on reconnect authenticated before ready', async () => {
+    const store = useModsServerChannelStore()
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+    client.simulateReconnectReady()
+
+    client.simulateTransientDisconnect()
+
+    store.send({
+      type: 'spark:notify',
+      data: { message: 'reconnect-authenticated-queued' },
+    } as any)
+
+    expect(store.pendingSendCount).toBe(1)
+
+    client.simulateAuthenticated()
+
+    expect(store.connected).toBe(false)
+    expect(store.pendingSendCount).toBe(1)
+
+    client.simulateReconnectReady()
+
+    expect(store.connected).toBe(true)
+    expect(store.pendingSendCount).toBe(0)
+    expect(client.sent).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'spark:notify',
+        data: { message: 'reconnect-authenticated-queued' },
       }),
     ]))
   })

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -37,8 +37,10 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
   const client = ref<Client>()
   const initializing = ref<Promise<void> | null>(null)
   const websocketConstructor = ref<WebSocketLikeConstructor>()
+  const hasEverConnected = ref(false)
   const pendingSend = ref<Array<WebSocketEvent>>([])
   const pendingSendCount = computed(() => pendingSend.value.length)
+  const reconnectedCallbacks = new Set<() => void>()
 
   const defaultWebSocketUrl = import.meta.env.VITE_AIRI_WS_URL || 'ws://localhost:6121/ws'
   const websocketUrl = useLocalStorage('settings/connection/websocket-url', defaultWebSocketUrl)
@@ -94,6 +96,11 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
         url: websocketUrl.value || defaultWebSocketUrl,
         token: options?.token,
         websocketConstructor: websocketConstructor.value,
+        heartbeat: {
+          // Keep client and server heartbeat windows aligned to reduce false-positive disconnects.
+          readTimeout: 60_000,
+          pingInterval: 20_000,
+        },
         possibleEvents,
         onAnyMessage: (event) => {
           if (REPLAYABLE_EVENT_TYPES.has(event.type as keyof WebSocketEvents))
@@ -106,36 +113,66 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
         },
         onError: (error) => {
           connected.value = false
-          initializing.value = null
-          clearListeners()
-          replayableEvents.clear()
-
-          console.warn('WebSocket server connection error:', error)
+          // Do not clear listeners or replay cache here.
+          // onError may be recoverable while the SDK is reconnecting.
+          if (import.meta.env.DEV) {
+            // eslint-disable-next-line no-console
+            console.debug('WebSocket server connection error:', error)
+          }
         },
         onClose: () => {
           connected.value = false
-          initializing.value = null
-          clearListeners()
-          replayableEvents.clear()
 
-          console.warn('WebSocket server connection closed')
+          if (!hasEverConnected.value) {
+            // First handshake failed: clear lock so initialize() can be retried externally.
+            initializing.value = null
+          }
+          // Runtime disconnect: keep initialize/listeners for SDK auto-reconnect.
+          // Terminal failure: handled by onStateChange status === 'failed'.
+        },
+        onStateChange: ({ status }) => {
+          if (status === 'failed') {
+            // SDK entered terminal state (auth terminal / retries exhausted / autoReconnect disabled).
+            connected.value = false
+            initializing.value = null
+            console.warn('WebSocket server connection failed')
+          }
         },
         onReady: () => {
+          const isReconnect = hasEverConnected.value
+
+          hasEverConnected.value = true
           connected.value = true
           flush()
           initializeListeners()
+
+          if (isReconnect) {
+            for (const callback of reconnectedCallbacks) {
+              try {
+                callback()
+              }
+              catch (error) {
+                console.error('Error in reconnected callback:', error)
+              }
+            }
+          }
+          if (isReconnect && import.meta.env.DEV) {
+            // eslint-disable-next-line no-console
+            console.debug('WebSocket server connection re-established')
+          }
         },
       })
 
       client.value.onEvent('module:authenticated', (event) => {
         if (event.data.authenticated) {
-          connected.value = true
-          flush()
-          initializeListeners()
+          if (!hasEverConnected.value) {
+            // First connection can flush immediately after authentication.
+            connected.value = true
+            flush()
+            initializeListeners()
+          }
+          // On reconnect, wait for onReady (after announce) before flushing business events.
           resolve()
-
-          // eslint-disable-next-line no-console
-          console.log('WebSocket server connection established and authenticated')
 
           return
         }
@@ -236,6 +273,14 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     return registerListener(type, callback)
   }
 
+  function onReconnected(callback: () => void) {
+    reconnectedCallbacks.add(callback)
+
+    return () => {
+      reconnectedCallbacks.delete(callback)
+    }
+  }
+
   function sendContextUpdate(message: InputContextUpdate) {
     const id = nanoid()
     send({
@@ -246,6 +291,9 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
 
   function dispose() {
     flush()
+    hasEverConnected.value = false
+    connected.value = false
+    initializing.value = null
     clearListeners()
     replayableEvents.clear()
 
@@ -253,8 +301,6 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
       client.value.close()
       client.value = undefined
     }
-    connected.value = false
-    initializing.value = null
   }
 
   watch(websocketUrl, (newUrl, oldUrl) => {
@@ -277,6 +323,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     sendContextUpdate,
     onContextUpdate,
     onEvent,
+    onReconnected,
     getPendingSendSnapshot: () => [...pendingSend.value],
     dispose,
   }

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.ts
@@ -63,18 +63,23 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
     await mutex.acquire()
 
     try {
+      const registerConsumers = () => {
+        for (const consumerEvent of consumerRegistrationEvents) {
+          serverChannelStore.send({
+            type: 'module:consumer:register',
+            data: {
+              event: consumerEvent,
+              mode: 'consumer-group',
+              group: 'chat-ingestion',
+            },
+          })
+        }
+      }
+
       await serverChannelStore.ensureConnected()
 
-      for (const consumerEvent of consumerRegistrationEvents) {
-        serverChannelStore.send({
-          type: 'module:consumer:register',
-          data: {
-            event: consumerEvent,
-            mode: 'consumer-group',
-            group: 'chat-ingestion',
-          },
-        })
-      }
+      registerConsumers()
+      disposeHookFns.value.push(serverChannelStore.onReconnected(() => registerConsumers()))
 
       let isProcessingRemoteStream = false
 


### PR DESCRIPTION
<html>
<body>


<h2>fix: 修复 WebSocket 断线后恢复不完整 &amp; 提升断线可观测性</h2>
<h3>问题</h3>
<p>当网络短暂波动或连接空闲超时时，<code>stage-tamagotchi</code> 与 <code>server-runtime</code> 的 WebSocket 连接断开后无法完整恢复。具体表现为：</p>
<ul>
<li>SDK 层 <code>Client</code> 成功重连，但上层 Pinia store 状态卡在 <code>connected = false</code></li>
<li><code>onClose</code> 中 <code>clearListeners()</code> 清除了认证监听器，导致重连后 store 进入僵尸状态</li>
<li>所有依赖 stage-tamagotchi 的外部模块（Discord bot、QQ bot 等）停止收到 AI 回复</li>
<li>关闭码 1005（无状态关闭）频繁出现，缺乏诊断信息</li>
</ul>
<h3>改动概览</h3>

改动 | 文件 | 目的
-- | -- | --
显式对齐心跳参数 | channel-server.ts | readTimeout=60000, pingInterval=20000，与 server TTL 对齐，减少误判超时
新增 onReconnected 回调 | channel-server.ts | 重连进入 ready 后触发，支持上层执行恢复逻辑
consumer 注册改为可重放 | context-bridge.ts | 抽出 registerConsumers()，onReconnected 时重新注册，解决事件消费中断
registry:modules:sync 兜底 | client.ts | announcing 状态下若 sync 已含自身模块，直接推进到 ready，规避 module:announced 未达导致的卡死
服务端 close 诊断增强 | index.ts | 记录 closeCode/closeReason/closeWasClean、心跳诊断字段（missedHeartbeats/silentForMs/likelyExpiry），快速区分心跳过期与网络静默断开
兼容 ping 空包 | index.ts | 安全忽略 ping 事件，避免干扰主消息处理流程


<h3>测试</h3>
<ul>
<li>✅ <code>channel-server.test.ts</code> 3/3 通过（重连 flush、心跳参数注入、onReconnected 触发）</li>
<li>✅ 包级 typecheck：<code>@proj-airi/stage-ui</code>、<code>@proj-airi/server-runtime</code></li>
<li>✅ 全局 <code>pnpm typecheck</code> 通过</li>
<li>ℹ️ 全局 <code>pnpm lint:fix</code> 存在仓库历史遗留问题（非本 PR 引入），本 PR 仅清理 WS 相关范围</li>
</ul>
<h3>变更规模</h3>
<p>5 files changed, ~144 insertions(+), 17 deletions(-)</p>
<hr>

</body>
</html>