### PR TITLE
 fix(stage-tamagotchi): harden cross-platform auto-updater flow, diagnostics, logs, and cache cleanup

### DIFF
--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -29,7 +29,9 @@
     "rename-artifacts": "mkdir -p bundle && tsx scripts/rename-artifacts.ts",
     "merge-latest-mac": "tsx scripts/merge-latest-mac.ts",
     "regenerate-windows-latest": "tsx scripts/regenerate-windows-latest.ts",
-    "artifacts-metadata": "tsx scripts/artifacts-metadata.ts"
+    "artifacts-metadata": "tsx scripts/artifacts-metadata.ts",
+    "update-test:generate": "tsx scripts/update-test/generate-manifest.ts",
+    "update-test:server": "tsx scripts/update-test/start-server.ts"
   },
   "dependencies": {
     "@date-fns/utc": "^2.1.1",

--- a/apps/stage-tamagotchi/scripts/update-test/README.md
+++ b/apps/stage-tamagotchi/scripts/update-test/README.md
@@ -1,0 +1,85 @@
+# AIRI Electron Updater Local Test Harness
+
+This directory provides a local mocked update-server workflow for Stage Tamagotchi.
+
+It is intended to verify AIRI's refactored updater path:
+
+- explicit `UPDATE_SERVER_URL` override mode
+- no GitHub Releases API dependency
+- no custom updater cache ownership
+- developer-only updater diagnostics inspection
+
+## Files
+
+- `generate-manifest.ts`: generate local `latest-*.yml` metadata and placeholder artifacts
+- `start-server.ts`: serve generated fixtures over HTTP
+- `setup.sh`: prepare the local fixture directories
+- `run-test.sh`: thin orchestration wrapper
+- `dev-app-update.local.yml`: optional generic-provider template for development-only experiments
+
+## Quick Start
+
+From the repo root:
+
+```bash
+bash apps/stage-tamagotchi/scripts/update-test/setup.sh
+pnpm -F @proj-airi/stage-tamagotchi update-test:generate \
+  --root scripts/update-test/fixtures/server \
+  --channel stable \
+  --target aarch64-apple-darwin \
+  --version 9.9.9-update-test.1
+pnpm -F @proj-airi/stage-tamagotchi update-test:server \
+  --port 8787 \
+  --root scripts/update-test/fixtures/server
+```
+
+Then, in another terminal:
+
+```bash
+cd apps/stage-tamagotchi
+UPDATE_SERVER_URL=http://127.0.0.1:8787/stable pnpm run dev
+```
+
+## Verification Flow
+
+1. Open the About page.
+2. Click `Check for updates`.
+3. Confirm the update becomes available.
+4. Click `Download update`.
+5. Confirm the updater reaches the `downloaded` state.
+6. Open `Settings > System > Developer`.
+7. Enable `Inspect updater diagnostics`.
+8. Open `Devtools > Updater`.
+9. Confirm:
+   - `overrideActive=true`
+   - `feedUrl` points to `http://127.0.0.1:8787/stable`
+   - `platform`, `arch`, and `channel` match the current runtime
+
+## Helper Wrapper
+
+You can also print the workflow commands with:
+
+```bash
+bash apps/stage-tamagotchi/scripts/update-test/run-test.sh
+```
+
+Environment variables supported by the wrapper:
+
+- `PORT`
+- `CHANNEL`
+- `TARGET`
+- `VERSION`
+
+Common targets:
+
+- Apple Silicon macOS: `aarch64-apple-darwin`
+- Intel macOS: `x86_64-apple-darwin`
+- Windows x64: `x86_64-pc-windows-msvc`
+- Linux x64: `x86_64-unknown-linux-gnu`
+
+## Notes
+
+- The generated artifact is a placeholder file meant for update discovery and early download flow verification.
+- Real signed installer execution remains a separate manual verification step.
+- The first pass is manual-first by design. A Playwright `_electron` smoke layer can be added on top later.
+- When invoking the package scripts through `pnpm -F @proj-airi/stage-tamagotchi`, treat `--root` as relative to `apps/stage-tamagotchi`, not the workspace root.

--- a/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/AIRI-9.9.9-update-test.1-darwin-arm64.dmg
+++ b/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/AIRI-9.9.9-update-test.1-darwin-arm64.dmg
@@ -1,0 +1,1 @@
+mock-update-stable-9.9.9-update-test.1

--- a/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/AIRI-9.9.9-update-test.1-windows-x64-setup.exe
+++ b/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/AIRI-9.9.9-update-test.1-windows-x64-setup.exe
@@ -1,0 +1,1 @@
+mock-update-stable-9.9.9-update-test.1

--- a/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/latest-arm64-mac.yml
+++ b/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/latest-arm64-mac.yml
@@ -1,0 +1,9 @@
+version: 9.9.9-update-test.1
+files:
+  - url: AIRI-9.9.9-update-test.1-darwin-arm64.dmg
+    sha512: D6msk0IrWPMUcpjWnMZfEVrY8Qe/yQN4iJO6O6mttkwl5pENCNazyxdvRJX+kOZFujznbCIc+m1z6dokPzHg2A==
+    size: 38
+path: AIRI-9.9.9-update-test.1-darwin-arm64.dmg
+sha512: D6msk0IrWPMUcpjWnMZfEVrY8Qe/yQN4iJO6O6mttkwl5pENCNazyxdvRJX+kOZFujznbCIc+m1z6dokPzHg2A==
+releaseDate: 2026-04-05T17:39:00.050Z
+releaseNotes: Mock update for AIRI local updater verification.

--- a/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/latest-x64.yml
+++ b/apps/stage-tamagotchi/scripts/update-test/fixtures/server/stable/latest-x64.yml
@@ -1,0 +1,9 @@
+version: 9.9.9-update-test.1
+files:
+  - url: AIRI-9.9.9-update-test.1-windows-x64-setup.exe
+    sha512: D6msk0IrWPMUcpjWnMZfEVrY8Qe/yQN4iJO6O6mttkwl5pENCNazyxdvRJX+kOZFujznbCIc+m1z6dokPzHg2A==
+    size: 38
+path: AIRI-9.9.9-update-test.1-windows-x64-setup.exe
+sha512: D6msk0IrWPMUcpjWnMZfEVrY8Qe/yQN4iJO6O6mttkwl5pENCNazyxdvRJX+kOZFujznbCIc+m1z6dokPzHg2A==
+releaseDate: 2026-04-05T14:51:10.149Z
+releaseNotes: Mock update for AIRI local updater verification.

--- a/apps/stage-tamagotchi/scripts/update-test/generate-manifest.test.ts
+++ b/apps/stage-tamagotchi/scripts/update-test/generate-manifest.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import * as yaml from 'yaml'
+
+import { generateManifestFixtures, resolveLatestFilenameForTarget } from './generate-manifest'
+
+describe('generateManifestFixtures', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.map(async (root) => {
+      await import('node:fs/promises').then(({ rm }) => rm(root, { recursive: true, force: true }))
+    }))
+    roots.length = 0
+  })
+
+  it('maps targets to the expected latest-yml filenames', () => {
+    expect(resolveLatestFilenameForTarget('x86_64-pc-windows-msvc')).toBe('latest-x64.yml')
+    expect(resolveLatestFilenameForTarget('aarch64-apple-darwin')).toBe('latest-arm64-mac.yml')
+    expect(resolveLatestFilenameForTarget('x86_64-apple-darwin')).toBe('latest-x64-mac.yml')
+    expect(resolveLatestFilenameForTarget('x86_64-unknown-linux-gnu')).toBe('latest-x64-linux.yml')
+    expect(resolveLatestFilenameForTarget('aarch64-unknown-linux-gnu')).toBe('latest-arm64-linux-arm64.yml')
+  })
+
+  it('generates a channel directory, manifest, and placeholder artifact', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'airi-update-test-'))
+    roots.push(root)
+
+    const result = await generateManifestFixtures({
+      rootDir: root,
+      channel: 'stable',
+      target: 'x86_64-pc-windows-msvc',
+      version: '9.9.9-test.1',
+      releaseNotes: 'Mock update for AIRI local updater verification.',
+      artifactContent: 'mock-installer-binary',
+    })
+
+    expect(result.channelDir).toBe(join(root, 'stable'))
+    expect(result.latestFilename).toBe('latest-x64.yml')
+    expect(result.artifactFilename).toBe('AIRI-9.9.9-test.1-windows-x64-setup.exe')
+
+    const manifest = yaml.parse(await readFile(result.manifestPath, 'utf8'))
+    expect(manifest).toMatchObject({
+      version: '9.9.9-test.1',
+      path: 'AIRI-9.9.9-test.1-windows-x64-setup.exe',
+      releaseNotes: 'Mock update for AIRI local updater verification.',
+      files: [
+        {
+          url: 'AIRI-9.9.9-test.1-windows-x64-setup.exe',
+        },
+      ],
+    })
+
+    expect(typeof manifest.sha512).toBe('string')
+    expect(typeof manifest.releaseDate).toBe('string')
+    expect(manifest.files[0]?.size).toBeGreaterThan(0)
+    await expect(readFile(result.artifactPath, 'utf8')).resolves.toBe('mock-installer-binary')
+  })
+})

--- a/apps/stage-tamagotchi/scripts/update-test/generate-manifest.ts
+++ b/apps/stage-tamagotchi/scripts/update-test/generate-manifest.ts
@@ -1,0 +1,136 @@
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { exit } from 'node:process'
+
+import { cac } from 'cac'
+
+import * as yaml from 'yaml'
+
+import { getFilenames } from '../utils'
+
+export type UpdateTestChannel = 'stable' | 'nightly' | 'canary'
+
+export interface GenerateManifestFixturesOptions {
+  rootDir: string
+  channel: UpdateTestChannel
+  target: string
+  version: string
+  releaseNotes: string
+  artifactContent?: string
+}
+
+export interface GenerateManifestFixturesResult {
+  channelDir: string
+  manifestPath: string
+  artifactPath: string
+  latestFilename: string
+  artifactFilename: string
+}
+
+export function resolveLatestFilenameForTarget(target: string) {
+  switch (target) {
+    case 'x86_64-pc-windows-msvc':
+      return 'latest-x64.yml'
+    case 'x86_64-unknown-linux-gnu':
+      return 'latest-x64-linux.yml'
+    case 'aarch64-unknown-linux-gnu':
+      return 'latest-arm64-linux-arm64.yml'
+    case 'x86_64-apple-darwin':
+      return 'latest-x64-mac.yml'
+    case 'aarch64-apple-darwin':
+      return 'latest-arm64-mac.yml'
+    default:
+      throw new Error(`Unsupported update-test target: ${target}`)
+  }
+}
+
+function encodeBase64Sha512(content: string) {
+  return createHash('sha512').update(content).digest('base64')
+}
+
+async function resolveArtifactFilename(target: string, version: string) {
+  const filenames = await getFilenames(target, {
+    release: true,
+    autoTag: false,
+    tag: [version],
+  })
+
+  const artifact = filenames.find(entry => !entry.optional && entry.extension !== 'blockmap')
+  if (!artifact)
+    throw new Error(`Unable to determine artifact filename for target: ${target}`)
+
+  return artifact.releaseArtifactFilename
+}
+
+export async function generateManifestFixtures(options: GenerateManifestFixturesOptions): Promise<GenerateManifestFixturesResult> {
+  const channelDir = join(options.rootDir, options.channel)
+  const latestFilename = resolveLatestFilenameForTarget(options.target)
+  const artifactFilename = await resolveArtifactFilename(options.target, options.version)
+  const manifestPath = join(channelDir, latestFilename)
+  const artifactPath = join(channelDir, artifactFilename)
+  const artifactContent = options.artifactContent ?? `mock-update-${options.channel}-${options.version}`
+
+  await mkdir(dirname(manifestPath), { recursive: true })
+  await writeFile(artifactPath, artifactContent, 'utf8')
+
+  const sha512 = encodeBase64Sha512(artifactContent)
+  const releaseDate = new Date().toISOString()
+  const size = Buffer.byteLength(artifactContent)
+
+  const manifest = {
+    version: options.version,
+    files: [
+      {
+        url: artifactFilename,
+        sha512,
+        size,
+      },
+    ],
+    path: artifactFilename,
+    sha512,
+    releaseDate,
+    releaseNotes: options.releaseNotes,
+  }
+
+  await writeFile(manifestPath, yaml.stringify(manifest), 'utf8')
+
+  return {
+    channelDir,
+    manifestPath,
+    artifactPath,
+    latestFilename,
+    artifactFilename,
+  }
+}
+
+async function main() {
+  const cli = cac('generate-update-test-manifest')
+    .option('--root <path>', 'Root directory for generated server fixtures', { default: 'scripts/update-test/fixtures/server' })
+    .option('--channel <channel>', 'Channel to generate', { default: 'stable' })
+    .option('--target <target>', 'Target triple to generate fixtures for', { default: 'x86_64-pc-windows-msvc' })
+    .option('--version <version>', 'Version to publish in the generated manifest', { default: '9.9.9-update-test.1' })
+    .option('--release-notes <notes>', 'Release notes content', { default: 'Mock update for AIRI local updater verification.' })
+
+  const parsed = cli.parse()
+  const result = await generateManifestFixtures({
+    rootDir: String(parsed.options.root),
+    channel: String(parsed.options.channel) as UpdateTestChannel,
+    target: String(parsed.options.target),
+    version: String(parsed.options.version),
+    releaseNotes: String(parsed.options.releaseNotes),
+  })
+
+  // eslint-disable-next-line no-console
+  console.log(`Generated ${result.latestFilename} in ${result.channelDir}`)
+  // eslint-disable-next-line no-console
+  console.log(`Artifact: ${result.artifactFilename}`)
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error)
+    exit(1)
+  })
+}

--- a/apps/stage-tamagotchi/scripts/update-test/run-test.sh
+++ b/apps/stage-tamagotchi/scripts/update-test/run-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PORT="${PORT:-8787}"
+CHANNEL="${CHANNEL:-stable}"
+TARGET="${TARGET:-x86_64-pc-windows-msvc}"
+VERSION="${VERSION:-9.9.9-update-test.1}"
+
+bash "${SCRIPT_DIR}/setup.sh"
+
+pnpm exec tsx "${SCRIPT_DIR}/generate-manifest.ts" \
+  --root "${SCRIPT_DIR}/fixtures/server" \
+  --channel "${CHANNEL}" \
+  --target "${TARGET}" \
+  --version "${VERSION}"
+
+echo
+echo "Start the local update server in another terminal:"
+echo "pnpm exec tsx ${SCRIPT_DIR}/start-server.ts --port ${PORT} --root ${SCRIPT_DIR}/fixtures/server"
+echo
+echo "Launch AIRI against the mocked update server:"
+echo "cd ${APP_DIR}"
+echo "UPDATE_SERVER_URL=http://127.0.0.1:${PORT}/${CHANNEL} pnpm run dev"
+echo
+echo "Verify:"
+echo "1. About page shows an available update."
+echo "2. Download reaches the downloaded state."
+echo "3. Settings > System > Developer enables updater diagnostics."
+echo "4. Devtools > Updater shows overrideActive=true and the local feed URL."

--- a/apps/stage-tamagotchi/scripts/update-test/setup.sh
+++ b/apps/stage-tamagotchi/scripts/update-test/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "${SCRIPT_DIR}/fixtures/server/stable"
+mkdir -p "${SCRIPT_DIR}/fixtures/server/nightly"
+mkdir -p "${SCRIPT_DIR}/fixtures/server/canary"
+
+chmod +x "${SCRIPT_DIR}/setup.sh" "${SCRIPT_DIR}/run-test.sh"
+
+echo "Prepared update-test fixtures in ${SCRIPT_DIR}/fixtures/server"

--- a/apps/stage-tamagotchi/scripts/update-test/start-server.ts
+++ b/apps/stage-tamagotchi/scripts/update-test/start-server.ts
@@ -1,0 +1,83 @@
+/* eslint-disable no-console */
+import process, { exit } from 'node:process'
+
+import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { extname, join, normalize } from 'node:path'
+
+import { cac } from 'cac'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.exe': 'application/vnd.microsoft.portable-executable',
+  '.yml': 'text/yaml; charset=utf-8',
+  '.yaml': 'text/yaml; charset=utf-8',
+  '.zip': 'application/zip',
+  '.dmg': 'application/octet-stream',
+  '.deb': 'application/vnd.debian.binary-package',
+  '.rpm': 'application/x-rpm',
+  '.txt': 'text/plain; charset=utf-8',
+}
+
+function getContentType(pathname: string) {
+  return CONTENT_TYPES[extname(pathname)] ?? 'application/octet-stream'
+}
+
+export async function startUpdateTestServer(options: { port: number, rootDir: string }) {
+  const server = createServer(async (request, response) => {
+    const pathname = request.url?.split('?')[0] || '/'
+    // eslint-disable-next-line e18e/prefer-static-regex
+    const safePath = normalize(pathname).replace(/^(\.\.(\/|\\|$))+/, '')
+    const filePath = join(options.rootDir, safePath === '/' ? '/index.html' : safePath)
+
+    try {
+      const body = await readFile(filePath)
+      response.writeHead(200, { 'content-type': getContentType(filePath) })
+      response.end(body)
+    }
+    catch {
+      response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' })
+      response.end(`Not found: ${pathname}`)
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(options.port, '127.0.0.1', () => resolve())
+  })
+
+  return server
+}
+
+async function main() {
+  const cli = cac('update-test-server')
+    .option('--port <port>', 'Port to listen on', { default: '8787' })
+    .option('--root <path>', 'Server root directory', { default: 'scripts/update-test/fixtures/server' })
+
+  const parsed = cli.parse()
+  const port = Number(parsed.options.port)
+  const rootDir = String(parsed.options.root)
+
+  const server = await startUpdateTestServer({ port, rootDir })
+
+  console.log(`Update test server listening on http://127.0.0.1:${port}`)
+  console.log(`stable:  http://127.0.0.1:${port}/stable`)
+  console.log(`nightly: http://127.0.0.1:${port}/nightly`)
+  console.log(`canary:  http://127.0.0.1:${port}/canary`)
+
+  const close = async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve())
+    })
+    exit(0)
+  }
+
+  process.on('SIGINT', () => { void close() })
+  process.on('SIGTERM', () => { void close() })
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error)
+    exit(1)
+  })
+}

--- a/apps/stage-tamagotchi/src/main/services/electron/auto-updater.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/auto-updater.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const appMock = vi.hoisted(() => ({
+  getVersion: vi.fn(() => '0.9.0-beta.4'),
+  getPath: vi.fn((name: string) => name === 'logs' ? '/tmp/airi/logs' : `/tmp/${name}`),
+  quit: vi.fn(),
+  isPackaged: false,
+}))
+
+const isDevState = vi.hoisted(() => ({
+  value: false,
+}))
+
+const updaterState = vi.hoisted(() => ({
+  instance: createUpdaterMock(),
+}))
+
+function createUpdaterMock() {
+  return {
+    on: vi.fn(),
+    autoDownload: true,
+    allowPrerelease: false,
+    channel: undefined as string | undefined,
+    logger: undefined as any,
+    forceDevUpdateConfig: false,
+    setFeedURL: vi.fn(),
+    checkForUpdates: vi.fn().mockResolvedValue(undefined),
+    downloadUpdate: vi.fn().mockResolvedValue(undefined),
+    quitAndInstall: vi.fn(),
+  }
+}
+
+vi.mock('electron', () => ({
+  app: appMock,
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: {
+    get dev() {
+      return isDevState.value
+    },
+  },
+}))
+
+vi.mock('@guiiai/logg', () => ({
+  useLogg: () => ({
+    useGlobalConfig: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      withError: () => ({
+        error: vi.fn(),
+      }),
+    }),
+  }),
+}))
+
+vi.mock('electron-updater', () => ({
+  default: {
+    get autoUpdater() {
+      return updaterState.instance
+    },
+  },
+}))
+
+vi.mock('~build/git', () => ({
+  committerDate: '2026-04-01T00:00:00.000Z',
+}))
+
+describe('setupAutoUpdater', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    updaterState.instance = createUpdaterMock()
+    appMock.getVersion.mockReturnValue('0.9.0-beta.4')
+    appMock.getPath.mockImplementation((name: string) => name === 'logs' ? '/tmp/airi/logs' : `/tmp/${name}`)
+    isDevState.value = false
+    delete process.env.UPDATE_SERVER_URL
+  })
+
+  it('does not query the GitHub Releases API during setup or manual checks', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { setupAutoUpdater } = await import('./auto-updater')
+    const service = setupAutoUpdater()
+
+    await Promise.resolve()
+    await service.checkForUpdates()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('only uses setFeedURL when an explicit update server override is provided', async () => {
+    process.env.UPDATE_SERVER_URL = 'http://localhost:8787/stable'
+
+    const { setupAutoUpdater } = await import('./auto-updater')
+    setupAutoUpdater()
+
+    expect(updaterState.instance.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'http://localhost:8787/stable',
+    })
+  })
+
+  it('uses the real updater in dev mode when an explicit update server override is provided', async () => {
+    isDevState.value = true
+    process.env.UPDATE_SERVER_URL = 'http://localhost:8787/stable'
+
+    const { setupAutoUpdater } = await import('./auto-updater')
+    setupAutoUpdater()
+
+    expect(updaterState.instance.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'http://localhost:8787/stable',
+    })
+    expect(updaterState.instance.forceDevUpdateConfig).toBe(true)
+  })
+
+  it('reports only authoritative diagnostics fields', async () => {
+    const { setupAutoUpdater } = await import('./auto-updater')
+    const service = setupAutoUpdater()
+
+    expect(service.state.diagnostics).toEqual(expect.objectContaining({
+      platform: process.platform,
+      arch: process.arch,
+      channel: 'latest-arm64',
+      executablePath: expect.any(String),
+      logFilePath: '/tmp/airi/logs',
+      isOverrideActive: false,
+    }))
+    expect(service.state.diagnostics).not.toHaveProperty('updaterCacheDir')
+    expect(service.state.diagnostics).not.toHaveProperty('pendingDir')
+    expect(service.state.diagnostics).not.toHaveProperty('uninstallPath')
+    expect(service.state.diagnostics).not.toHaveProperty('uninstallExists')
+  })
+
+  it('uses silent relaunch install on Windows only', async () => {
+    const originalPlatform = process.platform
+    vi.stubEnv('TEST_PLATFORM', '')
+
+    const { setupAutoUpdater } = await import('./auto-updater')
+    const service = setupAutoUpdater()
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    await service.quitAndInstall()
+    expect(updaterState.instance.quitAndInstall).toHaveBeenCalledWith(true, true)
+
+    updaterState.instance.quitAndInstall.mockClear()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    await service.quitAndInstall()
+    expect(updaterState.instance.quitAndInstall).toHaveBeenCalledWith()
+
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/electron/auto-updater.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/auto-updater.ts
@@ -3,10 +3,7 @@ import type { AutoUpdaterState } from '@proj-airi/electron-eventa/electron-updat
 import type { BrowserWindow } from 'electron'
 import type { UpdateInfo } from 'electron-updater'
 
-import fs from 'node:fs'
 import process from 'node:process'
-
-import { dirname, join } from 'node:path'
 
 import electronUpdater from 'electron-updater'
 
@@ -24,28 +21,13 @@ import {
 } from '../../../shared/eventa'
 import { MockAutoUpdater } from './mock-auto-updater'
 
-function getCacheRoot() {
-  switch (process.platform) {
-    case 'win32':
-      return process.env.LOCALAPPDATA || join(process.env.USERPROFILE || '', 'AppData', 'Local')
-    case 'darwin':
-      return join(process.env.HOME || '', 'Library', 'Caches')
-    default:
-      return process.env.XDG_CACHE_HOME || join(process.env.HOME || '', '.cache')
-  }
-}
-const CACHE_DIR = join(getCacheRoot(), 'stage-tamagotchi-updater')
-const UPDATER_LOG_FILE = join(CACHE_DIR, 'updater-log.txt')
-
 function getReleaseChannelName() {
-  const arch = process.arch
-
-  return arch === 'arm64' ? 'latest-arm64' : 'latest-x64'
+  return process.arch === 'arm64' ? 'latest-arm64' : 'latest-x64'
 }
 
-async function logToFile(level: string, msg: string) {
-  await fs.promises.mkdir(CACHE_DIR, { recursive: true }).catch(() => {})
-  await fs.promises.appendFile(UPDATER_LOG_FILE, `${new Date().toISOString()} [${level}] ${msg}\n`).catch(() => {})
+function getUpdateServerOverride() {
+  const value = process.env.UPDATE_SERVER_URL?.trim()
+  return value || undefined
 }
 
 export interface AppUpdaterLike {
@@ -58,17 +40,15 @@ export interface AppUpdaterLike {
   allowPrerelease?: boolean
   autoDownload?: boolean
   channel?: string
+  forceDevUpdateConfig?: boolean
 }
 
 // NOTICE: this part of code is copied from https://www.electron.build/auto-update
 // Or https://github.com/electron-userland/electron-builder/blob/b866e99ccd3ea9f85bc1e840f0f6a6a162fca388/pages/auto-update.md?plain=1#L57-L66
 export function fromImported(): AppUpdaterLike {
-  if (is.dev) {
+  if (is.dev && !getUpdateServerOverride())
     return new MockAutoUpdater()
-  }
 
-  // Using destructuring to access autoUpdater due to the CommonJS module of 'electron-updater'.
-  // It is a workaround for ESM compatibility issues, see https://github.com/electron-userland/electron-builder/issues/7976.
   const { autoUpdater } = electronUpdater
   return autoUpdater as unknown as AppUpdaterLike
 }
@@ -79,150 +59,49 @@ export interface AutoUpdater {
   state: AutoUpdaterState
   checkForUpdates: () => Promise<void>
   downloadUpdate: () => Promise<void>
-  quitAndInstall: () => void
+  quitAndInstall: () => Promise<void>
   subscribe: (callback: (state: AutoUpdaterState) => void) => () => void
 }
 
 export function setupAutoUpdater(): AutoUpdater {
   const semaphore = new Semaphore(1)
   const isPrereleaseBuild = app.getVersion().includes('-')
-
   const log = useLogg('auto-updater').useGlobalConfig()
   const autoUpdater = fromImported()
+  const feedUrlOverride = getUpdateServerOverride()
 
-  const OFFICIAL_UPDATER_CACHE_DIR = join(getCacheRoot(), 'ai.moeru.airi-updater')
-  const OFFICIAL_UPDATER_PENDING_DIR = join(OFFICIAL_UPDATER_CACHE_DIR, 'pending')
-  let resolvedFeedUrl = 'N/A'
-
-  // NOTICE: Diagnostics are intentionally included in updater state for supportability.
-  // Updater failures are often environment-dependent (platform/arch/channel/feed/cache path),
-  // and surfacing this context in logs/UI dramatically reduces reproduction time.
-  const getDiagnostics = () => {
-    const executablePath = process.execPath
-    const uninstallPath = process.platform === 'win32'
-      ? join(dirname(executablePath), 'Uninstall airi.exe')
-      : undefined
-
-    return {
-      platform: process.platform,
-      arch: process.arch,
-      channel: autoUpdater.channel || getReleaseChannelName(),
-      feedUrl: resolvedFeedUrl,
-      logFilePath: UPDATER_LOG_FILE,
-      updaterCacheDir: OFFICIAL_UPDATER_CACHE_DIR,
-      pendingDir: OFFICIAL_UPDATER_PENDING_DIR,
-      executablePath,
-      uninstallPath,
-      uninstallExists: uninstallPath ? fs.existsSync(uninstallPath) : undefined,
-    }
-  }
-
-  const logInstallDiagnostics = async () => {
-    const diagnostics = getDiagnostics()
-    await logToFile('INFO', `Install diagnostics: platform=${diagnostics.platform} arch=${diagnostics.arch} exe=${diagnostics.executablePath} uninstall=${diagnostics.uninstallPath || 'N/A'} uninstallExists=${String(diagnostics.uninstallExists ?? false)}`)
-  }
-
-  const broadcastUpdaterError = (error: unknown, reason: string) => {
-    const message = `${errorMessageFrom(error) || String(error)}\n\n(See full logs at ${UPDATER_LOG_FILE})`
-    broadcast({ status: 'error', error: { message } })
-    log.withError(error).error(reason)
-  }
-
-  const cleanupRootInstallerArtifacts = async () => {
-    const removed: string[] = []
-
-    const directTargets = [
-      join(OFFICIAL_UPDATER_CACHE_DIR, 'installer.exe'),
-      join(OFFICIAL_UPDATER_CACHE_DIR, 'installer'),
-    ]
-
-    for (const target of directTargets) {
-      if (fs.existsSync(target)) {
-        await fs.promises.rm(target, { force: true }).catch(() => {})
-        removed.push(target)
-      }
-    }
-
-    const entries = await fs.promises.readdir(OFFICIAL_UPDATER_CACHE_DIR, { withFileTypes: true }).catch(() => [])
-    for (const entry of entries) {
-      if (!entry.isFile())
-        continue
-
-      if (!/^installer(\..+)?$/i.test(entry.name))
-        continue
-
-      const target = join(OFFICIAL_UPDATER_CACHE_DIR, entry.name)
-      await fs.promises.rm(target, { force: true }).catch(() => {})
-      removed.push(target)
-    }
-
-    if (removed.length > 0)
-      await logToFile('INFO', `Removed updater root artifacts: ${removed.join(', ')}`)
-  }
-
-  const cleanupStaleUpdateFiles = async () => {
-    // Remove only installer executables from previous runs; keep pending update payloads intact.
-    await cleanupRootInstallerArtifacts()
-    await logToFile('INFO', `Updater cache cleanup attempted: ${OFFICIAL_UPDATER_PENDING_DIR}`)
-  }
-
-  const configureFeedForLatestRelease = async () => {
-    if (is.dev)
-      return
-
-    const archChannel = getReleaseChannelName()
-    // NOTICE: We query Releases API ourselves to enforce prerelease/stable matching with runtime version.
-    // The generic feed URL is then pinned to the chosen tag so updater metadata resolves deterministically.
-    // This avoids accidental cross-track updates (for example, stable app selecting prerelease metadata).
-    const releasesApi = 'https://api.github.com/repos/moeru-ai/airi/releases?per_page=20'
-    const response = await fetch(releasesApi, {
-      headers: {
-        'accept': 'application/vnd.github+json',
-        'User-Agent': 'airi-updater',
-      },
-    })
-
-    if (!response.ok)
-      throw new Error(`Failed to query releases API (${response.status})`)
-
-    const releases = await response.json() as Array<{ tag_name?: string, draft?: boolean, prerelease?: boolean }>
-    const latestRelease = releases.find(release => !!release.tag_name && !release.draft && !!release.prerelease === isPrereleaseBuild)
-      ?? releases.find(release => !!release.tag_name && !release.draft)
-    if (!latestRelease?.tag_name)
-      throw new Error('No published versions on GitHub')
-
-    const feedUrl = `https://github.com/moeru-ai/airi/releases/download/${latestRelease.tag_name}`
-    resolvedFeedUrl = feedUrl
-    autoUpdater.allowPrerelease = isPrereleaseBuild
-    autoUpdater.autoDownload = false
-    autoUpdater.channel = archChannel
-    autoUpdater.setFeedURL?.({ provider: 'generic', url: feedUrl })
-
-    await logToFile('INFO', `Updater feed set to ${feedUrl} (channel: ${archChannel})`)
-  }
-
-  // Configure updater defaults before dynamic feed resolution.
   autoUpdater.allowPrerelease = isPrereleaseBuild
   autoUpdater.autoDownload = false
   autoUpdater.channel = getReleaseChannelName()
-  void logInstallDiagnostics()
-  void cleanupStaleUpdateFiles()
-
+  autoUpdater.forceDevUpdateConfig = !!feedUrlOverride && !app.isPackaged
   autoUpdater.logger = {
-    info: (msg: string) => logToFile('INFO', msg),
-    warn: (msg: string) => logToFile('WARN', msg),
-    error: (msg: string) => logToFile('ERROR', msg),
-    debug: (msg: string) => logToFile('DEBUG', msg),
+    info: (message: string) => log.log(message),
+    warn: (message: string) => log.warn(message),
+    error: (message: string) => log.error(message),
+    debug: (message: string) => log.debug(message),
   }
 
-  let state: AutoUpdaterState = { status: 'idle' }
+  if (feedUrlOverride)
+    autoUpdater.setFeedURL?.({ provider: 'generic', url: feedUrlOverride })
+
+  const withDiagnostics = (next: AutoUpdaterState): AutoUpdaterState => ({
+    ...next,
+    diagnostics: {
+      platform: process.platform,
+      arch: process.arch,
+      channel: autoUpdater.channel || getReleaseChannelName(),
+      logFilePath: app.getPath('logs'),
+      executablePath: process.execPath,
+      isOverrideActive: !!feedUrlOverride,
+      ...(feedUrlOverride ? { feedUrl: feedUrlOverride } : {}),
+    },
+  })
+
+  let state: AutoUpdaterState = withDiagnostics({ status: 'idle' })
   const hooks = new Set<(state: AutoUpdaterState) => void>()
 
   function broadcast(next: AutoUpdaterState) {
-    state = {
-      ...next,
-      diagnostics: getDiagnostics(),
-    }
+    state = withDiagnostics(next)
 
     for (const listener of hooks) {
       try {
@@ -234,18 +113,26 @@ export function setupAutoUpdater(): AutoUpdater {
     }
   }
 
+  function broadcastUpdaterError(error: unknown, reason: string) {
+    broadcast({
+      status: 'error',
+      error: { message: errorMessageFrom(error) ?? String(error) },
+    })
+    log.withError(error).error(reason)
+  }
+
   autoUpdater.on('error', error => broadcastUpdaterError(error, 'autoUpdater error'))
   autoUpdater.on('checking-for-update', () => broadcast({ status: 'checking' }))
-  autoUpdater.on('update-available', (info: UpdateInfo) => {
-    void logToFile('INFO', `Update available: v${info.version}`)
-    broadcast({ status: 'available', info })
-  })
+  autoUpdater.on('update-available', (info: UpdateInfo) => broadcast({ status: 'available', info }))
   autoUpdater.on('update-downloaded', (info: UpdateInfo) => broadcast({ status: 'downloaded', info }))
-  autoUpdater.on('update-not-available', () => {
-    void logToFile('INFO', `Up to date: v${app.getVersion()}`)
-    void cleanupStaleUpdateFiles()
-    broadcast({ status: 'not-available', info: { version: app.getVersion(), files: [], releaseDate: committerDate } })
-  })
+  autoUpdater.on('update-not-available', () => broadcast({
+    status: 'not-available',
+    info: {
+      version: app.getVersion(),
+      files: [],
+      releaseDate: committerDate,
+    },
+  }))
   autoUpdater.on('download-progress', progress => broadcast({
     ...state,
     status: 'downloading',
@@ -257,15 +144,9 @@ export function setupAutoUpdater(): AutoUpdater {
     },
   }))
 
-  void (async () => {
-    try {
-      await configureFeedForLatestRelease()
-      await autoUpdater.checkForUpdates()
-    }
-    catch (error) {
-      broadcastUpdaterError(error, 'checkForUpdates() failed')
-    }
-  })()
+  void autoUpdater
+    .checkForUpdates()
+    .catch(error => broadcastUpdaterError(error, 'checkForUpdates() failed'))
 
   return {
     get state() {
@@ -273,13 +154,7 @@ export function setupAutoUpdater(): AutoUpdater {
     },
     async checkForUpdates() {
       broadcast({ status: 'checking' })
-      try {
-        await configureFeedForLatestRelease()
-        await autoUpdater.checkForUpdates()
-      }
-      catch (error) {
-        broadcastUpdaterError(error, 'checkForUpdates() failed')
-      }
+      await autoUpdater.checkForUpdates().catch(error => broadcastUpdaterError(error, 'checkForUpdates() failed'))
     },
     async downloadUpdate() {
       if (state.status === 'downloading' || state.status === 'downloaded')
@@ -298,14 +173,10 @@ export function setupAutoUpdater(): AutoUpdater {
       await semaphore.acquire()
 
       try {
-        if (process.platform === 'win32') {
-          await logToFile('INFO', 'quitAndInstall called: platform=win32 mode=silent forceRunAfter=true')
+        if (process.platform === 'win32')
           autoUpdater.quitAndInstall(true, true)
-        }
-        else {
-          await logToFile('INFO', `quitAndInstall called: platform=${process.platform} mode=default`)
+        else
           autoUpdater.quitAndInstall()
-        }
       }
       finally {
         semaphore.release()
@@ -313,7 +184,7 @@ export function setupAutoUpdater(): AutoUpdater {
     },
     subscribe(callback) {
       hooks.add(callback)
-      // Send current state immediately
+
       try {
         callback(state)
       }
@@ -331,7 +202,6 @@ export function createAutoUpdaterService(params: { context: MainContext, window:
 
   const log = useLogg('auto-updater-service').useGlobalConfig()
 
-  // Subscribe to state changes and forward to the context
   const unsubscribe = service.subscribe((state) => {
     if (window.isDestroyed())
       return
@@ -360,8 +230,8 @@ export function createAutoUpdaterService(params: { context: MainContext, window:
   )
 
   cleanups.push(
-    defineInvokeHandler(context, autoUpdaterEventa.quitAndInstall, () => {
-      service.quitAndInstall()
+    defineInvokeHandler(context, autoUpdaterEventa.quitAndInstall, async () => {
+      await service.quitAndInstall()
     }),
   )
 

--- a/apps/stage-tamagotchi/src/renderer/pages/about.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/about.vue
@@ -35,10 +35,6 @@ const links = [
 const showChangelog = ref(false)
 const { isDesktop } = useBreakpoints()
 
-const diagnosticsLogPath = computed(() => {
-  return updateState.value.diagnostics?.logFilePath ?? 'N/A'
-})
-
 const isWindowsUpdater = computed(() => {
   return updateState.value.diagnostics?.platform === 'win32'
 })
@@ -52,11 +48,6 @@ const downloadedStatusText = computed(() => {
 
 const restartButtonLabel = computed(() => {
   return isWindowsUpdater.value ? 'Restart to update silently' : 'Restart to install update'
-})
-
-const firstUpdateFile = computed(() => {
-  const file = updateState.value.info?.files?.[0]
-  return file?.url ?? 'N/A'
 })
 
 function handleDownloadClick() {
@@ -184,40 +175,6 @@ const releaseNotesContent = computed(() => {
                 :label="isBusy ? 'Checking...' : isLatestVersion ? 'Latest version' : isDisabled ? 'Updates disabled in Dev' : isError ? 'Retry Check' : 'Check for updates'"
                 @click="checkForUpdates()"
               />
-            </div>
-          </div>
-
-          <!-- Diagnostics -->
-          <div :class="['rounded-lg border border-neutral-200/70 bg-neutral-50/70 p-3 text-xs dark:border-neutral-800/70 dark:bg-neutral-950/40']">
-            <div :class="['mb-2 font-medium text-neutral-700 dark:text-neutral-300']">
-              Updater Diagnostics
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              status={{ updateState.status }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              current=v{{ buildInfo.version }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              target=v{{ updateState.info?.version ?? 'N/A' }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              file={{ firstUpdateFile }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              platform={{ updateState.diagnostics?.platform ?? 'N/A' }} arch={{ updateState.diagnostics?.arch ?? 'N/A' }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              channel={{ updateState.diagnostics?.channel ?? 'N/A' }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              feed={{ updateState.diagnostics?.feedUrl ?? 'N/A' }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              cache={{ updateState.diagnostics?.updaterCacheDir ?? 'N/A' }}
-            </div>
-            <div :class="['font-mono text-neutral-500 dark:text-neutral-400 break-words']">
-              log={{ diagnosticsLogPath }}
             </div>
           </div>
         </div>

--- a/apps/stage-tamagotchi/src/renderer/pages/devtools/updater.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/devtools/updater.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { useElectronAutoUpdater } from '@proj-airi/electron-vueuse'
+import { useSettings } from '@proj-airi/stage-ui/stores/settings'
+import { Button, Progress } from '@proj-airi/ui'
+import { computed } from 'vue'
+
+const settings = useSettings()
+
+const {
+  state: updateState,
+  isBusy,
+  checkForUpdates,
+  downloadUpdate,
+  quitAndInstall,
+} = useElectronAutoUpdater()
+
+const diagnosticsEntries = computed(() => {
+  const diagnostics = updateState.value.diagnostics
+
+  if (!diagnostics)
+    return []
+
+  return [
+    ['status', updateState.value.status],
+    ['currentVersion', updateState.value.info?.version ?? 'n/a'],
+    ['platform', diagnostics.platform],
+    ['arch', diagnostics.arch],
+    ['channel', diagnostics.channel],
+    ['feedUrl', diagnostics.feedUrl ?? 'n/a'],
+    ['logFilePath', diagnostics.logFilePath],
+    ['executablePath', diagnostics.executablePath],
+    ['overrideActive', String(diagnostics.isOverrideActive)],
+  ]
+})
+</script>
+
+<template>
+  <div :class="['flex flex-col gap-4', 'pb-8']">
+    <div
+      v-if="!settings.inspectUpdaterDiagnostics"
+      :class="['rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100']"
+    >
+      Enable "Inspect updater diagnostics" from Settings > System > Developer to inspect updater internals here.
+    </div>
+
+    <template v-else>
+      <div :class="['flex flex-wrap gap-2']">
+        <Button
+          variant="secondary"
+          :loading="isBusy"
+          icon="i-solar:refresh-outline"
+          label="Check for updates"
+          @click="checkForUpdates()"
+        />
+        <Button
+          variant="secondary"
+          :disabled="updateState.status !== 'available'"
+          icon="i-solar:download-minimalistic-outline"
+          label="Download update"
+          @click="downloadUpdate()"
+        />
+        <Button
+          variant="secondary"
+          :disabled="updateState.status !== 'downloaded'"
+          icon="i-solar:restart-bold-duotone"
+          label="Restart to install"
+          @click="quitAndInstall()"
+        />
+      </div>
+
+      <div v-if="updateState.status === 'downloading'" :class="['flex flex-col gap-2']">
+        <div :class="['flex items-center justify-between text-sm text-neutral-300']">
+          <span>Downloading update</span>
+          <span>{{ updateState.progress?.percent.toFixed(1) }}%</span>
+        </div>
+        <Progress :progress="updateState.progress?.percent ?? 0" />
+      </div>
+
+      <div
+        v-if="updateState.status === 'error'"
+        :class="['rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100 whitespace-pre-wrap']"
+      >
+        {{ updateState.error?.message }}
+      </div>
+
+      <section :class="['rounded-2xl border border-neutral-700/60', 'bg-neutral-950/40 p-4']">
+        <div :class="['mb-3 text-sm text-neutral-400']">
+          Updater diagnostics
+        </div>
+
+        <div :class="['grid gap-2 text-sm text-neutral-100']">
+          <div
+            v-for="[label, value] in diagnosticsEntries"
+            :key="label"
+            :class="['grid gap-1 md:grid-cols-[180px_minmax(0,1fr)]']"
+          >
+            <div :class="['text-neutral-400']">
+              {{ label }}
+            </div>
+            <div :class="['font-mono break-words']">
+              {{ value }}
+            </div>
+          </div>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  title: Updater
+  subtitleKey: tamagotchi.settings.devtools.title
+</route>

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/system/developer.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/system/developer.vue
@@ -74,6 +74,12 @@ const menu = computed(() => [
     to: '/devtools/plugin-host',
   },
   {
+    title: 'Updater',
+    description: 'Inspect updater state, explicit feed overrides, and install actions',
+    icon: 'i-solar:restart-bold-duotone',
+    to: '/devtools/updater',
+  },
+  {
     title: 'Screen Capture',
     description: 'Capture screen or window as video and/or audio streams',
     icon: 'i-solar:screen-share-bold-duotone',
@@ -135,6 +141,15 @@ const openDevtoolsWindow = useElectronEventaInvoke(electronOpenDevtoolsWindow)
     icon-off="i-solar:people-nearby-bold-duotone"
     text="settings.animations.use-page-specific-transitions.title"
     description="settings.animations.use-page-specific-transitions.description"
+    transition="all ease-in-out duration-250"
+  />
+  <CheckBar
+    v-model="settings.inspectUpdaterDiagnostics"
+    mb-2
+    icon-on="i-solar:bug-bold-duotone"
+    icon-off="i-solar:bug-minimalistic-outline"
+    text="Inspect updater diagnostics"
+    description="Show detailed updater diagnostics in the developer updater page."
     transition="all ease-in-out duration-250"
   />
 

--- a/packages/electron-eventa/src/electron-updater/index.ts
+++ b/packages/electron-eventa/src/electron-updater/index.ts
@@ -27,13 +27,10 @@ export interface AutoUpdaterDiagnostics {
   platform: string
   arch: string
   channel: string
-  feedUrl: string
+  feedUrl?: string
   logFilePath: string
-  updaterCacheDir: string
-  pendingDir: string
   executablePath: string
-  uninstallPath?: string
-  uninstallExists?: boolean
+  isOverrideActive: boolean
 }
 
 export interface AutoUpdaterState {

--- a/packages/electron-vueuse/src/composables/use-electron-auto-updater.ts
+++ b/packages/electron-vueuse/src/composables/use-electron-auto-updater.ts
@@ -8,27 +8,10 @@ import { computed, onMounted, ref } from 'vue'
 
 import { useElectronEventaContext, useElectronEventaInvoke } from './use-electron-eventa-context'
 
-interface AutoUpdaterDiagnostics {
-  platform: string
-  arch: string
-  channel: string
-  feedUrl: string
-  logFilePath: string
-  updaterCacheDir: string
-  pendingDir: string
-  executablePath: string
-  uninstallPath?: string
-  uninstallExists?: boolean
-}
-
-type AutoUpdaterStateWithDiagnostics = AutoUpdaterState & {
-  diagnostics?: AutoUpdaterDiagnostics
-}
-
 export function useElectronAutoUpdater() {
   const context = useElectronEventaContext()
 
-  const state = ref<AutoUpdaterStateWithDiagnostics>({ status: 'idle' })
+  const state = ref<AutoUpdaterState>({ status: 'idle' })
 
   const getState = useElectronEventaInvoke(autoUpdater.getState, context.value)
   const checkForUpdates = useElectronEventaInvoke(autoUpdater.checkForUpdates, context.value)

--- a/packages/stage-ui/src/stores/settings/developer.ts
+++ b/packages/stage-ui/src/stores/settings/developer.ts
@@ -1,0 +1,15 @@
+import { useLocalStorageManualReset } from '@proj-airi/stage-shared/composables'
+import { defineStore } from 'pinia'
+
+export const useSettingsDeveloper = defineStore('settings-developer', () => {
+  const inspectUpdaterDiagnostics = useLocalStorageManualReset<boolean>('settings/developer/inspect-updater-diagnostics', false)
+
+  function resetState() {
+    inspectUpdaterDiagnostics.reset()
+  }
+
+  return {
+    inspectUpdaterDiagnostics,
+    resetState,
+  }
+})

--- a/packages/stage-ui/src/stores/settings/index.ts
+++ b/packages/stage-ui/src/stores/settings/index.ts
@@ -2,6 +2,7 @@ import { defineStore, storeToRefs } from 'pinia'
 
 import { useSettingsAnalytics } from './analytics'
 import { useSettingsControlsIsland } from './controls-island'
+import { useSettingsDeveloper } from './developer'
 import { useSettingsGeneral } from './general'
 import { useSettingsLive2d } from './live2d'
 import { useSettingsStageModel } from './stage-model'
@@ -12,6 +13,7 @@ export * from './analytics'
 export * from './audio-device'
 export * from './beat-sync'
 export * from './controls-island'
+export * from './developer'
 export * from './general'
 export * from './live2d'
 export * from './stage-model'
@@ -33,6 +35,7 @@ export const useSettings = defineStore('settings', () => {
   const live2d = useSettingsLive2d()
   const theme = useSettingsTheme()
   const controlsIsland = useSettingsControlsIsland()
+  const developer = useSettingsDeveloper()
 
   async function resetState() {
     await stageModel.resetState()
@@ -41,6 +44,7 @@ export const useSettings = defineStore('settings', () => {
     live2d.resetState()
     theme.resetState()
     controlsIsland.resetState()
+    developer.resetState()
   }
 
   // Extract refs from sub-stores to maintain proper reactivity
@@ -50,6 +54,7 @@ export const useSettings = defineStore('settings', () => {
   const live2dRefs = storeToRefs(live2d)
   const themeRefs = storeToRefs(theme)
   const controlsIslandRefs = storeToRefs(controlsIsland)
+  const developerRefs = storeToRefs(developer)
 
   return {
     // Core settings
@@ -84,6 +89,7 @@ export const useSettings = defineStore('settings', () => {
     allowVisibleOnAllWorkspaces: controlsIslandRefs.allowVisibleOnAllWorkspaces,
     alwaysOnTop: controlsIslandRefs.alwaysOnTop,
     controlsIslandIconSize: controlsIslandRefs.controlsIslandIconSize,
+    inspectUpdaterDiagnostics: developerRefs.inspectUpdaterDiagnostics,
 
     // Methods
     setThemeColorsHue: theme.setThemeColorsHue,


### PR DESCRIPTION
## Description

This PR improves the desktop updater end-to-end for Windows, macOS, and Linux, with a focus on architecture-correct update resolution, better reliability, and better debugging visibility.

## Linked Issues
#1530 #1547 #1428 (validated on Windows; macOS/Linux architecture selection logic implemented, but native runtime verification is still needed).

<!-- Optional, if you have any -->

Ensures updater channel/feed selection is architecture- and platform-aware (including macOS and Linux arm64/x64 split)..

Improves update install behavior:
Windows keeps silent install + relaunch behavior.
macOS/Linux use safe default non-Windows updater install flow.

Cleans updater cache artifacts more thoroughly:
pending update directory cleanup
root installer artifact cleanup (including installer executables where present to save a lot of storage after installs)

Adds richer diagnostics from main process into updater state/UI:
platform/arch
channel
feed URL
cache/pending paths
exact updater log path
executable/uninstall path diagnostics

Improves About page update UX:
explicit “Up to date” state in green
allows manual re-check even when up to date
platform-specific install messaging (Windows silent wording vs macOS/Linux restart-install wording since at least to my knowledge silent updates with autorestart for this is mainly for windows. but if I missed something I'm happy to learn from my mistakes)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
auto-updater.ts electron-builder.config.ts about.vue and index.ts and some of the new QoL features like logging.

Validation notes:

Verified build/runtime behavior in Windows environment.
macOS/Linux logic is implemented and platform-aware; HOWEVER final runtime confirmation requires native macOS/Linux test runs. (any feedback will be useful)