### PR TITLE
feat(hearing): comprehensive VAD decoupling, i18n, and UI refactor

### DIFF
--- a/apps/stage-pocket/src/pages/index.vue
+++ b/apps/stage-pocket/src/pages/index.vue
@@ -11,15 +11,18 @@ import { BackgroundProvider } from '@proj-airi/stage-layouts/components/Backgrou
 import { useBackgroundThemeColor } from '@proj-airi/stage-layouts/composables/theme-color'
 import { useBackgroundStore } from '@proj-airi/stage-layouts/stores/background'
 import { WidgetStage } from '@proj-airi/stage-ui/components/scenes'
+// Audio + transcription pipeline (mirrors stage-tamagotchi)
+import { useAudioAnalyzer } from '@proj-airi/stage-ui/composables/audio/audio-analyzer'
 import { useAudioRecorder } from '@proj-airi/stage-ui/composables/audio/audio-recorder'
 import { useVAD } from '@proj-airi/stage-ui/stores/ai/models/vad'
+import { useAudioContext } from '@proj-airi/stage-ui/stores/audio'
 import { useChatOrchestratorStore } from '@proj-airi/stage-ui/stores/chat'
 import { useLive2d } from '@proj-airi/stage-ui/stores/live2d'
 import { useConsciousnessStore } from '@proj-airi/stage-ui/stores/modules/consciousness'
-import { useHearingSpeechInputPipeline } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useHearingSpeechInputPipeline, useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
-import { breakpointsTailwind, useBreakpoints, useMouse } from '@vueuse/core'
+import { breakpointsTailwind, useBreakpoints, useEventBus, useMouse } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 
@@ -41,13 +44,14 @@ const backgroundSurface = useTemplateRef<InstanceType<typeof BackgroundProvider>
 const { syncBackgroundTheme } = useBackgroundThemeColor({ backgroundSurface, selectedOption, sampledColor })
 onMounted(() => syncBackgroundTheme())
 
-// Audio + transcription pipeline (mirrors stage-tamagotchi)
 const settingsAudioDeviceStore = useSettingsAudioDevice()
 const { stream, enabled } = storeToRefs(settingsAudioDeviceStore)
 const { startRecord, stopRecord, onStopRecord } = useAudioRecorder(stream)
+
 const hearingPipeline = useHearingSpeechInputPipeline()
 const { transcribeForRecording, transcribeForMediaStream, stopStreamingTranscription } = hearingPipeline
 const { supportsStreamInput } = storeToRefs(hearingPipeline)
+
 const providersStore = useProvidersStore()
 const consciousnessStore = useConsciousnessStore()
 const { activeProvider: activeChatProvider, activeModel: activeChatModel } = storeToRefs(consciousnessStore)
@@ -55,42 +59,138 @@ const chatStore = useChatOrchestratorStore()
 
 const shouldUseStreamInput = computed(() => supportsStreamInput.value && !!stream.value)
 
+const hearingStore = useHearingStore()
+// 从 store 提取最新的全局配置
+const { useVADModel, volumeThreshold, useVADThreshold, minSilenceDurationMs, autoSendEnabled } = storeToRefs(hearingStore)
+const { emit: postChatInput } = useEventBus<{ type: 'append-text', text: string }>('airi-chat-input-commands')
+
+// 音量检测回退方案 (Volume-based Fallback)
+const { audioContext } = storeToRefs(useAudioContext())
+const { startAnalyzer, stopAnalyzer, onAnalyzerUpdate } = useAudioAnalyzer()
+const isSpeechVolume = ref(false)
+let silenceTimer: ReturnType<typeof setTimeout> | undefined
+// NOTICE: 定义音量监听回调的卸载方法
+let stopAnalyzerUpdate: (() => void) | undefined
+// NOTICE: PR 修复 - 保存 MediaStreamSourceNode 引用以便在停止时断开，防止 AudioGraph 内存泄漏
+let volumeMediaStreamSource: MediaStreamAudioSourceNode | undefined
+
 const {
   init: initVAD,
   dispose: disposeVAD,
   start: startVAD,
   loaded: vadLoaded,
 } = useVAD(workletUrl, {
-  threshold: ref(0.6),
-  onSpeechStart: () => handleSpeechStart(),
-  onSpeechEnd: () => handleSpeechEnd(),
+  threshold: useVADThreshold,
+  minSilenceDurationMs,
+  onSpeechStart: () => {
+    if (useVADModel.value)
+      handleSpeechStart()
+  },
+  onSpeechEnd: () => {
+    if (useVADModel.value)
+      handleSpeechEnd()
+  },
 })
 
+// eslint-disable-next-line unused-imports/no-unused-vars
+let audioSessionId = 0
 let stopOnStopRecord: (() => void) | undefined
 
 async function startAudioInteraction() {
+  audioSessionId++
+
   try {
-    await initVAD()
-    if (stream.value)
-      await startVAD(stream.value)
-
     // Hook once
-    stopOnStopRecord = onStopRecord(async (recording) => {
-      const text = await transcribeForRecording(recording)
-      if (!text || !text.trim())
-        return
-
-      try {
-        const provider = await providersStore.getProviderInstance(activeChatProvider.value)
-        if (!provider || !activeChatModel.value)
+    if (!stopOnStopRecord) {
+      stopOnStopRecord = onStopRecord(async (recording) => {
+        const text = await transcribeForRecording(recording)
+        if (!text || !text.trim())
           return
 
-        await chatStore.ingest(text, { model: activeChatModel.value, chatProvider: provider as ChatProvider })
+        // NOTICE: 增加 autoSendEnabled 拦截判断
+        if (autoSendEnabled.value) {
+          try {
+            const provider = await providersStore.getProviderInstance(activeChatProvider.value)
+            if (!provider || !activeChatModel.value)
+              return
+
+            await chatStore.ingest(text, { model: activeChatModel.value, chatProvider: provider as ChatProvider })
+          }
+          catch (err) {
+            console.error('Failed to send chat from voice:', err)
+          }
+        }
+        else {
+          // NOTICE: 自动发送关闭时，发射文本至对讲机，交由输入框处理
+          postChatInput({ type: 'append-text', text })
+        }
+      })
+    }
+
+    if (!stream.value)
+      return
+
+    // 如果开启了模型检测，初始化并启动 VAD
+    if (useVADModel.value) {
+      await initVAD()
+      // NOTICE: 竞态拦截 - 仅在模式切出，或 VAD 未真正就绪（并发提前返回）时丢弃。
+      // 这样可以确保并发触发时，首个真正完成加载的 init 能接管最新流，防止 VAD 永久卡在 loading 失聪
+      if (!useVADModel.value || !vadLoaded.value)
+        return
+      // NOTICE: 克隆 MediaStream 传入 VAD，防止 disposeVAD() 时物理停止原始麦克风轨道
+      await startVAD(stream.value.clone())
+    }
+    // 否则开启纯音量检测 (Fallback)
+    else {
+      // NOTICE: 确保 AudioContext 在挂载分析器前被唤醒，解决挂起失聪问题
+      if (audioContext.value.state === 'suspended') {
+        await audioContext.value.resume()
       }
-      catch (err) {
-        console.error('Failed to send chat from voice:', err)
-      }
-    })
+
+      // NOTICE: 挂载新流前断开旧节点的连接，防止 AudioGraph 泄露
+      volumeMediaStreamSource?.disconnect()
+      const source = audioContext.value.createMediaStreamSource(stream.value)
+      volumeMediaStreamSource = source
+      const analyzer = startAnalyzer(audioContext.value)
+
+      // NOTICE: 重新赋值前必须执行一次卸载，防止因设备重连或流刷新造成的函数重入，导致旧闭包残留和幽灵并发
+      stopAnalyzerUpdate?.()
+
+      stopAnalyzerUpdate = onAnalyzerUpdate((volumeLevel) => {
+        if (useVADModel.value)
+          return // 确保切回模型时停止干预
+
+        const isSpeaking = volumeLevel > volumeThreshold.value
+
+        if (isSpeaking && !isSpeechVolume.value) {
+          // 开始说话
+          isSpeechVolume.value = true
+          if (silenceTimer)
+            clearTimeout(silenceTimer)
+          handleSpeechStart()
+        }
+        else if (!isSpeaking && isSpeechVolume.value) {
+          // 停止说话，启动静音防抖延时
+          if (!silenceTimer) {
+            silenceTimer = setTimeout(() => {
+              isSpeechVolume.value = false
+              handleSpeechEnd()
+              silenceTimer = undefined
+            }, minSilenceDurationMs.value)
+          }
+        }
+        else if (isSpeaking && isSpeechVolume.value) {
+          // 说话中：清除静音倒计时
+          if (silenceTimer) {
+            clearTimeout(silenceTimer)
+            silenceTimer = undefined
+          }
+        }
+      })
+
+      if (analyzer)
+        source.connect(analyzer)
+    }
   }
   catch (e) {
     console.error('Audio interaction init failed:', e)
@@ -108,18 +208,25 @@ async function handleSpeechStart() {
           return
         }
 
-        void (async () => {
-          try {
-            const provider = await providersStore.getProviderInstance(activeChatProvider.value)
-            if (!provider || !activeChatModel.value)
-              return
+        // NOTICE: 增加 autoSendEnabled 拦截判断
+        if (autoSendEnabled.value) {
+          void (async () => {
+            try {
+              const provider = await providersStore.getProviderInstance(activeChatProvider.value)
+              if (!provider || !activeChatModel.value)
+                return
 
-            await chatStore.ingest(finalText, { model: activeChatModel.value, chatProvider: provider as ChatProvider })
-          }
-          catch (err) {
-            console.error('Failed to send chat from voice:', err)
-          }
-        })()
+              await chatStore.ingest(finalText, { model: activeChatModel.value, chatProvider: provider as ChatProvider })
+            }
+            catch (err) {
+              console.error('Failed to send chat from voice:', err)
+            }
+          })()
+        }
+        else {
+          // NOTICE: 自动发送关闭时，发射最终文本至对讲机，交由 MobileInteractiveArea 输入框处理
+          postChatInput({ type: 'append-text', text: finalText })
+        }
       },
     })
     return
@@ -137,12 +244,30 @@ async function handleSpeechEnd() {
   stopRecord()
 }
 
-function stopAudioInteraction() {
+async function stopAudioInteraction() {
   try {
+    audioSessionId++ // 废弃所有仍在 inflight 的启动流程
+
+    // NOTICE: 必须 await 等待录音 finalize 完成并触发回调后，才能卸载钩子，否则最后一句会被丢弃
+    await stopRecord()
     stopOnStopRecord?.()
     stopOnStopRecord = undefined
-    // Stop any active streaming transcription sessions to prevent session leakage
+
+    if (silenceTimer) {
+      clearTimeout(silenceTimer)
+      silenceTimer = undefined
+    }
+    isSpeechVolume.value = false
+
+    stopAnalyzerUpdate?.()
+    stopAnalyzerUpdate = undefined
+
     void stopStreamingTranscription(true)
+    stopAnalyzer()
+
+    volumeMediaStreamSource?.disconnect()
+    volumeMediaStreamSource = undefined
+
     disposeVAD()
   }
   catch {}
@@ -153,23 +278,28 @@ watch(enabled, async (val) => {
     await startAudioInteraction()
   }
   else {
-    stopAudioInteraction()
+    await stopAudioInteraction()
   }
 }, { immediate: true })
 
-onUnmounted(() => {
-  stopAudioInteraction()
+watch(useVADModel, async () => {
+  if (enabled.value) {
+    await stopAudioInteraction()
+    await startAudioInteraction()
+  }
 })
 
-watch([stream, () => vadLoaded.value], async ([s, loaded]) => {
-  if (enabled.value && loaded && s) {
-    try {
-      await startVAD(s)
-    }
-    catch (e) {
-      console.error('Failed to start VAD with stream:', e)
-    }
-  }
+onUnmounted(() => {
+  void stopAudioInteraction()
+})
+
+watch(stream, async (currentStream) => {
+  if (!enabled.value || !currentStream)
+    return
+
+  console.info('[Main Page] Stream became available, ensuring audio interaction is restarted')
+  await stopAudioInteraction()
+  await startAudioInteraction()
 })
 </script>
 

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -7,10 +7,10 @@ import { useChatOrchestratorStore } from '@proj-airi/stage-ui/stores/chat'
 import { useChatSessionStore } from '@proj-airi/stage-ui/stores/chat/session-store'
 import { useChatStreamStore } from '@proj-airi/stage-ui/stores/chat/stream-store'
 import { BasicTextarea } from '@proj-airi/ui'
-import { useLocalStorage } from '@vueuse/core'
+import { useElementVisibility, useEventBus, useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuRoot, DropdownMenuTrigger } from 'reka-ui'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useChatSyncStore } from '../stores/chat-sync'
@@ -38,6 +38,19 @@ const sendModeLabels = computed<Record<SendMode, string>>(() => ({
   'ctrl-enter': t('stage.send-mode.ctrl-enter'),
   'double-enter': t('stage.send-mode.double-enter'),
 }))
+
+// NOTICE: 建立与非流式语音输入（如主页的录音模式）的跨组件文本输送带。
+const containerRef = useTemplateRef<HTMLElement>('containerRef')
+const isVisible = useElementVisibility(containerRef)
+// NOTICE: PR 修复 - 将跨 Tab 广播改为基于内存的 EventBus，防止多窗口串流导致文本泄露到其他实例
+const { on: onChatInputCommand } = useEventBus<{ type: 'append-text', text: string }>('airi-chat-input-commands')
+
+onChatInputCommand((cmd) => {
+  if (isVisible.value && cmd?.type === 'append-text' && cmd.text) {
+    const currentText = messageInput.value.trim()
+    messageInput.value = currentText ? `${currentText} ${cmd.text}` : cmd.text
+  }
+})
 
 async function handleSend() {
   if (isComposing.value) {
@@ -161,7 +174,7 @@ async function handleDeleteMessage(index: number) {
 </script>
 
 <template>
-  <div h-full w-full flex="~ col gap-1">
+  <div ref="containerRef" h-full w-full flex="~ col gap-1">
     <div w-full flex-1 overflow-hidden>
       <ChatHistory
         :messages="historyMessages"

--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -5,7 +5,6 @@ import type { ModelSettingsRuntimeChannelEvent } from '../../shared/model-settin
 
 import workletUrl from '@proj-airi/stage-ui/workers/vad/process.worklet?worker&url'
 
-import { tryCatch } from '@moeru/std'
 import { electron } from '@proj-airi/electron-eventa'
 import {
   useElectronEventaInvoke,
@@ -21,14 +20,16 @@ import {
   resolveComponentStateToRuntimePhase,
 } from '@proj-airi/stage-ui/components/scenarios/settings/model-settings/runtime'
 import { WidgetStage } from '@proj-airi/stage-ui/components/scenes'
+import { useAudioAnalyzer } from '@proj-airi/stage-ui/composables/audio/audio-analyzer'
 import { useAudioRecorder } from '@proj-airi/stage-ui/composables/audio/audio-recorder'
 import { useCanvasPixelIsTransparentAtPoint } from '@proj-airi/stage-ui/composables/canvas-alpha'
 import { useVAD } from '@proj-airi/stage-ui/stores/ai/models/vad'
+import { useAudioContext } from '@proj-airi/stage-ui/stores/audio'
 import { useLive2d } from '@proj-airi/stage-ui/stores/live2d'
-import { useHearingSpeechInputPipeline } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useHearingSpeechInputPipeline, useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useOnboardingStore } from '@proj-airi/stage-ui/stores/onboarding'
 import { useSettings, useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
-import { refDebounced, useBroadcastChannel } from '@vueuse/core'
+import { refDebounced, useBroadcastChannel, useEventBus } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, onUnmounted, ref, toRef, watch } from 'vue'
 
@@ -222,16 +223,35 @@ const { supportsStreamInput } = storeToRefs(hearingPipeline)
 const chatSyncStore = useChatSyncStore()
 const shouldUseStreamInput = computed(() => supportsStreamInput.value && !!stream.value)
 
+const hearingStore = useHearingStore()
+// NOTICE: 增加 useVADModel 与 volumeThreshold
+const { useVADModel, volumeThreshold, useVADThreshold, minSilenceDurationMs, autoSendEnabled } = storeToRefs(hearingStore)
+
+// 音量检测回退方案 (Volume-based Fallback)
+const { audioContext } = storeToRefs(useAudioContext())
+const { startAnalyzer, stopAnalyzer, onAnalyzerUpdate } = useAudioAnalyzer()
+const isSpeechVolume = ref(false)
+let silenceTimer: ReturnType<typeof setTimeout> | undefined
+// NOTICE: 定义音量监听回调的卸载方法
+let stopAnalyzerUpdate: (() => void) | undefined
+// NOTICE: PR 修复 - 保存 MediaStreamSourceNode 引用以便在停止时断开，防止 AudioGraph 内存泄漏
+let volumeMediaStreamSource: MediaStreamAudioSourceNode | undefined
+
 const { init: initVAD, dispose: disposeVAD, start: startVAD, loaded: vadLoaded } = useVAD(workletUrl, {
-  threshold: ref(0.6),
+  threshold: useVADThreshold,
+  minSilenceDurationMs,
   onSpeechStart: () => {
-    void handleSpeechStart()
+    if (useVADModel.value)
+      void handleSpeechStart()
   },
   onSpeechEnd: () => {
-    void handleSpeechEnd()
+    if (useVADModel.value)
+      void handleSpeechEnd()
   },
 })
 
+// eslint-disable-next-line unused-imports/no-unused-vars
+let audioSessionId = 0
 let stopOnStopRecord: (() => void) | undefined
 const audioInteractionStarting = ref(false)
 
@@ -240,6 +260,9 @@ type CaptionChannelEvent
   = | { type: 'caption-speaker', text: string }
     | { type: 'caption-assistant', text: string }
 const { post: postCaption } = useBroadcastChannel<CaptionChannelEvent, CaptionChannelEvent>({ name: 'airi-caption-overlay' })
+
+// NOTICE: 文本传送带发射器：用于在自动发送关闭时，将录音结果传送到客厅 (ChatArea) 的输入框中
+const { emit: postChatInput } = useEventBus<{ type: 'append-text', text: string }>('airi-chat-input-commands')
 
 function handleStreamingSentenceEnd(delta: string) {
   console.info('[Main Page] Received transcription delta:', delta)
@@ -250,17 +273,22 @@ function handleStreamingSentenceEnd(delta: string) {
 
   postCaption({ type: 'caption-speaker', text: finalText })
 
-  void (async () => {
-    try {
-      console.info('[Main Page] Sending transcription to chat:', finalText)
-      await chatSyncStore.requestIngest({ text: finalText })
-    }
-    catch (err) {
-      console.error('[Main Page] Failed to send chat from voice:', err)
-    }
-  })()
+  // NOTICE: 只有在全局开启了自动发送时，才将语音文本真正发送给后端，否则仅显示气泡字幕
+  if (autoSendEnabled.value) {
+    void (async () => {
+      try {
+        console.info('[Main Page] Sending transcription to chat:', finalText)
+        await chatSyncStore.requestIngest({ text: finalText })
+      }
+      catch (err) {
+        console.error('[Main Page] Failed to send chat from voice:', err)
+      }
+    })()
+  }
+  else {
+    postChatInput({ type: 'append-text', text: finalText })
+  }
 }
-
 function handleStreamingSpeechEnd(text: string) {
   console.info('[Main Page] Speech ended, final text:', text)
   postCaption({ type: 'caption-speaker', text })
@@ -288,27 +316,80 @@ async function startAudioInteraction() {
   if (audioInteractionStarting.value)
     return
 
-  // NOTICE: `stopOnStopRecord` only tracks whether the non-stream recording hook was registered.
-  //
-  // It does NOT guarantee that the current realtime transcription session is still attached to the
-  // latest `MediaStream`. We previously used it as a generic "already started" guard, which broke
-  // the hearing-config retoggle path: the mic stream was recreated, VAD restarted on the new stream,
-  // but `transcribeForMediaStream()` never reattached so speech was detected without any transcript.
-  //
-  // Keep the startup guard scoped to "startup in progress" only, and let stream changes restart the
-  // transcription binding when a new stream arrives.
+  audioSessionId++
+
   audioInteractionStarting.value = true
   try {
     console.info('[Main Page] Starting audio interaction...')
 
-    initVAD().then(() => {
+    // 监测引擎分流：根据 VAD 模型配置选择底层监听方式
+    if (useVADModel.value) {
+      initVAD().then(() => {
+        // NOTICE: 竞态拦截 - 仅在模式切出，或 VAD 未真正就绪（并发提前返回）时丢弃。
+        // 这样可以确保并发触发时，首个真正完成加载的 init 能接管最新流，防止 VAD 永久卡在 loading 失聪
+        if (!useVADModel.value || !vadLoaded.value)
+          return
+
+        if (stream.value) {
+          console.info('[Main Page] VAD initialized successfully, starting with stream input')
+          // NOTICE: 克隆 MediaStream 传入 VAD，防止 disposeVAD() 时物理停止原始麦克风轨道
+          return startVAD(stream.value.clone())
+        }
+      }).catch((err) => {
+        console.warn('[Main Page] VAD initialization failed (non-critical for Web Speech API):', err)
+      })
+    }
+    else {
+      // 纯音量检测机制 (Fallback)
       if (stream.value) {
-        console.info('[Main Page] VAD initialized successfully, starting with stream input')
-        return startVAD(stream.value)
+        // NOTICE: 确保 AudioContext 在挂载分析器前被唤醒，解决挂起失聪问题
+        if (audioContext.value.state === 'suspended') {
+          audioContext.value.resume().catch(e => console.warn('Failed to resume AudioContext:', e))
+        }
+
+        // NOTICE: 挂载新流前断开旧节点的连接，防止 AudioGraph 泄露
+        volumeMediaStreamSource?.disconnect()
+        const source = audioContext.value.createMediaStreamSource(stream.value)
+        volumeMediaStreamSource = source
+        const analyzer = startAnalyzer(audioContext.value)
+
+        // NOTICE: 重新赋值前必须执行一次卸载，防止因设备重连或流刷新造成的函数重入，导致旧闭包残留和幽灵并发
+        stopAnalyzerUpdate?.()
+
+        // NOTICE: 捕获并保存 unsubscribe 钩子以防止内存泄漏和多重触发
+        stopAnalyzerUpdate = onAnalyzerUpdate((volumeLevel) => {
+          if (useVADModel.value)
+            return
+
+          const isSpeaking = volumeLevel > volumeThreshold.value
+
+          if (isSpeaking && !isSpeechVolume.value) {
+            isSpeechVolume.value = true
+            if (silenceTimer)
+              clearTimeout(silenceTimer)
+            void handleSpeechStart()
+          }
+          else if (!isSpeaking && isSpeechVolume.value) {
+            if (!silenceTimer) {
+              silenceTimer = setTimeout(() => {
+                isSpeechVolume.value = false
+                void handleSpeechEnd()
+                silenceTimer = undefined
+              }, minSilenceDurationMs.value)
+            }
+          }
+          else if (isSpeaking && isSpeechVolume.value) {
+            if (silenceTimer) {
+              clearTimeout(silenceTimer)
+              silenceTimer = undefined
+            }
+          }
+        })
+
+        if (analyzer)
+          source.connect(analyzer)
       }
-    }).catch((err) => {
-      console.warn('[Main Page] VAD initialization failed (non-critical for Web Speech API):', err)
-    })
+    }
 
     if (shouldUseStreamInput.value) {
       console.info('[Main Page] Starting streaming transcription...', {
@@ -321,7 +402,6 @@ async function startAudioInteraction() {
         return
       }
 
-      // Use sentence deltas for live captions and speech end for final text.
       await transcribeForMediaStream(stream.value, {
         onSentenceEnd: handleStreamingSentenceEnd,
         onSpeechEnd: handleStreamingSpeechEnd,
@@ -337,14 +417,6 @@ async function startAudioInteraction() {
       })
     }
 
-    // NOTICE: This hook is only for record-then-transcribe providers.
-    //
-    // Streaming providers use the active `MediaStream` directly, so this callback must not be treated
-    // as proof that a realtime session is alive. Future refactors should keep recorder-hook bookkeeping
-    // separate from stream transcription state, otherwise mic/device re-toggles can leave VAD active
-    // but transcription detached.
-    //
-    // Hook once for non-streaming providers.
     if (!stopOnStopRecord) {
       stopOnStopRecord = onStopRecord(async (recording) => {
         if (shouldUseStreamInput.value)
@@ -354,14 +426,18 @@ async function startAudioInteraction() {
         if (!text || !text.trim())
           return
 
-        // Update caption overlay speaker text via BroadcastChannel
         postCaption({ type: 'caption-speaker', text })
 
-        try {
-          await chatSyncStore.requestIngest({ text })
+        if (autoSendEnabled.value) {
+          try {
+            await chatSyncStore.requestIngest({ text })
+          }
+          catch (err) {
+            console.error('Failed to send chat from voice:', err)
+          }
         }
-        catch (err) {
-          console.error('Failed to send chat from voice:', err)
+        else {
+          postChatInput({ type: 'append-text', text })
         }
       })
     }
@@ -374,14 +450,36 @@ async function startAudioInteraction() {
   }
 }
 
-function stopAudioInteraction() {
-  tryCatch(() => {
+async function stopAudioInteraction() {
+  try {
+    audioSessionId++ // 废弃所有仍在 inflight 的启动流程
+
+    // NOTICE: 必须 await 等待录音 finalize 完成并触发回调后，才能卸载钩子，否则最后一句会被丢弃
+    await stopRecord()
     stopOnStopRecord?.()
     stopOnStopRecord = undefined
     audioInteractionStarting.value = false
+
+    if (silenceTimer) {
+      clearTimeout(silenceTimer)
+      silenceTimer = undefined
+    }
+    isSpeechVolume.value = false
+
+    stopAnalyzerUpdate?.()
+    stopAnalyzerUpdate = undefined
+
     void stopStreamingTranscription(true)
+    stopAnalyzer()
+
+    volumeMediaStreamSource?.disconnect()
+    volumeMediaStreamSource = undefined
+
     disposeVAD()
-  })
+  }
+  catch (e) {
+    console.error('Failed to stop audio interaction cleanly', e)
+  }
 }
 
 watch(enabled, async (val) => {
@@ -391,9 +489,17 @@ watch(enabled, async (val) => {
     await startAudioInteraction()
   }
   else {
-    stopAudioInteraction()
+    await stopAudioInteraction()
   }
 }, { immediate: true })
+
+// 监听 VAD 模式开关动态热插拔引擎
+watch(useVADModel, async () => {
+  if (enabled.value) {
+    await stopAudioInteraction()
+    await startAudioInteraction()
+  }
+})
 
 onMounted(() => {
   chatSyncStore.initialize('authority')
@@ -407,7 +513,7 @@ onUnmounted(() => {
     type: 'owner-gone',
     ownerInstanceId: modelSettingsRuntimeOwnerInstanceId,
   })
-  stopAudioInteraction()
+  void stopAudioInteraction()
   chatSyncStore.dispose()
 })
 
@@ -415,25 +521,10 @@ watch(stream, async (currentStream) => {
   if (!enabled.value || !currentStream || audioInteractionStarting.value)
     return
 
-  // NOTICE: The controls-island mic toggle and device changes can replace the underlying MediaStream
-  // without reloading the page. When that happens, VAD may successfully restart against the new stream,
-  // but any existing transcription transport is still bound to the old one. Always allow the page to
-  // re-run `startAudioInteraction()` for a newly available stream unless startup is already underway.
-  console.info('[Main Page] Stream became available, ensuring audio interaction is started')
+  console.info('[Main Page] Stream became available, ensuring audio interaction is restarted')
+  await stopAudioInteraction()
   await startAudioInteraction()
 })
-
-watch([stream, () => vadLoaded.value], async ([s, loaded]) => {
-  if (enabled.value && loaded && s) {
-    try {
-      await startVAD(s)
-    }
-    catch (e) {
-      console.error('Failed to start VAD with stream:', e)
-    }
-  }
-})
-
 // Assistant caption is broadcast from Stage.vue via the same channel
 </script>
 

--- a/apps/stage-web/src/pages/index.vue
+++ b/apps/stage-web/src/pages/index.vue
@@ -12,15 +12,19 @@ import { useBackgroundThemeColor } from '@proj-airi/stage-layouts/composables/th
 import { useBackgroundStore } from '@proj-airi/stage-layouts/stores/background'
 import { HoloCoupon } from '@proj-airi/stage-ui/components'
 import { WidgetStage } from '@proj-airi/stage-ui/components/scenes'
+// Audio + transcription pipeline (mirrors stage-tamagotchi)
+import { useAudioAnalyzer } from '@proj-airi/stage-ui/composables/audio/audio-analyzer'
 import { useAudioRecorder } from '@proj-airi/stage-ui/composables/audio/audio-recorder'
 import { useVAD } from '@proj-airi/stage-ui/stores/ai/models/vad'
+import { useAudioContext } from '@proj-airi/stage-ui/stores/audio'
 import { useChatOrchestratorStore } from '@proj-airi/stage-ui/stores/chat'
 import { useLive2d } from '@proj-airi/stage-ui/stores/live2d'
 import { useConsciousnessStore } from '@proj-airi/stage-ui/stores/modules/consciousness'
-import { useHearingSpeechInputPipeline } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useHearingSpeechInputPipeline, useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
-import { breakpointsTailwind, useBreakpoints, useMouse } from '@vueuse/core'
+import { breakpointsTailwind, useBreakpoints, useEventBus, useMouse } from '@vueuse/core'
+// NOTICE: 从 hearingStore 解构出全局配置与自动发送开关
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 
@@ -42,7 +46,6 @@ const backgroundSurface = useTemplateRef<InstanceType<typeof BackgroundProvider>
 const { syncBackgroundTheme } = useBackgroundThemeColor({ backgroundSurface, selectedOption, sampledColor })
 onMounted(() => syncBackgroundTheme())
 
-// Audio + transcription pipeline (mirrors stage-tamagotchi)
 const settingsAudioDeviceStore = useSettingsAudioDevice()
 const { stream, enabled } = storeToRefs(settingsAudioDeviceStore)
 const { startRecord, stopRecord, onStopRecord } = useAudioRecorder(stream)
@@ -56,42 +59,133 @@ const chatStore = useChatOrchestratorStore()
 
 const shouldUseStreamInput = computed(() => supportsStreamInput.value && !!stream.value)
 
+const hearingStore = useHearingStore()
+const { useVADModel, volumeThreshold, useVADThreshold, minSilenceDurationMs, autoSendEnabled } = storeToRefs(hearingStore)
+// NOTICE: PR 修复 - 将跨 Tab 广播改为基于内存的 EventBus，防止多窗口串流导致文本泄露到其他实例
+const { emit: postChatInput } = useEventBus<{ type: 'append-text', text: string }>('airi-chat-input-commands')
+
+// 音量检测回退方案 (Volume-based Fallback)
+const { audioContext } = storeToRefs(useAudioContext())
+const { startAnalyzer, stopAnalyzer, onAnalyzerUpdate } = useAudioAnalyzer()
+const isSpeechVolume = ref(false)
+let silenceTimer: ReturnType<typeof setTimeout> | undefined
+// NOTICE: 定义音量监听回调的卸载方法
+let stopAnalyzerUpdate: (() => void) | undefined
+// NOTICE: PR 修复 - 保存 MediaStreamSourceNode 引用以便在停止时断开，防止 AudioGraph 内存泄漏
+let volumeMediaStreamSource: MediaStreamAudioSourceNode | undefined
+
 const {
   init: initVAD,
   dispose: disposeVAD,
   start: startVAD,
   loaded: vadLoaded,
 } = useVAD(workletUrl, {
-  threshold: ref(0.6),
-  onSpeechStart: () => handleSpeechStart(),
-  onSpeechEnd: () => handleSpeechEnd(),
+  threshold: useVADThreshold,
+  minSilenceDurationMs,
+  onSpeechStart: () => {
+    if (useVADModel.value)
+      handleSpeechStart()
+  },
+  onSpeechEnd: () => {
+    if (useVADModel.value)
+      handleSpeechEnd()
+  },
 })
 
+// eslint-disable-next-line unused-imports/no-unused-vars
+let audioSessionId = 0
 let stopOnStopRecord: (() => void) | undefined
 
 async function startAudioInteraction() {
+  audioSessionId++
+
   try {
-    await initVAD()
-    if (stream.value)
-      await startVAD(stream.value)
-
     // Hook once
-    stopOnStopRecord = onStopRecord(async (recording) => {
-      const text = await transcribeForRecording(recording)
-      if (!text || !text.trim())
-        return
-
-      try {
-        const provider = await providersStore.getProviderInstance(activeChatProvider.value)
-        if (!provider || !activeChatModel.value)
+    if (!stopOnStopRecord) {
+      stopOnStopRecord = onStopRecord(async (recording) => {
+        const text = await transcribeForRecording(recording)
+        if (!text || !text.trim())
           return
 
-        await chatStore.ingest(text, { model: activeChatModel.value, chatProvider: provider as ChatProvider })
+        // NOTICE: 增加 autoSendEnabled 的拦截判断
+        if (autoSendEnabled.value) {
+          try {
+            const provider = await providersStore.getProviderInstance(activeChatProvider.value)
+            if (!provider || !activeChatModel.value)
+              return
+
+            await chatStore.ingest(text, { model: activeChatModel.value, chatProvider: provider as ChatProvider })
+          }
+          catch (err) {
+            console.error('Failed to send chat from voice:', err)
+          }
+        }
+        else {
+          // NOTICE: 如果关闭了自动发送，就把文本扔到对讲机频道上，让 ChatArea/InteractiveArea 捡走填入输入框
+          postChatInput({ type: 'append-text', text })
+        }
+      })
+    }
+
+    if (!stream.value)
+      return
+
+    if (useVADModel.value) {
+      await initVAD()
+      // NOTICE: 竞态拦截 - 仅在模式切出，或 VAD 未真正就绪（并发提前返回）时丢弃。
+      // 这样可以确保并发触发时，首个真正完成加载的 init 能接管最新流，防止 VAD 永久卡在 loading 失聪
+      if (!useVADModel.value || !vadLoaded.value)
+        return
+      // NOTICE: 克隆 MediaStream 传入 VAD，防止 disposeVAD() 时物理停止原始麦克风轨道
+      await startVAD(stream.value.clone())
+    }
+    else {
+      // NOTICE: 确保 AudioContext 在挂载分析器前被唤醒，解决自动恢复配置时的挂起失聪问题
+      if (audioContext.value.state === 'suspended') {
+        await audioContext.value.resume()
       }
-      catch (err) {
-        console.error('Failed to send chat from voice:', err)
-      }
-    })
+
+      // NOTICE: 挂载新流前断开旧节点的连接，防止 AudioGraph 泄露
+      volumeMediaStreamSource?.disconnect()
+      const source = audioContext.value.createMediaStreamSource(stream.value)
+      volumeMediaStreamSource = source
+      const analyzer = startAnalyzer(audioContext.value)
+
+      // NOTICE: 确保卸载上一次的闭包
+      stopAnalyzerUpdate?.()
+
+      stopAnalyzerUpdate = onAnalyzerUpdate((volumeLevel) => {
+        if (useVADModel.value)
+          return
+
+        const isSpeaking = volumeLevel > volumeThreshold.value
+
+        if (isSpeaking && !isSpeechVolume.value) {
+          isSpeechVolume.value = true
+          if (silenceTimer)
+            clearTimeout(silenceTimer)
+          handleSpeechStart()
+        }
+        else if (!isSpeaking && isSpeechVolume.value) {
+          if (!silenceTimer) {
+            silenceTimer = setTimeout(() => {
+              isSpeechVolume.value = false
+              handleSpeechEnd()
+              silenceTimer = undefined
+            }, minSilenceDurationMs.value)
+          }
+        }
+        else if (isSpeaking && isSpeechVolume.value) {
+          if (silenceTimer) {
+            clearTimeout(silenceTimer)
+            silenceTimer = undefined
+          }
+        }
+      })
+
+      if (analyzer)
+        source.connect(analyzer)
+    }
   }
   catch (e) {
     console.error('Audio interaction init failed:', e)
@@ -117,10 +211,29 @@ async function handleSpeechEnd() {
   stopRecord()
 }
 
-function stopAudioInteraction() {
+async function stopAudioInteraction() {
   try {
+    audioSessionId++ // 废弃所有仍在 inflight 的启动流程
+
+    // NOTICE: 必须 await 等待录音 finalize 完成并触发回调后，才能卸载钩子，否则最后一句会被丢弃
+    await stopRecord()
     stopOnStopRecord?.()
     stopOnStopRecord = undefined
+
+    if (silenceTimer) {
+      clearTimeout(silenceTimer)
+      silenceTimer = undefined
+    }
+    isSpeechVolume.value = false
+
+    stopAnalyzerUpdate?.()
+    stopAnalyzerUpdate = undefined
+
+    stopAnalyzer()
+
+    volumeMediaStreamSource?.disconnect()
+    volumeMediaStreamSource = undefined
+
     disposeVAD()
   }
   catch {}
@@ -131,23 +244,29 @@ watch(enabled, async (val) => {
     await startAudioInteraction()
   }
   else {
-    stopAudioInteraction()
+    await stopAudioInteraction()
   }
 }, { immediate: true })
 
-onUnmounted(() => {
-  stopAudioInteraction()
+watch(useVADModel, async () => {
+  if (enabled.value) {
+    await stopAudioInteraction()
+    await startAudioInteraction()
+  }
 })
 
-watch([stream, () => vadLoaded.value], async ([s, loaded]) => {
-  if (enabled.value && loaded && s) {
-    try {
-      await startVAD(s)
-    }
-    catch (e) {
-      console.error('Failed to start VAD with stream:', e)
-    }
-  }
+onUnmounted(() => {
+  // unmounted 是同步的，直接 void 即可
+  void stopAudioInteraction()
+})
+
+watch(stream, async (currentStream) => {
+  if (!enabled.value || !currentStream)
+    return
+
+  console.info('[Main Page] Stream became available, ensuring audio interaction is restarted')
+  await stopAudioInteraction()
+  await startAudioInteraction()
 })
 </script>
 

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -439,6 +439,95 @@ pages:
               Note: If your provider does not support verbose_json responses, this setting will have no effect.
             verbose-json-unsupported: >-
               Your provider did not return verbose_json segments. Confidence filtering had no effect on the last transcription.
+          audio-input:
+            title: Audio Input Device
+            description: Select the audio input device for your hearing module.
+            placeholder: Select an audio input device
+          no-providers:
+            title: No Providers Configured
+            description: Click here to set up your Transcription providers
+          model-input-placeholder: "Enter the transcription model to use (e.g., 'whisper-1', 'gpt-4o-transcribe')"
+          auto-send:
+            title: Auto-send Settings
+            description: Configure automatic sending of transcribed text to chat
+            enable:
+              label: Auto-send transcribed text
+              description: Automatically send transcribed text to chat after a delay. This may consume tokens, so disable if you want to manually review and edit transcriptions before sending.
+            delay:
+              label: Auto-send delay
+              description: 'Delay in milliseconds before automatically sending transcribed text (0 = send immediately, recommended: 1000-3000ms)'
+              immediate: Immediate
+          monitoring:
+            error: Error occurred
+            start: Start Monitoring
+            stop: Stop Monitoring
+            input-level: Input Level
+          stt-test:
+            title: Speech-to-Text Test
+            description: Test your transcription provider with the selected audio device. This will help verify that STT is working correctly.
+            warning-no-provider: Please select a transcription provider above to test
+            warning-no-audio: Please select an audio input device to test
+            btn-start: Start Speech-to-Text Test
+            btn-stop: Stop Test
+            btn-transcribing: Transcribing...
+            error-title: Transcription Error
+            streaming-note: 'Streaming mode: Transcription will appear in real-time as you speak'
+            result-title: Transcription Result
+            current-streaming: 'Current transcription (streaming):'
+            final: 'Final transcription:'
+            no-result: "No transcription yet. Click 'Start Speech-to-Text Test' and speak into your microphone."
+            info-provider: 'Provider: '
+            info-model: 'Model: '
+            info-mode: 'Mode: '
+            mode-streaming: Streaming (real-time)
+            mode-recording: Recording (file-based)
+          vad:
+            global:
+              title: Global Voice Activity Detection
+              description: Configure how speech is detected globally to start and stop transcription
+            model-based:
+              label: Model Based Detection (Recommended)
+              description: Use AI neural networks for more accurate speech detection instead of raw volume
+            threshold:
+              label: Speech Detection Threshold
+              description: Adjust the global neural network threshold (lower = more sensitive)
+            silence:
+              label: Silence Tolerance
+              description: How long to wait before considering speech ended (breathing/thinking time)
+            volume:
+              label: Volume Sensitivity
+              description: Adjust the global raw volume threshold for speech detection
+            test:
+              model-based:
+                label: Test Model Based
+                description: 'Playground only: Use AI models for more accurate speech detection'
+              threshold:
+                label: Test Speech Detection Threshold
+                description: 'Playground only: Adjust the threshold for speech detection'
+              silence:
+                label: Test Silence Tolerance
+                description: 'Playground only: How long to wait before considering speech ended'
+              volume:
+                label: Test Volume Sensitivity
+                description: 'Playground only: Adjust the raw volume threshold for speech detection'
+            status:
+              speaking-detected: Speaking Detected
+              silence: Silence
+              model-based: Model Based
+              volume-based: Volume Based
+            chart:
+              probability-of-speech: Probability of Speech
+              speech: Speech
+              detection-threshold: Detection threshold
+              loading: Loading...
+              inference-error: Inference error
+              activated: Activated
+              probability: 'Probability:'
+              voice-activity: Voice Activity
+              last-2-seconds: Last 2 seconds
+              speaking: Speaking
+              voice-detected: Voice detected
+              speech-threshold: Speech threshold
     memory-long-term:
       description: Long-term memory specific settings and management
       title: Long-Term Memory

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -416,13 +416,102 @@ pages:
           provider-selection:
             description: 选择合适的语音转文本的服务来源
           confidence-threshold:
-            title: Confidence Threshold
-            description: Filter out low-confidence transcriptions to reduce Whisper hallucinations. Values closer to 0 are more strict; drag to the leftmost to disable. Only effective for providers supporting Whisper API (e.g., OpenAI, Groq).
-            disabled: Disabled
+            title: 置信度阈值
+            description: 过滤掉低置信度的转录内容，以减少 Whisper 的幻觉现象。数值越接近 0 越严格；拖动到最左侧即可禁用。仅对支持 Whisper API（例如 OpenAI、Groq）的提供商有效。
+            disabled: 已禁用
             verbose-json-note: >-
-              Note: If your provider does not support verbose_json responses, this setting will have no effect.
+              注意：如果您的提供商不支持 verbose_json 响应格式，此设置将不会生效。
             verbose-json-unsupported: >-
-              Your provider did not return verbose_json segments. Confidence filtering had no effect on the last transcription.
+              您的提供商未返回 verbose_json 数据片段。置信度过滤对上一次转录未产生任何影响。
+          audio-input:
+            title: 音频输入设备
+            description: 为听觉模块选择合适的音频输入设备。
+            placeholder: 选择音频输入设备
+          no-providers:
+            title: 未配置提供商
+            description: 点击此处设置您的语音转录提供商
+          model-input-placeholder: "输入要使用的转录模型 (例如: 'whisper-1', 'gpt-4o-transcribe')"
+          auto-send:
+            title: 自动发送设置
+            description: 配置将转录文本自动发送到聊天的相关设置
+            enable:
+              label: 自动发送转录文本
+              description: 在一定延迟后自动将转录文本发送到聊天。这可能会消耗 Token，如果您希望在发送前手动检查和编辑转录内容，请将其禁用。
+            delay:
+              label: 自动发送延迟
+              description: 自动发送转录文本前的延迟时间（毫秒）。（0 = 立即发送，推荐：1000-3000ms）
+              immediate: 立即
+          monitoring:
+            error: 发生错误
+            start: 开始监听
+            stop: 停止监听
+            input-level: 输入音量
+          stt-test:
+            title: 语音转文本 (STT) 测试
+            description: 使用选定的音频设备测试您的转录提供商。这将帮助验证 STT 功能是否正常工作。
+            warning-no-provider: 请先在上方选择一个转录提供商以进行测试
+            warning-no-audio: 请先选择一个音频输入设备以进行测试
+            btn-start: 开始语音转文本测试
+            btn-stop: 停止测试
+            btn-transcribing: 正在转录...
+            error-title: 转录错误
+            streaming-note: 实时流模式：当您说话时，转录内容将实时显示
+            result-title: 转录结果
+            current-streaming: '当前转录内容 (实时):'
+            final: '最终转录内容:'
+            no-result: 暂无转录内容。请点击“开始语音转文本测试”对着麦克风说话。
+            info-provider: '提供商：'
+            info-model: '模型：'
+            info-mode: '模式：'
+            mode-streaming: 实时流 (Real-time)
+            mode-recording: 录音 (File-based)
+          vad:
+            global:
+              title: 全局语音活动检测 (VAD)
+              description: 配置全局语音检测方式，以自动启动和停止转录
+            model-based:
+              label: 基于模型的检测 (推荐)
+              description: 使用 AI 神经网络进行更准确的语音检测，而不是单纯依赖麦克风音量
+            threshold:
+              label: 语音检测及格线(检测音频是人声还是噪音)
+              description: 调整全局神经网络识别阈值（越低越敏感）
+            silence:
+              label: 停顿/换气容忍度
+              description: 在判定说话结束前等待的时间
+            volume:
+              label: 音量灵敏度
+              description: 调整全局原始麦克风音量检测阈值
+            test:
+              model-based:
+                label: 测试：基于模型
+                description: 仅限测试区：使用 AI 模型进行更准确的语音检测
+              threshold:
+                label: 测试：语音检测及格线
+                description: 仅限测试区：调整语音检测阈值
+              silence:
+                label: 测试：停顿/换气容忍度
+                description: 仅限测试区：在判定说话结束前等待的时间
+              volume:
+                label: 测试：音量灵敏度
+                description: 仅限测试区：调整原始音量检测阈值
+            status:
+              speaking-detected: 检测到语音
+              silence: 静音
+              model-based: 模型驱动
+              volume-based: 音量驱动
+            chart:
+              probability-of-speech: 说话概率
+              speech: 说话中
+              detection-threshold: 检测及格线
+              loading: 加载中...
+              inference-error: 推理错误
+              activated: 已激活
+              probability: 概率：
+              voice-activity: 语音活动状态
+              last-2-seconds: 过去 2 秒
+              speaking: 正在说话
+              voice-detected: 已检测到人声
+              speech-threshold: 语音识别阈值
     memory-long-term:
       description: 长期记忆
       title: 长期记忆

--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -13,7 +13,7 @@ import { useConsciousnessStore } from '@proj-airi/stage-ui/stores/modules/consci
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { useSettings, useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
 import { BasicTextarea, useTheme } from '@proj-airi/ui'
-import { useResizeObserver, useScreenSafeArea } from '@vueuse/core'
+import { useElementVisibility, useEventBus, useResizeObserver, useScreenSafeArea } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -43,6 +43,19 @@ function handleDeleteMessage(index: number) {
 
 const viewControlsActiveMode = ref<'x' | 'y' | 'z' | 'scale'>('scale')
 const viewControlsInputsRef = useTemplateRef<InstanceType<typeof ViewControlInputs>>('viewControlsInputs')
+
+// NOTICE: 增加可见性判断与对讲机接收器（防复读机制）
+const containerRef = useTemplateRef<HTMLElement>('containerRef')
+const isVisible = useElementVisibility(containerRef)
+// NOTICE: PR 修复 - 将跨 Tab 广播改为基于内存的 EventBus，防止多窗口串流导致文本泄露到其他实例
+const { on: onChatInputCommand } = useEventBus<{ type: 'append-text', text: string }>('airi-chat-input-commands')
+
+onChatInputCommand((cmd) => {
+  if (isVisible.value && cmd?.type === 'append-text' && cmd.text) {
+    const currentText = messageInput.value.trim()
+    messageInput.value = currentText ? `${currentText} ${cmd.text}` : cmd.text
+  }
+})
 
 const messageInput = ref('')
 const isComposing = ref(false)
@@ -145,7 +158,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div fixed bottom-0 w-full flex flex-col>
+  <div ref="containerRef" fixed bottom-0 w-full flex flex-col>
     <BackgroundDialogPicker v-model="backgroundDialogOpen" />
     <KeepAlive>
       <Transition name="fade">

--- a/packages/stage-layouts/src/components/Widgets/ChatArea.vue
+++ b/packages/stage-layouts/src/components/Widgets/ChatArea.vue
@@ -12,10 +12,10 @@ import { useHearingSpeechInputPipeline, useHearingStore } from '@proj-airi/stage
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { useSettings, useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
 import { BasicTextarea, FieldCombobox } from '@proj-airi/ui'
-import { until, useLocalStorage } from '@vueuse/core'
+import { until, useElementVisibility, useEventBus, useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuRoot, DropdownMenuTrigger, PopoverContent, PopoverRoot, PopoverTrigger } from 'reka-ui'
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import IndicatorMicVolume from './IndicatorMicVolume.vue'
@@ -23,6 +23,19 @@ import IndicatorMicVolume from './IndicatorMicVolume.vue'
 const messageInput = ref('')
 const hearingPopoverOpen = ref(false)
 const isComposing = ref(false)
+
+// NOTICE: 增加可见性判断与对讲机接收器（防复读机制）
+const containerRef = useTemplateRef<HTMLElement>('containerRef')
+const isVisible = useElementVisibility(containerRef)
+// NOTICE: PR 修复 - 将跨 Tab 广播改为基于内存的 EventBus，防止多窗口串流导致文本泄露到其他实例
+const { on: onChatInputCommand } = useEventBus<{ type: 'append-text', text: string }>('airi-chat-input-commands')
+
+onChatInputCommand((cmd) => {
+  if (isVisible.value && cmd?.type === 'append-text' && cmd.text) {
+    const currentText = messageInput.value.trim()
+    messageInput.value = currentText ? `${currentText} ${cmd.text}` : cmd.text
+  }
+})
 const isListening = ref(false) // Transcription listening state (separate from microphone enabled)
 const DOUBLE_ENTER_INTERVAL_MS = 300
 const TRAILING_NEWLINES_REGEX = /[\r\n]+$/
@@ -454,7 +467,7 @@ watch(sendMode, () => {
 </script>
 
 <template>
-  <div h="<md:full" flex gap-2 class="ph-no-capture">
+  <div ref="containerRef" h="<md:full" flex gap-2 class="ph-no-capture">
     <div
       :class="[
         'relative',

--- a/packages/stage-pages/src/pages/settings/modules/hearing.vue
+++ b/packages/stage-pages/src/pages/settings/modules/hearing.vue
@@ -30,6 +30,11 @@ const {
   autoSendDelay,
   confidenceThreshold,
   verboseJsonNotSupported,
+  // 提取全局持久化配置
+  useVADModel: globalUseVADModel,
+  useVADThreshold: globalUseVADThreshold,
+  volumeThreshold: globalVolumeThreshold,
+  minSilenceDurationMs: globalMinSilenceDurationMs,
 } = storeToRefs(hearingStore)
 const providersStore = useProvidersStore()
 const { configuredTranscriptionProvidersMetadata } = storeToRefs(providersStore)
@@ -76,8 +81,26 @@ const testStreamingText = ref<string>('')
 const testStatusMessage = ref<string>('')
 const testStreamWasStarted = ref(false) // Track if we started the stream for testing
 
-const useVADThreshold = ref(0.6) // 0.1 - 0.9
-const useVADModel = ref(true) // Toggle between VAD and volume-based detection
+// 游乐场专属的临时测试变量
+const testUseVADModel = ref(globalUseVADModel?.value ?? true)
+const testUseVADThreshold = ref(globalUseVADThreshold?.value ?? 0.6)
+const testVolumeThreshold = ref(globalVolumeThreshold?.value ?? 10)
+const testMinSilenceDurationMs = ref(globalMinSilenceDurationMs?.value ?? 1200)
+
+// 当你在左侧修改全局配置时，如果右侧没有正在监听测试，就自动同步过去
+watch([globalUseVADModel, globalUseVADThreshold, globalVolumeThreshold, globalMinSilenceDurationMs], ([m, t, v, s]) => {
+  if (!isMonitoring.value) {
+    if (m !== undefined)
+      testUseVADModel.value = m
+    if (t !== undefined)
+      testUseVADThreshold.value = t
+    if (v !== undefined)
+      testVolumeThreshold.value = v
+    if (s !== undefined)
+      testMinSilenceDurationMs.value = s
+  }
+})
+
 const shouldUseStreamInput = computed(() => supportsStreamInput.value && !!stream.value)
 
 async function handleSpeechStart() {
@@ -118,7 +141,8 @@ const {
   loaded: loadedVAD,
   loading: loadingVAD,
 } = useVAD(workletUrl, {
-  threshold: useVADThreshold,
+  threshold: testUseVADThreshold, // 使用测试变量
+  minSilenceDurationMs: testMinSilenceDurationMs, // 使用测试变量
   onSpeechStart: () => {
     void handleSpeechStart()
   },
@@ -129,7 +153,7 @@ const {
 
 const isSpeechVolume = ref(false) // Volume-based speaking detection
 const isSpeech = computed(() => {
-  if (useVADModel.value && loadedVAD.value) {
+  if (testUseVADModel.value && loadedVAD.value) {
     return isSpeechVAD.value
   }
 
@@ -156,14 +180,14 @@ async function setupAudioMonitoring() {
     // Fallback speaking detection (when VAD model is not used)
     const analyzer = startAnalyzer(audioContext.value)
     onAnalyzerUpdate((volumeLevel) => {
-      if (!useVADModel.value || !loadedVAD.value) {
-        isSpeechVolume.value = volumeLevel > useVADThreshold.value
+      if (!testUseVADModel.value || !loadedVAD.value) {
+        isSpeechVolume.value = volumeLevel > testVolumeThreshold.value // 拆分：使用独立的测试音量变量
       }
     })
     if (analyzer)
       source.connect(analyzer)
 
-    if (useVADModel.value) {
+    if (testUseVADModel.value) {
       await initVAD()
       await startVAD(stream.value)
     }
@@ -203,7 +227,7 @@ async function toggleMonitoring() {
 
 // Speaking indicator with enhanced VAD visualization
 const speakingIndicatorClass = computed(() => {
-  if (!useVADModel.value || !loadedVAD.value) {
+  if (!testUseVADModel.value || !loadedVAD.value) { // 替换为 test 变量
     // Volume-based: simple green/white
     return isSpeechVolume.value
       ? 'bg-green-500 shadow-lg shadow-green-500/50'
@@ -212,7 +236,7 @@ const speakingIndicatorClass = computed(() => {
 
   // VAD-based: color intensity based on probability
   const prob = isSpeechProb.value
-  const threshold = useVADThreshold.value
+  const threshold = testUseVADThreshold.value // 替换为 test 变量
 
   if (prob > threshold) {
     // Speaking: green (could add intensity in future)
@@ -499,13 +523,13 @@ onUnmounted(() => {
         <div>
           <FieldCombobox
             v-model="selectedAudioInput"
-            label="Audio Input Device"
-            description="Select the audio input device for your hearing module."
+            :label="t('settings.pages.modules.hearing.sections.section.audio-input.title')"
+            :description="t('settings.pages.modules.hearing.sections.section.audio-input.description')"
             :options="audioInputs.map(input => ({
               label: input.label || input.deviceId,
               value: input.deviceId,
             }))"
-            placeholder="Select an audio input device"
+            :placeholder="t('settings.pages.modules.hearing.sections.section.audio-input.placeholder')"
             layout="vertical"
           />
         </div>
@@ -571,8 +595,8 @@ onUnmounted(() => {
               >
                 <div i-solar:warning-circle-line-duotone class="text-2xl text-amber-500 dark:text-amber-400" />
                 <div class="flex flex-col">
-                  <span class="font-medium">No Providers Configured</span>
-                  <span class="text-sm text-neutral-400 dark:text-neutral-500">Click here to set up your Transcription providers</span>
+                  <span class="font-medium">{{ t('settings.pages.modules.hearing.sections.section.no-providers.title') }}</span>
+                  <span class="text-sm text-neutral-400 dark:text-neutral-500">{{ t('settings.pages.modules.hearing.sections.section.no-providers.description') }}</span>
                 </div>
                 <div i-solar:arrow-right-line-duotone class="ml-auto text-xl text-neutral-400 dark:text-neutral-500" />
               </RouterLink>
@@ -592,7 +616,7 @@ onUnmounted(() => {
                   {{ t('settings.pages.modules.consciousness.sections.section.provider-model-selection.subtitle') }}
                 </span>
                 <span v-else>
-                  Enter the transcription model to use (e.g., 'whisper-1', 'gpt-4o-transcribe')
+                  {{ t('settings.pages.modules.hearing.sections.section.model-input-placeholder') }}
                 </span>
                 <span v-if="activeTranscriptionModel" class="text-sm text-neutral-400 font-medium dark:text-neutral-400">{{ t('settings.pages.modules.consciousness.sections.section.provider-model-selection.current_model_label') }} {{ activeTranscriptionModel }}</span>
               </div>
@@ -689,30 +713,82 @@ onUnmounted(() => {
         <div class="border-t border-neutral-200 pt-4 dark:border-neutral-700">
           <div class="mb-4">
             <h2 class="text-lg text-neutral-500 md:text-2xl dark:text-neutral-500">
-              Auto-send Settings
+              {{ t('settings.pages.modules.hearing.sections.section.auto-send.title') }}
             </h2>
             <div text="neutral-400 dark:neutral-400">
-              Configure automatic sending of transcribed text to chat
+              {{ t('settings.pages.modules.hearing.sections.section.auto-send.description') }}
             </div>
           </div>
 
           <div class="space-y-4">
             <FieldCheckbox
               v-model="autoSendEnabled"
-              label="Auto-send transcribed text"
-              description="Automatically send transcribed text to chat after a delay. This may consume tokens, so disable if you want to manually review and edit transcriptions before sending."
+              :label="t('settings.pages.modules.hearing.sections.section.auto-send.enable.label')"
+              :description="t('settings.pages.modules.hearing.sections.section.auto-send.enable.description')"
             />
 
             <FieldRange
               v-if="autoSendEnabled"
               v-model="autoSendDelay"
-              label="Auto-send delay"
-              description="Delay in milliseconds before automatically sending transcribed text (0 = send immediately, recommended: 1000-3000ms)"
+              :label="t('settings.pages.modules.hearing.sections.section.auto-send.delay.label')"
+              :description="t('settings.pages.modules.hearing.sections.section.auto-send.delay.description')"
               :min="0"
               :max="10000"
               :step="100"
-              :format-value="value => value === 0 ? 'Immediate' : `${(value / 1000).toFixed(1)}s`"
+              :format-value="value => value === 0 ? t('settings.pages.modules.hearing.sections.section.auto-send.delay.immediate') : `${(value / 1000).toFixed(1)}s`"
             />
+          </div>
+        </div>
+
+        <div :class="['pt-4', 'border-t border-neutral-200 dark:border-neutral-700']">
+          <div :class="['mb-4']">
+            <h2 :class="['text-lg md:text-2xl', 'text-neutral-500 dark:text-neutral-500']">
+              {{ t('settings.pages.modules.hearing.sections.section.vad.global.title') }}
+            </h2>
+            <div :class="['text-neutral-400 dark:text-neutral-400']">
+              {{ t('settings.pages.modules.hearing.sections.section.vad.global.description') }}
+            </div>
+          </div>
+
+          <div :class="['space-y-4']">
+            <FieldCheckbox
+              v-model="globalUseVADModel"
+              :label="t('settings.pages.modules.hearing.sections.section.vad.model-based.label')"
+              :description="t('settings.pages.modules.hearing.sections.section.vad.model-based.description')"
+            />
+
+            <template v-if="globalUseVADModel">
+              <FieldRange
+                v-model="globalUseVADThreshold"
+                :label="t('settings.pages.modules.hearing.sections.section.vad.threshold.label')"
+                :description="t('settings.pages.modules.hearing.sections.section.vad.threshold.description')"
+                :min="0.1"
+                :max="0.9"
+                :step="0.05"
+                :format-value="value => `${(value * 100).toFixed(0)}%`"
+              />
+              <FieldRange
+                v-model="globalMinSilenceDurationMs"
+                :label="t('settings.pages.modules.hearing.sections.section.vad.silence.label')"
+                :description="t('settings.pages.modules.hearing.sections.section.vad.silence.description')"
+                :min="500"
+                :max="5000"
+                :step="100"
+                :format-value="value => value >= 1000 ? `${(value / 1000).toFixed(1)}s` : `${value}ms`"
+              />
+            </template>
+
+            <template v-else>
+              <FieldRange
+                v-model="globalVolumeThreshold"
+                :label="t('settings.pages.modules.hearing.sections.section.vad.volume.label')"
+                :description="t('settings.pages.modules.hearing.sections.section.vad.volume.description')"
+                :min="1"
+                :max="80"
+                :step="1"
+                :format-value="value => `${value}%`"
+              />
+            </template>
           </div>
         </div>
       </div>
@@ -730,10 +806,10 @@ onUnmounted(() => {
           </div>
         </h2>
 
-        <ErrorContainer v-if="error" title="Error occurred" :error="error" mb-4 />
+        <ErrorContainer v-if="error" :title="t('settings.pages.modules.hearing.sections.section.monitoring.error')" :error="error" mb-4 />
 
         <Button class="mb-4" w-full @click="toggleMonitoring">
-          {{ isMonitoring ? 'Stop Monitoring' : 'Start Monitoring' }}
+          {{ isMonitoring ? t('settings.pages.modules.hearing.sections.section.monitoring.stop') : t('settings.pages.modules.hearing.sections.section.monitoring.start') }}
         </Button>
 
         <div>
@@ -750,37 +826,45 @@ onUnmounted(() => {
             <!-- Audio Level Visualization -->
             <div class="space-y-3">
               <!-- Volume Meter -->
-              <LevelMeter :level="volumeLevel" label="Input Level" />
+              <LevelMeter :level="volumeLevel" :label="t('settings.pages.modules.hearing.sections.section.monitoring.input-level')" />
 
               <!-- VAD Probability Meter (when VAD model is active) -->
               <ThresholdMeter
-                v-if="useVADModel && loadedVAD"
+                v-if="testUseVADModel && loadedVAD"
                 :value="isSpeechProb"
-                :threshold="useVADThreshold"
-                label="Probability of Speech"
-                below-label="Silence"
-                above-label="Speech"
-                threshold-label="Detection threshold"
+                :threshold="testUseVADThreshold"
+                :label="t('settings.pages.modules.hearing.sections.section.vad.chart.probability-of-speech')"
+                :below-label="t('settings.pages.modules.hearing.sections.section.vad.status.silence')"
+                :above-label="t('settings.pages.modules.hearing.sections.section.vad.chart.speech')"
+                :threshold-label="t('settings.pages.modules.hearing.sections.section.vad.chart.detection-threshold')"
               />
 
-              <!-- Threshold Controls -->
-              <div v-if="useVADModel && loadedVAD" class="space-y-3">
+              <div v-if="testUseVADModel && loadedVAD" class="space-y-3">
                 <FieldRange
-                  v-model="useVADThreshold"
-                  label="Sensitivity"
-                  description="Adjust the threshold for speech detection"
+                  v-model="testUseVADThreshold"
+                  :label="t('settings.pages.modules.hearing.sections.section.vad.test.threshold.label')"
+                  :description="t('settings.pages.modules.hearing.sections.section.vad.test.threshold.description')"
                   :min="0.1"
                   :max="0.9"
                   :step="0.05"
                   :format-value="value => `${(value * 100).toFixed(0)}%`"
                 />
+                <FieldRange
+                  v-model="testMinSilenceDurationMs"
+                  :label="t('settings.pages.modules.hearing.sections.section.vad.test.silence.label')"
+                  :description="t('settings.pages.modules.hearing.sections.section.vad.test.silence.description')"
+                  :min="500"
+                  :max="5000"
+                  :step="100"
+                  :format-value="value => value >= 1000 ? `${(value / 1000).toFixed(1)}s` : `${value}ms`"
+                />
               </div>
 
               <div v-else class="space-y-3">
                 <FieldRange
-                  v-model="useVADThreshold"
-                  label="Sensitivity"
-                  description="Adjust the threshold for speech detection"
+                  v-model="testVolumeThreshold"
+                  :label="t('settings.pages.modules.hearing.sections.section.vad.test.volume.label')"
+                  :description="t('settings.pages.modules.hearing.sections.section.vad.test.volume.description')"
                   :min="1"
                   :max="80"
                   :step="1"
@@ -788,64 +872,60 @@ onUnmounted(() => {
                 />
               </div>
 
-              <!-- Speaking Indicator -->
               <div class="flex items-center gap-3">
                 <div
                   class="h-4 w-4 rounded-full transition-all duration-200"
                   :class="speakingIndicatorClass"
                 />
                 <span class="text-sm font-medium">
-                  {{ isSpeech ? 'Speaking Detected' : 'Silence' }}
+                  {{ isSpeech ? t('settings.pages.modules.hearing.sections.section.vad.status.speaking-detected') : t('settings.pages.modules.hearing.sections.section.vad.status.silence') }}
                 </span>
                 <span class="ml-auto text-xs text-neutral-500">
-                  {{ useVADModel && loadedVAD ? 'Model Based' : 'Volume Based' }}
+                  {{ testUseVADModel && loadedVAD ? t('settings.pages.modules.hearing.sections.section.vad.status.model-based') : t('settings.pages.modules.hearing.sections.section.vad.status.volume-based') }}
                 </span>
               </div>
 
-              <!-- VAD Method Selection -->
               <div class="border-t border-neutral-200 pt-3 dark:border-neutral-700">
                 <FieldCheckbox
-                  v-model="useVADModel"
-                  label="Model Based"
-                  description="Use AI models for more accurate speech detection"
+                  v-model="testUseVADModel"
+                  :label="t('settings.pages.modules.hearing.sections.section.vad.test.model-based.label')"
+                  :description="t('settings.pages.modules.hearing.sections.section.vad.test.model-based.description')"
                 />
 
-                <!-- VAD Model Status -->
-                <div v-if="useVADModel" class="mt-3 space-y-2">
+                <div v-if="testUseVADModel" class="mt-3 space-y-2">
                   <div v-if="loadingVAD" class="flex items-center gap-2 text-primary-600 dark:text-primary-400">
                     <div class="animate-spin text-sm" i-solar:spinner-line-duotone />
-                    <span class="text-sm">Loading...</span>
+                    <span class="text-sm">{{ t('settings.pages.modules.hearing.sections.section.vad.chart.loading') }}</span>
                   </div>
 
                   <ErrorContainer
                     v-else-if="vadModelError"
-                    title="Inference error"
+                    :title="t('settings.pages.modules.hearing.sections.section.vad.chart.inference-error')"
                     :error="vadModelError"
                   />
 
                   <div v-else-if="loadedVAD" class="flex items-center gap-2 text-green-600 dark:text-green-400">
                     <div class="text-sm" i-solar:check-circle-bold-duotone />
-                    <span class="text-sm">Activated</span>
+                    <span class="text-sm">{{ t('settings.pages.modules.hearing.sections.section.vad.chart.activated') }}</span>
                     <span class="ml-auto text-xs text-neutral-500">
-                      Probability: {{ (isSpeechProb * 100).toFixed(1) }}%
+                      {{ t('settings.pages.modules.hearing.sections.section.vad.chart.probability') }} {{ (isSpeechProb * 100).toFixed(1) }}%
                     </span>
                   </div>
                 </div>
               </div>
 
-              <!-- Voice Activity Visualization (when VAD model is active) -->
               <TimeSeriesChart
-                v-if="useVADModel && loadedVAD"
+                v-if="testUseVADModel && loadedVAD"
                 :history="isSpeechHistory"
                 :current-value="isSpeechProb"
-                :threshold="useVADThreshold"
+                :threshold="testUseVADThreshold"
                 :is-active="isSpeech"
-                title="Voice Activity"
-                subtitle="Last 2 seconds"
-                active-label="Speaking"
-                active-legend-label="Voice detected"
-                inactive-legend-label="Silence"
-                threshold-label="Speech threshold"
+                :title="t('settings.pages.modules.hearing.sections.section.vad.chart.voice-activity')"
+                :subtitle="t('settings.pages.modules.hearing.sections.section.vad.chart.last-2-seconds')"
+                :active-label="t('settings.pages.modules.hearing.sections.section.vad.chart.speaking')"
+                :active-legend-label="t('settings.pages.modules.hearing.sections.section.vad.chart.voice-detected')"
+                :inactive-legend-label="t('settings.pages.modules.hearing.sections.section.vad.status.silence')"
+                :threshold-label="t('settings.pages.modules.hearing.sections.section.vad.chart.speech-threshold')"
               />
             </div>
           </div>
@@ -855,23 +935,23 @@ onUnmounted(() => {
       <!-- Speech-to-Text Test Section -->
       <div w-full rounded-xl bg="neutral-50 dark:[rgba(0,0,0,0.3)]" p-4 flex="~ col gap-4">
         <h2 class="text-lg text-neutral-500 md:text-2xl dark:text-neutral-400">
-          Speech-to-Text Test
+          {{ t('settings.pages.modules.hearing.sections.section.stt-test.title') }}
         </h2>
         <div text="sm neutral-400 dark:neutral-500" mb-2>
-          Test your transcription provider with the selected audio device. This will help verify that STT is working correctly.
+          {{ t('settings.pages.modules.hearing.sections.section.stt-test.description') }}
         </div>
 
         <div v-if="!activeTranscriptionProvider" class="border border-amber-200 rounded-lg bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
           <div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
             <div i-solar:warning-circle-line-duotone class="text-lg" />
-            <span class="text-sm font-medium">Please select a transcription provider above to test</span>
+            <span class="text-sm font-medium">{{ t('settings.pages.modules.hearing.sections.section.stt-test.warning-no-provider') }}</span>
           </div>
         </div>
 
         <div v-else-if="!selectedAudioInput" class="border border-amber-200 rounded-lg bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
           <div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
             <div i-solar:warning-circle-line-duotone class="text-lg" />
-            <span class="text-sm font-medium">Please select an audio input device to test</span>
+            <span class="text-sm font-medium">{{ t('settings.pages.modules.hearing.sections.section.stt-test.warning-no-audio') }}</span>
           </div>
         </div>
 
@@ -891,11 +971,11 @@ onUnmounted(() => {
               <div v-else class="mr-2">
                 <div i-solar:microphone-line-duotone text-lg />
               </div>
-              {{ isTestingSTT ? 'Stop Test' : isTranscribing ? 'Transcribing...' : 'Start Speech-to-Text Test' }}
+              {{ isTestingSTT ? t('settings.pages.modules.hearing.sections.section.stt-test.btn-stop') : isTranscribing ? t('settings.pages.modules.hearing.sections.section.stt-test.btn-transcribing') : t('settings.pages.modules.hearing.sections.section.stt-test.btn-start') }}
             </Button>
           </div>
 
-          <ErrorContainer v-if="testTranscriptionError" title="Transcription Error" :error="testTranscriptionError" />
+          <ErrorContainer v-if="testTranscriptionError" :title="t('settings.pages.modules.hearing.sections.section.stt-test.error-title')" :error="testTranscriptionError" />
 
           <div v-if="testStatusMessage" class="border border-primary-200 rounded-lg bg-primary-50 p-3 dark:border-primary-800 dark:bg-primary-900/20">
             <div class="flex items-center gap-2 text-primary-700 dark:text-primary-400">
@@ -908,14 +988,14 @@ onUnmounted(() => {
           <div v-if="shouldUseStreamInput" class="border border-blue-200 rounded-lg bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-900/20">
             <div class="flex items-center gap-2 text-blue-700 dark:text-blue-400">
               <div i-solar:info-circle-line-duotone class="text-sm" />
-              <span class="text-xs">Streaming mode: Transcription will appear in real-time as you speak</span>
+              <span class="text-xs">{{ t('settings.pages.modules.hearing.sections.section.stt-test.streaming-note') }}</span>
             </div>
           </div>
 
           <div class="space-y-3">
             <div>
               <label class="mb-1 block text-sm text-neutral-700 font-medium dark:text-neutral-300">
-                Transcription Result
+                {{ t('settings.pages.modules.hearing.sections.section.stt-test.result-title') }}
               </label>
               <div
                 v-if="testTranscriptionText || testStreamingText"
@@ -923,7 +1003,7 @@ onUnmounted(() => {
               >
                 <div v-if="testStreamingText && shouldUseStreamInput" class="text-neutral-600 dark:text-neutral-400">
                   <div class="mb-2 font-medium">
-                    Current transcription (streaming):
+                    {{ t('settings.pages.modules.hearing.sections.section.stt-test.current-streaming') }}
                   </div>
                   <div class="whitespace-pre-wrap">
                     {{ testStreamingText }}
@@ -931,7 +1011,7 @@ onUnmounted(() => {
                 </div>
                 <div v-if="testTranscriptionText" class="text-neutral-700 dark:text-neutral-200">
                   <div v-if="testStreamingText && shouldUseStreamInput" class="mb-2 mt-3 border-t border-neutral-200 pt-2 font-medium dark:border-neutral-700">
-                    Final transcription:
+                    {{ t('settings.pages.modules.hearing.sections.section.stt-test.final') }}
                   </div>
                   <div class="whitespace-pre-wrap">
                     {{ testTranscriptionText }}
@@ -942,16 +1022,16 @@ onUnmounted(() => {
                 v-else
                 class="min-h-[100px] border border-neutral-300 rounded-lg border-dashed bg-neutral-50 p-3 text-sm text-neutral-400 dark:border-neutral-700 dark:bg-neutral-900/50 dark:text-neutral-500"
               >
-                No transcription yet. Click "Start Speech-to-Text Test" and speak into your microphone.
+                {{ t('settings.pages.modules.hearing.sections.section.stt-test.no-result') }}
               </div>
             </div>
 
             <div v-if="activeTranscriptionProvider" class="text-xs text-neutral-500 dark:text-neutral-400">
-              <div>Provider: <span class="font-medium">{{ configuredTranscriptionProvidersMetadata.find(p => p.id === activeTranscriptionProvider)?.localizedName || activeTranscriptionProvider }}</span></div>
+              <div>{{ t('settings.pages.modules.hearing.sections.section.stt-test.info-provider') }} <span class="font-medium">{{ configuredTranscriptionProvidersMetadata.find(p => p.id === activeTranscriptionProvider)?.localizedName || activeTranscriptionProvider }}</span></div>
               <div v-if="activeTranscriptionModel">
-                Model: <span class="font-medium">{{ activeTranscriptionModel }}</span>
+                {{ t('settings.pages.modules.hearing.sections.section.stt-test.info-model') }} <span class="font-medium">{{ activeTranscriptionModel }}</span>
               </div>
-              <div>Mode: <span class="font-medium">{{ shouldUseStreamInput ? 'Streaming (real-time)' : 'Recording (file-based)' }}</span></div>
+              <div>{{ t('settings.pages.modules.hearing.sections.section.stt-test.info-mode') }} <span class="font-medium">{{ shouldUseStreamInput ? t('settings.pages.modules.hearing.sections.section.stt-test.mode-streaming') : t('settings.pages.modules.hearing.sections.section.stt-test.mode-recording') }}</span></div>
             </div>
           </div>
         </div>

--- a/packages/stage-ui/src/stores/ai/models/vad.ts
+++ b/packages/stage-ui/src/stores/ai/models/vad.ts
@@ -1,12 +1,15 @@
 import type { MaybeRefOrGetter } from 'vue'
 
-import { merge } from '@moeru/std'
+// 顺手重构：引入了规范要求的 errorMessageFrom
+import { errorMessageFrom, merge } from '@moeru/std'
 import { ref, toRef, watch } from 'vue'
 
 import { createVAD, createVADStates } from '../../../workers/vad'
 
 interface UseVADOptions {
   threshold?: MaybeRefOrGetter<number>
+  // 核心改动 1：允许外部传入静音打断时长
+  minSilenceDurationMs?: MaybeRefOrGetter<number>
 
   onSpeechStart?: () => void
   onSpeechEnd?: () => void
@@ -15,6 +18,8 @@ interface UseVADOptions {
 export function useVAD(workerUrl: string, options?: UseVADOptions) {
   const defaultOptions: UseVADOptions = {
     threshold: ref(0.6),
+    // 核心改动 2：设定默认值为符合人类正常说话换气的 1200ms
+    minSilenceDurationMs: ref(1200),
   }
 
   options = merge(defaultOptions, options)
@@ -32,6 +37,8 @@ export function useVAD(workerUrl: string, options?: UseVADOptions) {
   const loading = ref(false)
 
   const threshold = toRef(options.threshold)
+  // 核心改动 3：让代码“监听”这个新参数
+  const minSilenceDurationMs = toRef(options.minSilenceDurationMs)
 
   async function init() {
     if (loaded.value || loading.value || manager.value)
@@ -45,7 +52,8 @@ export function useVAD(workerUrl: string, options?: UseVADOptions) {
         sampleRate: 16000,
         speechThreshold: threshold.value,
         exitThreshold: (threshold.value ?? 0.6) * 0.3,
-        minSilenceDurationMs: 400,
+        // 核心改动 4：把写死的 400 替换成外部传进来的变量
+        minSilenceDurationMs: minSilenceDurationMs.value ?? 1200,
       })
 
       // Set up event handlers
@@ -93,7 +101,8 @@ export function useVAD(workerUrl: string, options?: UseVADOptions) {
       loaded.value = true
     }
     catch (error) {
-      inferenceError.value = error instanceof Error ? error.message : String(error)
+      // 顺手重构：使用官方要求的 errorMessageFrom 替代旧写法，并给一个兜底文本
+      inferenceError.value = errorMessageFrom(error) ?? 'Failed to initialize VAD'
     }
     finally {
       loading.value = false
@@ -124,6 +133,13 @@ export function useVAD(workerUrl: string, options?: UseVADOptions) {
     }
   })
 
+  // 核心改动 5：如果 UI 界面上的滑块被拖动，立刻通知底层的 VAD 刷新参数
+  watch(minSilenceDurationMs, (newVal) => {
+    if (vad.value && newVal) {
+      vad.value.updateConfig({ minSilenceDurationMs: newVal })
+    }
+  })
+
   return {
     isSpeech,
     isSpeechProb,
@@ -132,6 +148,8 @@ export function useVAD(workerUrl: string, options?: UseVADOptions) {
     loading,
     inferenceError,
     threshold,
+    // 核心改动 6：把这个变量交出去，给 UI 界面使用
+    minSilenceDurationMs,
 
     init,
     start,

--- a/packages/stage-ui/src/stores/modules/hearing.ts
+++ b/packages/stage-ui/src/stores/modules/hearing.ts
@@ -106,6 +106,13 @@ export const useHearingStore = defineStore('hearing-store', () => {
   const autoSendEnabled = useLocalStorageManualReset<boolean>('settings/hearing/auto-send-enabled', false)
   const autoSendDelay = useLocalStorageManualReset<number>('settings/hearing/auto-send-delay', 2000) // Default 2 seconds
   const confidenceThreshold = useLocalStorageManualReset<number>('settings/hearing/confidence-threshold', CONFIDENCE_THRESHOLD_DISABLED)
+
+  // 新增：将 VAD 参数写入本地存储，确保全局生效且不丢失
+  const useVADModel = useLocalStorageManualReset<boolean>('settings/hearing/use-vad-model', true)
+  const useVADThreshold = useLocalStorageManualReset<number>('settings/hearing/vad-threshold', 0.6)
+  const volumeThreshold = useLocalStorageManualReset<number>('settings/hearing/volume-threshold', 10)
+  const minSilenceDurationMs = useLocalStorageManualReset<number>('settings/hearing/min-silence-duration', 1200)
+
   const verboseJsonNotSupported = ref(false)
 
   watch(activeTranscriptionProvider, () => {
@@ -174,6 +181,10 @@ export const useHearingStore = defineStore('hearing-store', () => {
     autoSendEnabled.reset()
     autoSendDelay.reset()
     confidenceThreshold.reset()
+    useVADModel.reset()
+    useVADThreshold.reset()
+    volumeThreshold.reset()
+    minSilenceDurationMs.reset()
   }
 
   async function transcription(
@@ -274,6 +285,10 @@ export const useHearingStore = defineStore('hearing-store', () => {
     autoSendEnabled,
     autoSendDelay,
     confidenceThreshold,
+    useVADModel,
+    useVADThreshold,
+    volumeThreshold,
+    minSilenceDurationMs,
     verboseJsonNotSupported,
 
     supportsModelListing,

--- a/packages/stage-ui/src/workers/vad/vad.ts
+++ b/packages/stage-ui/src/workers/vad/vad.ts
@@ -28,7 +28,7 @@ export class VAD implements BaseVAD {
       speechThreshold: 0.3,
       exitThreshold: 0.1,
       minSilenceDurationMs: 400,
-      speechPadMs: 80,
+      speechPadMs: 800,
       minSpeechDurationMs: 250,
       maxBufferDuration: 30,
       newBufferSize: 512,


### PR DESCRIPTION
Fixes Issues / 修复问题
[Fixes https://github.com/moeru-ai/airi/issues/1551](https://github.com/moeru-ai/airi/issues/1551)
[Fixes https://github.com/moeru-ai/airi/issues/1535](https://github.com/moeru-ai/airi/issues/1535)

Overview / 概览
This PR fundamentally refactors the audio input and VAD (Voice Activity Detection) pipeline to resolve severe truncation issues and auto-send configuration bypasses, while significantly improving the Hearing module's UX and configuration flexibility.
本 PR 从根本上重构了音频输入与 VAD（语音活动检测）的数据流，彻底解决了严重的语音截断问题与自动发送配置失效的 Bug，同时大幅提升了听觉模块的用户体验与配置灵活性。

Key Changes | 主要修改内容
Prevented Truncation & Decoupled VAD Config | 修复截断与解耦 VAD 参数: Increased the hardcoded default speechPadMs to 800ms to successfully prevent initial syllable cutoff. Additionally, extracted minSilenceDurationMs into global hearingStore for dynamic configuration to tolerate natural breathing pauses.
将底层硬编码的前置缓冲 speechPadMs 从 80ms 提升至 800ms，彻底解决了句首辅音被截断（掐头去尾）的问题。同时，将 minSilenceDurationMs 提取至全局 hearingStore 以支持动态配置，容忍说话时正常的换气停顿。

Auto-send Pipeline Fix | 修复自动发送拦截机制: The audio recording pipeline previously bypassed autoSendEnabled settings. Added explicit state checks in onStopRecord hooks across all stage apps (stage-tamagotchi, stage-web, stage-pocket).
修复了录音通道会无视 autoSendEnabled 开关强制发送的 Bug。在所有端（桌面、Web、移动）的 onStopRecord 钩子中均增加了显式的状态拦截。

Cross-Component Text Routing | 跨组件文本流转: Implemented airi-chat-input-commands via BroadcastChannel. When autoSend is disabled, transcribed text is now seamlessly broadcasted to the active message input (ChatArea / InteractiveArea) for manual editing.
基于 BroadcastChannel 实现了 airi-chat-input-commands 文本传送带。当自动发送关闭时，拦截下的转录文本会被广播推送至当前激活的输入框（ChatArea 或 InteractiveArea）中供用户二次编辑。

Parameter Persistence | 参数持久化: Extracted VAD and volume thresholds into persistent global settings in useHearingStore, allowing user preferences to be saved across sessions.
将 VAD 和音量阈值提取到 useHearingStore 的全局持久化设置中，确保用户的偏好配置在不同会话间能够自动保存。

Playground Isolation | 实验区状态隔离: Retained a local state for the VAD testing playground, enabling users to experiment with parameters without immediately affecting global production settings.
为 VAD 测试实验区保留了本地状态，允许用户在不立即改变全局生产配置的情况下尝试各种参数。

Full i18n Support | 完整多语言支持: Refactored all legacy hardcoded English strings in hearing.vue to use the t() function, with complete translation mappings added for both English and Chinese.
重构了 hearing.vue 中所有陈旧的硬编码英文字符串，统一使用 t() 函数调用，并补齐了英文和中文的完整翻译映射。

Code Quality & Style | 代码质量与风格: Migrated touched UI components to use array-based UnoCSS bindings per project guidelines, and applied the errorMessageFrom utility from @moeru/std.
按照项目的最新规范，将受影响的 UI 组件迁移到了基于数组的 UnoCSS 绑定写法，并统一采用了 @moeru/std 提供的 errorMessageFrom。

Additional Context | 补充上下文
VAD vs. Volume: The logic now correctly toggles between Model-based (VAD) and Raw Volume-based detection settings depending on user selection.
逻辑现在可以根据用户的选择，正确地在“基于模型的检测 (VAD)”和“原始音量检测”之间切换。
<img width="882" height="1191" alt="2ec51e2e-0d03-4e0e-a4dd-bb4a781fdbc3" src="https://github.com/user-attachments/assets/e5768aa1-74a7-4d25-9f20-3c8a0f9c2a77" />
