### PR TITLE
feat(stage-ui): add GPT-SoVITS speech provider support

### DIFF
--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -28,6 +28,7 @@ import { setupServerChannel } from './services/airi/channel-server'
 import { setupMcpStdioManager } from './services/airi/mcp-servers'
 import { setupPluginHost } from './services/airi/plugins'
 import { setupAutoUpdater } from './services/electron/auto-updater'
+import { createFetchService } from './services/electron/fetch'
 import { setupTray } from './tray'
 import { setupAboutWindowReusable } from './windows/about'
 import { setupBeatSync } from './windows/beat-sync'
@@ -96,6 +97,8 @@ app.whenReady().then(async () => {
       return
     void fileLogger.appendLog(formatted)
   })
+
+  createFetchService()
 
   injeca.setLogger(createLoggLogger(useLogg('injeca').useGlobalConfig()))
 

--- a/apps/stage-tamagotchi/src/main/services/electron/fetch.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/fetch.ts
@@ -1,0 +1,58 @@
+import { ipcMain } from 'electron'
+
+export const ELECTRON_FETCH_IPC_CHANNEL = 'airi:electron:fetch'
+
+export interface ElectronFetchPayload {
+  url: string
+  method?: string
+  headers?: Record<string, string>
+  body?: string
+}
+
+export interface ElectronFetchResult {
+  ok: boolean
+  status: number
+  statusText: string
+  headers: Record<string, string>
+  body: string
+  bodyBase64?: string
+}
+
+export function createFetchService() {
+  ipcMain.handle(ELECTRON_FETCH_IPC_CHANNEL, async (_event, payload: ElectronFetchPayload): Promise<ElectronFetchResult> => {
+    const response = await fetch(payload.url, {
+      method: payload.method ?? 'GET',
+      headers: payload.headers,
+      body: payload.body,
+    })
+
+    const headers: Record<string, string> = {}
+    response.headers.forEach((value, key) => {
+      headers[key] = value
+    })
+
+    const contentType = headers['content-type'] || ''
+    const isBinary = contentType.includes('audio/') || contentType.includes('image/') || contentType.includes('video/') || contentType.includes('application/octet-stream')
+
+    if (isBinary) {
+      const arrayBuffer = await response.arrayBuffer()
+      const base64 = Buffer.from(arrayBuffer).toString('base64')
+      return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+        body: '',
+        bodyBase64: base64,
+      }
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+      body: await response.text(),
+    }
+  })
+}

--- a/apps/stage-tamagotchi/src/main/services/electron/fetch.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/fetch.ts
@@ -18,7 +18,14 @@ export interface ElectronFetchResult {
   bodyBase64?: string
 }
 
+let fetchServiceRegistered = false
+
 export function createFetchService() {
+  if (fetchServiceRegistered)
+    return
+
+  fetchServiceRegistered = true
+
   ipcMain.handle(ELECTRON_FETCH_IPC_CHANNEL, async (_event, payload: ElectronFetchPayload): Promise<ElectronFetchResult> => {
     const response = await fetch(payload.url, {
       method: payload.method ?? 'GET',

--- a/apps/stage-tamagotchi/src/main/windows/settings/rpc/index.electron.ts
+++ b/apps/stage-tamagotchi/src/main/windows/settings/rpc/index.electron.ts
@@ -16,7 +16,8 @@ import { electronOpenDevtoolsWindow, electronOpenSettingsDevtools } from '../../
 import { createAuthService } from '../../../services/airi/auth'
 import { createMcpServersService } from '../../../services/airi/mcp-servers'
 import { createWidgetsService } from '../../../services/airi/widgets'
-import { createAutoUpdaterService } from '../../../services/electron'
+import { createAutoUpdaterService } from '../../../services/electron/auto-updater'
+import { createFetchService } from '../../../services/electron/fetch'
 import { setupBaseWindowElectronInvokes } from '../../shared/window'
 
 export async function setupSettingsWindowInvokes(params: {
@@ -40,6 +41,7 @@ export async function setupSettingsWindowInvokes(params: {
 
   createWidgetsService({ context, widgetsManager: params.widgetsManager, window: params.settingsWindow })
   createAutoUpdaterService({ context, window: params.settingsWindow, service: params.autoUpdater })
+  createFetchService()
   createMcpServersService({ context, manager: params.mcpStdioManager })
   createAuthService({ context, window: params.settingsWindow, windowAuthManager: params.windowAuthManager })
 

--- a/apps/stage-tamagotchi/src/main/windows/settings/rpc/index.electron.ts
+++ b/apps/stage-tamagotchi/src/main/windows/settings/rpc/index.electron.ts
@@ -17,7 +17,6 @@ import { createAuthService } from '../../../services/airi/auth'
 import { createMcpServersService } from '../../../services/airi/mcp-servers'
 import { createWidgetsService } from '../../../services/airi/widgets'
 import { createAutoUpdaterService } from '../../../services/electron/auto-updater'
-import { createFetchService } from '../../../services/electron/fetch'
 import { setupBaseWindowElectronInvokes } from '../../shared/window'
 
 export async function setupSettingsWindowInvokes(params: {
@@ -41,7 +40,6 @@ export async function setupSettingsWindowInvokes(params: {
 
   createWidgetsService({ context, widgetsManager: params.widgetsManager, window: params.settingsWindow })
   createAutoUpdaterService({ context, window: params.settingsWindow, service: params.autoUpdater })
-  createFetchService()
   createMcpServersService({ context, manager: params.mcpStdioManager })
   createAuthService({ context, window: params.settingsWindow, windowAuthManager: params.windowAuthManager })
 

--- a/nix/assets-hash.txt
+++ b/nix/assets-hash.txt
@@ -1,1 +1,0 @@
-sha256-69tCpJaxRUnyR9CrHlmWJWEWLDpYzyzska7ui9++QoY=

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -820,6 +820,34 @@ pages:
               description: Speech Service region
               label: Region
         title: Microsoft / Azure Speech
+      gpt-sovits:
+        description: github.com/RVC-Boss/GPT-SoVITS
+        title: GPT-SoVITS
+        callout_no_model_title: No model field support
+        callout_model_switch: GPT-SoVITS does not use the standard TTS model field. To switch models, fill in the GPT / SoVITS weight paths below and AIRI will call the api_v2.py switching endpoints.
+        callout_no_api_key: GPT-SoVITS does not require an API key. The field above can be left blank.
+        fields:
+          baseUrl:
+            description: Base URL of the GPT-SoVITS api_v2.py server
+            label: Base URL
+          refAudioPath:
+            description: Absolute path to reference audio file on the server
+            label: Reference Audio Path
+          promptText:
+            description: The text spoken in the reference audio, optional
+            label: Reference Audio Text
+          promptLang:
+            description: Language of the reference audio (zh / en / ja / ko / yue)
+            label: Reference Audio Language
+          textLang:
+            description: Language of the text to synthesize (zh / en / ja / ko / yue)
+            label: Synthesis Language
+          gptWeightsPath:
+            description: GPT weights path. If filled, AIRI will call /set_gpt_weights.
+            label: GPT Weights Path
+          sovitsWeightsPath:
+            description: SoVITS weights path. If filled, AIRI will call /set_sovits_weights.
+            label: SoVITS Weights Path
       index-tts-vllm:
         description: https://index-tts.github.io/
         title: Bilibili / IndexTTS

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -785,6 +785,34 @@ pages:
               description: 服务 Endpoint 地区（比如亚太 eastasia 区域）
               label: Endpoint 地区
         title: Microsoft / Azure 语音服务
+      gpt-sovits:
+        description: github.com/RVC-Boss/GPT-SoVITS
+        title: GPT-SoVITS
+        callout_no_model_title: 不支持请求内模型字段
+        callout_model_switch: GPT-SoVITS 不使用标准 TTS 的 model 字段；如需切换模型，请填写下方 GPT / SoVITS 权重路径，AIRI 会调用 api_v2.py 的切换接口。
+        callout_no_api_key: GPT-SoVITS 不需要 API Key，上方字段留空即可。
+        fields:
+          baseUrl:
+            description: GPT-SoVITS api_v2.py 服务器的 Base URL
+            label: Base URL
+          refAudioPath:
+            description: 服务器上参考音频文件的绝对路径
+            label: 参考音频路径
+          promptText:
+            description: 参考音频中说的文字内容，可留空
+            label: 参考音频文本
+          promptLang:
+            description: 参考音频的语言（zh / en / ja / ko / yue）
+            label: 参考音频语言
+          textLang:
+            description: 需要合成的文本语言（zh / en / ja / ko / yue）
+            label: 合成语言
+          gptWeightsPath:
+            description: GPT 权重路径；填写后会调用 /set_gpt_weights 切换
+            label: GPT 权重路径
+          sovitsWeightsPath:
+            description: SoVITS 权重路径；填写后会调用 /set_sovits_weights 切换
+            label: SoVITS 权重路径
       index-tts-vllm:
         description: https://index-tts.github.io/
         title: Bilibili / IndexTTS

--- a/packages/stage-pages/src/pages/settings/providers/speech/gpt-sovits.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/gpt-sovits.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import type { SpeechProvider } from '@xsai-ext/providers/utils'
+
+import {
+  SpeechPlayground,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { FieldInput } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const providerId = 'gpt-sovits'
+const defaultModel = 'gpt-sovits'
+
+const speechStore = useSpeechStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore)
+
+const refAudioPath = computed({
+  get: () => providers.value[providerId]?.refAudioPath as string | undefined || '',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].refAudioPath = value
+  },
+})
+
+const promptText = computed({
+  get: () => providers.value[providerId]?.promptText as string | undefined || '',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].promptText = value
+  },
+})
+
+const promptLang = computed({
+  get: () => providers.value[providerId]?.promptLang as string | undefined || 'zh',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].promptLang = value
+  },
+})
+
+const textLang = computed({
+  get: () => providers.value[providerId]?.textLang as string | undefined || 'zh',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].textLang = value
+  },
+})
+
+const gptWeightsPath = computed({
+  get: () => providers.value[providerId]?.gptWeightsPath as string | undefined || '',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].gptWeightsPath = value
+  },
+})
+
+const sovitsWeightsPath = computed({
+  get: () => providers.value[providerId]?.sovitsWeightsPath as string | undefined || '',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].sovitsWeightsPath = value
+  },
+})
+
+const apiKeyConfigured = computed(() => !!providers.value[providerId]?.baseUrl)
+
+const availableVoices = computed(() => speechStore.availableVoices[providerId] || [])
+
+onMounted(async () => {
+  await speechStore.loadVoicesForProvider(providerId)
+})
+
+watch([apiKeyConfigured], async () => {
+  await speechStore.loadVoicesForProvider(providerId)
+})
+
+async function handleGenerateSpeech(input: string, voiceId: string) {
+  const provider = await providersStore.getProviderInstance(providerId) as SpeechProvider
+  if (!provider)
+    throw new Error('Failed to initialize speech provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+
+  return await speechStore.speech(provider, defaultModel, input, voiceId, providerConfig)
+}
+</script>
+
+<template>
+  <SpeechProviderSettings :provider-id="providerId" :default-model="defaultModel">
+    <template #basic-settings>
+      <p :class="['text-sm', 'text-blue-500', 'dark:text-blue-400', 'px-1']">
+        ⓘ {{ t('settings.pages.providers.provider.gpt-sovits.callout_model_switch') }}
+      </p>
+      <p :class="['text-sm', 'text-neutral-400', 'dark:text-neutral-500', 'px-1']">
+        ⓘ {{ t('settings.pages.providers.provider.gpt-sovits.callout_no_api_key') }}
+      </p>
+      <FieldInput
+        v-model="refAudioPath"
+        :label="t('settings.pages.providers.provider.gpt-sovits.fields.refAudioPath.label')"
+        :description="t('settings.pages.providers.provider.gpt-sovits.fields.refAudioPath.description')"
+        placeholder="/path/to/reference.wav"
+        required
+        type="text"
+      />
+      <FieldInput
+        v-model="promptText"
+        :label="t('settings.pages.providers.provider.gpt-sovits.fields.promptText.label')"
+        :description="t('settings.pages.providers.provider.gpt-sovits.fields.promptText.description')"
+        placeholder="参考音频中说的文字（可选）"
+        type="text"
+      />
+      <FieldInput
+        v-model="gptWeightsPath"
+        :label="t('settings.pages.providers.provider.gpt-sovits.fields.gptWeightsPath.label')"
+        :description="t('settings.pages.providers.provider.gpt-sovits.fields.gptWeightsPath.description')"
+        placeholder="/path/to/gpt.ckpt"
+        type="text"
+      />
+      <FieldInput
+        v-model="sovitsWeightsPath"
+        :label="t('settings.pages.providers.provider.gpt-sovits.fields.sovitsWeightsPath.label')"
+        :description="t('settings.pages.providers.provider.gpt-sovits.fields.sovitsWeightsPath.description')"
+        placeholder="/path/to/sovits.pth"
+        type="text"
+      />
+    </template>
+
+    <template #voice-settings>
+      <FieldInput
+        v-model="promptLang"
+        :label="t('settings.pages.providers.provider.gpt-sovits.fields.promptLang.label')"
+        :description="t('settings.pages.providers.provider.gpt-sovits.fields.promptLang.description')"
+        placeholder="zh"
+        type="text"
+      />
+      <FieldInput
+        v-model="textLang"
+        :label="t('settings.pages.providers.provider.gpt-sovits.fields.textLang.label')"
+        :description="t('settings.pages.providers.provider.gpt-sovits.fields.textLang.description')"
+        placeholder="zh"
+        type="text"
+      />
+    </template>
+
+    <template #playground>
+      <SpeechPlayground
+        :available-voices="availableVoices"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="apiKeyConfigured"
+        :use-ssml="false"
+        default-text="你好，我是 AIRI，很高兴认识你！"
+      />
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+  meta:
+    layout: settings
+    stageTransition:
+      name: slide
+  </route>

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -69,6 +69,8 @@ const ALIYUN_NLS_REGIONS = [
 
 type AliyunNlsRegion = typeof ALIYUN_NLS_REGIONS[number]
 
+const TRAILING_SLASH_RE = /\/$/
+
 export interface ProviderMetadata {
   id: string
   order?: number
@@ -1152,6 +1154,206 @@ export const useProvidersStore = defineStore('providers', () => {
         },
       },
     },
+    'gpt-sovits': {
+      id: 'gpt-sovits',
+      category: 'speech',
+      tasks: ['text-to-speech'],
+      nameKey: 'settings.pages.providers.provider.gpt-sovits.title',
+      name: 'GPT-SoVITS',
+      descriptionKey: 'settings.pages.providers.provider.gpt-sovits.description',
+      description: 'github.com/RVC-Boss/GPT-SoVITS',
+      iconColor: 'i-lobe-icons:openai',
+      defaultOptions: () => ({
+        baseUrl: 'http://127.0.0.1:9880',
+        refAudioPath: '',
+        promptText: '',
+        promptLang: 'zh',
+        textLang: 'zh',
+        gptWeightsPath: '',
+        sovitsWeightsPath: '',
+      }),
+      createProvider: async (config) => {
+        const baseUrl = (config.baseUrl as string).replace(TRAILING_SLASH_RE, '')
+        const refAudioPath = config.refAudioPath as string
+        const promptText = config.promptText as string
+        const promptLang = (config.promptLang as string) || 'zh'
+        const textLang = (config.textLang as string) || 'zh'
+        const gptWeightsPath = (config.gptWeightsPath as string) || ''
+        const sovitsWeightsPath = (config.sovitsWeightsPath as string) || ''
+
+        const fetchThroughElectronIfAvailable = async (url: string, init?: RequestInit) => {
+          if (typeof window !== 'undefined' && 'electron' in window && (window as any).electron?.ipcRenderer) {
+            const result = await (window as any).electron.ipcRenderer.invoke('airi:electron:fetch', {
+              url,
+              method: init?.method ?? 'GET',
+              headers: init?.headers && typeof init.headers === 'object' && !Array.isArray(init.headers)
+                ? Object.fromEntries(Object.entries(init.headers as Record<string, string>))
+                : undefined,
+              body: typeof init?.body === 'string' ? init.body : undefined,
+            })
+
+            let responseBody: BodyInit
+            if (result.bodyBase64) {
+              // Decode base64 to ArrayBuffer for binary responses
+              const binaryString = atob(result.bodyBase64)
+              const bytes = new Uint8Array(binaryString.length)
+              for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i)
+              }
+              responseBody = bytes.buffer
+            }
+            else {
+              responseBody = result.body
+            }
+
+            return new Response(responseBody, {
+              status: result.status,
+              statusText: result.statusText,
+              headers: result.headers,
+            })
+          }
+
+          return await globalThis.fetch(url, init)
+        }
+
+        // Switch models if paths provided
+        if (gptWeightsPath) {
+          await fetchThroughElectronIfAvailable(`${baseUrl}/set_gpt_weights?weights_path=${encodeURIComponent(gptWeightsPath)}`).catch(() => {})
+        }
+        if (sovitsWeightsPath) {
+          await fetchThroughElectronIfAvailable(`${baseUrl}/set_sovits_weights?weights_path=${encodeURIComponent(sovitsWeightsPath)}`).catch(() => {})
+        }
+
+        const provider: SpeechProvider = {
+          speech: () => ({
+            baseURL: `${baseUrl}/`,
+            model: 'gpt-sovits',
+            // Custom fetch that rewrites the request to GPT-SoVITS api_v2.py format
+            fetch: async (_url: RequestInfo | URL, init?: RequestInit) => {
+              const body = JSON.parse(init?.body as string ?? '{}')
+              const ttsBody = {
+                text: body.input ?? '',
+                text_lang: textLang,
+                ref_audio_path: refAudioPath,
+                prompt_text: promptText,
+                prompt_lang: promptLang,
+                media_type: 'wav',
+                streaming_mode: false,
+              }
+              const ttsUrl = `${baseUrl}/tts`
+              return await fetchThroughElectronIfAvailable(ttsUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(ttsBody),
+                signal: init?.signal ?? undefined,
+              })
+            },
+          }),
+        }
+        return provider
+      },
+      capabilities: {
+        listModels: async () => [
+          {
+            id: 'gpt-sovits',
+            name: 'GPT-SoVITS',
+            provider: 'gpt-sovits',
+            description: 'GPT-SoVITS voice cloning model',
+            contextLength: 0,
+            deprecated: false,
+          },
+        ],
+        listVoices: async () => [
+          {
+            id: 'default',
+            name: 'Default (configured reference audio)',
+            provider: 'gpt-sovits',
+            languages: [
+              { code: 'zh', title: 'Chinese' },
+              { code: 'en', title: 'English' },
+              { code: 'ja', title: 'Japanese' },
+            ],
+          },
+        ],
+      },
+      validators: {
+        chatPingCheckAvailable: false,
+        validateProviderConfig: async (config) => {
+          console.log('[gpt-sovits validator] config:', config)
+          if (!config.baseUrl) {
+            console.log('[gpt-sovits validator] no baseUrl, returning invalid')
+            return { errors: [new Error('Base URL is required')], reason: 'Base URL is required', valid: false }
+          }
+
+          const res = baseUrlValidator.value(config.baseUrl)
+          if (res) {
+            console.log('[gpt-sovits validator] baseUrlValidator failed:', res)
+            return res
+          }
+
+          try {
+            const baseUrl = (config.baseUrl as string).replace(TRAILING_SLASH_RE, '')
+            console.log('[gpt-sovits validator] fetching:', `${baseUrl}/set_gpt_weights`)
+
+            // Use Electron main process fetch if available to bypass CORS
+            let response: Response
+            if (typeof window !== 'undefined' && 'electron' in window && (window as any).electron?.ipcRenderer) {
+              const result = await (window as any).electron.ipcRenderer.invoke('airi:electron:fetch', {
+                url: `${baseUrl}/set_gpt_weights`,
+                method: 'GET',
+              })
+
+              let responseBody: BodyInit
+              if (result.bodyBase64) {
+                const binaryString = atob(result.bodyBase64)
+                const bytes = new Uint8Array(binaryString.length)
+                for (let i = 0; i < binaryString.length; i++) {
+                  bytes[i] = binaryString.charCodeAt(i)
+                }
+                responseBody = bytes.buffer
+              }
+              else {
+                responseBody = result.body
+              }
+
+              response = new Response(responseBody, {
+                status: result.status,
+                statusText: result.statusText,
+                headers: result.headers,
+              })
+            }
+            else {
+              const controller = new AbortController()
+              const timeout = setTimeout(() => controller.abort(), 5000)
+              response = await fetch(`${baseUrl}/set_gpt_weights`, { signal: controller.signal })
+              clearTimeout(timeout)
+            }
+
+            console.log('[gpt-sovits validator] response status:', response.status, response.statusText)
+
+            // /set_gpt_weights without params returns 400 {"message":"gpt weight path is required"} — server is up
+            if (!response.ok && response.status !== 400) {
+              const reason = `GPT-SoVITS unreachable: HTTP ${response.status} ${response.statusText}`
+              console.log('[gpt-sovits validator] unreachable:', reason)
+              return { errors: [new Error(reason)], reason, valid: false }
+            }
+            console.log('[gpt-sovits validator] server is up, returning valid')
+          }
+          catch (err) {
+            console.log('[gpt-sovits validator] fetch error:', err)
+            if (!(err instanceof Error) || err.name !== 'AbortError') {
+              const reason = `GPT-SoVITS connection failed: ${String(err)}`
+              console.log('[gpt-sovits validator] connection failed:', reason)
+              return { errors: [err as Error], reason, valid: false }
+            }
+            console.log('[gpt-sovits validator] AbortError, treating as timeout failure')
+            return { errors: [err as Error], reason: 'Connection timeout', valid: false }
+          }
+
+          return { errors: [], reason: '', valid: true }
+        },
+      },
+    },
     'index-tts-vllm': {
       id: 'index-tts-vllm',
       category: 'speech',
@@ -1793,9 +1995,12 @@ export const useProvidersStore = defineStore('providers', () => {
 
   // Configuration validation functions
   async function validateProvider(providerId: string, options: { force?: boolean } = {}): Promise<boolean> {
+    console.log('[validateProvider]', providerId, 'force:', options.force)
     const metadata = providerMetadata[providerId]
-    if (!metadata)
+    if (!metadata) {
+      console.log('[validateProvider]', providerId, 'no metadata, returning false')
       return false
+    }
 
     // Web Speech API doesn't require credentials - use empty config if not present
     if (providerId === 'browser-web-speech-api') {
@@ -1805,31 +2010,38 @@ export const useProvidersStore = defineStore('providers', () => {
     }
 
     const config = providerCredentials.value[providerId]
-    if (!config && providerId !== 'browser-web-speech-api')
+    if (!config && providerId !== 'browser-web-speech-api') {
+      console.log('[validateProvider]', providerId, 'no config, returning false')
       return false
+    }
 
     const configString = JSON.stringify(config || {})
     const runtimeState = providerRuntimeState.value[providerId]
     const cacheKey = `${providerId}:${configString}`
     const forceValidation = options.force === true
 
-    if (!forceValidation && runtimeState?.validatedCredentialHash === configString && typeof runtimeState.isConfigured === 'boolean')
+    if (!forceValidation && runtimeState?.validatedCredentialHash === configString && typeof runtimeState.isConfigured === 'boolean') {
+      console.log('[validateProvider]', providerId, 'cache hit, returning:', runtimeState.isConfigured)
       return runtimeState.isConfigured
+    }
 
     if (!forceValidation) {
       const pending = providerValidationInFlight.get(cacheKey)
       if (pending) {
+        console.log('[validateProvider]', providerId, 'validation in flight, returning pending promise')
         return pending
       }
     }
 
     const runValidation = async () => {
+      console.log('[validateProvider]', providerId, 'running validation with config:', config)
       // PITFALL: Please consider skip chat ping check during automatic/background validation,
       // since this can consume API tokens and may only be triggered
       // by user action (e.g. "Ping API" button on settings pages) or other user intentions.
       const validationResult = await metadata.validators.validateProviderConfig(config || {}, {
         skipChatPingCheck: true,
       })
+      console.log('[validateProvider]', providerId, 'validation result:', validationResult)
 
       if (providerRuntimeState.value[providerId]) {
         providerRuntimeState.value[providerId].isConfigured = validationResult.valid
@@ -1840,6 +2052,7 @@ export const useProvidersStore = defineStore('providers', () => {
         }
       }
 
+      console.log('[validateProvider]', providerId, 'final result:', validationResult.valid)
       return validationResult.valid
     }
 

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -1183,12 +1183,25 @@ export const useProvidersStore = defineStore('providers', () => {
 
         const fetchThroughElectronIfAvailable = async (url: string, init?: RequestInit) => {
           if (typeof window !== 'undefined' && 'electron' in window && (window as any).electron?.ipcRenderer) {
+            const normalizedHeaders: Record<string, string> = {}
+            if (init?.headers instanceof Headers) {
+              init.headers.forEach((value, key) => {
+                normalizedHeaders[key] = value
+              })
+            }
+            else if (Array.isArray(init?.headers)) {
+              for (const [key, value] of init.headers) {
+                normalizedHeaders[key] = value
+              }
+            }
+            else if (init?.headers && typeof init.headers === 'object') {
+              Object.assign(normalizedHeaders, init.headers as Record<string, string>)
+            }
+
             const result = await (window as any).electron.ipcRenderer.invoke('airi:electron:fetch', {
               url,
               method: init?.method ?? 'GET',
-              headers: init?.headers && typeof init.headers === 'object' && !Array.isArray(init.headers)
-                ? Object.fromEntries(Object.entries(init.headers as Record<string, string>))
-                : undefined,
+              headers: Object.keys(normalizedHeaders).length > 0 ? normalizedHeaders : undefined,
               body: typeof init?.body === 'string' ? init.body : undefined,
             })
 
@@ -1279,21 +1292,17 @@ export const useProvidersStore = defineStore('providers', () => {
       validators: {
         chatPingCheckAvailable: false,
         validateProviderConfig: async (config) => {
-          console.log('[gpt-sovits validator] config:', config)
           if (!config.baseUrl) {
-            console.log('[gpt-sovits validator] no baseUrl, returning invalid')
             return { errors: [new Error('Base URL is required')], reason: 'Base URL is required', valid: false }
           }
 
           const res = baseUrlValidator.value(config.baseUrl)
           if (res) {
-            console.log('[gpt-sovits validator] baseUrlValidator failed:', res)
             return res
           }
 
           try {
             const baseUrl = (config.baseUrl as string).replace(TRAILING_SLASH_RE, '')
-            console.log('[gpt-sovits validator] fetching:', `${baseUrl}/set_gpt_weights`)
 
             // Use Electron main process fetch if available to bypass CORS
             let response: Response
@@ -1329,24 +1338,17 @@ export const useProvidersStore = defineStore('providers', () => {
               clearTimeout(timeout)
             }
 
-            console.log('[gpt-sovits validator] response status:', response.status, response.statusText)
-
             // /set_gpt_weights without params returns 400 {"message":"gpt weight path is required"} — server is up
             if (!response.ok && response.status !== 400) {
               const reason = `GPT-SoVITS unreachable: HTTP ${response.status} ${response.statusText}`
-              console.log('[gpt-sovits validator] unreachable:', reason)
               return { errors: [new Error(reason)], reason, valid: false }
             }
-            console.log('[gpt-sovits validator] server is up, returning valid')
           }
           catch (err) {
-            console.log('[gpt-sovits validator] fetch error:', err)
             if (!(err instanceof Error) || err.name !== 'AbortError') {
               const reason = `GPT-SoVITS connection failed: ${String(err)}`
-              console.log('[gpt-sovits validator] connection failed:', reason)
               return { errors: [err as Error], reason, valid: false }
             }
-            console.log('[gpt-sovits validator] AbortError, treating as timeout failure')
             return { errors: [err as Error], reason: 'Connection timeout', valid: false }
           }
 
@@ -1995,10 +1997,8 @@ export const useProvidersStore = defineStore('providers', () => {
 
   // Configuration validation functions
   async function validateProvider(providerId: string, options: { force?: boolean } = {}): Promise<boolean> {
-    console.log('[validateProvider]', providerId, 'force:', options.force)
     const metadata = providerMetadata[providerId]
     if (!metadata) {
-      console.log('[validateProvider]', providerId, 'no metadata, returning false')
       return false
     }
 
@@ -2011,7 +2011,6 @@ export const useProvidersStore = defineStore('providers', () => {
 
     const config = providerCredentials.value[providerId]
     if (!config && providerId !== 'browser-web-speech-api') {
-      console.log('[validateProvider]', providerId, 'no config, returning false')
       return false
     }
 
@@ -2021,27 +2020,23 @@ export const useProvidersStore = defineStore('providers', () => {
     const forceValidation = options.force === true
 
     if (!forceValidation && runtimeState?.validatedCredentialHash === configString && typeof runtimeState.isConfigured === 'boolean') {
-      console.log('[validateProvider]', providerId, 'cache hit, returning:', runtimeState.isConfigured)
       return runtimeState.isConfigured
     }
 
     if (!forceValidation) {
       const pending = providerValidationInFlight.get(cacheKey)
       if (pending) {
-        console.log('[validateProvider]', providerId, 'validation in flight, returning pending promise')
         return pending
       }
     }
 
     const runValidation = async () => {
-      console.log('[validateProvider]', providerId, 'running validation with config:', config)
       // PITFALL: Please consider skip chat ping check during automatic/background validation,
       // since this can consume API tokens and may only be triggered
       // by user action (e.g. "Ping API" button on settings pages) or other user intentions.
       const validationResult = await metadata.validators.validateProviderConfig(config || {}, {
         skipChatPingCheck: true,
       })
-      console.log('[validateProvider]', providerId, 'validation result:', validationResult)
 
       if (providerRuntimeState.value[providerId]) {
         providerRuntimeState.value[providerId].isConfigured = validationResult.valid
@@ -2052,7 +2047,6 @@ export const useProvidersStore = defineStore('providers', () => {
         }
       }
 
-      console.log('[validateProvider]', providerId, 'final result:', validationResult.valid)
       return validationResult.valid
     }
 


### PR DESCRIPTION
## Summary

feat(stage-ui): add GPT-SoVITS speech provider support

## Description

- add GPT-SoVITS as a configurable speech provider in AIRI settings
- add provider-specific settings UI and i18n entries for base URL, reference audio, prompt language, text language, and model weight switching
- add Electron-side fetch proxy so remote GPT-SoVITS health checks and speech generation work in desktop without renderer CORS failures

### Notes
- GPT-SoVITS integration targets api_v2.py style endpoints (api_v2.py provided by GPT-SoVITS original repo)
- health check validates service availability through /set_gpt_weights
  - model switching is handled through GPT/SoVITS weight path endpoints instead of standard model selection

### Validation
- pnpm typecheck ✅
- pnpm lint ❌ (repository has pre-existing unrelated lint errors outside this change set)

## Linked Issues

#532 #1360 

<!-- Optional, if you have any -->

<!-- ## Additional Context -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->
