### PR TITLE
fix(stage-tamagotchi): add drag region to onboarding layout

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/onboarding.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/onboarding.vue
@@ -47,7 +47,7 @@ async function handleConfigured() {
 </script>
 
 <template>
-  <div class="onboarding-root" h-full w-full flex flex-col overflow-x-hidden overflow-y-auto overscroll-none :class="bgClass">
+  <div class="onboarding-root" h-full w-full flex flex-col overflow-x-hidden overflow-y-auto overscroll-none drag-region :class="bgClass">
     <div :class="bgClass" w="100dvw" min-h="12" w-full flex-shrink-0 select-none />
     <div class="onboarding-scroll" w-full flex-1 px-10>
       <div class="onboarding-content" h-full>


### PR DESCRIPTION
## Description

Adds the `drag-region` class to the onboarding page root container in `stage-tamagotchi` so the Electron window can be dragged from that area (consistent with other chrome that uses the same pattern). Without it, users may hit a dead zone where the window does not move when dragging over onboarding content.

## Linked Issues

<!-- N/A -->

## Additional Context

- Scope: `apps/stage-tamagotchi/src/renderer/pages/onboarding.vue` only.
- Please sanity-check onboarding on macOS/Windows: drag from the top/empty chrome and scroll behavior inside the onboarding content still feels correct (`drag-region` is on the outer flex root; inner interactive areas should remain non-drag if already styled that way elsewhere).
