### PR TITLE
feat(stage-ui): add browser-local Whisper transcription provider

### DIFF
--- a/packages/stage-ui/src/stores/modules/hearing.ts
+++ b/packages/stage-ui/src/stores/modules/hearing.ts
@@ -150,10 +150,10 @@ export const useHearingStore = defineStore('hearing-store', () => {
     if (!activeTranscriptionProvider.value)
       return false
 
-    // Web Speech API doesn't strictly need a model selected (it has a default)
-    // but we still check to maintain consistency
-    if (activeTranscriptionProvider.value === 'browser-web-speech-api') {
-      return true // Web Speech API is ready if provider is selected and available
+    // Web Speech API and browser-local don't strictly need a model selected
+    if (activeTranscriptionProvider.value === 'browser-web-speech-api'
+      || activeTranscriptionProvider.value === 'browser-local-audio-transcription') {
+      return true
     }
 
     // For OpenAI Compatible providers, check provider config as fallback

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -20,8 +20,6 @@ import type {
 
 import type { AliyunRealtimeSpeechExtraOptions } from './providers/aliyun/stream-transcription'
 
-import { createBrowserLocalTranscriptionProvider } from './providers/browser-local/transcription'
-
 import { isStageTamagotchi, isUrl } from '@proj-airi/stage-shared'
 import { computedAsync, useIntervalFn, useLocalStorage } from '@vueuse/core'
 import {
@@ -54,6 +52,7 @@ import { getKokoroWorker } from '../workers/kokoro'
 import { getDefaultKokoroModel, KOKORO_MODELS, kokoroModelsToModelInfo } from '../workers/kokoro/constants'
 import { useAuthStore } from './auth'
 import { createAliyunNLSProvider as createAliyunNlsStreamProvider } from './providers/aliyun/stream-transcription'
+import { createBrowserLocalTranscriptionProvider } from './providers/browser-local/transcription'
 import { convertProviderDefinitionsToMetadata } from './providers/converters'
 import { models as elevenLabsModels } from './providers/elevenlabs/list-models'
 import { buildOpenAICompatibleProvider } from './providers/openai-compatible-builder'

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -20,6 +20,8 @@ import type {
 
 import type { AliyunRealtimeSpeechExtraOptions } from './providers/aliyun/stream-transcription'
 
+import { createBrowserLocalTranscriptionProvider } from './providers/browser-local/transcription'
+
 import { isStageTamagotchi, isUrl } from '@proj-airi/stage-shared'
 import { computedAsync, useIntervalFn, useLocalStorage } from '@vueuse/core'
 import {
@@ -384,33 +386,28 @@ export const useProvidersStore = defineStore('providers', () => {
     }),
     'browser-local-audio-transcription': buildOpenAICompatibleProvider({
       id: 'browser-local-audio-transcription',
-      name: 'Browser (Local)',
+      name: 'Browser (Local Whisper)',
       nameKey: 'settings.pages.providers.provider.browser-local-audio-transcription.title',
       descriptionKey: 'settings.pages.providers.provider.browser-local-audio-transcription.description',
       icon: 'i-lobe-icons:huggingface',
-      description: 'https://github.com/moeru-ai/xsai-transformers',
+      description: 'In-browser Whisper ASR via @xsai-transformers/transcription. Supports Chinese and 90+ languages. No API key needed.',
       category: 'transcription',
       tasks: ['speech-to-text', 'automatic-speech-recognition', 'asr', 'stt'],
       isAvailableBy: isBrowserAndMemoryEnough,
-      creator: createOpenAI,
+      creator: () => createBrowserLocalTranscriptionProvider() as any,
+      transcriptionFeatures: {
+        supportsGenerate: true,
+        supportsStreamOutput: false,
+        supportsStreamInput: false,
+      },
       validation: [],
       validators: {
         chatPingCheckAvailable: false,
-        validateProviderConfig: (config) => {
-          if (!config.baseUrl) {
-            return {
-              errors: [new Error('Base URL is required.')],
-              reason: 'Base URL is required. This is likely a bug, report to developers on https://github.com/moeru-ai/airi/issues.',
-              valid: false,
-            }
-          }
-
-          return {
-            errors: [],
-            reason: '',
-            valid: true,
-          }
-        },
+        validateProviderConfig: () => ({
+          errors: [],
+          reason: '',
+          valid: true,
+        }),
       },
     }),
     'openai-audio-speech': buildOpenAICompatibleProvider({

--- a/packages/stage-ui/src/stores/providers/browser-local/transcription.ts
+++ b/packages/stage-ui/src/stores/providers/browser-local/transcription.ts
@@ -1,5 +1,5 @@
-import type { LoadableTranscriptionProvider } from '@xsai-transformers/transcription'
 import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+import type { LoadableTranscriptionProvider } from '@xsai-transformers/transcription'
 
 import { createTranscriptionProvider } from '@xsai-transformers/transcription'
 import { shallowRef } from 'vue'

--- a/packages/stage-ui/src/stores/providers/browser-local/transcription.ts
+++ b/packages/stage-ui/src/stores/providers/browser-local/transcription.ts
@@ -1,0 +1,66 @@
+import type { LoadableTranscriptionProvider } from '@xsai-transformers/transcription'
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import { createTranscriptionProvider } from '@xsai-transformers/transcription'
+import { shallowRef } from 'vue'
+
+export type BrowserLocalTranscriptionProvider = LoadableTranscriptionProvider<TranscriptionProviderWithExtraOptions>
+
+const DEFAULT_MODEL = 'onnx-community/whisper-small'
+
+const AVAILABLE_MODELS = [
+  { id: 'onnx-community/whisper-tiny', name: 'Whisper Tiny (~150MB)', size: 'tiny' },
+  { id: 'onnx-community/whisper-base', name: 'Whisper Base (~290MB)', size: 'base' },
+  { id: 'onnx-community/whisper-small', name: 'Whisper Small (~950MB)', size: 'small' },
+] as const
+
+export const browserLocalTranscriptionLoading = shallowRef(false)
+export const browserLocalTranscriptionReady = shallowRef(false)
+export const browserLocalTranscriptionError = shallowRef<string | null>(null)
+
+let cachedProvider: BrowserLocalTranscriptionProvider | null = null
+
+export function createBrowserLocalTranscriptionProvider(): BrowserLocalTranscriptionProvider {
+  if (cachedProvider)
+    return cachedProvider
+
+  const provider = createTranscriptionProvider({
+    name: 'browser-local',
+  })
+
+  cachedProvider = provider
+  return provider
+}
+
+export async function loadBrowserLocalModel(model?: string): Promise<void> {
+  const provider = createBrowserLocalTranscriptionProvider()
+
+  browserLocalTranscriptionLoading.value = true
+  browserLocalTranscriptionError.value = null
+  browserLocalTranscriptionReady.value = false
+
+  try {
+    await provider.loadTranscribe(model || DEFAULT_MODEL)
+    browserLocalTranscriptionReady.value = true
+  }
+  catch (err) {
+    browserLocalTranscriptionError.value = err instanceof Error ? err.message : String(err)
+    throw err
+  }
+  finally {
+    browserLocalTranscriptionLoading.value = false
+  }
+}
+
+export function terminateBrowserLocalModel(): void {
+  if (cachedProvider) {
+    cachedProvider.terminateTranscribe()
+    cachedProvider = null
+    browserLocalTranscriptionReady.value = false
+    browserLocalTranscriptionLoading.value = false
+  }
+}
+
+export function getAvailableLocalModels() {
+  return AVAILABLE_MODELS
+}


### PR DESCRIPTION
## Summary
- Implement browser-local ASR using `@xsai-transformers/transcription` with ONNX Whisper models
- Supports Chinese and 90+ languages with no API key required
- Update the existing `browser-local-audio-transcription` provider placeholder with real implementation

Addresses the "In-App Inference (Edge AI)" item in the v0.9 roadmap (#840).

## Changes
- **New**: `providers/browser-local/transcription.ts` — Browser-local Whisper provider with model loading/unloading lifecycle, supports tiny/base/small models
- **Modified**: `providers.ts` — Update `browser-local-audio-transcription` metadata to use real provider, set correct transcription features
- **Modified**: `hearing.ts` — Add `browser-local-audio-transcription` to configured check (no model selection needed)

## Test plan
- [ ] Select "Browser (Local Whisper)" as transcription provider in settings
- [ ] Verify model downloads and loads successfully
- [ ] Test transcription with microphone input in Chinese and English

🤖 Generated with [Claude Code](https://claude.com/claude-code)