### PR TITLE
fix(stage-ui): improve LLM KV-cache compatibility for datetime context injection

### DIFF
--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -13,7 +13,7 @@ import { ref, toRaw } from 'vue'
 import { useAnalytics } from '../composables'
 import { useLlmmarkerParser } from '../composables/llm-marker-parser'
 import { categorizeResponse, createStreamingCategorizer } from '../composables/response-categoriser'
-import { buildContextPromptMessage } from './chat/context-prompt'
+import { formatContextPromptText } from './chat/context-prompt'
 import { createDatetimeContext, createMinecraftContext } from './chat/context-providers'
 import { useChatContextStore } from './chat/context-store'
 import { createChatHooks } from './chat/hooks'
@@ -279,7 +279,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
         ],
       })
 
-      let newMessages = sessionMessagesForSend.map((msg) => {
+      const newMessages = sessionMessagesForSend.map((msg) => {
         const { context: _context, id: _id, createdAt: _createdAt, ...withoutContext } = msg
         const rawMessage = toRaw(withoutContext)
 
@@ -292,16 +292,27 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       })
 
       const contextsSnapshot = chatContext.getContextsSnapshot()
-      const contextPromptMessage = buildContextPromptMessage(contextsSnapshot)
-      if (contextPromptMessage) {
-        const system = newMessages.slice(0, 1)
-        const afterSystem = newMessages.slice(1, newMessages.length)
+      const contextPromptText = formatContextPromptText(contextsSnapshot)
+      if (contextPromptText) {
+        // Merge context into the latest user message instead of inserting a
+        // separate user message, which would create consecutive same-role
+        // messages forbidden by some providers (e.g. Anthropic → 400 error).
+        // Appending at the end keeps the static history prefix stable for
+        // LLM KV-cache reuse.
+        // See: https://github.com/moeru-ai/airi/issues/1539
+        const lastMessage = newMessages.at(-1)
+        if (lastMessage && lastMessage.role === 'user') {
+          // Preserve existing content parts (including non-text parts like
+          // image_url for vision requests) and prepend context as a text part.
+          const existingParts = typeof lastMessage.content === 'string'
+            ? [{ type: 'text' as const, text: lastMessage.content }]
+            : lastMessage.content
 
-        newMessages = [
-          ...system,
-          contextPromptMessage,
-          ...afterSystem,
-        ]
+          lastMessage.content = [
+            { type: 'text' as const, text: contextPromptText },
+            ...existingParts,
+          ]
+        }
 
         contextObservability.recordLifecycle({
           phase: 'prompt-context-built',
@@ -309,7 +320,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
           sessionId,
           details: {
             contexts: contextsSnapshot,
-            promptMessage: contextPromptMessage,
+            promptText: contextPromptText,
           },
         })
       }
@@ -319,7 +330,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
         sessionId,
         message: sendingMessage,
         contexts: contextsSnapshot,
-        promptMessage: contextPromptMessage,
+        promptMessage: undefined,
         composedMessage: newMessages as Message[],
       })
       contextObservability.recordLifecycle({

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -302,15 +302,16 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
         // See: https://github.com/moeru-ai/airi/issues/1539
         const lastMessage = newMessages.at(-1)
         if (lastMessage && lastMessage.role === 'user') {
-          // Preserve existing content parts (including non-text parts like
-          // image_url for vision requests) and prepend context as a text part.
+          // Append context after the user's content, separated by a newline.
+          // Keeping it at the end of the last message preserves the static
+          // history prefix for LLM KV-cache reuse.
           const existingParts = typeof lastMessage.content === 'string'
             ? [{ type: 'text' as const, text: lastMessage.content }]
             : lastMessage.content
 
           lastMessage.content = [
-            { type: 'text' as const, text: contextPromptText },
             ...existingParts,
+            { type: 'text' as const, text: `\n${contextPromptText}` },
           ]
         }
 

--- a/packages/stage-ui/src/stores/chat/context-prompt.test.ts
+++ b/packages/stage-ui/src/stores/chat/context-prompt.test.ts
@@ -1,0 +1,75 @@
+import type { ContextSnapshot } from './context-prompt'
+
+import { ContextUpdateStrategy } from '@proj-airi/server-sdk'
+import { describe, expect, it } from 'vitest'
+
+import { buildContextPromptMessage, formatContextPromptText } from './context-prompt'
+
+function makeContext(overrides: Record<string, unknown> = {}): ContextSnapshot {
+  return {
+    'system:datetime': [
+      {
+        id: 'volatile-random-id',
+        contextId: 'system:datetime',
+        strategy: ContextUpdateStrategy.ReplaceSelf,
+        text: 'Current datetime: 2026-04-07T12:34:00.000Z',
+        createdAt: 1743940440000,
+        metadata: {
+          source: {
+            id: 'system:datetime',
+            kind: 'plugin' as const,
+            plugin: { id: 'airi:system:datetime' },
+          },
+        },
+        ...overrides,
+      },
+    ],
+  }
+}
+
+describe('formatContextPromptText', () => {
+  it('returns empty string for empty snapshot', () => {
+    expect(formatContextPromptText({})).toBe('')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1539
+  it('Issue #1539: excludes id, createdAt, and metadata from serialized output', () => {
+    const text = formatContextPromptText(makeContext())
+
+    expect(text).not.toContain('volatile-random-id')
+    expect(text).not.toContain('1743940440000')
+    expect(text).not.toContain('metadata')
+    expect(text).not.toContain('airi:system:datetime')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1539
+  it('Issue #1539: includes only contextId, strategy, and text', () => {
+    const text = formatContextPromptText(makeContext())
+
+    expect(text).toContain('system:datetime')
+    expect(text).toContain('replace-self')
+    expect(text).toContain('Current datetime: 2026-04-07T12:34:00.000Z')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1539
+  it('Issue #1539: produces identical output regardless of volatile fields', () => {
+    const a = formatContextPromptText(makeContext({ id: 'aaa', createdAt: 1 }))
+    const b = formatContextPromptText(makeContext({ id: 'bbb', createdAt: 2 }))
+
+    expect(a).toBe(b)
+  })
+})
+
+describe('buildContextPromptMessage', () => {
+  it('returns null for empty snapshot', () => {
+    expect(buildContextPromptMessage({})).toBeNull()
+  })
+
+  it('returns a user message with context text', () => {
+    const msg = buildContextPromptMessage(makeContext())
+
+    expect(msg).not.toBeNull()
+    expect(msg!.role).toBe('user')
+    expect(msg!.content).toBeInstanceOf(Array)
+  })
+})

--- a/packages/stage-ui/src/stores/chat/context-prompt.test.ts
+++ b/packages/stage-ui/src/stores/chat/context-prompt.test.ts
@@ -38,16 +38,16 @@ describe('formatContextPromptText', () => {
 
     expect(text).not.toContain('volatile-random-id')
     expect(text).not.toContain('1743940440000')
-    expect(text).not.toContain('metadata')
     expect(text).not.toContain('airi:system:datetime')
   })
 
   // https://github.com/moeru-ai/airi/issues/1539
-  it('issue #1539: includes only contextId, strategy, and text', () => {
+  it('issue #1539: only includes text content in XML format', () => {
     const text = formatContextPromptText(makeContext())
 
-    expect(text).toContain('system:datetime')
-    expect(text).toContain('replace-self')
+    expect(text).toContain('<context>')
+    expect(text).toContain('</context>')
+    expect(text).toContain('<module name="system:datetime">')
     expect(text).toContain('Current datetime: 2026-04-07T12:34:00.000Z')
   })
 
@@ -57,6 +57,35 @@ describe('formatContextPromptText', () => {
     const b = formatContextPromptText(makeContext({ id: 'bbb', createdAt: 2 }))
 
     expect(a).toBe(b)
+  })
+
+  it('formats multiple modules', () => {
+    const snapshot: ContextSnapshot = {
+      'system:datetime': [
+        {
+          id: 'a',
+          contextId: 'system:datetime',
+          strategy: ContextUpdateStrategy.ReplaceSelf,
+          text: 'Current datetime: 2026-04-07T12:34:00.000Z',
+          createdAt: 0,
+        },
+      ],
+      'system:minecraft': [
+        {
+          id: 'b',
+          contextId: 'system:minecraft',
+          strategy: ContextUpdateStrategy.ReplaceSelf,
+          text: 'Bot is online',
+          createdAt: 0,
+        },
+      ],
+    }
+
+    const text = formatContextPromptText(snapshot)
+
+    expect(text).toContain('<module name="system:datetime">')
+    expect(text).toContain('<module name="system:minecraft">')
+    expect(text).toContain('Bot is online')
   })
 })
 

--- a/packages/stage-ui/src/stores/chat/context-prompt.test.ts
+++ b/packages/stage-ui/src/stores/chat/context-prompt.test.ts
@@ -33,7 +33,7 @@ describe('formatContextPromptText', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/1539
-  it('Issue #1539: excludes id, createdAt, and metadata from serialized output', () => {
+  it('issue #1539: excludes id, createdAt, and metadata from serialized output', () => {
     const text = formatContextPromptText(makeContext())
 
     expect(text).not.toContain('volatile-random-id')
@@ -43,7 +43,7 @@ describe('formatContextPromptText', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/1539
-  it('Issue #1539: includes only contextId, strategy, and text', () => {
+  it('issue #1539: includes only contextId, strategy, and text', () => {
     const text = formatContextPromptText(makeContext())
 
     expect(text).toContain('system:datetime')
@@ -52,7 +52,7 @@ describe('formatContextPromptText', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/1539
-  it('Issue #1539: produces identical output regardless of volatile fields', () => {
+  it('issue #1539: produces identical output regardless of volatile fields', () => {
     const a = formatContextPromptText(makeContext({ id: 'aaa', createdAt: 1 }))
     const b = formatContextPromptText(makeContext({ id: 'bbb', createdAt: 2 }))
 

--- a/packages/stage-ui/src/stores/chat/context-prompt.ts
+++ b/packages/stage-ui/src/stores/chat/context-prompt.ts
@@ -4,13 +4,30 @@ import type { ContextMessage } from '../../types/chat'
 
 export type ContextSnapshot = Record<string, ContextMessage[]>
 
+/**
+ * Fields serialized into the LLM prompt.
+ * Keeping this whitelist small and deterministic avoids volatile metadata
+ * (random IDs, millisecond timestamps) from breaking LLM KV-cache prefix matching.
+ * See: https://github.com/moeru-ai/airi/issues/1539
+ */
+const SERIALIZED_FIELDS: (keyof ContextMessage)[] = ['contextId', 'strategy', 'text']
+
+function pickSerializedFields(message: ContextMessage): Partial<ContextMessage> {
+  const picked: Record<string, unknown> = {}
+  for (const key of SERIALIZED_FIELDS) {
+    if (key in message)
+      picked[key] = message[key]
+  }
+  return picked as Partial<ContextMessage>
+}
+
 export function formatContextPromptText(contextsSnapshot: ContextSnapshot) {
   if (Object.keys(contextsSnapshot).length === 0)
     return ''
 
   return ''
     + 'These are the contextual information retrieved or on-demand updated from other modules, you may use them as context for chat, or reference of the next action, tool call, etc.:\n'
-    + `${Object.entries(contextsSnapshot).map(([key, value]) => `Module ${key}: ${JSON.stringify(value)}`).join('\n')}\n`
+    + `${Object.entries(contextsSnapshot).map(([key, value]) => `Module ${key}: ${JSON.stringify(value.map(pickSerializedFields))}`).join('\n')}\n`
 }
 
 export function buildContextPromptMessage(contextsSnapshot: ContextSnapshot): UserMessage | null {

--- a/packages/stage-ui/src/stores/chat/context-prompt.ts
+++ b/packages/stage-ui/src/stores/chat/context-prompt.ts
@@ -2,32 +2,32 @@ import type { UserMessage } from '@xsai/shared-chat'
 
 import type { ContextMessage } from '../../types/chat'
 
+import { toXml } from 'xast-util-to-xml'
+import { x } from 'xastscript'
+
 export type ContextSnapshot = Record<string, ContextMessage[]>
 
 /**
- * Fields serialized into the LLM prompt.
- * Keeping this whitelist small and deterministic avoids volatile metadata
- * (random IDs, millisecond timestamps) from breaking LLM KV-cache prefix matching.
+ * Build an xast tree from context snapshot.
+ * Only the `text` field is included — volatile metadata (random IDs,
+ * millisecond timestamps) is excluded to keep the output deterministic
+ * and friendly to LLM KV-cache prefix matching.
  * See: https://github.com/moeru-ai/airi/issues/1539
  */
-const SERIALIZED_FIELDS: (keyof ContextMessage)[] = ['contextId', 'strategy', 'text']
+function buildContextTree(contextsSnapshot: ContextSnapshot) {
+  const modules = Object.entries(contextsSnapshot).map(([key, messages]) =>
+    x('module', { name: key }, messages.map(m => x(null, m.text))),
+  )
 
-function pickSerializedFields(message: ContextMessage): Partial<ContextMessage> {
-  const picked: Record<string, unknown> = {}
-  for (const key of SERIALIZED_FIELDS) {
-    if (key in message)
-      picked[key] = message[key]
-  }
-  return picked as Partial<ContextMessage>
+  return x('context', modules)
 }
 
 export function formatContextPromptText(contextsSnapshot: ContextSnapshot) {
-  if (Object.keys(contextsSnapshot).length === 0)
+  const entries = Object.entries(contextsSnapshot)
+  if (entries.length === 0)
     return ''
 
-  return ''
-    + 'These are the contextual information retrieved or on-demand updated from other modules, you may use them as context for chat, or reference of the next action, tool call, etc.:\n'
-    + `${Object.entries(contextsSnapshot).map(([key, value]) => `Module ${key}: ${JSON.stringify(value.map(pickSerializedFields))}`).join('\n')}\n`
+  return toXml(buildContextTree(contextsSnapshot))
 }
 
 export function buildContextPromptMessage(contextsSnapshot: ContextSnapshot): UserMessage | null {

--- a/packages/stage-ui/src/stores/chat/context-providers/datetime.test.ts
+++ b/packages/stage-ui/src/stores/chat/context-providers/datetime.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createDatetimeContext } from './datetime'
+
+describe('createDatetimeContext', () => {
+  // https://github.com/moeru-ai/airi/issues/1539
+  it('Issue #1539: uses a fixed deterministic id instead of a random one', () => {
+    const a = createDatetimeContext()
+    const b = createDatetimeContext()
+    expect(a.id).toBe(b.id)
+    expect(a.id).toBe('system:datetime:singleton')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1539
+  it('Issue #1539: quantizes time to the minute (seconds and ms are zeroed)', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-04-07T12:34:56.789Z'))
+      const ctx = createDatetimeContext()
+
+      expect(ctx.text).toContain('2026-04-07T12:34:00.000Z')
+      expect(ctx.createdAt).toBe(new Date('2026-04-07T12:34:00.000Z').getTime())
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1539
+  it('Issue #1539: produces identical output for calls within the same minute', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-04-07T12:34:10.000Z'))
+      const a = createDatetimeContext()
+
+      vi.setSystemTime(new Date('2026-04-07T12:34:45.999Z'))
+      const b = createDatetimeContext()
+
+      expect(a.id).toBe(b.id)
+      expect(a.text).toBe(b.text)
+      expect(a.createdAt).toBe(b.createdAt)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('produces different text when the minute changes', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-04-07T12:34:00.000Z'))
+      const a = createDatetimeContext()
+
+      vi.setSystemTime(new Date('2026-04-07T12:35:00.000Z'))
+      const b = createDatetimeContext()
+
+      expect(a.text).not.toBe(b.text)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/stage-ui/src/stores/chat/context-providers/datetime.test.ts
+++ b/packages/stage-ui/src/stores/chat/context-providers/datetime.test.ts
@@ -3,49 +3,28 @@ import { describe, expect, it, vi } from 'vitest'
 import { createDatetimeContext } from './datetime'
 
 describe('createDatetimeContext', () => {
-  // https://github.com/moeru-ai/airi/issues/1539
-  it('issue #1539: uses a fixed deterministic id instead of a random one', () => {
-    const a = createDatetimeContext()
-    const b = createDatetimeContext()
-    expect(a.id).toBe(b.id)
-    expect(a.id).toBe('system:datetime:singleton')
+  it('returns a context message with datetime text', () => {
+    const ctx = createDatetimeContext()
+
+    expect(ctx.contextId).toBe('system:datetime')
+    expect(ctx.text).toContain('Current datetime:')
+    expect(ctx.strategy).toBe('replace-self')
   })
 
-  // https://github.com/moeru-ai/airi/issues/1539
-  it('issue #1539: quantizes time to the minute (seconds and ms are zeroed)', () => {
+  it('includes ISO string in text', () => {
     vi.useFakeTimers()
     try {
       vi.setSystemTime(new Date('2026-04-07T12:34:56.789Z'))
       const ctx = createDatetimeContext()
 
-      expect(ctx.text).toContain('2026-04-07T12:34:00.000Z')
-      expect(ctx.createdAt).toBe(new Date('2026-04-07T12:34:00.000Z').getTime())
+      expect(ctx.text).toContain('2026-04-07T12:34:56.789Z')
     }
     finally {
       vi.useRealTimers()
     }
   })
 
-  // https://github.com/moeru-ai/airi/issues/1539
-  it('issue #1539: produces identical output for calls within the same minute', () => {
-    vi.useFakeTimers()
-    try {
-      vi.setSystemTime(new Date('2026-04-07T12:34:10.000Z'))
-      const a = createDatetimeContext()
-
-      vi.setSystemTime(new Date('2026-04-07T12:34:45.999Z'))
-      const b = createDatetimeContext()
-
-      expect(a.id).toBe(b.id)
-      expect(a.text).toBe(b.text)
-      expect(a.createdAt).toBe(b.createdAt)
-    }
-    finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('produces different text when the minute changes', () => {
+  it('produces different text at different times', () => {
     vi.useFakeTimers()
     try {
       vi.setSystemTime(new Date('2026-04-07T12:34:00.000Z'))

--- a/packages/stage-ui/src/stores/chat/context-providers/datetime.test.ts
+++ b/packages/stage-ui/src/stores/chat/context-providers/datetime.test.ts
@@ -4,7 +4,7 @@ import { createDatetimeContext } from './datetime'
 
 describe('createDatetimeContext', () => {
   // https://github.com/moeru-ai/airi/issues/1539
-  it('Issue #1539: uses a fixed deterministic id instead of a random one', () => {
+  it('issue #1539: uses a fixed deterministic id instead of a random one', () => {
     const a = createDatetimeContext()
     const b = createDatetimeContext()
     expect(a.id).toBe(b.id)
@@ -12,7 +12,7 @@ describe('createDatetimeContext', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/1539
-  it('Issue #1539: quantizes time to the minute (seconds and ms are zeroed)', () => {
+  it('issue #1539: quantizes time to the minute (seconds and ms are zeroed)', () => {
     vi.useFakeTimers()
     try {
       vi.setSystemTime(new Date('2026-04-07T12:34:56.789Z'))
@@ -27,7 +27,7 @@ describe('createDatetimeContext', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/1539
-  it('Issue #1539: produces identical output for calls within the same minute', () => {
+  it('issue #1539: produces identical output for calls within the same minute', () => {
     vi.useFakeTimers()
     try {
       vi.setSystemTime(new Date('2026-04-07T12:34:10.000Z'))

--- a/packages/stage-ui/src/stores/chat/context-providers/datetime.ts
+++ b/packages/stage-ui/src/stores/chat/context-providers/datetime.ts
@@ -1,35 +1,23 @@
 import type { ContextMessage } from '../../../types/chat'
 
 import { ContextUpdateStrategy } from '@proj-airi/server-sdk'
+import { nanoid } from 'nanoid'
 
 const DATETIME_CONTEXT_ID = 'system:datetime'
 
 /**
- * Quantize a Date to the start of its minute so the text stays stable
- * across calls within the same minute, improving LLM KV-cache hit rates.
- * See: https://github.com/moeru-ai/airi/issues/1539
- */
-function quantizeToMinute(date: Date): Date {
-  const quantized = new Date(date)
-  quantized.setSeconds(0, 0)
-  return quantized
-}
-
-/**
  * Creates a context message containing the current datetime information.
  * This context is injected before each chat message to provide temporal awareness.
- *
- * Uses a fixed ID and minute-level quantization to maximise LLM KV-cache reuse.
  */
 export function createDatetimeContext(): ContextMessage {
-  const now = quantizeToMinute(new Date())
+  const now = new Date()
 
   return {
-    id: `${DATETIME_CONTEXT_ID}:singleton`,
+    id: nanoid(),
     contextId: DATETIME_CONTEXT_ID,
     strategy: ContextUpdateStrategy.ReplaceSelf,
-    text: `Current datetime: ${now.toISOString()}`,
-    createdAt: now.getTime(),
+    text: `Current datetime: ${now.toISOString()} (${now.toLocaleString()})`,
+    createdAt: Date.now(),
     metadata: {
       source: {
         id: DATETIME_CONTEXT_ID,

--- a/packages/stage-ui/src/stores/chat/context-providers/datetime.ts
+++ b/packages/stage-ui/src/stores/chat/context-providers/datetime.ts
@@ -1,23 +1,35 @@
 import type { ContextMessage } from '../../../types/chat'
 
 import { ContextUpdateStrategy } from '@proj-airi/server-sdk'
-import { nanoid } from 'nanoid'
 
 const DATETIME_CONTEXT_ID = 'system:datetime'
 
 /**
+ * Quantize a Date to the start of its minute so the text stays stable
+ * across calls within the same minute, improving LLM KV-cache hit rates.
+ * See: https://github.com/moeru-ai/airi/issues/1539
+ */
+function quantizeToMinute(date: Date): Date {
+  const quantized = new Date(date)
+  quantized.setSeconds(0, 0)
+  return quantized
+}
+
+/**
  * Creates a context message containing the current datetime information.
  * This context is injected before each chat message to provide temporal awareness.
+ *
+ * Uses a fixed ID and minute-level quantization to maximise LLM KV-cache reuse.
  */
 export function createDatetimeContext(): ContextMessage {
-  const now = new Date()
+  const now = quantizeToMinute(new Date())
 
   return {
-    id: nanoid(),
+    id: `${DATETIME_CONTEXT_ID}:singleton`,
     contextId: DATETIME_CONTEXT_ID,
     strategy: ContextUpdateStrategy.ReplaceSelf,
-    text: `Current datetime: ${now.toISOString()} (${now.toLocaleString()})`,
-    createdAt: Date.now(),
+    text: `Current datetime: ${now.toISOString()}`,
+    createdAt: now.getTime(),
     metadata: {
       source: {
         id: DATETIME_CONTEXT_ID,


### PR DESCRIPTION
## Summary

Fixes #1539 — the `airi:system:datetime` plugin was breaking LLM KV-cache prefix matching on every turn, causing severe TTFT degradation for local backends.

**Root cause**: A random `nanoid()` ID and millisecond-precision `createdAt` timestamp were serialized into the prompt right after the system message, invalidating the entire KV-cache prefix on every request.

**Changes**:
- **Move context injection to end of messages** (`chat.ts`) — context block is now inserted just before the latest user message instead of after the system prompt, so static chat history stays prefix-matched
- **Whitelist serialized fields** (`context-prompt.ts`) — only `contextId`, `strategy`, and `text` are included in the prompt; volatile `id`, `createdAt`, and `metadata` are excluded
- **Quantize datetime to the minute** (`datetime.ts`) — seconds and milliseconds are zeroed, so calls within the same minute produce identical output
- **Use fixed deterministic ID** (`datetime.ts`) — replace `nanoid()` with a stable singleton ID

## Test plan

- [x] Added unit tests for `createDatetimeContext()` — fixed ID, minute quantization, same-minute stability, cross-minute difference
- [x] Added unit tests for `formatContextPromptText()` — volatile field exclusion, whitelist-only serialization, identical output regardless of volatile fields
- [x] All 10 tests passing via `pnpm -F @proj-airi/stage-ui exec vitest run`