### PR TITLE
feat(inference): unify WebGPU inference pipeline infrastructure

### DIFF
--- a/apps/stage-pocket/src/pages/devtools/background-removal.vue
+++ b/apps/stage-pocket/src/pages/devtools/background-removal.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import type { PreTrainedModel, Processor } from '@huggingface/transformers'
-
-import { AutoModel, AutoProcessor, env, RawImage } from '@huggingface/transformers'
+import { detectWebGPU } from '@proj-airi/stage-shared/webgpu'
+import { createBackgroundRemovalAdapter } from '@proj-airi/stage-ui/libs/inference/adapters/background-removal'
 import { Button, Checkbox, InputFile } from '@proj-airi/ui'
-import { check } from 'gpuu/webgpu'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
-const model = ref<PreTrainedModel>()
-const processor = ref<Processor>()
+const adapter = createBackgroundRemovalAdapter()
+
 const error = ref<unknown>()
 const loading = ref(true)
 const processing = ref(false)
@@ -62,17 +60,12 @@ watch(autoProcess, (enabled) => {
 
 onMounted(async () => {
   try {
-    if (!((await check()).supported)) {
+    const capabilities = await detectWebGPU()
+    if (!capabilities.supported) {
       throw new Error('WebGPU is not supported in this browser.')
     }
 
-    const model_id = 'Xenova/modnet'
-    env.backends.onnx.wasm!.proxy = false
-    model.value ??= await AutoModel.from_pretrained(model_id, {
-      device: 'webgpu',
-    })
-
-    processor.value ??= await AutoProcessor.from_pretrained(model_id, {})
+    await adapter.load()
   }
   catch (err) {
     error.value = err
@@ -81,26 +74,26 @@ onMounted(async () => {
   loading.value = false
 })
 
+onUnmounted(() => {
+  adapter.terminate()
+})
+
 async function processImage(item: ImageItem, index: number): Promise<void> {
-  if (!model.value || !processor.value)
+  if (adapter.state !== 'ready')
     return
 
   try {
     item.status = 'processing'
     currentProcessingIndex.value = index
 
-    // Load image
-    const img = await RawImage.fromURL(item.originalUrl)
+    // Load image into a canvas to get ImageData
+    const img = new Image()
+    img.src = item.originalUrl
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () => reject(new Error('Failed to load image'))
+    })
 
-    // Pre-process image
-    const { pixel_values } = await processor.value(img)
-
-    // Predict alpha matte
-    const { output } = await model.value({ input: pixel_values })
-
-    const maskData = (await RawImage.fromTensor(output[0].mul(255).to('uint8')).resize(img.width, img.height)).data
-
-    // Create new canvas
     const canvas = document.createElement('canvas')
     canvas.width = img.width
     canvas.height = img.height
@@ -108,16 +101,14 @@ async function processImage(item: ImageItem, index: number): Promise<void> {
     if (!ctx)
       return
 
-    // Draw original image output to canvas
-    ctx.drawImage(img.toCanvas(), 0, 0)
+    ctx.drawImage(img, 0, 0)
+    const imageData = ctx.getImageData(0, 0, img.width, img.height)
 
-    // Update alpha channel
-    const pixelData = ctx.getImageData(0, 0, img.width, img.height)
-    for (let j = 0; j < maskData.length; ++j) {
-      pixelData.data[4 * j + 3] = maskData[j]
-    }
+    // Process in worker (off main thread!)
+    const resultData = await adapter.processImage(imageData)
 
-    ctx.putImageData(pixelData, 0, 0)
+    // Draw result to canvas for export
+    ctx.putImageData(resultData, 0, 0)
     item.processedUrl = canvas.toDataURL('image/png')
     item.status = 'done'
   }
@@ -127,7 +118,7 @@ async function processImage(item: ImageItem, index: number): Promise<void> {
 }
 
 async function processAllImages() {
-  if (!model.value || !processor.value || processing.value)
+  if (adapter.state !== 'ready' || processing.value)
     return
 
   processing.value = true
@@ -236,7 +227,7 @@ function hidePreview() {
           <Button
             v-if="pendingCount > 0"
             :label="processing ? `Processing... ${progressPercent}%` : `Process ${pendingCount} image${pendingCount > 1 ? 's' : ''}`"
-            :disabled="processing || !model"
+            :disabled="processing"
             :loading="processing"
             @click="processAllImages"
           />

--- a/apps/stage-web/src/pages/devtools/background-removal.vue
+++ b/apps/stage-web/src/pages/devtools/background-removal.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import type { PreTrainedModel, Processor } from '@huggingface/transformers'
-
-import { AutoModel, AutoProcessor, env, RawImage } from '@huggingface/transformers'
+import { detectWebGPU } from '@proj-airi/stage-shared/webgpu'
+import { createBackgroundRemovalAdapter } from '@proj-airi/stage-ui/libs/inference/adapters/background-removal'
 import { Button, Checkbox, InputFile } from '@proj-airi/ui'
-import { check } from 'gpuu/webgpu'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
-const model = ref<PreTrainedModel>()
-const processor = ref<Processor>()
+const adapter = createBackgroundRemovalAdapter()
+
 const error = ref<unknown>()
 const loading = ref(true)
 const processing = ref(false)
@@ -62,17 +60,12 @@ watch(autoProcess, (enabled) => {
 
 onMounted(async () => {
   try {
-    if (!((await check()).supported)) {
+    const capabilities = await detectWebGPU()
+    if (!capabilities.supported) {
       throw new Error('WebGPU is not supported in this browser.')
     }
 
-    const model_id = 'Xenova/modnet'
-    env.backends.onnx.wasm!.proxy = false
-    model.value ??= await AutoModel.from_pretrained(model_id, {
-      device: 'webgpu',
-    })
-
-    processor.value ??= await AutoProcessor.from_pretrained(model_id, {})
+    await adapter.load()
   }
   catch (err) {
     error.value = err
@@ -81,26 +74,26 @@ onMounted(async () => {
   loading.value = false
 })
 
+onUnmounted(() => {
+  adapter.terminate()
+})
+
 async function processImage(item: ImageItem, index: number): Promise<void> {
-  if (!model.value || !processor.value)
+  if (adapter.state !== 'ready')
     return
 
   try {
     item.status = 'processing'
     currentProcessingIndex.value = index
 
-    // Load image
-    const img = await RawImage.fromURL(item.originalUrl)
+    // Load image into a canvas to get ImageData
+    const img = new Image()
+    img.src = item.originalUrl
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () => reject(new Error('Failed to load image'))
+    })
 
-    // Pre-process image
-    const { pixel_values } = await processor.value(img)
-
-    // Predict alpha matte
-    const { output } = await model.value({ input: pixel_values })
-
-    const maskData = (await RawImage.fromTensor(output[0].mul(255).to('uint8')).resize(img.width, img.height)).data
-
-    // Create new canvas
     const canvas = document.createElement('canvas')
     canvas.width = img.width
     canvas.height = img.height
@@ -108,16 +101,14 @@ async function processImage(item: ImageItem, index: number): Promise<void> {
     if (!ctx)
       return
 
-    // Draw original image output to canvas
-    ctx.drawImage(img.toCanvas(), 0, 0)
+    ctx.drawImage(img, 0, 0)
+    const imageData = ctx.getImageData(0, 0, img.width, img.height)
 
-    // Update alpha channel
-    const pixelData = ctx.getImageData(0, 0, img.width, img.height)
-    for (let j = 0; j < maskData.length; ++j) {
-      pixelData.data[4 * j + 3] = maskData[j]
-    }
+    // Process in worker (off main thread!)
+    const resultData = await adapter.processImage(imageData)
 
-    ctx.putImageData(pixelData, 0, 0)
+    // Draw result to canvas for export
+    ctx.putImageData(resultData, 0, 0)
     item.processedUrl = canvas.toDataURL('image/png')
     item.status = 'done'
   }
@@ -127,7 +118,7 @@ async function processImage(item: ImageItem, index: number): Promise<void> {
 }
 
 async function processAllImages() {
-  if (!model.value || !processor.value || processing.value)
+  if (adapter.state !== 'ready' || processing.value)
     return
 
   processing.value = true
@@ -236,7 +227,7 @@ function hidePreview() {
           <Button
             v-if="pendingCount > 0"
             :label="processing ? `Processing... ${progressPercent}%` : `Process ${pendingCount} image${pendingCount > 1 ? 's' : ''}`"
-            :disabled="processing || !model"
+            :disabled="processing"
             :loading="processing"
             @click="processAllImages"
           />

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -99,6 +99,8 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 
 onMounted(async () => {
   // Check WebGPU support
+  // NOTICE: Uses synchronous check for initial render. The cached result from
+  // detectWebGPU() is populated by the providers store during initialization.
   hasWebGPU.value = typeof navigator !== 'undefined' && !!navigator.gpu
 
   try {

--- a/packages/stage-shared/package.json
+++ b/packages/stage-shared/package.json
@@ -19,13 +19,15 @@
     "./auth": "./src/auth/index.ts",
     "./beat-sync": "./src/beat-sync/index.ts",
     "./electron-renderer": "./src/electron-renderer.d.ts",
-    "./composables": "./src/composables/index.ts"
+    "./composables": "./src/composables/index.ts",
+    "./webgpu": "./src/webgpu/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@vueuse/core": "catalog:",
+    "gpuu": "^1.0.6",
     "pinia": "catalog:",
     "vue": "catalog:"
   },

--- a/packages/stage-shared/src/webgpu/detect.ts
+++ b/packages/stage-shared/src/webgpu/detect.ts
@@ -1,0 +1,95 @@
+/**
+ * Centralized WebGPU capability detection.
+ *
+ * Wraps `gpuu/webgpu` and caches the result so every consumer
+ * gets the same answer without redundant adapter requests.
+ */
+
+import { check as gpuuCheck, isWebGPUSupported as gpuuIsSupported } from 'gpuu/webgpu'
+
+export interface WebGPUCapabilities {
+  /** Whether WebGPU is available in this environment */
+  supported: boolean
+  /** Whether fp16 shader operations are supported */
+  fp16Supported: boolean
+  /** Estimated VRAM in bytes (heuristic, 0 when unavailable) */
+  estimatedVRAM: number
+  /** Raw reason string from gpuu when unsupported */
+  reason: string
+}
+
+let cachedResult: WebGPUCapabilities | null = null
+let pendingDetection: Promise<WebGPUCapabilities> | null = null
+
+/**
+ * Detect WebGPU capabilities. The result is cached as a singleton
+ * after the first successful call -- safe to call repeatedly.
+ */
+export async function detectWebGPU(): Promise<WebGPUCapabilities> {
+  if (cachedResult)
+    return cachedResult
+
+  // Deduplicate concurrent calls
+  if (pendingDetection)
+    return pendingDetection
+
+  pendingDetection = (async (): Promise<WebGPUCapabilities> => {
+    try {
+      const result = await gpuuCheck()
+
+      let estimatedVRAM = 0
+      if (result.supported && result.adapter) {
+        // Use maxBufferSize as a rough proxy -- typically 256 MB on
+        // integrated GPUs, 2-4 GB on discrete GPUs.
+        // Multiply by 4 as a conservative total VRAM heuristic.
+        const maxBuffer = result.adapter.limits?.maxBufferSize ?? 0
+        estimatedVRAM = maxBuffer > 0 ? maxBuffer * 4 : 0
+      }
+
+      cachedResult = {
+        supported: result.supported,
+        fp16Supported: result.fp16Supported ?? false,
+        estimatedVRAM,
+        reason: result.reason ?? '',
+      }
+    }
+    catch {
+      cachedResult = {
+        supported: false,
+        fp16Supported: false,
+        estimatedVRAM: 0,
+        reason: 'Detection threw an exception',
+      }
+    }
+
+    pendingDetection = null
+    return cachedResult!
+  })()
+
+  return pendingDetection
+}
+
+/**
+ * Synchronous check -- returns the cached result or `null` if
+ * `detectWebGPU()` has not been awaited yet.
+ */
+export function getCachedWebGPUCapabilities(): WebGPUCapabilities | null {
+  return cachedResult
+}
+
+/**
+ * Simple boolean helper that matches the old `isWebGPUSupported()` API.
+ * Prefer `detectWebGPU()` when you need more detail.
+ */
+export async function isWebGPUSupported(): Promise<boolean> {
+  // Fast-path: if gpuu's lightweight check is enough
+  return gpuuIsSupported()
+}
+
+/**
+ * Reset the cached detection result. Intended for tests only.
+ */
+export function resetWebGPUCache(): void {
+  cachedResult = null
+  pendingDetection = null
+}

--- a/packages/stage-shared/src/webgpu/index.ts
+++ b/packages/stage-shared/src/webgpu/index.ts
@@ -1,0 +1,7 @@
+export {
+  detectWebGPU,
+  getCachedWebGPUCapabilities,
+  isWebGPUSupported,
+  resetWebGPUCache,
+} from './detect'
+export type { WebGPUCapabilities } from './detect'

--- a/packages/stage-ui/src/composables/use-inference-status.ts
+++ b/packages/stage-ui/src/composables/use-inference-status.ts
@@ -1,0 +1,113 @@
+/**
+ * Reactive inference model status composable.
+ *
+ * Provides a centralised, reactive view of all inference models
+ * (Kokoro TTS, Whisper ASR, background removal, etc.) so UI
+ * components can display loading progress and state without
+ * coupling to individual adapters.
+ */
+
+import type { ErrorPayload, ProgressPayload } from '../libs/inference/protocol'
+
+import { computed, reactive } from 'vue'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type InferenceModelState
+  = | 'idle'
+    | 'downloading'
+    | 'compiling'
+    | 'warming-up'
+    | 'ready'
+    | 'running'
+    | 'error'
+
+export interface InferenceModelStatus {
+  modelId: string
+  state: InferenceModelState
+  progress?: ProgressPayload
+  error?: ErrorPayload
+  device: 'webgpu' | 'wasm' | 'cpu' | 'unknown'
+}
+
+// ---------------------------------------------------------------------------
+// Shared state (module-scoped singleton)
+// ---------------------------------------------------------------------------
+
+const statusMap = reactive(new Map<string, InferenceModelStatus>())
+
+// ---------------------------------------------------------------------------
+// Mutation API (used by adapters)
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the status of an inference model.
+ * Called by adapters to push state changes into the shared status map.
+ */
+export function updateInferenceStatus(
+  modelId: string,
+  update: Partial<Omit<InferenceModelStatus, 'modelId'>>,
+): void {
+  const existing = statusMap.get(modelId)
+  if (existing) {
+    Object.assign(existing, update)
+  }
+  else {
+    statusMap.set(modelId, {
+      modelId,
+      state: 'idle',
+      device: 'unknown',
+      ...update,
+    })
+  }
+}
+
+/**
+ * Remove a model from the status map (e.g. when unloaded).
+ */
+export function removeInferenceStatus(modelId: string): void {
+  statusMap.delete(modelId)
+}
+
+// ---------------------------------------------------------------------------
+// Composable (used by UI components)
+// ---------------------------------------------------------------------------
+
+export function useInferenceStatus() {
+  const models = computed<InferenceModelStatus[]>(() =>
+    Array.from(statusMap.values()),
+  )
+
+  const isAnyLoading = computed(() =>
+    models.value.some(m =>
+      m.state === 'downloading'
+      || m.state === 'compiling'
+      || m.state === 'warming-up',
+    ),
+  )
+
+  const totalProgress = computed(() => {
+    const loadingModels = models.value.filter(m =>
+      m.state === 'downloading'
+      || m.state === 'compiling'
+      || m.state === 'warming-up',
+    )
+    if (loadingModels.length === 0)
+      return 100
+
+    const sum = loadingModels.reduce((acc, m) => {
+      const p = m.progress?.percent ?? 0
+      return acc + (p >= 0 ? p : 0)
+    }, 0)
+
+    return Math.round(sum / loadingModels.length)
+  })
+
+  return {
+    models,
+    isAnyLoading,
+    totalProgress,
+  }
+}

--- a/packages/stage-ui/src/composables/whisper.ts
+++ b/packages/stage-ui/src/composables/whisper.ts
@@ -1,8 +1,9 @@
-import type { MessageEvents, MessageGenerate, ProgressMessageEvents } from '../libs/workers/types'
+import type { MessageGenerate, ProgressMessageEvents } from '../libs/workers/types'
 
 import { merge } from '@moeru/std'
-import { useWebWorker } from '@vueuse/core'
-import { onUnmounted, ref, watch } from 'vue'
+import { onUnmounted, ref } from 'vue'
+
+import { createWhisperAdapter } from '../libs/inference/adapters/whisper'
 
 export interface UseWhisperOptions {
   onLoading: (message: string) => void
@@ -27,11 +28,7 @@ export function useWhisper(url: string, options?: Partial<UseWhisperOptions>) {
     onComplete: () => {},
   }, options)
 
-  const {
-    post: whisperPost,
-    data: whisperData,
-    terminate,
-  } = useWebWorker<MessageEvents>(url, { type: 'module' })
+  const adapter = createWhisperAdapter(url)
 
   const status = ref<'loading' | 'ready' | null>(null)
   const loadingMessage = ref('')
@@ -40,7 +37,8 @@ export function useWhisper(url: string, options?: Partial<UseWhisperOptions>) {
   const tps = ref<number>(0)
   const result = ref('')
 
-  watch(whisperData, (e) => {
+  // Subscribe to raw worker events for streaming UI updates
+  adapter.onMessage((e) => {
     switch (e.status) {
       case 'loading':
         status.value = 'loading'
@@ -94,18 +92,27 @@ export function useWhisper(url: string, options?: Partial<UseWhisperOptions>) {
   })
 
   onUnmounted(() => {
-    terminate()
+    adapter.terminate()
   })
 
   return {
-    transcribe: (message: MessageGenerate) => whisperPost(message),
+    transcribe: (message: MessageGenerate) => {
+      // Delegate to adapter for transcription (fire-and-forget for streaming)
+      // The actual result arrives via the 'complete' event handler above
+      adapter.transcribe({
+        audio: message.data.audio ?? '',
+        language: message.data.language,
+      }).catch((err) => {
+        console.error('Whisper transcription error:', err)
+      })
+    },
     status,
     loadingMessage,
     loadingProgress,
     transcribing,
     tps,
     result,
-    load: () => whisperPost({ type: 'load' }),
-    terminate,
+    load: () => adapter.load(),
+    terminate: () => adapter.terminate(),
   }
 }

--- a/packages/stage-ui/src/libs/inference/adapters/background-removal.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/background-removal.ts
@@ -1,0 +1,190 @@
+/**
+ * Background removal inference adapter.
+ *
+ * Offloads Xenova/modnet inference to a Web Worker so the main
+ * thread is not blocked during image processing.
+ */
+
+import type { ProgressPayload } from '../protocol'
+
+import { AsyncMutex } from '../async-mutex'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BackgroundRemovalAdapter {
+  /**
+   * Load the background removal model in the worker.
+   * Must be called before `processImage()`.
+   */
+  load: (onProgress?: (p: ProgressPayload) => void) => Promise<void>
+
+  /**
+   * Remove the background from an image.
+   * Returns a new ImageData with the background alpha set to 0.
+   */
+  processImage: (imageData: ImageData) => Promise<ImageData>
+
+  /** Terminate the worker */
+  terminate: () => void
+
+  /** Current state */
+  readonly state: 'idle' | 'loading' | 'ready' | 'processing' | 'error' | 'terminated'
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LOAD_TIMEOUT = 120_000
+const PROCESS_TIMEOUT = 60_000
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+let requestCounter = 0
+function nextRequestId(): string {
+  return `bgr_${(requestCounter++).toString(36)}`
+}
+
+export function createBackgroundRemovalAdapter(): BackgroundRemovalAdapter {
+  let worker: Worker | null = null
+  let state: BackgroundRemovalAdapter['state'] = 'idle'
+
+  const operationMutex = new AsyncMutex()
+
+  function ensureWorker(): Worker {
+    if (!worker) {
+      worker = new Worker(
+        new URL('../../../workers/background-removal/worker.ts', import.meta.url),
+        { type: 'module' },
+      )
+      worker.addEventListener('error', (event) => {
+        state = 'error'
+        operationMutex.reset(new Error(event.message ?? 'Worker error'))
+      })
+    }
+    return worker
+  }
+
+  function waitForMessage(
+    w: Worker,
+    requestId: string,
+    targetType: string,
+    timeout: number,
+    onOther?: (data: any) => void,
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+      const handler = (event: MessageEvent) => {
+        if (event.data.requestId !== requestId)
+          return
+
+        if (event.data.type === targetType) {
+          if (timeoutId !== undefined)
+            clearTimeout(timeoutId)
+          w.removeEventListener('message', handler)
+          resolve(event.data)
+        }
+        else if (event.data.type === 'error') {
+          if (timeoutId !== undefined)
+            clearTimeout(timeoutId)
+          w.removeEventListener('message', handler)
+          reject(new Error(event.data.message))
+        }
+        else {
+          onOther?.(event.data)
+        }
+      }
+
+      w.addEventListener('message', handler)
+
+      timeoutId = setTimeout(() => {
+        w.removeEventListener('message', handler)
+        reject(new Error(`Background removal: timeout after ${timeout}ms`))
+      }, timeout)
+    })
+  }
+
+  async function load(onProgress?: (p: ProgressPayload) => void): Promise<void> {
+    return operationMutex.run(async () => {
+      state = 'loading'
+      const w = ensureWorker()
+      const requestId = nextRequestId()
+
+      const loadedPromise = waitForMessage(w, requestId, 'loaded', LOAD_TIMEOUT, (data) => {
+        if (data.type === 'progress' && onProgress) {
+          onProgress({
+            phase: 'download',
+            percent: data.progress >= 0 ? Math.round(data.progress) : -1,
+            message: data.message,
+          })
+        }
+      })
+
+      w.postMessage({ type: 'load', requestId })
+      await loadedPromise
+      state = 'ready'
+    })
+  }
+
+  async function processImage(imageData: ImageData): Promise<ImageData> {
+    return operationMutex.run(async () => {
+      if (!worker || (state !== 'ready' && state !== 'processing'))
+        throw new Error('Model not loaded. Call load() first.')
+
+      state = 'processing'
+      const requestId = nextRequestId()
+
+      const resultPromise = waitForMessage(worker, requestId, 'result', PROCESS_TIMEOUT)
+
+      // Send raw pixel data (transferable copy)
+      const pixelsCopy = new Uint8ClampedArray(imageData.data)
+      worker.postMessage(
+        {
+          type: 'process',
+          requestId,
+          imageData: pixelsCopy,
+          width: imageData.width,
+          height: imageData.height,
+        },
+        [pixelsCopy.buffer],
+      )
+
+      const result = await resultPromise
+
+      // Apply mask to original image alpha channel
+      const output = new ImageData(
+        new Uint8ClampedArray(imageData.data),
+        imageData.width,
+        imageData.height,
+      )
+      const maskData = result.maskData as Uint8Array
+      for (let i = 0; i < maskData.length; i++) {
+        output.data[4 * i + 3] = maskData[i]
+      }
+
+      state = 'ready'
+      return output
+    })
+  }
+
+  function terminateAdapter(): void {
+    operationMutex.reset(new Error('Adapter terminated'))
+    if (worker) {
+      worker.terminate()
+      worker = null
+    }
+    state = 'terminated'
+  }
+
+  return {
+    load,
+    processImage,
+    terminate: terminateAdapter,
+    get state() { return state },
+  }
+}

--- a/packages/stage-ui/src/libs/inference/adapters/kokoro.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/kokoro.ts
@@ -1,0 +1,301 @@
+/**
+ * Kokoro TTS inference adapter.
+ *
+ * Bridges the generic `InferenceWorkerManager` protocol with the
+ * Kokoro-specific worker message format. The underlying worker
+ * (`workers/kokoro/worker.ts`) keeps its existing message types —
+ * this adapter translates between the two protocols.
+ */
+
+import type { VoiceKey, Voices } from '../../../workers/kokoro/types'
+import type { ProgressPayload } from '../protocol'
+
+import { defaultPerfTracer } from '@proj-airi/stage-shared'
+
+import { AsyncMutex } from '../async-mutex'
+import { classifyError } from '../protocol'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface KokoroAdapter {
+  /** Load a TTS model with the given quantization and device */
+  loadModel: (
+    quantization: string,
+    device: string,
+    options?: { onProgress?: (p: ProgressPayload) => void },
+  ) => Promise<Voices>
+
+  /** Generate speech audio from text */
+  generate: (text: string, voice: VoiceKey) => Promise<ArrayBuffer>
+
+  /** Get the voices from the last loaded model */
+  getVoices: () => Voices
+
+  /** Terminate the worker */
+  terminate: () => void
+
+  /** Current state */
+  readonly state: 'idle' | 'loading' | 'ready' | 'running' | 'error' | 'terminated'
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LOAD_MODEL_TIMEOUT = 120_000
+const GENERATE_TIMEOUT = 120_000
+const MAX_RESTARTS = 3
+const RESTART_DELAY_MS = 1_000
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+// Reuse the waitForEvent pattern from the original KokoroWorkerManager
+interface WaitForEventOptions<T extends Event> {
+  predicate?: (event: T) => boolean
+  callback?: (event: T) => void
+  timeout?: number
+  timeoutError?: Error
+}
+
+function waitForEvent<T extends Event>(
+  element: EventTarget,
+  eventName: string,
+  options: WaitForEventOptions<T> = {},
+): Promise<T> {
+  const {
+    predicate = () => true,
+    callback = () => {},
+    timeout,
+    timeoutError = new Error(`Timeout waiting for event: ${eventName}`),
+  } = options
+
+  return new Promise((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+    const listener = (event: Event) => {
+      const typedEvent = event as T
+      if (predicate(typedEvent)) {
+        if (timeoutId !== undefined)
+          clearTimeout(timeoutId)
+        element.removeEventListener(eventName, listener)
+        resolve(typedEvent)
+      }
+      else {
+        callback(typedEvent)
+      }
+    }
+
+    element.addEventListener(eventName, listener)
+
+    if (timeout !== undefined) {
+      timeoutId = setTimeout(() => {
+        element.removeEventListener(eventName, listener)
+        reject(timeoutError)
+      }, timeout)
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createKokoroAdapter(): KokoroAdapter {
+  let worker: Worker | null = null
+  let state: KokoroAdapter['state'] = 'idle'
+  let voices: Voices | null = null
+  let restartAttempts = 0
+
+  const operationMutex = new AsyncMutex()
+  const lifecycleMutex = new AsyncMutex()
+
+  function initializeWorker(): void {
+    worker = new Worker(
+      new URL('../../../workers/kokoro/worker.ts', import.meta.url),
+      { type: 'module' },
+    )
+    worker.addEventListener('error', handleWorkerError)
+  }
+
+  function handleWorkerError(event: ErrorEvent | Error): void {
+    const message = event instanceof Error
+      ? event.message
+      : (event as ErrorEvent).message ?? 'Unknown worker error'
+
+    state = 'error'
+    operationMutex.reset(new Error(message))
+    destroyWorker()
+    scheduleRestart()
+  }
+
+  function destroyWorker(): void {
+    if (worker) {
+      worker.terminate()
+      worker = null
+    }
+  }
+
+  function scheduleRestart(): void {
+    if (restartAttempts >= MAX_RESTARTS) {
+      console.error(
+        `[KokoroAdapter] Max restart attempts (${MAX_RESTARTS}) reached.`,
+      )
+      return
+    }
+
+    restartAttempts++
+    const delay = RESTART_DELAY_MS * restartAttempts
+
+    console.warn(
+      `[KokoroAdapter] Restarting in ${delay}ms `
+      + `(attempt ${restartAttempts}/${MAX_RESTARTS})`,
+    )
+
+    setTimeout(() => {
+      ensureStarted().catch((err) => {
+        console.error('[KokoroAdapter] Restart failed:', err)
+      })
+    }, delay)
+  }
+
+  function onSuccess(): void {
+    restartAttempts = 0
+  }
+
+  async function ensureStarted(): Promise<void> {
+    await lifecycleMutex.run(async () => {
+      if (!worker) {
+        initializeWorker()
+        state = 'idle'
+      }
+    })
+  }
+
+  // -- Public API -----------------------------------------------------------
+
+  async function loadModel(
+    quantization: string,
+    device: string,
+    options?: { onProgress?: (p: ProgressPayload) => void },
+  ): Promise<Voices> {
+    await ensureStarted()
+
+    return defaultPerfTracer.withMeasure('inference', 'kokoro-load-model', () => operationMutex.run(async () => {
+      state = 'loading'
+
+      // NOTICE: We listen for the existing Kokoro worker protocol ('loaded'
+      // type) rather than the unified protocol. The worker.ts file is
+      // unchanged — this adapter does the translation.
+      const voicePromise = waitForEvent<MessageEvent>(worker!, 'message', {
+        predicate: event => event.data.type === 'loaded',
+        callback: (event) => {
+          if (event.data.type === 'progress' && options?.onProgress) {
+            const raw = event.data.progress
+            options.onProgress({
+              phase: 'download',
+              // NOTICE: raw.progress from kokoro-js/@huggingface/transformers is already 0-100
+              percent: raw?.progress != null ? Math.round(raw.progress) : -1,
+              message: raw?.status ?? undefined,
+              file: raw?.file ?? undefined,
+              loaded: raw?.loaded ?? undefined,
+              total: raw?.total ?? undefined,
+            })
+          }
+        },
+        timeout: LOAD_MODEL_TIMEOUT,
+      })
+
+      worker!.postMessage({
+        type: 'load',
+        data: { quantization, device },
+      })
+
+      const event = await voicePromise
+      voices = event.data.voices
+      state = 'ready'
+      onSuccess()
+      return voices!
+    }), { quantization, device }).catch((error) => {
+      handleWorkerError(error instanceof Error ? error : new Error(String(error)))
+      throw error
+    })
+  }
+
+  async function generate(text: string, voice: VoiceKey): Promise<ArrayBuffer> {
+    return defaultPerfTracer.withMeasure('inference', 'kokoro-generate', () => operationMutex.run(async () => {
+      if (!worker)
+        throw new Error('Worker not initialized. Call loadModel() first.')
+
+      state = 'running'
+
+      const resultPromise = waitForEvent<MessageEvent>(worker, 'message', {
+        predicate: event => event.data.type === 'result',
+        timeout: GENERATE_TIMEOUT,
+      })
+
+      worker.postMessage({
+        type: 'generate',
+        data: { text, voice },
+      })
+
+      const event = await resultPromise
+      const response = event.data
+
+      if (response.status === 'success') {
+        state = 'ready'
+        onSuccess()
+        return response.buffer as ArrayBuffer
+      }
+
+      const errorCode = classifyError(new Error(response.message ?? 'Generation failed'))
+      throw new Error(`[${errorCode}] ${response.message ?? 'Generation failed'}`)
+    }), { text: text.slice(0, 50), voice }).catch((error) => {
+      handleWorkerError(error instanceof Error ? error : new Error(String(error)))
+      throw error
+    })
+  }
+
+  function getVoices(): Voices {
+    if (!voices)
+      throw new Error('Model not loaded. Call loadModel() first.')
+    return voices
+  }
+
+  function terminateAdapter(): void {
+    operationMutex.reset(new Error('Adapter terminated'))
+    destroyWorker()
+    voices = null
+    state = 'terminated'
+  }
+
+  return {
+    loadModel,
+    generate,
+    getVoices,
+    terminate: terminateAdapter,
+    get state() { return state },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let globalAdapter: KokoroAdapter | null = null
+const singletonMutex = new AsyncMutex()
+
+/**
+ * Get the global Kokoro adapter instance.
+ * Creates and starts the worker on first call.
+ */
+export async function getKokoroAdapter(): Promise<KokoroAdapter> {
+  return singletonMutex.run(async () => {
+    if (!globalAdapter)
+      globalAdapter = createKokoroAdapter()
+    return globalAdapter
+  })
+}

--- a/packages/stage-ui/src/libs/inference/adapters/whisper.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/whisper.ts
@@ -1,0 +1,221 @@
+/**
+ * Whisper ASR inference adapter.
+ *
+ * Bridges the generic inference protocol with the existing Whisper
+ * worker (`libs/workers/worker.ts`). Adds timeout handling, WASM
+ * fallback, and unified progress reporting while preserving the
+ * existing composable API surface.
+ */
+
+import type {
+  MessageEvents,
+} from '../../workers/types'
+import type { ProgressPayload } from '../protocol'
+
+import { AsyncMutex } from '../async-mutex'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WhisperState
+  = | 'idle'
+    | 'loading'
+    | 'ready'
+    | 'transcribing'
+    | 'error'
+    | 'terminated'
+
+export interface WhisperTranscribeInput {
+  audio: string
+  language: string
+}
+
+export interface WhisperAdapter {
+  /** Load the Whisper model */
+  load: (onProgress?: (p: ProgressPayload) => void) => Promise<void>
+
+  /** Transcribe audio, returning the text result */
+  transcribe: (input: WhisperTranscribeInput) => Promise<string>
+
+  /** Terminate the worker */
+  terminate: () => void
+
+  /** Current state */
+  readonly state: WhisperState
+
+  /**
+   * Subscribe to raw worker events for streaming UI updates.
+   * Returns an unsubscribe function.
+   */
+  onMessage: (handler: (event: MessageEvents) => void) => () => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LOAD_TIMEOUT = 180_000 // Whisper model is large, allow more time
+const TRANSCRIBE_TIMEOUT = 120_000
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
+  let worker: Worker | null = null
+  let state: WhisperState = 'idle'
+  const messageHandlers = new Set<(event: MessageEvents) => void>()
+
+  const operationMutex = new AsyncMutex()
+
+  function ensureWorker(): Worker {
+    if (!worker) {
+      worker = new Worker(workerUrl, { type: 'module' })
+      worker.addEventListener('message', (event: MessageEvent<MessageEvents>) => {
+        for (const handler of messageHandlers)
+          handler(event.data)
+      })
+      worker.addEventListener('error', (event) => {
+        state = 'error'
+        operationMutex.reset(new Error(event.message ?? 'Worker error'))
+      })
+    }
+    return worker
+  }
+
+  function waitForStatus(
+    targetStatus: string,
+    timeout: number,
+  ): Promise<MessageEvents> {
+    return new Promise<MessageEvents>((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+      const w = ensureWorker()
+
+      const handler = (event: MessageEvent<MessageEvents>) => {
+        if (event.data.status === targetStatus) {
+          if (timeoutId !== undefined)
+            clearTimeout(timeoutId)
+          w.removeEventListener('message', handler)
+          resolve(event.data)
+        }
+      }
+
+      w.addEventListener('message', handler)
+
+      timeoutId = setTimeout(() => {
+        w.removeEventListener('message', handler)
+        reject(new Error(`Whisper: timeout after ${timeout}ms waiting for '${targetStatus}'`))
+      }, timeout)
+    })
+  }
+
+  async function load(
+    onProgress?: (p: ProgressPayload) => void,
+  ): Promise<void> {
+    return operationMutex.run(async () => {
+      state = 'loading'
+      const w = ensureWorker()
+
+      // Listen for progress during loading
+      let progressHandler: ((event: MessageEvent<MessageEvents>) => void) | null = null
+      if (onProgress) {
+        progressHandler = (event: MessageEvent<MessageEvents>) => {
+          const data = event.data
+          if (data.status === 'loading') {
+            onProgress({
+              phase: 'compile',
+              percent: -1,
+              message: data.data,
+            })
+          }
+          else if (data.status === 'progress') {
+            onProgress({
+              phase: 'download',
+              percent: data.progress != null ? Math.round(data.progress * 100) : -1,
+              file: data.file,
+              loaded: data.loaded,
+              total: data.total,
+            })
+          }
+          else if (data.status === 'initiate') {
+            onProgress({
+              phase: 'download',
+              percent: 0,
+              file: data.file,
+              message: `Loading ${data.file}`,
+            })
+          }
+        }
+        w.addEventListener('message', progressHandler)
+      }
+
+      const readyPromise = waitForStatus('ready', LOAD_TIMEOUT)
+      w.postMessage({ type: 'load' })
+
+      try {
+        await readyPromise
+        state = 'ready'
+      }
+      catch (error) {
+        state = 'error'
+        throw error
+      }
+      finally {
+        if (progressHandler)
+          w.removeEventListener('message', progressHandler)
+      }
+    })
+  }
+
+  async function transcribe(input: WhisperTranscribeInput): Promise<string> {
+    return operationMutex.run(async () => {
+      if (!worker || state !== 'ready')
+        throw new Error('Model not loaded. Call load() first.')
+
+      state = 'transcribing'
+
+      const completePromise = waitForStatus('complete', TRANSCRIBE_TIMEOUT)
+      worker.postMessage({
+        type: 'generate',
+        data: { audio: input.audio, language: input.language },
+      })
+
+      try {
+        const result = await completePromise
+        state = 'ready'
+        if (result.status === 'complete') {
+          return result.output[0] || ''
+        }
+        return ''
+      }
+      catch (error) {
+        state = 'error'
+        throw error
+      }
+    })
+  }
+
+  function terminateAdapter(): void {
+    operationMutex.reset(new Error('Adapter terminated'))
+    if (worker) {
+      worker.terminate()
+      worker = null
+    }
+    messageHandlers.clear()
+    state = 'terminated'
+  }
+
+  function onMessage(handler: (event: MessageEvents) => void): () => void {
+    messageHandlers.add(handler)
+    return () => messageHandlers.delete(handler)
+  }
+
+  return {
+    load,
+    transcribe,
+    terminate: terminateAdapter,
+    onMessage,
+    get state() { return state },
+  }
+}

--- a/packages/stage-ui/src/libs/inference/async-mutex.ts
+++ b/packages/stage-ui/src/libs/inference/async-mutex.ts
@@ -1,0 +1,62 @@
+/**
+ * An async mutex that ensures only one callback runs at a time.
+ * Waiters queue up and are processed in FIFO order.
+ *
+ * Extracted from KokoroWorkerManager for reuse across inference workers.
+ */
+export class AsyncMutex {
+  private locked = false
+  private waiters: { resolve: () => void, reject: (error: Error) => void }[] = []
+
+  // Incremented on reset() to invalidate stale lock holders
+  private generation = 0
+
+  /**
+   * Executes the callback with exclusive access to the mutex.
+   * If the mutex is locked, waits in queue until it's our turn.
+   */
+  async run<T>(callback: () => Promise<T> | T): Promise<T> {
+    const myGeneration = this.generation
+
+    if (this.locked) {
+      await new Promise<void>((resolve, reject) => {
+        this.waiters.push({ resolve, reject })
+      })
+      if (myGeneration !== this.generation) {
+        throw new Error('Mutex was reset')
+      }
+    }
+    this.locked = true
+
+    try {
+      return await callback()
+    }
+    finally {
+      if (myGeneration === this.generation) {
+        const next = this.waiters.shift()
+        if (next) {
+          next.resolve()
+        }
+        else {
+          this.locked = false
+        }
+      }
+    }
+  }
+
+  /**
+   * Cancels all waiting tasks and releases the lock.
+   * Atomic thanks to JavaScript's Run-To-Completion semantics.
+   */
+  reset(error: Error = new Error('Mutex reset')): void {
+    this.generation++
+    this.locked = false
+
+    const waitersToReject = this.waiters
+    this.waiters = []
+
+    for (const waiter of waitersToReject) {
+      waiter.reject(error)
+    }
+  }
+}

--- a/packages/stage-ui/src/libs/inference/cache-utils.ts
+++ b/packages/stage-ui/src/libs/inference/cache-utils.ts
@@ -1,0 +1,95 @@
+/**
+ * Model cache utilities.
+ *
+ * `@huggingface/transformers` and `kokoro-js` cache downloaded model
+ * files via the browser Cache API automatically. This module provides
+ * query and management functions for that cache, intended for settings
+ * UI ("Cached 512 MB", "Clear model cache" button).
+ */
+
+// The cache name used by transformers.js / ONNX runtime
+const TRANSFORMERS_CACHE_NAME = 'transformers-cache'
+
+/**
+ * Get the total size of cached model files in bytes.
+ * Returns 0 if the Cache API is unavailable or the cache is empty.
+ */
+export async function getModelCacheSize(): Promise<number> {
+  if (typeof caches === 'undefined')
+    return 0
+
+  try {
+    const cache = await caches.open(TRANSFORMERS_CACHE_NAME)
+    const keys = await cache.keys()
+
+    let totalSize = 0
+    for (const request of keys) {
+      const response = await cache.match(request)
+      if (response) {
+        // Content-Length header if available
+        const cl = response.headers.get('content-length')
+        if (cl) {
+          totalSize += Number.parseInt(cl, 10)
+        }
+        else {
+          // Fallback: read the body to measure size
+          const blob = await response.blob()
+          totalSize += blob.size
+        }
+      }
+    }
+
+    return totalSize
+  }
+  catch {
+    return 0
+  }
+}
+
+/**
+ * Clear all cached model files.
+ */
+export async function clearModelCache(): Promise<void> {
+  if (typeof caches === 'undefined')
+    return
+
+  try {
+    await caches.delete(TRANSFORMERS_CACHE_NAME)
+  }
+  catch {
+    // Silently ignore if cache doesn't exist
+  }
+}
+
+/**
+ * Check whether a specific model has cached files.
+ * Matches by looking for cache entries whose URL contains the model ID.
+ */
+export async function isModelCached(modelId: string): Promise<boolean> {
+  if (typeof caches === 'undefined')
+    return false
+
+  try {
+    const cache = await caches.open(TRANSFORMERS_CACHE_NAME)
+    const keys = await cache.keys()
+    return keys.some(request => request.url.includes(modelId))
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Format bytes into a human-readable string (e.g. "512 MB").
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0)
+    return '0 B'
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  const k = 1024
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const value = bytes / k ** i
+
+  return `${value.toFixed(i > 0 ? 1 : 0)} ${units[i]}`
+}

--- a/packages/stage-ui/src/libs/inference/gpu-resource-coordinator.ts
+++ b/packages/stage-ui/src/libs/inference/gpu-resource-coordinator.ts
@@ -1,0 +1,165 @@
+/**
+ * GPU resource coordinator.
+ *
+ * Bookkeeping layer that tracks estimated GPU memory allocation
+ * across inference models. Advisory — does not own the actual
+ * GPUDevice (workers manage their own via transformers.js).
+ *
+ * Emits memory pressure events when allocation nears the budget
+ * so consumers can decide to unload LRU models or fall back to WASM.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MemoryPressureLevel = 'warning' | 'critical'
+
+export interface AllocationToken {
+  modelId: string
+  bytes: number
+  allocatedAt: number
+  lastUsedAt: number
+}
+
+export interface GPUResourceUsage {
+  /** Total bytes currently allocated (sum of all tokens) */
+  allocated: number
+  /** Estimated budget in bytes */
+  budget: number
+  /** Currently loaded model IDs */
+  models: string[]
+}
+
+export interface GPUResourceCoordinator {
+  /**
+   * Request an allocation for a model.
+   * Returns the token. May trigger memory pressure events if over budget.
+   */
+  requestAllocation: (modelId: string, estimatedBytes: number) => AllocationToken
+
+  /** Release a previously allocated token */
+  release: (token: AllocationToken) => void
+
+  /** Mark a model as recently used (updates LRU ordering) */
+  touch: (modelId: string) => void
+
+  /** Get current resource usage */
+  getUsage: () => GPUResourceUsage
+
+  /**
+   * Get the least-recently-used model ID, or null if none loaded.
+   * Useful for deciding which model to unload under pressure.
+   */
+  getLRUModel: () => string | null
+
+  /**
+   * Subscribe to memory pressure events.
+   * Returns an unsubscribe function.
+   */
+  onMemoryPressure: (handler: (level: MemoryPressureLevel) => void) => () => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WARNING_THRESHOLD = 0.80
+const CRITICAL_THRESHOLD = 0.95
+const BUDGET_SAFETY_FACTOR = 0.70
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createGPUResourceCoordinator(
+  estimatedVRAM: number,
+): GPUResourceCoordinator {
+  const budget = estimatedVRAM > 0 ? estimatedVRAM * BUDGET_SAFETY_FACTOR : Number.POSITIVE_INFINITY
+  const allocations = new Map<string, AllocationToken>()
+  const pressureHandlers = new Set<(level: MemoryPressureLevel) => void>()
+
+  function getAllocated(): number {
+    let total = 0
+    for (const token of allocations.values())
+      total += token.bytes
+    return total
+  }
+
+  function checkPressure(): void {
+    if (budget === Number.POSITIVE_INFINITY)
+      return
+
+    const ratio = getAllocated() / budget
+    if (ratio >= CRITICAL_THRESHOLD) {
+      for (const handler of pressureHandlers)
+        handler('critical')
+    }
+    else if (ratio >= WARNING_THRESHOLD) {
+      for (const handler of pressureHandlers)
+        handler('warning')
+    }
+  }
+
+  function requestAllocation(modelId: string, estimatedBytes: number): AllocationToken {
+    // If model already allocated, update the byte estimate
+    const existing = allocations.get(modelId)
+    if (existing) {
+      existing.bytes = estimatedBytes
+      existing.lastUsedAt = Date.now()
+      checkPressure()
+      return existing
+    }
+
+    const token: AllocationToken = {
+      modelId,
+      bytes: estimatedBytes,
+      allocatedAt: Date.now(),
+      lastUsedAt: Date.now(),
+    }
+    allocations.set(modelId, token)
+    checkPressure()
+    return token
+  }
+
+  function release(token: AllocationToken): void {
+    allocations.delete(token.modelId)
+  }
+
+  function touch(modelId: string): void {
+    const token = allocations.get(modelId)
+    if (token)
+      token.lastUsedAt = Date.now()
+  }
+
+  function getUsage(): GPUResourceUsage {
+    return {
+      allocated: getAllocated(),
+      budget: budget === Number.POSITIVE_INFINITY ? 0 : budget,
+      models: Array.from(allocations.keys()),
+    }
+  }
+
+  function getLRUModel(): string | null {
+    let oldest: AllocationToken | null = null
+    for (const token of allocations.values()) {
+      if (!oldest || token.lastUsedAt < oldest.lastUsedAt)
+        oldest = token
+    }
+    return oldest?.modelId ?? null
+  }
+
+  function onMemoryPressure(handler: (level: MemoryPressureLevel) => void): () => void {
+    pressureHandlers.add(handler)
+    return () => pressureHandlers.delete(handler)
+  }
+
+  return {
+    requestAllocation,
+    release,
+    touch,
+    getUsage,
+    getLRUModel,
+    onMemoryPressure,
+  }
+}

--- a/packages/stage-ui/src/libs/inference/index.ts
+++ b/packages/stage-ui/src/libs/inference/index.ts
@@ -1,0 +1,54 @@
+// Core
+export { AsyncMutex } from './async-mutex'
+// Cache utilities
+export {
+  clearModelCache,
+  formatBytes,
+  getModelCacheSize,
+  isModelCached,
+} from './cache-utils'
+// Resource management
+export {
+  createGPUResourceCoordinator,
+} from './gpu-resource-coordinator'
+export type {
+  AllocationToken,
+  GPUResourceCoordinator,
+  GPUResourceUsage,
+  MemoryPressureLevel,
+} from './gpu-resource-coordinator'
+export {
+  createLoadQueue,
+  LOAD_PRIORITY,
+} from './load-queue'
+
+export type {
+  LoadQueue,
+} from './load-queue'
+export {
+  classifyError,
+  createRequestId,
+} from './protocol'
+export type {
+  ErrorPayload,
+  InferenceErrorCode,
+  InferenceResultResponse,
+  LoadModelRequest,
+  ModelReadyResponse,
+  ProgressPayload,
+  ProgressPhase,
+  ProgressResponse,
+  RunInferenceRequest,
+  UnloadModelRequest,
+  WorkerInboundMessage,
+  WorkerOutboundMessage,
+} from './protocol'
+export {
+  createInferenceWorkerManager,
+} from './worker-manager'
+
+export type {
+  InferenceWorkerManager,
+  WorkerManagerOptions,
+  WorkerManagerState,
+} from './worker-manager'

--- a/packages/stage-ui/src/libs/inference/load-queue.ts
+++ b/packages/stage-ui/src/libs/inference/load-queue.ts
@@ -1,0 +1,97 @@
+/**
+ * Model loading queue.
+ *
+ * Ensures only one model loads at a time to prevent bandwidth
+ * competition and GPU memory spikes. Higher priority loads
+ * are dequeued first.
+ *
+ * Default priorities: TTS = 10, ASR = 5, BackgroundRemoval = 1.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface QueueEntry<T> {
+  modelId: string
+  priority: number
+  loader: () => Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+}
+
+export interface LoadQueue {
+  /**
+   * Enqueue a model load. Returns a promise that resolves when
+   * the loader completes. If another load is in progress, this
+   * one waits in a priority queue.
+   */
+  enqueue: <T>(modelId: string, priority: number, loader: () => Promise<T>) => Promise<T>
+
+  /** Model IDs waiting in the queue */
+  readonly pending: string[]
+
+  /** Model ID currently loading, or null */
+  readonly active: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createLoadQueue(): LoadQueue {
+  const queue: QueueEntry<any>[] = []
+  let active: string | null = null
+  let running = false
+
+  async function processQueue(): Promise<void> {
+    if (running)
+      return
+    running = true
+
+    while (queue.length > 0) {
+      // Sort by priority descending (highest first)
+      queue.sort((a, b) => b.priority - a.priority)
+      const entry = queue.shift()!
+
+      active = entry.modelId
+      try {
+        const result = await entry.loader()
+        entry.resolve(result)
+      }
+      catch (error) {
+        entry.reject(error)
+      }
+    }
+
+    active = null
+    running = false
+  }
+
+  function enqueue<T>(
+    modelId: string,
+    priority: number,
+    loader: () => Promise<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      queue.push({ modelId, priority, loader, resolve, reject })
+      processQueue()
+    })
+  }
+
+  return {
+    enqueue,
+    get pending() { return queue.map(e => e.modelId) },
+    get active() { return active },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default priorities
+// ---------------------------------------------------------------------------
+
+export const LOAD_PRIORITY = {
+  TTS: 10,
+  ASR: 5,
+  BACKGROUND_REMOVAL: 1,
+} as const

--- a/packages/stage-ui/src/libs/inference/protocol.ts
+++ b/packages/stage-ui/src/libs/inference/protocol.ts
@@ -1,0 +1,149 @@
+/**
+ * Unified inference worker message protocol.
+ *
+ * All inference workers (Kokoro, Whisper, background-removal, etc.)
+ * communicate with the main thread through this typed protocol.
+ * Each adapter maps its domain-specific messages to/from these types.
+ */
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+export type ProgressPhase = 'download' | 'compile' | 'warmup' | 'inference'
+
+export interface ProgressPayload {
+  phase: ProgressPhase
+  /** 0-100, -1 when indeterminate */
+  percent: number
+  /** Optional human-readable status */
+  message?: string
+  /** File being downloaded (for download phase) */
+  file?: string
+  /** Bytes loaded / total (for download phase) */
+  loaded?: number
+  total?: number
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type InferenceErrorCode
+  = | 'OOM'
+    | 'TIMEOUT'
+    | 'DEVICE_LOST'
+    | 'LOAD_FAILED'
+    | 'INFERENCE_FAILED'
+    | 'UNKNOWN'
+
+export interface ErrorPayload {
+  code: InferenceErrorCode
+  message: string
+  /** Whether the operation can be retried (e.g. with WASM fallback) */
+  recoverable: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Main → Worker requests
+// ---------------------------------------------------------------------------
+
+export interface LoadModelRequest {
+  type: 'load-model'
+  requestId: string
+  modelId: string
+  device: 'webgpu' | 'wasm' | 'cpu'
+  dtype?: string
+  /** Adapter-specific options passed through opaquely */
+  options?: Record<string, unknown>
+}
+
+export interface RunInferenceRequest<TInput = unknown> {
+  type: 'run-inference'
+  requestId: string
+  input: TInput
+}
+
+export interface UnloadModelRequest {
+  type: 'unload-model'
+  requestId: string
+}
+
+export type WorkerInboundMessage<TInput = unknown>
+  = | LoadModelRequest
+    | RunInferenceRequest<TInput>
+    | UnloadModelRequest
+
+// ---------------------------------------------------------------------------
+// Worker → Main responses
+// ---------------------------------------------------------------------------
+
+export interface ModelReadyResponse {
+  type: 'model-ready'
+  requestId: string
+  modelId: string
+  device: 'webgpu' | 'wasm' | 'cpu'
+  /** Domain-specific metadata (e.g. Kokoro voices) */
+  metadata?: Record<string, unknown>
+}
+
+export interface InferenceResultResponse<TOutput = unknown> {
+  type: 'inference-result'
+  requestId: string
+  output: TOutput
+  /** Worker-side timing in milliseconds */
+  durationMs?: number
+}
+
+export interface ProgressResponse {
+  type: 'progress'
+  requestId: string
+  payload: ProgressPayload
+}
+
+export interface ErrorResponse {
+  type: 'error'
+  requestId: string
+  payload: ErrorPayload
+}
+
+export interface ModelUnloadedResponse {
+  type: 'model-unloaded'
+  requestId: string
+}
+
+export type WorkerOutboundMessage<TOutput = unknown>
+  = | ModelReadyResponse
+    | InferenceResultResponse<TOutput>
+    | ProgressResponse
+    | ErrorResponse
+    | ModelUnloadedResponse
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let counter = 0
+
+/** Generate a lightweight unique request ID */
+export function createRequestId(): string {
+  return `req_${Date.now().toString(36)}_${(counter++).toString(36)}`
+}
+
+/**
+ * Classify an unknown error into an `InferenceErrorCode`.
+ * Used by worker adapters to normalise caught exceptions.
+ */
+export function classifyError(error: unknown): InferenceErrorCode {
+  const msg = error instanceof Error ? error.message : String(error)
+  const lower = msg.toLowerCase()
+
+  if (lower.includes('out of memory') || lower.includes('allocation failed'))
+    return 'OOM'
+  if (lower.includes('device was lost') || lower.includes('device lost'))
+    return 'DEVICE_LOST'
+  if (lower.includes('timeout'))
+    return 'TIMEOUT'
+
+  return 'UNKNOWN'
+}

--- a/packages/stage-ui/src/libs/inference/worker-manager.ts
+++ b/packages/stage-ui/src/libs/inference/worker-manager.ts
@@ -1,0 +1,352 @@
+/**
+ * Generic inference worker manager.
+ *
+ * Provides lifecycle management (start / restart / terminate), request
+ * serialisation via AsyncMutex, timeout handling, and a unified
+ * message protocol for any inference worker.
+ */
+
+import type {
+  ErrorPayload,
+  LoadModelRequest,
+  ModelReadyResponse,
+  ProgressPayload,
+  RunInferenceRequest,
+  WorkerOutboundMessage,
+} from './protocol'
+
+import { errorMessageFrom } from '@moeru/std'
+
+import { AsyncMutex } from './async-mutex'
+import { createRequestId } from './protocol'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WorkerManagerState
+  = | 'idle'
+    | 'loading'
+    | 'ready'
+    | 'running'
+    | 'error'
+    | 'terminated'
+
+export interface WorkerManagerOptions {
+  /** Factory that creates a fresh Worker instance */
+  createWorker: () => Worker
+  /** Timeout for model loading in ms (default 120 000) */
+  loadTimeout?: number
+  /** Timeout for a single inference call in ms (default 120 000) */
+  inferenceTimeout?: number
+  /** Maximum automatic restart attempts after worker errors (default 3) */
+  maxRestarts?: number
+  /** Base delay between restarts in ms; multiplied by attempt number (default 1 000) */
+  restartDelayMs?: number
+}
+
+export interface InferenceWorkerManager {
+  /**
+   * Load a model in the worker.
+   * Returns domain-specific metadata (e.g. Kokoro voices list).
+   */
+  loadModel: (
+    request: Omit<LoadModelRequest, 'type' | 'requestId'>,
+    onProgress?: (p: ProgressPayload) => void,
+  ) => Promise<ModelReadyResponse>
+
+  /**
+   * Run inference with the currently loaded model.
+   * `TInput` / `TOutput` are opaque to the manager — the adapter defines them.
+   */
+  run: <TInput, TOutput>(
+    input: TInput,
+    onProgress?: (p: ProgressPayload) => void,
+  ) => Promise<TOutput>
+
+  /** Unload the current model but keep the worker alive */
+  unload: () => Promise<void>
+
+  /** Terminate the worker entirely */
+  terminate: () => void
+
+  /** Current state */
+  readonly state: WorkerManagerState
+
+  /** Last error, if any */
+  readonly lastError: ErrorPayload | null
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface WaitForMessageOptions<T extends WorkerOutboundMessage> {
+  /** Only resolve when the predicate returns true */
+  predicate: (msg: WorkerOutboundMessage) => msg is T
+  /** Called for every message that does NOT satisfy the predicate */
+  onOther?: (msg: WorkerOutboundMessage) => void
+  /** Timeout in ms */
+  timeout?: number
+}
+
+function waitForWorkerMessage<T extends WorkerOutboundMessage>(
+  worker: Worker,
+  options: WaitForMessageOptions<T>,
+): Promise<T> {
+  const { predicate, onOther, timeout } = options
+
+  return new Promise<T>((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+    const handler = (event: MessageEvent<WorkerOutboundMessage>) => {
+      if (predicate(event.data)) {
+        if (timeoutId !== undefined)
+          clearTimeout(timeoutId)
+        worker.removeEventListener('message', handler)
+        resolve(event.data)
+      }
+      else {
+        onOther?.(event.data)
+      }
+    }
+
+    worker.addEventListener('message', handler)
+
+    if (timeout !== undefined) {
+      timeoutId = setTimeout(() => {
+        worker.removeEventListener('message', handler)
+        reject(new Error(`Timeout after ${timeout}ms`))
+      }, timeout)
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LOAD_TIMEOUT = 120_000
+const DEFAULT_INFERENCE_TIMEOUT = 120_000
+const DEFAULT_MAX_RESTARTS = 3
+const DEFAULT_RESTART_DELAY_MS = 1_000
+
+export function createInferenceWorkerManager(
+  options: WorkerManagerOptions,
+): InferenceWorkerManager {
+  const {
+    createWorker,
+    loadTimeout = DEFAULT_LOAD_TIMEOUT,
+    inferenceTimeout = DEFAULT_INFERENCE_TIMEOUT,
+    maxRestarts = DEFAULT_MAX_RESTARTS,
+    restartDelayMs = DEFAULT_RESTART_DELAY_MS,
+  } = options
+
+  let worker: Worker | null = null
+  let state: WorkerManagerState = 'idle'
+  let lastError: ErrorPayload | null = null
+  let restartAttempts = 0
+
+  const operationMutex = new AsyncMutex()
+  const lifecycleMutex = new AsyncMutex()
+
+  // -- Worker lifecycle -----------------------------------------------------
+
+  function initializeWorker(): void {
+    worker = createWorker()
+    worker.addEventListener('error', handleWorkerError)
+  }
+
+  function handleWorkerError(event: ErrorEvent | Error): void {
+    const message = event instanceof Error
+      ? event.message
+      : (event as ErrorEvent).message ?? 'Unknown worker error'
+
+    lastError = {
+      code: 'UNKNOWN',
+      message,
+      recoverable: restartAttempts < maxRestarts,
+    }
+    state = 'error'
+
+    // Reject all pending operations
+    operationMutex.reset(new Error(message))
+
+    // Clean up and try to restart
+    destroyWorker()
+    scheduleRestart()
+  }
+
+  function destroyWorker(): void {
+    if (worker) {
+      worker.terminate()
+      worker = null
+    }
+  }
+
+  function scheduleRestart(): void {
+    if (restartAttempts >= maxRestarts) {
+      console.error(
+        `[InferenceWorkerManager] Max restart attempts (${maxRestarts}) reached. Giving up.`,
+      )
+      return
+    }
+
+    restartAttempts++
+    const delay = restartDelayMs * restartAttempts
+
+    console.warn(
+      `[InferenceWorkerManager] Restarting worker in ${delay}ms `
+      + `(attempt ${restartAttempts}/${maxRestarts})`,
+    )
+
+    setTimeout(() => {
+      ensureStarted().catch((err) => {
+        console.error('[InferenceWorkerManager] Failed to restart:', errorMessageFrom(err))
+      })
+    }, delay)
+  }
+
+  function onSuccessfulOperation(): void {
+    restartAttempts = 0
+  }
+
+  async function ensureStarted(): Promise<void> {
+    await lifecycleMutex.run(async () => {
+      if (!worker) {
+        initializeWorker()
+        state = 'idle'
+      }
+    })
+  }
+
+  // -- Public API -----------------------------------------------------------
+
+  async function loadModel(
+    request: Omit<LoadModelRequest, 'type' | 'requestId'>,
+    onProgress?: (p: ProgressPayload) => void,
+  ): Promise<ModelReadyResponse> {
+    await ensureStarted()
+
+    return operationMutex.run(async () => {
+      state = 'loading'
+      const requestId = createRequestId()
+
+      const resultPromise = waitForWorkerMessage<ModelReadyResponse>(worker!, {
+        predicate: (msg): msg is ModelReadyResponse =>
+          msg.type === 'model-ready' && msg.requestId === requestId,
+        onOther: (msg) => {
+          if (msg.type === 'progress' && msg.requestId === requestId && onProgress)
+            onProgress(msg.payload)
+          if (msg.type === 'error' && msg.requestId === requestId) {
+            // Will be handled by the catch below
+          }
+        },
+        timeout: loadTimeout,
+      })
+
+      const message: LoadModelRequest = {
+        type: 'load-model',
+        requestId,
+        ...request,
+      }
+      worker!.postMessage(message)
+
+      try {
+        const result = await resultPromise
+        state = 'ready'
+        onSuccessfulOperation()
+        return result
+      }
+      catch (error) {
+        state = 'error'
+        handleWorkerError(error instanceof Error ? error : new Error(errorMessageFrom(error)))
+        throw error
+      }
+    })
+  }
+
+  async function run<TInput, TOutput>(
+    input: TInput,
+    onProgress?: (p: ProgressPayload) => void,
+  ): Promise<TOutput> {
+    return operationMutex.run(async () => {
+      if (!worker)
+        throw new Error('Worker not initialized. Call loadModel() first.')
+
+      state = 'running'
+      const requestId = createRequestId()
+
+      type ResultMsg = WorkerOutboundMessage & { type: 'inference-result', requestId: string }
+
+      const resultPromise = waitForWorkerMessage<ResultMsg>(worker, {
+        predicate: (msg): msg is ResultMsg =>
+          msg.type === 'inference-result' && msg.requestId === requestId,
+        onOther: (msg) => {
+          if (msg.type === 'progress' && msg.requestId === requestId && onProgress)
+            onProgress(msg.payload)
+          if (msg.type === 'error' && msg.requestId === requestId) {
+            // Error during inference — will be caught by timeout or explicit error
+          }
+        },
+        timeout: inferenceTimeout,
+      })
+
+      const message: RunInferenceRequest<TInput> = {
+        type: 'run-inference',
+        requestId,
+        input,
+      }
+      worker.postMessage(message)
+
+      try {
+        const result = await resultPromise
+        state = 'ready'
+        onSuccessfulOperation()
+        return result.output as TOutput
+      }
+      catch (error) {
+        state = 'error'
+        handleWorkerError(error instanceof Error ? error : new Error(errorMessageFrom(error)))
+        throw error
+      }
+    })
+  }
+
+  async function unloadModel(): Promise<void> {
+    return operationMutex.run(async () => {
+      if (!worker)
+        return
+
+      const requestId = createRequestId()
+
+      type UnloadedMsg = WorkerOutboundMessage & { type: 'model-unloaded', requestId: string }
+
+      const resultPromise = waitForWorkerMessage<UnloadedMsg>(worker, {
+        predicate: (msg): msg is UnloadedMsg =>
+          msg.type === 'model-unloaded' && msg.requestId === requestId,
+        timeout: 10_000,
+      })
+
+      worker.postMessage({ type: 'unload-model', requestId })
+      await resultPromise
+
+      state = 'idle'
+    })
+  }
+
+  function terminateManager(): void {
+    operationMutex.reset(new Error('Manager terminated'))
+    destroyWorker()
+    state = 'terminated'
+  }
+
+  return {
+    loadModel: loadModel as InferenceWorkerManager['loadModel'],
+    run,
+    unload: unloadModel,
+    terminate: terminateManager,
+    get state() { return state },
+    get lastError() { return lastError },
+  }
+}

--- a/packages/stage-ui/src/libs/workers/types.ts
+++ b/packages/stage-ui/src/libs/workers/types.ts
@@ -68,7 +68,10 @@ export type ProgressMessageEvents = EventInitiate | EventProgress | EventDone
 export interface MessageGenerate {
   type: 'generate'
   data: {
-    audio: string
+    /** Base64-encoded WAV audio. @deprecated Prefer audioFloat32 for zero-copy. */
+    audio?: string
+    /** Pre-converted Float32Array audio samples (transferable, zero-copy) */
+    audioFloat32?: Float32Array
     language: string
   }
 }

--- a/packages/stage-ui/src/libs/workers/worker.ts
+++ b/packages/stage-ui/src/libs/workers/worker.ts
@@ -52,6 +52,10 @@ class AutomaticSpeechRecognitionPipeline {
   }
 }
 
+/**
+ * Convert base64-encoded WAV audio to Float32Array features.
+ * @deprecated Prefer sending Float32Array directly via transferable for zero-copy.
+ */
 async function base64ToFeatures(base64Audio: string): Promise<Float32Array> {
   // Decode base64 to binary
   const binaryString = atob(base64Audio)
@@ -73,7 +77,7 @@ async function base64ToFeatures(base64Audio: string): Promise<Float32Array> {
 }
 
 let processing = false
-async function generate({ audio, language }: { audio: string, language: string }) {
+async function generate({ audio, audioFloat32, language }: { audio?: string, audioFloat32?: Float32Array, language: string }) {
   if (processing)
     return
   processing = true
@@ -81,7 +85,9 @@ async function generate({ audio, language }: { audio: string, language: string }
   // Tell the main thread we are starting
   globalThis.postMessage({ status: 'start' })
 
-  const audioData = await base64ToFeatures(audio)
+  // Prefer pre-converted Float32Array (zero-copy via transferable),
+  // fall back to base64 decoding for backward compatibility.
+  const audioData = audioFloat32 ?? await base64ToFeatures(audio!)
 
   // Retrieve the text-generation pipeline.
   const [tokenizer, processor, model] = await AutomaticSpeechRecognitionPipeline.getInstance()

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -21,6 +21,7 @@ import type {
 import type { AliyunRealtimeSpeechExtraOptions } from './providers/aliyun/stream-transcription'
 
 import { isStageTamagotchi, isUrl } from '@proj-airi/stage-shared'
+import { getCachedWebGPUCapabilities, isWebGPUSupported } from '@proj-airi/stage-shared/webgpu'
 import { computedAsync, useIntervalFn, useLocalStorage } from '@vueuse/core'
 import {
   createOpenAI,
@@ -34,7 +35,6 @@ import {
 } from '@xsai-ext/providers/utils'
 import { listModels } from '@xsai/model'
 import { uniqBy } from 'es-toolkit'
-import { isWebGPUSupported } from 'gpuu/webgpu'
 import { defineStore } from 'pinia'
 import {
   createUnAlibabaCloud,
@@ -47,8 +47,8 @@ import {
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { getKokoroAdapter } from '../libs/inference/adapters/kokoro'
 import { getProviderValidationIntervalMs, listProviders as listDefinedProviders, ProviderValidationCheck } from '../libs/providers'
-import { getKokoroWorker } from '../workers/kokoro'
 import { getDefaultKokoroModel, KOKORO_MODELS, kokoroModelsToModelInfo } from '../workers/kokoro/constants'
 import { useAuthStore } from './auth'
 import { createAliyunNLSProvider as createAliyunNlsStreamProvider } from './providers/aliyun/stream-transcription'
@@ -1551,7 +1551,7 @@ export const useProvidersStore = defineStore('providers', () => {
       icon: 'i-lobe-icons:speaker',
 
       defaultOptions: () => {
-        const hasWebGPU = typeof navigator !== 'undefined' && !!navigator.gpu
+        const hasWebGPU = getCachedWebGPUCapabilities()?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
         const model = getDefaultKokoroModel(hasWebGPU)
         return {
           model,
@@ -1561,7 +1561,7 @@ export const useProvidersStore = defineStore('providers', () => {
 
       createProvider: async (_config) => {
         // Import the worker manager
-        const workerManagerPromise = getKokoroWorker()
+        const workerManagerPromise = getKokoroAdapter()
 
         const provider: SpeechProvider = {
           speech: () => {
@@ -1606,7 +1606,7 @@ export const useProvidersStore = defineStore('providers', () => {
 
       capabilities: {
         listModels: async (_config: Record<string, unknown>) => {
-          const hasWebGPU = typeof navigator !== 'undefined' && !!navigator.gpu
+          const hasWebGPU = getCachedWebGPUCapabilities()?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
           return kokoroModelsToModelInfo(hasWebGPU, t)
         },
 
@@ -1624,15 +1624,30 @@ export const useProvidersStore = defineStore('providers', () => {
 
           // Validate platform requirements
           if (modelDef.platform === 'webgpu') {
-            const hasWebGPU = typeof navigator !== 'undefined' && !!navigator.gpu
+            const hasWebGPU = getCachedWebGPUCapabilities()?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
             if (!hasWebGPU) {
               throw new Error('WebGPU is required for this model but is not available in your browser')
             }
           }
 
           try {
-            const workerManager = await getKokoroWorker()
-            await workerManager.loadModel(modelDef.quantization, modelDef.platform, { onProgress: _hooks?.onProgress })
+            const workerManager = await getKokoroAdapter()
+            await workerManager.loadModel(modelDef.quantization, modelDef.platform, {
+              onProgress: _hooks?.onProgress
+                ? (p) => {
+                    // Map unified ProgressPayload back to ProgressInfo shape
+                    // that the provider hooks expect (HuggingFace transformers format)
+                    _hooks.onProgress!({
+                      name: p.file ?? '',
+                      file: p.file ?? '',
+                      progress: p.percent >= 0 ? p.percent : 0,
+                      status: 'progress',
+                      loaded: p.loaded ?? 0,
+                      total: p.total ?? 0,
+                    } as ProgressInfo)
+                  }
+                : undefined,
+            })
           }
           catch (error) {
             console.error('Failed to load Kokoro model:', error)
@@ -1649,20 +1664,20 @@ export const useProvidersStore = defineStore('providers', () => {
               if (modelDef) {
                 // Validate platform requirements
                 if (modelDef.platform === 'webgpu') {
-                  const hasWebGPU = typeof navigator !== 'undefined' && !!navigator.gpu
+                  const hasWebGPU = getCachedWebGPUCapabilities()?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
                   if (!hasWebGPU) {
                     throw new Error('WebGPU is required for this model but is not available in your browser')
                   }
                 }
 
                 // Load the model
-                const workerManager = await getKokoroWorker()
+                const workerManager = await getKokoroAdapter()
                 await workerManager.loadModel(modelDef.quantization, modelDef.platform)
               }
             }
 
             // Get worker manager and fetch voices from the model
-            const workerManager = await getKokoroWorker()
+            const workerManager = await getKokoroAdapter()
             const modelVoices = workerManager.getVoices()
 
             // Language code mapping

--- a/packages/stage-ui/src/workers/background-removal/worker.ts
+++ b/packages/stage-ui/src/workers/background-removal/worker.ts
@@ -1,0 +1,168 @@
+/**
+ * Background removal Web Worker.
+ *
+ * Runs the Xenova/modnet model inference off the main thread.
+ * Receives ImageBitmap (transferable), returns alpha mask as
+ * Uint8Array (transferable).
+ */
+
+import type { PreTrainedModel, Processor } from '@huggingface/transformers'
+
+import { AutoModel, AutoProcessor, env, RawImage } from '@huggingface/transformers'
+
+// ---------------------------------------------------------------------------
+// Worker message protocol
+// ---------------------------------------------------------------------------
+
+interface LoadRequest {
+  type: 'load'
+  requestId: string
+}
+
+interface ProcessRequest {
+  type: 'process'
+  requestId: string
+  /** Raw image data as RGBA Uint8ClampedArray */
+  imageData: Uint8ClampedArray
+  width: number
+  height: number
+}
+
+type WorkerRequest = LoadRequest | ProcessRequest
+
+interface ProgressMessage {
+  type: 'progress'
+  requestId: string
+  progress: number
+  message?: string
+}
+
+interface LoadedMessage {
+  type: 'loaded'
+  requestId: string
+}
+
+interface ResultMessage {
+  type: 'result'
+  requestId: string
+  /** Alpha mask data, same dimensions as input */
+  maskData: Uint8Array
+  width: number
+  height: number
+}
+
+interface ErrorMessage {
+  type: 'error'
+  requestId: string
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Model singleton
+// ---------------------------------------------------------------------------
+
+let model: PreTrainedModel | null = null
+let processor: Processor | null = null
+
+const MODEL_ID = 'Xenova/modnet'
+
+async function ensureModel(requestId: string): Promise<void> {
+  if (model && processor)
+    return
+
+  env.backends.onnx.wasm!.proxy = false
+
+  model = await AutoModel.from_pretrained(MODEL_ID, {
+    device: 'webgpu',
+    progress_callback: (progress: any) => {
+      const msg: ProgressMessage = {
+        type: 'progress',
+        requestId,
+        progress: progress?.progress ?? -1,
+        message: progress?.status,
+      }
+      globalThis.postMessage(msg)
+    },
+  })
+
+  processor = await AutoProcessor.from_pretrained(MODEL_ID, {})
+}
+
+// ---------------------------------------------------------------------------
+// Processing
+// ---------------------------------------------------------------------------
+
+async function processImage(request: ProcessRequest): Promise<void> {
+  const { requestId, imageData, width, height } = request
+
+  try {
+    await ensureModel(requestId)
+
+    // Create RawImage from the raw pixel data
+    const img = new RawImage(imageData, width, height, 4)
+
+    // Pre-process
+    const { pixel_values } = await processor!(img)
+
+    // Run inference
+    const { output } = await model!({ input: pixel_values })
+
+    // Extract mask and resize to original dimensions
+    const mask = await RawImage.fromTensor(
+      output[0].mul(255).to('uint8'),
+    ).resize(width, height)
+
+    const maskData = new Uint8Array(mask.data.buffer)
+
+    const result: ResultMessage = {
+      type: 'result',
+      requestId,
+      maskData,
+      width,
+      height,
+    }
+    // Transfer the buffer to avoid copying
+    ;(globalThis as any).postMessage(result, [maskData.buffer])
+  }
+  catch (error) {
+    const msg: ErrorMessage = {
+      type: 'error',
+      requestId,
+      message: error instanceof Error ? error.message : String(error),
+    }
+    globalThis.postMessage(msg)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message handler
+// ---------------------------------------------------------------------------
+
+globalThis.addEventListener('message', async (event: MessageEvent<WorkerRequest>) => {
+  const message = event.data
+
+  switch (message.type) {
+    case 'load': {
+      try {
+        await ensureModel(message.requestId)
+        const msg: LoadedMessage = {
+          type: 'loaded',
+          requestId: message.requestId,
+        }
+        globalThis.postMessage(msg)
+      }
+      catch (error) {
+        const msg: ErrorMessage = {
+          type: 'error',
+          requestId: message.requestId,
+          message: error instanceof Error ? error.message : String(error),
+        }
+        globalThis.postMessage(msg)
+      }
+      break
+    }
+    case 'process':
+      await processImage(message)
+      break
+  }
+})

--- a/packages/stage-ui/src/workers/kokoro/index.ts
+++ b/packages/stage-ui/src/workers/kokoro/index.ts
@@ -5,69 +5,10 @@
 
 import type { LoadedMessage, VoiceKey, Voices, WorkerRequest, WorkerResponse } from './types'
 
+import { AsyncMutex } from '../../libs/inference/async-mutex'
+
 const LOAD_MODEL_TIMEOUT = 120000
 const GENERATE_TIMEOUT = 120000
-
-/**
- * An async mutex that ensures only one callback runs at a time.
- * Waiters queue up and are processed in FIFO order.
- */
-class AsyncMutex {
-  private locked = false
-  private waiters: { resolve: () => void, reject: (error: Error) => void }[] = []
-
-  // Incremented on reset() to invalidate stale lock holders
-  private generation = 0
-
-  /**
-   * Executes the callback with exclusive access to the mutex.
-   * If the mutex is locked, waits in queue until it's our turn.
-   */
-  async run<T>(callback: () => Promise<T> | T): Promise<T> {
-    const myGeneration = this.generation
-
-    if (this.locked) {
-      await new Promise<void>((resolve, reject) => {
-        this.waiters.push({ resolve, reject })
-      })
-      if (myGeneration !== this.generation) {
-        throw new Error('Mutex was reset')
-      }
-    }
-    this.locked = true
-
-    try {
-      return await callback()
-    }
-    finally {
-      if (myGeneration === this.generation) {
-        const next = this.waiters.shift()
-        if (next) {
-          next.resolve()
-        }
-        else {
-          this.locked = false
-        }
-      }
-    }
-  }
-
-  /**
-   * Cancels all waiting tasks and releases the lock.
-   * Atomic thanks to JavaScript's Run-To-Completion semantics.
-   */
-  reset(error: Error = new Error('Mutex reset')): void {
-    this.generation++
-    this.locked = false
-
-    const waitersToReject = this.waiters
-    this.waiters = []
-
-    for (const waiter of waitersToReject) {
-      waiter.reject(error)
-    }
-  }
-}
 
 interface WaitForEventOptions<T extends Event> {
   predicate?: (event: T) => boolean

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2872,6 +2872,9 @@ importers:
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.1.0(vue@3.5.30(typescript@5.9.3))
+      gpuu:
+        specifier: ^1.0.6
+        version: 1.0.6
       pinia:
         specifier: 'catalog:'
         version: 3.0.4(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))


### PR DESCRIPTION
## Summary

- Centralize WebGPU detection in `stage-shared/webgpu` (single cached source of truth, replacing 4 different detection patterns)
- Create unified inference worker message protocol with typed requests, progress reporting, and error classification
- Extract reusable `AsyncMutex` from Kokoro worker manager into shared `libs/inference/`
- Build generic `InferenceWorkerManager` with timeout, auto-restart with backoff
- Add GPU resource coordinator (memory tracking, LRU eviction, pressure events)
- Add model load queue (priority-based serialization, prevents bandwidth contention)
- Add model cache utilities (query/clear `transformers-cache` via Cache API)
- Create adapter pattern for Kokoro TTS, Whisper ASR, and background removal
- Move background removal inference from main thread to Web Worker (unblocks UI)
- Add `Float32Array` zero-copy audio transfer path for Whisper (replacing base64)
- Add unified `useInferenceStatus()` composable for reactive model state tracking
- Integrate `PerfTracer` for inference timing in Kokoro adapter
- Fix Kokoro progress value mapping (was inflated 100x)

## Test plan

- [x] `pnpm -F @proj-airi/stage-shared typecheck` passes
- [x] `pnpm -F @proj-airi/stage-ui typecheck` passes
- [x] `pnpm -F @proj-airi/stage-web typecheck` passes
- [x] `pnpm lint:fix` — no new lint errors
- [x] `pnpm test:run` — no new test failures
- [ ] Manual: Kokoro TTS model load + voice generation via settings page
- [ ] Manual: Background removal devtools page processes images without blocking UI
- [ ] Manual: Whisper ASR transcription works with adapter