### PR TITLE
fix(stage-pages): persist default Kokoro model on first visit

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -108,6 +108,12 @@ onMounted(async () => {
     await providersStore.fetchModelsForProvider(providerId)
 
     const config = providersStore.getProviderConfig(providerId)
+
+    // Persist the default model if none is saved yet so validation passes on first visit
+    if (!config.model) {
+      config.model = getDefaultKokoroModel(hasWebGPU.value)
+    }
+
     const metadata = providersStore.getProviderMetadata(providerId)
     const validationResult = await metadata.validators.validateProviderConfig(config)
     if (validationResult.valid) {


### PR DESCRIPTION
## Summary

- On first visit to the Kokoro TTS settings page, `config.model` is `undefined` (never been saved to the store), causing `validateProviderConfig` to return `valid: false`
- This silently prevents the model from loading and leaves the voice list empty, so the user sees a blank playground with no selectable voices
- The fix persists the hardware-appropriate default model (`q4f16` for WASM, `fp32-webgpu` for WebGPU) into the store config before validation runs, so the model initialises correctly on first visit without requiring the user to manually open the dropdown

## Test plan

- [x] Open Kokoro TTS settings for the first time (or clear localStorage) — model should start downloading automatically without needing to select from the dropdown
- [x] Voices populate after download completes
- [x] Selecting a different model from the dropdown still works and reloads voices correctly
- [x] On a WebGPU-capable browser, the WebGPU model is selected as default; on WASM-only, `q4f16` is selected