### PR TITLE
fix(stage-tamagotchi): fix window title

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/index.html
+++ b/apps/stage-tamagotchi/src/renderer/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>AIRI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, viewport-fit=cover" />
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <!-- <meta


### PR DESCRIPTION
Closes #1625 
Removed the title set in index.html to prevent it from overriding the expected window titles.
Test with both the settings window and main window open.
Before:
```
Window ID 12:
  Title: "AIRI"
  App ID: "ai.moeru.airi"
  Is floating: yes
  PID: 21354
  Workspace ID: 2
  Layout:
    Tile size: 219 x 432
    Workspace-view position: 1217, 470.50
    Window size: 219 x 432
    Window offset in tile: 0 x 0

Window ID 14:
  Title: "AIRI"
  App ID: "ai.moeru.airi"
  Is floating: yes
  PID: 21354
  Workspace ID: 2
  Layout:
    Tile size: 600 x 800
    Workspace-view position: 664.50, 54.50
    Window size: 600 x 800
    Window offset in tile: 0 x 0
```
After:
```
Window ID 56:
  Title: "AIRI"
  App ID: "ai.moeru.airi"
  Is floating: yes
  PID: 139523
  Workspace ID: 1
  Layout:
    Tile size: 204 x 402
    Workspace-view position: 618, 249
    Window size: 204 x 402
    Window offset in tile: 0 x 0

Window ID 57:
  Title: "Settings"
  App ID: "ai.moeru.airi"
  Is floating: yes
  PID: 139523
  Workspace ID: 1
  Layout:
    Tile size: 600 x 800
    Workspace-view position: 112.50, 84.50
    Window size: 600 x 800
    Window offset in tile: 0 x 0
```
