### PR TITLE
fix(stage-pages): allow clearing OpenAI-compatible speech model field

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/speech/openai-compatible-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/openai-compatible-audio-speech.vue
@@ -35,9 +35,12 @@ const speed = ref<number>(
   || defaultVoiceSettings.speed,
 )
 
-// Model selection
+// Model selection (store raw string; empty string is valid while editing — default is applied only at API call)
 const model = computed({
-  get: () => providers.value[providerId]?.model as string | undefined || defaultModel,
+  get: () => {
+    const raw = providers.value[providerId]?.model as string | undefined | null
+    return raw ?? ''
+  },
   set: (value) => {
     if (!providers.value[providerId])
       providers.value[providerId] = {}
@@ -66,8 +69,8 @@ watch(
       if (Math.abs(speed.value - newSpeed) > 0.001) // Use small epsilon for float comparison
         speed.value = newSpeed
 
-      // Sync model if it was reset
-      if (!config.model && model.value !== defaultModel)
+      // Sync model if property was cleared externally (undefined/null), not when user sets empty string
+      if (config.model == null && model.value !== defaultModel)
         model.value = defaultModel
 
       // Sync voice if it was reset
@@ -89,13 +92,9 @@ const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 
 // Ensure provider config is initialized on mount
 onMounted(() => {
-  if (!providers.value[providerId]) {
-    providers.value[providerId] = {}
-  }
-  // Initialize model and voice if they don't exist
-  if (!providers.value[providerId].model) {
-    providers.value[providerId].model = defaultModel
-  }
+  providers.value[providerId] ??= {}
+  // Only assign default when model is null/undefined; empty string is kept intentionally
+  providers.value[providerId].model ??= defaultModel
   if (!providers.value[providerId].voice) {
     providers.value[providerId].voice = 'alloy'
   }
@@ -131,14 +130,6 @@ watch(speed, async () => {
   if (!providers.value[providerId])
     providers.value[providerId] = {}
   providers.value[providerId].speed = speed.value
-})
-
-watch(model, () => {
-  // Ensure provider config exists
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-  // Save model to provider config (this persists to localStorage automatically)
-  providers.value[providerId].model = model.value
 })
 
 watch(voice, () => {

--- a/packages/stage-pages/src/pages/settings/providers/speech/openai-compatible-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/openai-compatible-audio-speech.vue
@@ -27,6 +27,7 @@ const defaultVoiceSettings = {
 // Get provider metadata
 const providerId = 'openai-compatible-audio-speech'
 const defaultModel = 'tts-1'
+const defaultVoice = 'alloy'
 
 // Initialize speed from provider config or default
 const speed = ref<number>(
@@ -49,7 +50,10 @@ const model = computed({
 })
 
 const voice = computed({
-  get: () => providers.value[providerId]?.voice || 'alloy',
+  get: () => {
+    const raw = providers.value[providerId]?.voice as string | undefined | null
+    return raw ?? ''
+  },
   set: (value) => {
     if (!providers.value[providerId])
       providers.value[providerId] = {}
@@ -73,15 +77,15 @@ watch(
       if (config.model == null && model.value !== defaultModel)
         model.value = defaultModel
 
-      // Sync voice if it was reset
-      if (!config.voice && voice.value !== 'alloy')
-        voice.value = 'alloy'
+      // Sync voice if property was cleared externally (undefined/null), not when user sets empty string
+      if (config.voice == null && voice.value !== defaultVoice)
+        voice.value = defaultVoice
     }
     else {
       // Provider config was reset, reset our local refs to defaults
       speed.value = defaultVoiceSettings.speed
       model.value = defaultModel
-      voice.value = 'alloy'
+      voice.value = defaultVoice
     }
   },
   { deep: true, immediate: true },
@@ -93,11 +97,9 @@ const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 // Ensure provider config is initialized on mount
 onMounted(() => {
   providers.value[providerId] ??= {}
-  // Only assign default when model is null/undefined; empty string is kept intentionally
+  // Defaults only when unset (null/undefined); empty strings are kept intentionally
   providers.value[providerId].model ??= defaultModel
-  if (!providers.value[providerId].voice) {
-    providers.value[providerId].voice = 'alloy'
-  }
+  providers.value[providerId].voice ??= defaultVoice
 })
 
 // Generate speech with OpenAI-compatible parameters
@@ -117,7 +119,7 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
     provider,
     modelToUse,
     input,
-    voiceId || (voice.value as string),
+    voiceId || voice.value || defaultVoice,
     {
       ...providerConfig,
       ...defaultVoiceSettings,
@@ -130,14 +132,6 @@ watch(speed, async () => {
   if (!providers.value[providerId])
     providers.value[providerId] = {}
   providers.value[providerId].speed = speed.value
-})
-
-watch(voice, () => {
-  // Ensure provider config exists
-  if (!providers.value[providerId])
-    providers.value[providerId] = {}
-  // Save voice to provider config (this persists to localStorage automatically)
-  providers.value[providerId].voice = voice.value
 })
 
 // Use the composable to get validation logic and state


### PR DESCRIPTION
## Description

On **Settings → Providers → Speech → OpenAI-compatible audio speech**, the **Model** field kept snapping back to `tts-1` while deleting (including after clearing the input). That came from two things working together:

1. The `model` computed **getter** used `stored || defaultModel`, so an empty string was treated like “missing” and displayed as `tts-1`.
2. A **`watch(model)`** wrote `model.value` (the getter result) back into Pinia, so clearing the field immediately persisted `tts-1` again.

This PR:

- **Persists the raw string** from the store in the getter (`undefined` / `null` → `''` for the input; no `|| defaultModel` in the getter).
- **Removes** the redundant `watch(model)` (the `v-model` setter already updates the store).
- **Defaults only when unset**: `onMounted` uses `model ??= defaultModel`, and the deep `watch` on provider config uses `config.model == null` (not `!config.model`) so an intentional **empty string** is preserved. Runtime / playground still uses `modelId || model.value || defaultModel` so API calls keep a safe fallback when the field is empty.

## Linked Issues

<!-- N/A — add `Fixes #123` if you have a GitHub issue -->

## Additional Context

- **Behavior change**: Users can now save an **empty** model in settings; TTS calls still fall back to `tts-1` where `handleGenerateSpeech` applies `|| defaultModel`. If any other code path reads `providerConfig.model` without a similar fallback, that is worth a quick sanity check (out of scope for this page-only fix unless you find a regression).