### PR TITLE
fix(inference): correctness and resilience fixes for browser-side inference infra

### DIFF
--- a/packages/stage-ui/src/libs/inference/adapters/background-removal.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/background-removal.ts
@@ -57,8 +57,19 @@ export function createBackgroundRemovalAdapter(): BackgroundRemovalAdapter {
   let worker: Worker | null = null
   let state: BackgroundRemovalAdapter['state'] = 'idle'
   let allocationToken: AllocationToken | null = null
+  let errorListener: ((event: Event) => void) | null = null
 
   const operationMutex = new Mutex()
+
+  function destroyWorker(): void {
+    if (worker) {
+      if (errorListener)
+        worker.removeEventListener('error', errorListener)
+      errorListener = null
+      worker.terminate()
+      worker = null
+    }
+  }
 
   function ensureWorker(): Worker {
     if (!worker) {
@@ -66,10 +77,11 @@ export function createBackgroundRemovalAdapter(): BackgroundRemovalAdapter {
         new URL('../../../workers/background-removal/worker.ts', import.meta.url),
         { type: 'module' },
       )
-      worker.addEventListener('error', (_event) => {
+      errorListener = (_event: Event) => {
         state = 'error'
         operationMutex.cancel()
-      })
+      }
+      worker.addEventListener('error', errorListener)
     }
     return worker
   }
@@ -223,10 +235,7 @@ export function createBackgroundRemovalAdapter(): BackgroundRemovalAdapter {
 
   function terminateAdapter(): void {
     operationMutex.cancel()
-    if (worker) {
-      worker.terminate()
-      worker = null
-    }
+    destroyWorker()
     if (allocationToken) {
       removeInferenceStatus(MODEL_NAMES.BG_REMOVAL)
       getGPUCoordinator().release(allocationToken)

--- a/packages/stage-ui/src/libs/inference/adapters/kokoro.test.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/kokoro.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock Worker globally since it's not available in Node
+class MockWorker {
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+  postMessage = vi.fn()
+  terminate = vi.fn()
+}
+vi.stubGlobal('Worker', MockWorker)
+
+// Mock dependencies that require browser APIs or Vue
+vi.mock('../../../composables/use-inference-status', () => ({
+  updateInferenceStatus: vi.fn(),
+  removeInferenceStatus: vi.fn(),
+}))
+
+vi.mock('../coordinator', () => ({
+  getGPUCoordinator: () => ({
+    requestAllocation: vi.fn(() => ({ modelId: 'test', estimatedBytes: 0 })),
+    release: vi.fn(),
+  }),
+  getLoadQueue: () => ({
+    enqueue: vi.fn((_id: string, _p: number, loader: () => Promise<unknown>) => loader()),
+  }),
+  MODEL_VRAM_ESTIMATES: {},
+}))
+
+vi.mock('@proj-airi/stage-shared', () => ({
+  defaultPerfTracer: {
+    withMeasure: vi.fn((_cat: string, _name: string, fn: () => unknown) => fn()),
+  },
+}))
+
+describe('kokoro adapter - singleton recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('should create adapter with idle state', async () => {
+    const { createKokoroAdapter } = await import('./kokoro')
+    const adapter = createKokoroAdapter()
+    expect(adapter.state).toBe('idle')
+  })
+
+  it('should transition to terminated state after calling terminate', async () => {
+    const { createKokoroAdapter } = await import('./kokoro')
+    const adapter = createKokoroAdapter()
+    adapter.terminate()
+    expect(adapter.state).toBe('terminated')
+  })
+
+  it('should expose state getter correctly across transitions', async () => {
+    const { createKokoroAdapter } = await import('./kokoro')
+    const adapter = createKokoroAdapter()
+
+    expect(adapter.state).toBe('idle')
+    adapter.terminate()
+    expect(adapter.state).toBe('terminated')
+  })
+})
+
+describe('classifyError phase integration', () => {
+  it('should produce LOAD_FAILED for load-phase errors', async () => {
+    const { classifyError } = await import('../protocol')
+    expect(classifyError(new Error('shader compilation failed'), 'load')).toBe('LOAD_FAILED')
+  })
+
+  it('should produce INFERENCE_FAILED for inference-phase errors', async () => {
+    const { classifyError } = await import('../protocol')
+    expect(classifyError(new Error('tensor shape mismatch'), 'inference')).toBe('INFERENCE_FAILED')
+  })
+})

--- a/packages/stage-ui/src/libs/inference/adapters/kokoro.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/kokoro.ts
@@ -160,6 +160,7 @@ export function createKokoroAdapter(): KokoroAdapter {
   let restartAttempts = 0
   let allocationToken: AllocationToken | null = null
   let currentModelStatusId: string | null = null
+  let errorListener: ((event: ErrorEvent) => void) | null = null
 
   const operationMutex = new Mutex()
   const lifecycleMutex = new Mutex()
@@ -169,7 +170,8 @@ export function createKokoroAdapter(): KokoroAdapter {
       new URL('../../../workers/kokoro/worker.ts', import.meta.url),
       { type: 'module' },
     )
-    worker.addEventListener('error', handleWorkerError)
+    errorListener = (event: ErrorEvent) => handleWorkerError(event)
+    worker.addEventListener('error', errorListener)
   }
 
   function handleWorkerError(_event: ErrorEvent | Error): void {
@@ -181,6 +183,9 @@ export function createKokoroAdapter(): KokoroAdapter {
 
   function destroyWorker(): void {
     if (worker) {
+      if (errorListener)
+        worker.removeEventListener('error', errorListener)
+      errorListener = null
       worker.terminate()
       worker = null
     }
@@ -191,6 +196,9 @@ export function createKokoroAdapter(): KokoroAdapter {
       console.error(
         `[KokoroAdapter] Max restart attempts (${MAX_RESTARTS}) reached.`,
       )
+      // NOTICE: Transition to 'terminated' so getKokoroAdapter() can detect
+      // the dead singleton and create a fresh adapter on next access.
+      state = 'terminated'
       return
     }
 
@@ -285,7 +293,9 @@ export function createKokoroAdapter(): KokoroAdapter {
         state = 'ready'
         updateInferenceStatus(modelStatusId, { state: 'ready', device: (response.device ?? device) as any })
         onSuccess()
-        return voices!
+        if (!voices)
+          throw new Error('Kokoro worker did not return voice metadata')
+        return voices
       })
     }), { quantization, device }).catch((error) => {
       handleWorkerError(error instanceof Error ? error : new Error(String(error)))
@@ -367,11 +377,18 @@ const singletonMutex = new Mutex()
 /**
  * Get the global Kokoro adapter instance.
  * Creates and starts the worker on first call.
+ * Automatically re-creates the adapter if it has entered a terminal state
+ * ('terminated' or 'error' after max restarts exhausted).
  */
 export async function getKokoroAdapter(): Promise<KokoroAdapter> {
   return singletonMutex.runExclusive(async () => {
-    if (!globalAdapter)
+    if (
+      !globalAdapter
+      || globalAdapter.state === 'terminated'
+      || globalAdapter.state === 'error'
+    ) {
       globalAdapter = createKokoroAdapter()
+    }
     return globalAdapter
   })
 }

--- a/packages/stage-ui/src/libs/inference/adapters/whisper.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/whisper.ts
@@ -82,6 +82,8 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
   let state: WhisperState = 'idle'
   let allocationToken: AllocationToken | null = null
   let restartAttempts = 0
+  let messageListener: ((event: MessageEvent) => void) | null = null
+  let errorListener: ((event: ErrorEvent) => void) | null = null
   const messageHandlers = new Set<(event: WhisperEvent) => void>()
 
   const operationMutex = new Mutex()
@@ -95,6 +97,12 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
 
   function destroyWorker(): void {
     if (worker) {
+      if (messageListener)
+        worker.removeEventListener('message', messageListener)
+      if (errorListener)
+        worker.removeEventListener('error', errorListener)
+      messageListener = null
+      errorListener = null
       worker.terminate()
       worker = null
     }
@@ -103,6 +111,9 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
   function scheduleRestart(): void {
     if (restartAttempts >= MAX_RESTARTS) {
       console.error(`[WhisperAdapter] Max restart attempts (${MAX_RESTARTS}) reached.`)
+      // NOTICE: Transition to 'terminated' so callers can detect the dead adapter
+      // instead of being stuck in 'error' state indefinitely.
+      state = 'terminated'
       return
     }
 
@@ -122,7 +133,7 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
   function ensureWorker(): Worker {
     if (!worker) {
       worker = new Worker(workerUrl, { type: 'module' })
-      worker.addEventListener('message', (event: MessageEvent) => {
+      messageListener = (event: MessageEvent) => {
         const data = event.data
         // Forward unified protocol messages to subscribers
         if (data.type === 'progress') {
@@ -141,10 +152,12 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
           const evt: WhisperEvent = { type: 'error', payload: data.payload }
           for (const handler of messageHandlers) handler(evt)
         }
-      })
-      worker.addEventListener('error', (event) => {
+      }
+      errorListener = (event: ErrorEvent) => {
         handleWorkerError(event)
-      })
+      }
+      worker.addEventListener('message', messageListener)
+      worker.addEventListener('error', errorListener)
     }
     return worker
   }
@@ -283,10 +296,7 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
 
   function terminateAdapter(): void {
     operationMutex.cancel()
-    if (worker) {
-      worker.terminate()
-      worker = null
-    }
+    destroyWorker()
     if (allocationToken) {
       removeInferenceStatus(MODEL_NAMES.WHISPER)
       getGPUCoordinator().release(allocationToken)

--- a/packages/stage-ui/src/libs/inference/protocol.test.ts
+++ b/packages/stage-ui/src/libs/inference/protocol.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyError, isRecoverable } from './protocol'
+
+describe('classifyError', () => {
+  it('should classify OOM errors', () => {
+    expect(classifyError(new Error('out of memory'))).toBe('OOM')
+    expect(classifyError(new Error('GPU allocation failed'))).toBe('OOM')
+  })
+
+  it('should classify DEVICE_LOST errors', () => {
+    expect(classifyError(new Error('device was lost'))).toBe('DEVICE_LOST')
+    expect(classifyError(new Error('WebGPU device lost unexpectedly'))).toBe('DEVICE_LOST')
+  })
+
+  it('should classify TIMEOUT errors', () => {
+    expect(classifyError(new Error('operation timeout after 120s'))).toBe('TIMEOUT')
+  })
+
+  it('should classify LOAD_FAILED with load phase', () => {
+    expect(classifyError(new Error('some unknown error'), 'load')).toBe('LOAD_FAILED')
+  })
+
+  it('should classify INFERENCE_FAILED with inference phase', () => {
+    expect(classifyError(new Error('some unknown error'), 'inference')).toBe('INFERENCE_FAILED')
+  })
+
+  it('should prioritize specific error patterns over phase hint', () => {
+    // OOM during load should still be OOM, not LOAD_FAILED
+    expect(classifyError(new Error('out of memory'), 'load')).toBe('OOM')
+    // DEVICE_LOST during inference should still be DEVICE_LOST
+    expect(classifyError(new Error('device was lost'), 'inference')).toBe('DEVICE_LOST')
+    // TIMEOUT during load should still be TIMEOUT
+    expect(classifyError(new Error('timeout'), 'load')).toBe('TIMEOUT')
+  })
+
+  it('should return UNKNOWN without phase hint for unrecognized errors', () => {
+    expect(classifyError(new Error('something went wrong'))).toBe('UNKNOWN')
+  })
+
+  it('should handle non-Error inputs', () => {
+    expect(classifyError('out of memory')).toBe('OOM')
+    expect(classifyError('random string'), 'load').toBe('UNKNOWN')
+    expect(classifyError(42)).toBe('UNKNOWN')
+  })
+})
+
+describe('isRecoverable', () => {
+  it('should mark TIMEOUT as recoverable', () => {
+    expect(isRecoverable('TIMEOUT')).toBe(true)
+  })
+
+  it('should mark DEVICE_LOST as recoverable', () => {
+    expect(isRecoverable('DEVICE_LOST')).toBe(true)
+  })
+
+  it('should mark OOM as not recoverable', () => {
+    expect(isRecoverable('OOM')).toBe(false)
+  })
+
+  it('should mark LOAD_FAILED as not recoverable', () => {
+    expect(isRecoverable('LOAD_FAILED')).toBe(false)
+  })
+
+  it('should mark INFERENCE_FAILED as not recoverable', () => {
+    expect(isRecoverable('INFERENCE_FAILED')).toBe(false)
+  })
+
+  it('should mark UNKNOWN as not recoverable', () => {
+    expect(isRecoverable('UNKNOWN')).toBe(false)
+  })
+})

--- a/packages/stage-ui/src/libs/inference/protocol.ts
+++ b/packages/stage-ui/src/libs/inference/protocol.ts
@@ -151,8 +151,12 @@ export function createRequestId(): string {
 /**
  * Classify an unknown error into an `InferenceErrorCode`.
  * Used by worker adapters to normalise caught exceptions.
+ *
+ * Specific error patterns (OOM, DEVICE_LOST, TIMEOUT) take priority
+ * over the `phase` hint. When no specific pattern matches, `phase`
+ * determines whether the code is `LOAD_FAILED` or `INFERENCE_FAILED`.
  */
-export function classifyError(error: unknown): InferenceErrorCode {
+export function classifyError(error: unknown, phase?: 'load' | 'inference'): InferenceErrorCode {
   const msg = error instanceof Error ? error.message : String(error)
   const lower = msg.toLowerCase()
 
@@ -163,5 +167,19 @@ export function classifyError(error: unknown): InferenceErrorCode {
   if (lower.includes('timeout'))
     return 'TIMEOUT'
 
+  if (phase === 'load')
+    return 'LOAD_FAILED'
+  if (phase === 'inference')
+    return 'INFERENCE_FAILED'
+
   return 'UNKNOWN'
+}
+
+/**
+ * Determine whether an error code represents a potentially recoverable
+ * condition. TIMEOUT and DEVICE_LOST may succeed on retry (e.g. with
+ * WASM fallback or after device re-acquisition).
+ */
+export function isRecoverable(code: InferenceErrorCode): boolean {
+  return code === 'TIMEOUT' || code === 'DEVICE_LOST'
 }

--- a/packages/stage-ui/src/libs/workers/worker.ts
+++ b/packages/stage-ui/src/libs/workers/worker.ts
@@ -33,7 +33,7 @@ import {
 } from '@huggingface/transformers'
 
 import { MODEL_IDS, MODEL_NAMES } from '../inference/constants'
-import { classifyError } from '../inference/protocol'
+import { classifyError, isRecoverable } from '../inference/protocol'
 
 // ---------------------------------------------------------------------------
 // Inference-specific input/output types
@@ -116,16 +116,35 @@ class AutomaticSpeechRecognitionPipeline {
       progress_callback,
     })
 
-    this.model ??= WhisperForConditionalGeneration.from_pretrained(this.model_id, {
-      dtype: {
-        // [v3.x] Cannot load whisper-v3-large-turbo · Issue #989 · huggingface/transformers.js
-        // https://github.com/huggingface/transformers.js/issues/989
-        encoder_model: 'fp16',
-        decoder_model_merged: 'q4', // 'fp16' is broken for decoder
-      },
-      device: actualDevice,
-      progress_callback,
-    })
+    // NOTICE: fp16 encoder may fail on some devices/browsers. Fall back to fp32
+    // if the initial load fails. Decoder fp16 is known broken (see Issue #989).
+    // https://github.com/huggingface/transformers.js/issues/989
+    this.model ??= (async () => {
+      try {
+        return await WhisperForConditionalGeneration.from_pretrained(this.model_id!, {
+          dtype: {
+            encoder_model: 'fp16',
+            decoder_model_merged: 'q4',
+          },
+          device: actualDevice,
+          progress_callback,
+        })
+      }
+      catch (error) {
+        console.warn(
+          '[Whisper Worker] fp16 encoder failed, falling back to fp32:',
+          error instanceof Error ? error.message : error,
+        )
+        return await WhisperForConditionalGeneration.from_pretrained(this.model_id!, {
+          dtype: {
+            encoder_model: 'fp32',
+            decoder_model_merged: 'q4',
+          },
+          device: actualDevice,
+          progress_callback,
+        })
+      }
+    })()
 
     return Promise.all([this.tokenizer, this.processor, this.model])
   }
@@ -169,15 +188,16 @@ function sendProgress(requestId: string, phase: 'download' | 'compile' | 'warmup
   globalThis.postMessage(msg)
 }
 
-function sendError(requestId: string, error: unknown): void {
+function sendError(requestId: string, error: unknown, phase?: 'load' | 'inference'): void {
   const message = error instanceof Error ? error.message : String(error)
+  const code = classifyError(error, phase)
   const msg: ErrorResponse = {
     type: 'error',
     requestId,
     payload: {
-      code: classifyError(error),
+      code,
       message,
-      recoverable: false,
+      recoverable: isRecoverable(code),
     },
   }
   globalThis.postMessage(msg)
@@ -232,7 +252,7 @@ async function loadModel(request: LoadModelRequest): Promise<void> {
     globalThis.postMessage(ready)
   }
   catch (error) {
-    sendError(requestId, error)
+    sendError(requestId, error, 'load')
   }
   finally {
     currentLoadRequestId = null
@@ -248,8 +268,10 @@ let processing = false
 async function runInference(request: RunInferenceRequest<WhisperInput>): Promise<void> {
   const { requestId, input } = request
 
-  if (processing)
+  if (processing) {
+    sendError(requestId, new Error('Worker is busy processing another request'), 'inference')
     return
+  }
   processing = true
 
   try {
@@ -297,7 +319,7 @@ async function runInference(request: RunInferenceRequest<WhisperInput>): Promise
     globalThis.postMessage(result)
   }
   catch (error) {
-    sendError(requestId, error)
+    sendError(requestId, error, 'inference')
   }
   finally {
     processing = false

--- a/packages/stage-ui/src/workers/background-removal/worker.ts
+++ b/packages/stage-ui/src/workers/background-removal/worker.ts
@@ -20,7 +20,7 @@ import type {
 import { AutoModel, AutoProcessor, env, RawImage } from '@huggingface/transformers'
 
 import { MODEL_IDS, MODEL_NAMES } from '../../libs/inference/constants'
-import { classifyError } from '../../libs/inference/protocol'
+import { classifyError, isRecoverable } from '../../libs/inference/protocol'
 
 // ---------------------------------------------------------------------------
 // Inference-specific input/output types
@@ -60,15 +60,16 @@ function sendProgress(requestId: string, percent: number, message?: string): voi
   globalThis.postMessage(msg)
 }
 
-function sendError(requestId: string, error: unknown): void {
+function sendError(requestId: string, error: unknown, phase?: 'load' | 'inference'): void {
   const message = error instanceof Error ? error.message : String(error)
+  const code = classifyError(error, phase)
   const msg: ErrorResponse = {
     type: 'error',
     requestId,
     payload: {
-      code: classifyError(error),
+      code,
       message,
-      recoverable: false,
+      recoverable: isRecoverable(code),
     },
   }
   globalThis.postMessage(msg)
@@ -137,7 +138,7 @@ async function loadModel(request: LoadModelRequest): Promise<void> {
     globalThis.postMessage(ready)
   }
   catch (error) {
-    sendError(requestId, error)
+    sendError(requestId, error, 'load')
   }
 }
 
@@ -179,7 +180,7 @@ async function runInference(request: RunInferenceRequest<BackgroundRemovalInput>
     ;(globalThis as any).postMessage(result, [maskData.buffer])
   }
   catch (error) {
-    sendError(requestId, error)
+    sendError(requestId, error, 'inference')
   }
 }
 

--- a/packages/stage-ui/src/workers/kokoro/worker.ts
+++ b/packages/stage-ui/src/workers/kokoro/worker.ts
@@ -19,7 +19,7 @@ import type { VoiceKey, Voices } from './types'
 import { KokoroTTS } from 'kokoro-js'
 
 import { MODEL_IDS, MODEL_NAMES } from '../../libs/inference/constants'
-import { classifyError } from '../../libs/inference/protocol'
+import { classifyError, isRecoverable } from '../../libs/inference/protocol'
 
 // ---------------------------------------------------------------------------
 // Inference-specific input/output types
@@ -58,15 +58,32 @@ let ttsModel: KokoroTTS | null = null
 let currentQuantization: string | null = null
 let currentDevice: string | null = null
 
-function sendError(requestId: string, error: unknown): void {
+// NOTICE: Fallback chains for dtype/device when the requested format is
+// unsupported at runtime. Tries progressively lower precision before giving up.
+const DTYPE_FALLBACK: Record<string, string[]> = {
+  fp16: ['fp32', 'q8', 'q4'],
+  fp32: ['q8', 'q4'],
+  q8: ['q4', 'fp32'],
+  q4: ['q4f16', 'fp32'],
+  q4f16: ['q4', 'fp32'],
+}
+
+const DEVICE_FALLBACK: Record<string, string[]> = {
+  webgpu: ['wasm'],
+  wasm: [],
+  cpu: [],
+}
+
+function sendError(requestId: string, error: unknown, phase?: 'load' | 'inference'): void {
   const message = error instanceof Error ? error.message : String(error)
+  const code = classifyError(error, phase)
   const msg: ErrorResponse = {
     type: 'error',
     requestId,
     payload: {
-      code: classifyError(error),
+      code,
       message,
-      recoverable: false,
+      recoverable: isRecoverable(code),
     },
   }
   globalThis.postMessage(msg)
@@ -95,44 +112,73 @@ async function loadModel(request: LoadModelRequest): Promise<void> {
       ? quantization.slice(0, -'-webgpu'.length)
       : quantization
 
-    ttsModel = await KokoroTTS.from_pretrained(
-      MODEL_IDS.KOKORO,
-      {
-        dtype: modelQuantization as 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16',
-        device: device as 'wasm' | 'webgpu' | 'cpu',
-        progress_callback: (progress: any) => {
-          const msg: ProgressResponse = {
-            type: 'progress',
-            requestId,
-            payload: {
-              phase: 'download',
-              // NOTICE: raw.progress from kokoro-js/@huggingface/transformers is already 0-100
-              percent: progress?.progress ?? -1,
-              message: progress?.status,
-              file: progress?.file,
-              loaded: progress?.loaded,
-              total: progress?.total,
+    // Build ordered list of (dtype, device) pairs to attempt
+    const attempts: Array<{ dtype: string, device: string }> = [
+      { dtype: modelQuantization, device },
+    ]
+    for (const fallbackDtype of (DTYPE_FALLBACK[modelQuantization] ?? []))
+      attempts.push({ dtype: fallbackDtype, device })
+    for (const fallbackDevice of (DEVICE_FALLBACK[device] ?? []))
+      attempts.push({ dtype: modelQuantization, device: fallbackDevice })
+
+    let lastError: unknown
+    for (const attempt of attempts) {
+      try {
+        ttsModel = await KokoroTTS.from_pretrained(
+          MODEL_IDS.KOKORO,
+          {
+            dtype: attempt.dtype as 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16',
+            device: attempt.device as 'wasm' | 'webgpu' | 'cpu',
+            progress_callback: (progress: any) => {
+              const msg: ProgressResponse = {
+                type: 'progress',
+                requestId,
+                payload: {
+                  phase: 'download',
+                  // NOTICE: raw.progress from kokoro-js/@huggingface/transformers is already 0-100
+                  percent: progress?.progress ?? -1,
+                  message: progress?.status,
+                  file: progress?.file,
+                  loaded: progress?.loaded,
+                  total: progress?.total,
+                },
+              }
+              globalThis.postMessage(msg)
             },
-          }
-          globalThis.postMessage(msg)
-        },
-      },
-    )
+          },
+        )
 
-    currentQuantization = quantization
-    currentDevice = device
+        currentQuantization = quantization
+        currentDevice = attempt.device
 
-    const ready: ModelReadyResponse = {
-      type: 'model-ready',
-      requestId,
-      modelId: MODEL_NAMES.KOKORO,
-      device: device as 'webgpu' | 'wasm' | 'cpu',
-      metadata: { voices: ttsModel.voices },
+        const ready: ModelReadyResponse = {
+          type: 'model-ready',
+          requestId,
+          modelId: MODEL_NAMES.KOKORO,
+          device: attempt.device as 'webgpu' | 'wasm' | 'cpu',
+          metadata: {
+            voices: ttsModel.voices,
+            actualDtype: attempt.dtype,
+            actualDevice: attempt.device,
+          },
+        }
+        globalThis.postMessage(ready)
+        return
+      }
+      catch (error) {
+        lastError = error
+        console.warn(
+          `[Kokoro Worker] Failed with dtype=${attempt.dtype} device=${attempt.device}, trying next fallback...`,
+          error instanceof Error ? error.message : error,
+        )
+      }
     }
-    globalThis.postMessage(ready)
+
+    // All attempts exhausted
+    sendError(requestId, lastError ?? new Error('All dtype/device combinations failed'), 'load')
   }
   catch (error) {
-    sendError(requestId, error)
+    sendError(requestId, error, 'load')
   }
 }
 
@@ -170,7 +216,7 @@ async function runInference(request: RunInferenceRequest<KokoroInferenceInput>):
     ;(globalThis as any).postMessage(result, [samples.buffer])
   }
   catch (error) {
-    sendError(requestId, error)
+    sendError(requestId, error, 'inference')
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses **Phase 1** of the inference infrastructure roadmap (#1661). Six correctness and resilience issues fixed across adapters, workers, and the unified protocol layer.

**Scope:** `packages/stage-ui/src/libs/inference/`, `packages/stage-ui/src/libs/workers/`, `packages/stage-ui/src/workers/`

---

## Problems & Motivation

### 1. Kokoro Singleton cannot recover from terminal state

`getKokoroAdapter()` creates a singleton that is never reset. Once the adapter reaches `terminated` or `error` (restarts exhausted), the singleton is permanently dead -- users must refresh the page.

**Root cause:** `globalAdapter` is only re-created when `null`, never checks the state of the existing instance. `scheduleRestart()` silently returns when retries are exhausted, leaving state stuck at `'error'` instead of transitioning to `'terminated'`.

**Fix:**
- `getKokoroAdapter()` now detects `terminated` / `error` states and re-creates the adapter automatically
- `scheduleRestart()` in both Kokoro and Whisper adapters transitions to `'terminated'` when max restarts are exhausted, making the dead state detectable

### 2. `voices!` non-null assertion after nullable assignment

`kokoro.ts:275` assigns `voices = (response.metadata?.voices as Voices) ?? null` (can be null), but L288 returns `voices!` -- if the worker returns unexpected metadata, callers receive `null` but the type system promises `Voices`, causing downstream crashes.

**Fix:** Replaced with explicit null check + throw, routing into the existing error recovery path.

### 3. Whisper Worker silently drops concurrent requests

The worker's `runInference()` has `if (processing) return` which silently drops the request. The adapter's `waitForMessage()` never receives a response, causing the Promise to hang for 120 seconds until timeout.

**Root cause:** The bare boolean is safe in a single-threaded worker -- the real bug is the silent `return` with no error response.

**Fix:** Replaced with `sendError(requestId, ...)` so the adapter receives an immediate rejection.

### 4. Whisper adapter leaks event listeners on worker restart

`ensureWorker()` attaches anonymous `message` and `error` listeners each time a new Worker is created. `destroyWorker()` only calls `worker.terminate()` without removing listeners. On restart paths (`scheduleRestart -> ensureWorker`), old Worker listener closures may prevent GC.

**Impact:** Whisper is most critical (2 listeners + restart logic). Kokoro and Background Removal have the same pattern but lower risk.

**Fix:** All 3 adapters now store listener references and call `removeEventListener` before `terminate()`. Whisper's `terminateAdapter()` routes through `destroyWorker()` instead of direct `worker.terminate()`.

### 5. Error classification is incomplete

`classifyError()` only matches 3 string patterns (OOM, DEVICE_LOST, TIMEOUT). `LOAD_FAILED` and `INFERENCE_FAILED` are defined in the `InferenceErrorCode` type but never produced. All workers hardcode `recoverable: false`.

**Fix:**
- `classifyError(error, phase?)` gains a `phase` parameter: specific patterns (OOM etc.) take priority, unmatched errors fall through to `LOAD_FAILED` / `INFERENCE_FAILED` based on phase
- New `isRecoverable(code)` helper: TIMEOUT and DEVICE_LOST are recoverable
- All 3 workers' `sendError()` updated to pass phase and use dynamic recoverability

### 6. No dtype/device fallback chain

Kokoro Worker attempts model loading once with the requested dtype; failure is terminal. Whisper Worker hardcodes `encoder_model: 'fp16'` which crashes on devices that don't support it.

**Fix:**
- **Kokoro Worker:** New `DTYPE_FALLBACK` and `DEVICE_FALLBACK` maps. Tries `fp16 -> fp32 -> q8 -> q4` on the same device, then `webgpu -> wasm` device fallback. Reports `actualDtype` and `actualDevice` in `ModelReadyResponse.metadata`
- **Whisper Worker:** Wraps fp16 encoder load in try-catch; falls back to fp32

---

## State after changes

| Component | Before | After |
|-----------|--------|-------|
| Kokoro singleton | Returns dead instance forever after terminal error | Auto-detects and re-creates |
| `voices` return | `voices!` can return null, lying to type system | Explicit throw, enters error recovery path |
| Whisper Worker concurrency | Silent drop, Promise hangs 120s | Immediate error response |
| Event listeners | Anonymous, never cleaned up | Stored references, removeEventListener on destroy |
| Error classification | 4/6 codes reachable, recoverable hardcoded false | 6/6 codes reachable, dynamic recoverability |
| dtype loading | Single attempt, failure is terminal | Progressive fallback chain, reports actual config used |

---

## Files changed

| File | Changes |
|------|---------|
| `libs/inference/protocol.ts` | `classifyError` phase param, new `isRecoverable` helper |
| `libs/inference/protocol.test.ts` | **New** -- 14 tests for classification and recoverability |
| `libs/workers/worker.ts` | Silent drop fix, sendError phase, fp16 fallback |
| `workers/kokoro/worker.ts` | sendError phase, dtype/device fallback chain |
| `workers/background-removal/worker.ts` | sendError phase |
| `libs/inference/adapters/whisper.ts` | Listener cleanup, terminateAdapter uses destroyWorker, scheduleRestart terminal state |
| `libs/inference/adapters/kokoro.ts` | Singleton recovery, voices assertion fix, listener cleanup, scheduleRestart terminal state |
| `libs/inference/adapters/kokoro.test.ts` | **New** -- 5 tests for singleton and state transitions |
| `libs/inference/adapters/background-removal.ts` | Listener cleanup, extracted destroyWorker |

## Test plan

- [x] `pnpm exec vitest run packages/stage-ui/src/libs/inference/` -- 30/30 tests pass (protocol, kokoro adapter, GPU coordinator, load queue)
- [x] `pnpm -F @proj-airi/stage-ui typecheck` -- clean
- [x] `npx eslint` on all 9 changed files -- clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
