### PR TITLE
fix(stage-tamagotchi): hide chat input scrollbar when content fits

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -252,12 +252,12 @@ async function handleDeleteMessage(index: number) {
       v-model="messageInput"
       :submit-on-enter="false"
       :placeholder="t('stage.message')"
-      class="ph-no-capture"
+      class="ph-no-capture [scrollbar-gutter:stable]"
       text="primary-600 dark:primary-100  placeholder:primary-500 dark:placeholder:primary-200"
       border="solid 2 primary-200/20 dark:primary-400/20"
       bg="primary-100/50 dark:primary-900/70"
       max-h="[10lh]" min-h="[1lh]"
-      [scrollbar-gutter:stable] w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none
+      w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none
       transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
       @compositionstart="isComposing = true"
       @compositionend="isComposing = false"

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -257,7 +257,7 @@ async function handleDeleteMessage(index: number) {
       border="solid 2 primary-200/20 dark:primary-400/20"
       bg="primary-100/50 dark:primary-900/70"
       max-h="[10lh]" min-h="[1lh]"
-      w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none [scrollbar-gutter:stable]
+      [scrollbar-gutter:stable] w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none
       transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
       @compositionstart="isComposing = true"
       @compositionend="isComposing = false"

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -257,7 +257,7 @@ async function handleDeleteMessage(index: number) {
       border="solid 2 primary-200/20 dark:primary-400/20"
       bg="primary-100/50 dark:primary-900/70"
       max-h="[10lh]" min-h="[1lh]"
-      w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none
+      w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none [scrollbar-gutter:stable]
       transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
       @compositionstart="isComposing = true"
       @compositionend="isComposing = false"

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -257,7 +257,7 @@ async function handleDeleteMessage(index: number) {
       border="solid 2 primary-200/20 dark:primary-400/20"
       bg="primary-100/50 dark:primary-900/70"
       max-h="[10lh]" min-h="[1lh]"
-      w-full shrink-0 resize-none overflow-y-scroll rounded-xl p-2 font-medium outline-none
+      w-full shrink-0 resize-none overflow-y-auto rounded-xl p-2 font-medium outline-none
       transition="all duration-250 ease-in-out placeholder:all placeholder:duration-250 placeholder:ease-in-out"
       @compositionstart="isComposing = true"
       @compositionend="isComposing = false"


### PR DESCRIPTION
Fixes #1567

## Problem

The chat input textarea in the desktop app (stage-tamagotchi) uses `overflow-y-scroll`, which forces the browser to always render a vertical scrollbar, even when the input is empty or contains only a small amount of text. This makes the UI look visually broken.

## Solution

Changed `overflow-y-scroll` to `overflow-y-auto` in `apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue`.

With `overflow-y-auto`:
- No scrollbar is shown when content fits within the textarea's height (auto-resize keeps height == scrollHeight)
- Scrollbar appears only when content exceeds the `max-h` constraint (`10lh`)

This matches the expected behavior described in the issue.

## Testing

- Open the desktop app (stage-tamagotchi)
- Verify the chat input shows no scrollbar when empty or with a short message
- Type a long multi-line message that exceeds the max height and verify a scrollbar appears