### PR TITLE
fix(server): trust https localhost and loopback for mkcert Vite dev

### DIFF
--- a/apps/server/src/utils/origin.ts
+++ b/apps/server/src/utils/origin.ts
@@ -19,21 +19,25 @@ const TRUSTED_ORIGIN_PATTERNS = [
   /^http:\/\/localhost(:\d+)?$/,
   // Loopback interface for Electron OIDC callbacks (RFC 8252 S7.3)
   /^http:\/\/127\.0\.0\.1(:\d+)?$/,
+  // Vite + mkcert (https://localhost:5273, etc.)
+  /^https:\/\/localhost(:\d+)?$/,
+  /^https:\/\/127\.0\.0\.1(:\d+)?$/,
   // Cloudflare Workers subdomains
   /^https:\/\/.*\.kwaa\.workers\.dev$/,
 ]
 
 export function getTrustedOrigin(origin: string): string {
+  let resolved: string
   if (!origin)
-    return origin
+    resolved = origin
+  else if (TRUSTED_EXACT_ORIGINS.includes(origin))
+    resolved = origin
+  else if (TRUSTED_ORIGIN_PATTERNS.some(pattern => pattern.test(origin)))
+    resolved = origin
+  else
+    resolved = ''
 
-  if (TRUSTED_EXACT_ORIGINS.includes(origin))
-    return origin
-
-  if (TRUSTED_ORIGIN_PATTERNS.some(pattern => pattern.test(origin)))
-    return origin
-
-  return ''
+  return resolved
 }
 
 export function resolveTrustedRequestOrigin(request: Request): string | undefined {

--- a/apps/server/src/utils/origin.ts
+++ b/apps/server/src/utils/origin.ts
@@ -27,17 +27,16 @@ const TRUSTED_ORIGIN_PATTERNS = [
 ]
 
 export function getTrustedOrigin(origin: string): string {
-  let resolved: string
   if (!origin)
-    resolved = origin
-  else if (TRUSTED_EXACT_ORIGINS.includes(origin))
-    resolved = origin
-  else if (TRUSTED_ORIGIN_PATTERNS.some(pattern => pattern.test(origin)))
-    resolved = origin
-  else
-    resolved = ''
+    return origin
 
-  return resolved
+  if (TRUSTED_EXACT_ORIGINS.includes(origin))
+    return origin
+
+  if (TRUSTED_ORIGIN_PATTERNS.some(pattern => pattern.test(origin)))
+    return origin
+
+  return ''
 }
 
 export function resolveTrustedRequestOrigin(request: Request): string | undefined {

--- a/apps/server/src/utils/tests/origin.test.ts
+++ b/apps/server/src/utils/tests/origin.test.ts
@@ -7,6 +7,11 @@ describe('origin utils', () => {
     expect(getTrustedOrigin('http://localhost:5173')).toBe('http://localhost:5173')
   })
 
+  it('allows https localhost (mkcert dev)', () => {
+    expect(getTrustedOrigin('https://localhost:5273')).toBe('https://localhost:5273')
+    expect(getTrustedOrigin('https://127.0.0.1:5273')).toBe('https://127.0.0.1:5273')
+  })
+
   it('rejects untrusted origins', () => {
     expect(getTrustedOrigin('https://example.com')).toBe('')
   })


### PR DESCRIPTION
## Description

Treat `https://localhost` and loopback origins as trusted during development when using mkcert for HTTPS, so origin checks stay compatible with Vite local HTTPS setups.

## Linked Issues

None

## Additional Context

None