### PR TITLE
chore(docs): add missing tamagotchi setup-and-use page to sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -295,7 +295,7 @@ export default defineConfig<ThemeConfig>({
                 ],
               },
               {
-                text: '用户手册',
+                text: '安装与使用',
                 link: withBase('/zh-Hans/docs/manual/tamagotchi/setup-and-use/'),
               },
               {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -152,7 +152,7 @@ export default defineConfig<ThemeConfig>({
                   { text: 'Web Version', link: withBase('/en/docs/manual/web/') },
                 ],
               },
-              { text: 'Project AIRI Manual', link: withBase('/en/docs/manual/tamagotchi/setup-and-use/') },
+              { text: 'Setup and Use', link: withBase('/en/docs/manual/tamagotchi/setup-and-use/') },
               {
                 text: 'Configuration',
                 items: [

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -152,6 +152,7 @@ export default defineConfig<ThemeConfig>({
                   { text: 'Web Version', link: withBase('/en/docs/manual/web/') },
                 ],
               },
+              { text: 'Project AIRI Manual', link: withBase('/en/docs/manual/tamagotchi/setup-and-use/') },
               {
                 text: 'Configuration',
                 items: [
@@ -292,6 +293,10 @@ export default defineConfig<ThemeConfig>({
                   { text: '桌面版', link: withBase('/zh-Hans/docs/manual/tamagotchi/') },
                   { text: '网页版', link: withBase('/zh-Hans/docs/manual/web/') },
                 ],
+              },
+              {
+                text: '用户手册',
+                link: withBase('/zh-Hans/docs/manual/tamagotchi/setup-and-use/'),
               },
               {
                 text: '配置',


### PR DESCRIPTION
### 修复内容 (Fix)
补充了一个已存在但未被收录到侧边栏导航中的页面。

- **新增路径**: `/docs/manual/tamagotchi/setup-and-use/`
- **位置**: 用户手册 -> 安装与使用

*此 PR 响应了 @nekomeowww 的反馈，拆分为独立的小型 PR 以加快 Merge 速度。*