### PR TITLE
fix(stage-tamagotchi): render server-channel QR always as dark-on-light

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/settings/connection/server-channel-qr-card.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/connection/server-channel-qr-card.vue
@@ -3,7 +3,7 @@ import type { ServerChannelQrPayload } from '@proj-airi/stage-shared/server-chan
 
 import { errorMessageFrom } from '@moeru/std'
 import { useElectronEventaInvoke } from '@proj-airi/electron-vueuse'
-import { Button, Callout, Collapsible, useTheme } from '@proj-airi/ui'
+import { Button, Callout, Collapsible } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { renderSVG } from 'uqr'
 import { computed, shallowRef, watch } from 'vue'
@@ -12,7 +12,6 @@ import { useI18n } from 'vue-i18n'
 import { electronGetServerChannelQrPayload } from '../../../../shared/eventa'
 import { useServerChannelSettingsStore } from '../../../stores/settings/server-channel'
 
-const { isDark } = useTheme()
 const { t } = useI18n()
 const getServerChannelQrPayload = useElectronEventaInvoke(electronGetServerChannelQrPayload)
 const { authToken, hostname, tlsConfig } = storeToRefs(useServerChannelSettingsStore())
@@ -34,12 +33,22 @@ const qrCodeSource = computed(() => {
     return ''
   }
 
+  // NOTICE:
+  // Always render the QR as dark foreground on a white background, regardless of
+  // theme. Some mobile barcode scanners (including the underlying reader used by
+  // `@capacitor/barcode-scanner` on Android) fail to detect color-inverted QRs,
+  // which is what the previous theme-aware palette produced in dark mode.
+  // See https://github.com/moeru-ai/airi/issues/1606 and
+  // https://github.com/ionic-team/capacitor-barcode-scanner/issues/60 for context.
+  // Removal condition: once the Android scanner reliably recognizes light-on-dark QRs
+  // (e.g. after migrating to ML Kit with `TryInverted` enabled), this can revert to
+  // a theme-aware palette.
   const svg = renderSVG(payloadText.value, {
     border: 2,
     ecc: 'M',
     pixelSize: 8,
-    whiteColor: 'transparent',
-    blackColor: isDark.value ? '#D5D5D5' : '#121212',
+    whiteColor: '#FFFFFF',
+    blackColor: '#121212',
   })
 
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`


### PR DESCRIPTION
## Description

The server-channel connection card in Tamagotchi generated the pairing QR with `whiteColor: 'transparent'` and a theme-dependent foreground, so in dark mode the matrix rendered as light pixels on a dark background — a color-inverted QR.

The reader that backs `@capacitor/barcode-scanner` on Android does not detect color-inverted QRs (see [`ionic-team/capacitor-barcode-scanner#60`](https://github.com/ionic-team/capacitor-barcode-scanner/issues/60)), so Stage Pocket on Android silently failed to scan the pairing QR whenever Tamagotchi was in dark mode.

This PR drops the theme hookup in `server-channel-qr-card.vue` and renders the QR with a white background and dark foreground in both themes, so the encoded matrix is always within the scanner's expected polarity. A `// NOTICE:` comment explains the constraint and the removal condition so the theme-aware palette can come back once the mobile scanner side is upgraded (e.g. to ML Kit with `TryInverted`).

## Linked Issues

Fixes #1606

## Additional Context

- Reviewers may want to sanity-check the visual result in dark mode: the QR is now a small bright card inside the dark settings surface, which is consistent with how other dark-mode apps show QR codes that have to be scanned by a phone camera.
- Scope is intentionally limited to `server-channel-qr-card.vue` since it is the only `renderSVG` call in the repo (verified via grep over `packages/` and `apps/`).
- `pnpm -F @proj-airi/stage-tamagotchi typecheck` and `pnpm exec moeru-lint ...` on the changed file were run locally and both pass.