### PR TITLE
fix(stage-tamagotchi): show friendly empty state when widgets window has no id

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/widgets.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/widgets.vue
@@ -3,9 +3,12 @@ import type { WidgetSnapshot, WidgetWindowSize } from '../../shared/eventa'
 
 import { useElectronEventaContext, useElectronEventaInvoke } from '@proj-airi/electron-vueuse'
 import { computed, defineAsyncComponent, defineComponent, h, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
 import { widgetsClearEvent, widgetsFetch, widgetsRemove, widgetsRemoveEvent, widgetsRenderEvent, widgetsUpdateEvent } from '../../shared/eventa'
+
+const { t } = useI18n()
 
 type SizePreset = 's' | 'm' | 'l' | { cols?: number, rows?: number }
 
@@ -203,23 +206,38 @@ function handleClose() {
 </script>
 
 <template>
-  <div class="relative h-full w-full">
+  <div :class="['relative h-full w-full']">
     <button
       :class="[
         'absolute right-2 top-2 z-10 size-7 rounded-full text-xs text-white transition',
         'bg-black/40 hover:bg-black/60',
       ]"
-      title="Close widget"
+      :title="t('tamagotchi.stage.widgets.close')"
+      :aria-label="t('tamagotchi.stage.widgets.close')"
       @click="handleClose"
     >
       ✕
     </button>
-    <div v-if="!widgetId" class="h-full flex items-center justify-center">
-      <div class="rounded-xl bg-neutral-900/40 px-4 py-3 text-sm text-neutral-200/80 backdrop-blur">
-        Missing widget id. Launch the window via a component call to populate this view.
+    <div v-if="!widgetId" :class="['h-full flex items-center justify-center p-6']">
+      <div
+        :class="[
+          'max-w-xs flex flex-col items-center gap-3 text-center',
+          'rounded-xl bg-neutral-900/40 px-5 py-4 backdrop-blur',
+          'text-neutral-200/80',
+        ]"
+      >
+        <div :class="['i-solar:widget-4-line-duotone size-8 text-neutral-300/80']" />
+        <div :class="['flex flex-col gap-1']">
+          <div :class="['text-sm font-medium text-neutral-100']">
+            {{ t('tamagotchi.stage.widgets.empty.title') }}
+          </div>
+          <p :class="['m-0 text-xs leading-5']">
+            {{ t('tamagotchi.stage.widgets.empty.description') }}
+          </p>
+        </div>
       </div>
     </div>
-    <div v-else-if="widget" class="relative h-full">
+    <div v-else-if="widget" :class="['relative h-full']">
       <component
         :is="resolveWidgetComponent(widget.componentName)"
         :id="widget.id"
@@ -230,9 +248,9 @@ function handleClose() {
         v-bind="widget.componentProps"
       />
     </div>
-    <div v-else class="h-full flex items-center justify-center">
-      <div class="rounded-xl bg-neutral-900/40 px-4 py-3 text-sm text-neutral-200/80 backdrop-blur">
-        {{ loading ? 'Loading widget...' : `Waiting for widget data for "${widgetId}"` }}
+    <div v-else :class="['h-full flex items-center justify-center']">
+      <div :class="['rounded-xl bg-neutral-900/40 px-4 py-3 text-sm text-neutral-200/80 backdrop-blur']">
+        {{ loading ? t('tamagotchi.stage.widgets.loading') : t('tamagotchi.stage.widgets.waiting', { id: widgetId }) }}
       </div>
     </div>
   </div>

--- a/packages/i18n/src/locales/en/tamagotchi/stage.yaml
+++ b/packages/i18n/src/locales/en/tamagotchi/stage.yaml
@@ -30,6 +30,14 @@ docs:
   'account': Account
   'logout': Sign out
 
+widgets:
+  close: Close widget
+  empty:
+    title: No widget active
+    description: Widgets will appear here when a tool or plugin spawns one.
+  loading: Loading widget…
+  waiting: Waiting for widget data for "{id}"…
+
 notice:
   'fade-on-hover':
     title: Fade on Hover


### PR DESCRIPTION
## Description

The tray entry `Open Widgets` calls `WidgetsWindowManager.getWindow()` without first preparing a widget id, so the renderer route `/widgets` loads with an empty `?id=` query. The renderer then rendered the developer-facing string

> `Missing widget id. Launch the window via a component call to populate this view.`

which was clearly intended as a debug placeholder, not end-user copy.

This PR replaces the placeholder with a proper localized empty state (icon + heading + description) that tells the user no widgets are active yet and that they will appear when a tool or plugin spawns one. While touching the template, the remaining hard-coded English strings (`Loading widget...`, the backtick-template `Waiting for widget data for "${widgetId}"`, and the `title` on the close button) are also moved behind i18n keys and wired up through `vue-i18n`.

### i18n

- New keys live under `tamagotchi.stage.widgets` in the English locale (`packages/i18n/src/locales/en/tamagotchi/stage.yaml`).
- Non-English locales fall back to `en` through the existing `fallbackLocale: 'en'` config in each renderer's `modules/i18n.ts`, so no translation regressions. Crowdin will pick up the new keys on the next sync (per `crowdin.yml`).

### Small drive-by cleanup

- The touched template is migrated from inline `class=\"...\"` strings to the `:class=\"[...]\"` array style called for in `AGENTS.md` (Styling & Components).

## Linked Issues

Fixes #1597

## Additional Context

- `pnpm -F @proj-airi/stage-tamagotchi typecheck` and `pnpm -F @proj-airi/i18n typecheck` pass locally on the change.
- `pnpm exec moeru-lint ...` on both changed files reports `0 warnings and 0 errors`.
- `pnpm -F @proj-airi/stage-tamagotchi exec vitest run` shows two pre-existing failures unrelated to this change (`src/main/services/airi/plugins/index.test.ts` and `src/renderer/stores/tools/builtin/image-journal.test.ts`, both also failing on `main` at `c6c04949`).
- The deeper UX question of whether the tray should spawn the widgets window at all when there are no active widgets is left out of scope — this PR only ensures the surface the user is dropped onto is friendly.