### PR TITLE
feat(computer-use-mcp): add transcript truth source and safe projection

### DIFF
--- a/services/computer-use-mcp/src/transcript/block-parser.ts
+++ b/services/computer-use-mcp/src/transcript/block-parser.ts
@@ -79,19 +79,28 @@ export function parseTranscriptBlocks(entries: readonly TranscriptEntry[]): Tran
         // Consume contiguous tool messages that match claimed ids
         while (j < entries.length && entries[j].role === 'tool') {
           const toolEntry = entries[j]
-          if (
-            toolEntry.toolCallId
-            && claimedIds.has(toolEntry.toolCallId)
-            && !seenResultIds.has(toolEntry.toolCallId)
-          ) {
-            seenResultIds.add(toolEntry.toolCallId)
-            toolResults.push(toolEntry)
-            lastId = toolEntry.id
-            j++
-          }
-          else {
+
+          if (!toolEntry.toolCallId || !claimedIds.has(toolEntry.toolCallId)) {
+            // Not claimed by this block — stop consuming; this entry belongs to
+            // the next block (orphan handling or a separate assistant turn).
             break
           }
+
+          if (seenResultIds.has(toolEntry.toolCallId)) {
+            // NOTICE: Duplicate tool result row for an already-consumed id.
+            // In normal append-only flow this should not occur, but retry/replay
+            // can surface it. We skip the duplicate (j++) rather than break so
+            // that later valid results for other declared tool_call_ids are still
+            // attached to this block. Example: [tc1, tc1(dup), tc2] → tc2 must
+            // still be consumed here, not left orphaned for the next block.
+            j++
+            continue
+          }
+
+          seenResultIds.add(toolEntry.toolCallId)
+          toolResults.push(toolEntry)
+          lastId = toolEntry.id
+          j++
         }
 
         const block: ToolInteractionBlock = {

--- a/services/computer-use-mcp/src/transcript/block-parser.ts
+++ b/services/computer-use-mcp/src/transcript/block-parser.ts
@@ -1,0 +1,129 @@
+/**
+ * Block Parser - groups flat TranscriptEntry[] into logical TranscriptBlock[].
+ *
+ * A TranscriptBlock is the atomic unit of prompt projection: you never split
+ * a block. Either the whole block goes into the prompt, or it gets compacted.
+ *
+ * Block types:
+ *   - ToolInteractionBlock: assistant(tool_calls) + matching tool results
+ *   - TextBlock: assistant text-only (no tool_calls)
+ *   - UserBlock: user message
+ *   - SystemBlock: system message
+ */
+
+import type {
+  SystemBlock,
+  TextBlock,
+  ToolInteractionBlock,
+  TranscriptBlock,
+  TranscriptEntry,
+  UserBlock,
+} from './types'
+
+/**
+ * Parse a flat array of transcript entries into an ordered sequence of blocks.
+ *
+ * Walk forward through entries:
+ *   - `role:system` -> SystemBlock
+ *   - `role:user` -> UserBlock
+ *   - `role:assistant` with `toolCalls` -> ToolInteractionBlock
+ *     (consumes subsequent `role:tool` entries matching the claimed ids)
+ *   - `role:assistant` without `toolCalls` -> TextBlock
+ *   - `role:tool` without a preceding assistant -> treated as orphan,
+ *     wrapped in a TextBlock defensively (should not appear in valid sequences)
+ */
+export function parseTranscriptBlocks(entries: readonly TranscriptEntry[]): TranscriptBlock[] {
+  const blocks: TranscriptBlock[] = []
+  let i = 0
+
+  while (i < entries.length) {
+    const entry = entries[i]
+
+    if (entry.role === 'system') {
+      const block: SystemBlock = {
+        kind: 'system',
+        entry,
+        entryIdRange: [entry.id, entry.id],
+      }
+      blocks.push(block)
+      i++
+      continue
+    }
+
+    if (entry.role === 'user') {
+      const block: UserBlock = {
+        kind: 'user',
+        entry,
+        entryIdRange: [entry.id, entry.id],
+      }
+      blocks.push(block)
+      i++
+      continue
+    }
+
+    if (entry.role === 'assistant') {
+      if (entry.toolCalls && entry.toolCalls.length > 0) {
+        // ToolInteractionBlock: assistant + all matching tool results
+        const claimedIds = new Set<string>(entry.toolCalls.map(tc => tc.id))
+        const toolResults: TranscriptEntry[] = []
+        let lastId = entry.id
+        let j = i + 1
+
+        // Consume contiguous tool messages that match claimed ids
+        while (j < entries.length && entries[j].role === 'tool') {
+          const toolEntry = entries[j]
+          if (toolEntry.toolCallId && claimedIds.has(toolEntry.toolCallId)) {
+            toolResults.push(toolEntry)
+            lastId = toolEntry.id
+            j++
+          }
+          else {
+            break
+          }
+        }
+
+        const block: ToolInteractionBlock = {
+          kind: 'tool_interaction',
+          assistant: entry,
+          toolResults,
+          entryIdRange: [entry.id, lastId],
+        }
+        blocks.push(block)
+        i = j
+      }
+      else {
+        // TextBlock: plain assistant text
+        const block: TextBlock = {
+          kind: 'text',
+          entry,
+          entryIdRange: [entry.id, entry.id],
+        }
+        blocks.push(block)
+        i++
+      }
+      continue
+    }
+
+    if (entry.role === 'tool') {
+      // Orphan tool message - defensive wrapping.
+      // NOTICE: This should not happen in valid sequences. If it does,
+      // something upstream produced a broken tool result without a matching
+      // assistant tool_call. We wrap it so it remains representable for
+      // compaction/inspection, even though provider-facing projection may
+      // still filter `TextBlock` entries whose `entry.role === 'tool'`.
+      const block: TextBlock = {
+        kind: 'text',
+        entry,
+        entryIdRange: [entry.id, entry.id],
+      }
+      blocks.push(block)
+      i++
+      continue
+    }
+
+    // Unknown role - skip
+    i++
+  }
+
+  return blocks
+}

--- a/services/computer-use-mcp/src/transcript/block-parser.ts
+++ b/services/computer-use-mcp/src/transcript/block-parser.ts
@@ -1,5 +1,5 @@
 /**
- * Block Parser - groups flat TranscriptEntry[] into logical TranscriptBlock[].
+ * Block Parser — groups flat TranscriptEntry[] into logical TranscriptBlock[].
  *
  * A TranscriptBlock is the atomic unit of prompt projection: you never split
  * a block. Either the whole block goes into the prompt, or it gets compacted.
@@ -24,12 +24,12 @@ import type {
  * Parse a flat array of transcript entries into an ordered sequence of blocks.
  *
  * Walk forward through entries:
- *   - `role:system` -> SystemBlock
- *   - `role:user` -> UserBlock
- *   - `role:assistant` with `toolCalls` -> ToolInteractionBlock
+ *   - `role:system` → SystemBlock
+ *   - `role:user` → UserBlock
+ *   - `role:assistant` with `toolCalls` → ToolInteractionBlock
  *     (consumes subsequent `role:tool` entries matching the claimed ids)
- *   - `role:assistant` without `toolCalls` -> TextBlock
- *   - `role:tool` without a preceding assistant -> treated as orphan,
+ *   - `role:assistant` without `toolCalls` → TextBlock
+ *   - `role:tool` without a preceding assistant → treated as orphan,
  *     wrapped in a TextBlock defensively (should not appear in valid sequences)
  */
 export function parseTranscriptBlocks(entries: readonly TranscriptEntry[]): TranscriptBlock[] {
@@ -66,13 +66,25 @@ export function parseTranscriptBlocks(entries: readonly TranscriptEntry[]): Tran
         // ToolInteractionBlock: assistant + all matching tool results
         const claimedIds = new Set<string>(entry.toolCalls.map(tc => tc.id))
         const toolResults: TranscriptEntry[] = []
+        // NOTICE: seenResultIds guards against duplicate tool result rows for the
+        // same tool_call_id. In normal flow the store is append-only and won't
+        // produce duplicates, but retry/replay edge cases can surface them.
+        // Deduplicating here (keeping the first occurrence) ensures projection
+        // never emits multiple tool messages for the same id, which most
+        // providers reject as invalid conversation state.
+        const seenResultIds = new Set<string>()
         let lastId = entry.id
         let j = i + 1
 
         // Consume contiguous tool messages that match claimed ids
         while (j < entries.length && entries[j].role === 'tool') {
           const toolEntry = entries[j]
-          if (toolEntry.toolCallId && claimedIds.has(toolEntry.toolCallId)) {
+          if (
+            toolEntry.toolCallId
+            && claimedIds.has(toolEntry.toolCallId)
+            && !seenResultIds.has(toolEntry.toolCallId)
+          ) {
+            seenResultIds.add(toolEntry.toolCallId)
             toolResults.push(toolEntry)
             lastId = toolEntry.id
             j++
@@ -105,12 +117,10 @@ export function parseTranscriptBlocks(entries: readonly TranscriptEntry[]): Tran
     }
 
     if (entry.role === 'tool') {
-      // Orphan tool message - defensive wrapping.
+      // Orphan tool message — defensive wrapping.
       // NOTICE: This should not happen in valid sequences. If it does,
       // something upstream produced a broken tool result without a matching
-      // assistant tool_call. We wrap it so it remains representable for
-      // compaction/inspection, even though provider-facing projection may
-      // still filter `TextBlock` entries whose `entry.role === 'tool'`.
+      // assistant tool_call. We wrap it so it doesn't get silently lost.
       const block: TextBlock = {
         kind: 'text',
         entry,
@@ -121,7 +131,7 @@ export function parseTranscriptBlocks(entries: readonly TranscriptEntry[]): Tran
       continue
     }
 
-    // Unknown role - skip
+    // Unknown role — skip
     i++
   }
 

--- a/services/computer-use-mcp/src/transcript/compactor.ts
+++ b/services/computer-use-mcp/src/transcript/compactor.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic Compactor - summarizes transcript blocks without LLM calls.
+ *
+ * When a transcript block is removed from the prompt, the compactor generates
+ * a lightweight, deterministic summary so the model doesn't experience a
+ * complete context blackout in the middle of the conversation.
+ *
+ * Rules:
+ *   - Tool interaction blocks: tool name and deterministic result snippets
+ *   - Text blocks: truncated first N chars of the assistant text
+ *   - User blocks: truncated first N chars
+ *   - System blocks: "[system message]"
+ *   - Compacted blocks are explicitly tagged; they cannot be confused with
+ *     original transcript entries.
+ */
+
+import type { CompactedBlock, TranscriptBlock } from './types'
+
+/** Maximum characters for content snippets in compacted summaries. */
+const SUMMARY_SNIPPET_LENGTH = 120
+
+/**
+ * Coerce transcript entry content to a string for summarization.
+ * Handles the widened `string | unknown[]` content type.
+ */
+function contentToString(content: string | unknown[] | undefined): string {
+  if (content === undefined || content === null)
+    return ''
+  if (typeof content === 'string')
+    return content
+  if (Array.isArray(content)) {
+    // Extract text parts from structured content arrays
+    return content
+      .map((part) => {
+        if (typeof part === 'string')
+          return part
+        if (isTextContentPart(part))
+          return part.text
+        return ''
+      })
+      .filter(Boolean)
+      .join(' ')
+  }
+  return String(content)
+}
+
+function isTextContentPart(part: unknown): part is { type: 'text', text: string } {
+  if (typeof part !== 'object' || part === null)
+    return false
+  const record = part as { type?: unknown, text?: unknown }
+  return record.type === 'text' && typeof record.text === 'string'
+}
+
+/**
+ * Truncate a string to the snippet length, appending '...' if truncated.
+ */
+function snippet(text: string): string {
+  if (text.length <= SUMMARY_SNIPPET_LENGTH)
+    return text
+  return `${text.slice(0, SUMMARY_SNIPPET_LENGTH)}...`
+}
+
+/**
+ * Generate a deterministic compacted summary for a transcript block.
+ */
+export function compactBlock(block: TranscriptBlock): CompactedBlock {
+  switch (block.kind) {
+    case 'tool_interaction': {
+      const toolNames = (block.assistant.toolCalls ?? [])
+        .map(tc => tc.function.name)
+        .join(', ')
+
+      const resultSummaries = block.toolResults.map((tr) => {
+        const text = contentToString(tr.content)
+        return `${tr.toolCallId}: ${snippet(text)}`
+      })
+
+      const summary = [
+        `[Compacted tool interaction] Tools: ${toolNames}`,
+        ...resultSummaries.map(r => `  ${r}`),
+      ].join('\n')
+
+      return {
+        kind: 'compacted',
+        originalKind: 'tool_interaction',
+        summary,
+        entryIdRange: block.entryIdRange,
+      }
+    }
+
+    case 'text': {
+      const text = contentToString(block.entry.content)
+      return {
+        kind: 'compacted',
+        originalKind: 'text',
+        summary: `[Compacted ${block.entry.role} text] ${snippet(text)}`,
+        entryIdRange: block.entryIdRange,
+      }
+    }
+
+    case 'user': {
+      const text = contentToString(block.entry.content)
+      return {
+        kind: 'compacted',
+        originalKind: 'user',
+        summary: `[Compacted user message] ${snippet(text)}`,
+        entryIdRange: block.entryIdRange,
+      }
+    }
+
+    case 'system': {
+      return {
+        kind: 'compacted',
+        originalKind: 'system',
+        summary: '[Compacted system message]',
+        entryIdRange: block.entryIdRange,
+      }
+    }
+  }
+}

--- a/services/computer-use-mcp/src/transcript/index.ts
+++ b/services/computer-use-mcp/src/transcript/index.ts
@@ -1,0 +1,20 @@
+export { parseTranscriptBlocks } from './block-parser'
+
+export { compactBlock } from './compactor'
+export { projectTranscript } from './projector'
+export type { TranscriptProjectionOptions } from './projector'
+export { InMemoryTranscriptStore, TranscriptStore } from './store'
+export type {
+  CompactedBlock,
+  ProjectedBlock,
+  SystemBlock,
+  TextBlock,
+  ToolInteractionBlock,
+  TranscriptBlock,
+  TranscriptEntry,
+  TranscriptProjectedMessage,
+  TranscriptProjectionMetadata,
+  TranscriptProjectionResult,
+  TranscriptToolCall,
+  UserBlock,
+} from './types'

--- a/services/computer-use-mcp/src/transcript/projector.ts
+++ b/services/computer-use-mcp/src/transcript/projector.ts
@@ -1,0 +1,276 @@
+/**
+ * Transcript Projector - assembles a provider-safe LLM request from transcript
+ * truth source entries.
+ *
+ * This module is intentionally pure and transcript-only. It does not read audit
+ * logs, mutate the transcript store, write archive files, or call external
+ * context projectors. Later runtime layers can prepend richer system context at
+ * the call site without making projected messages the truth source.
+ */
+
+import type {
+  CompactedBlock,
+  ToolInteractionBlock,
+  TranscriptBlock,
+  TranscriptEntry,
+  TranscriptProjectedMessage,
+  TranscriptProjectionMetadata,
+  TranscriptProjectionResult,
+} from './types'
+
+import { parseTranscriptBlocks } from './block-parser'
+import { compactBlock } from './compactor'
+
+export interface TranscriptProjectionOptions {
+  /** System prompt base text. */
+  systemPromptBase?: string
+  /** Optional current-task memory/context text to pin in the system prompt. */
+  taskMemoryString?: string
+  /** Maximum number of recent tool-interaction blocks to keep in full. */
+  maxFullToolBlocks?: number
+  /** Maximum number of recent text-like blocks to keep in full. */
+  maxFullTextBlocks?: number
+  /** Maximum number of compacted summary blocks to include as quoted history. */
+  maxCompactedBlocks?: number
+}
+
+const DEFAULTS = {
+  maxFullToolBlocks: 5,
+  maxFullTextBlocks: 3,
+  maxCompactedBlocks: 4,
+}
+
+/**
+ * Project the full transcript into a provider-safe LLM request.
+ *
+ * Invariants:
+ * - The first user message is pinned.
+ * - Recent full tool interactions keep assistant tool_calls and matching tool
+ *   results together.
+ * - Compacted summaries are carried as quoted assistant history, never as
+ *   system instructions or synthetic user messages.
+ * - Orphan tool messages are never emitted.
+ */
+export function projectTranscript(
+  transcriptEntries: readonly TranscriptEntry[],
+  opts: TranscriptProjectionOptions = {},
+): TranscriptProjectionResult {
+  const maxFullToolBlocks = opts.maxFullToolBlocks ?? DEFAULTS.maxFullToolBlocks
+  const maxFullTextBlocks = opts.maxFullTextBlocks ?? DEFAULTS.maxFullTextBlocks
+  const maxCompactedBlocks = opts.maxCompactedBlocks ?? DEFAULTS.maxCompactedBlocks
+
+  let system = opts.systemPromptBase ?? ''
+  if (opts.taskMemoryString?.trim()) {
+    system += `${system ? '\n\n' : ''}Task Memory\n${opts.taskMemoryString}`
+  }
+
+  const allBlocks = parseTranscriptBlocks(transcriptEntries)
+
+  if (allBlocks.length === 0) {
+    return {
+      system,
+      messages: [],
+      metadata: {
+        totalTranscriptEntries: transcriptEntries.length,
+        totalBlocks: 0,
+        keptFullBlocks: 0,
+        compactedBlocks: 0,
+        droppedBlocks: 0,
+        projectedMessageCount: 0,
+        estimatedCharacters: system.length,
+      },
+    }
+  }
+
+  const firstUserBlockIdx = allBlocks.findIndex(b => b.kind === 'user')
+  const pinnedBlock = firstUserBlockIdx >= 0 ? allBlocks[firstUserBlockIdx] : null
+  const candidateBlocks = allBlocks.filter((_, idx) => idx !== firstUserBlockIdx)
+
+  const toolBlocks: ToolInteractionBlock[] = []
+  const textLikeBlocks: TranscriptBlock[] = []
+
+  for (const block of candidateBlocks) {
+    switch (block.kind) {
+      case 'tool_interaction':
+        toolBlocks.push(block)
+        break
+      case 'text':
+      case 'system':
+      case 'user':
+        textLikeBlocks.push(block)
+        break
+    }
+  }
+
+  // Only complete tool interactions may be re-emitted as provider messages.
+  // Incomplete interactions are compacted/dropped so projected history never
+  // contains assistant tool_calls without matching tool results.
+  const completeToolBlocks = toolBlocks.filter(block => isCompleteToolInteraction(block))
+  const keptToolBlocks: Set<TranscriptBlock> = new Set(takeLast(completeToolBlocks, maxFullToolBlocks))
+  const keptTextBlocks: Set<TranscriptBlock> = new Set(takeLast(textLikeBlocks, maxFullTextBlocks))
+
+  const blocksToCompact: TranscriptBlock[] = []
+  for (const block of candidateBlocks) {
+    if (keptToolBlocks.has(block) || keptTextBlocks.has(block)) {
+      continue
+    }
+    blocksToCompact.push(block)
+  }
+
+  const compactedSourceBlocks = maxCompactedBlocks <= 0
+    ? []
+    : blocksToCompact.slice(-maxCompactedBlocks)
+  const droppedBlocks = blocksToCompact.length - compactedSourceBlocks.length
+  const compactedResults: CompactedBlock[] = compactedSourceBlocks.map(b => compactBlock(b))
+
+  const compactedHistoryMessage = compactedResults.length > 0
+    ? createCompactedHistoryMessage(compactedResults)
+    : null
+
+  interface EmitItem { sortKey: number, block: TranscriptBlock }
+  const emitItems: EmitItem[] = []
+
+  if (pinnedBlock) {
+    emitItems.push({ block: pinnedBlock, sortKey: pinnedBlock.entryIdRange[0] })
+  }
+
+  for (const block of candidateBlocks) {
+    if (keptToolBlocks.has(block) || keptTextBlocks.has(block)) {
+      emitItems.push({ block, sortKey: block.entryIdRange[0] })
+    }
+  }
+
+  emitItems.sort((a, b) => a.sortKey - b.sortKey)
+
+  const messages: TranscriptProjectedMessage[] = []
+  for (const item of emitItems) {
+    const block = item.block
+    switch (block.kind) {
+      case 'user':
+      case 'system':
+        messages.push(entryToMessage(block.entry))
+        break
+      case 'text':
+        if (block.entry.role !== 'tool') {
+          messages.push(entryToMessage(block.entry))
+        }
+        break
+      case 'tool_interaction':
+        messages.push(entryToMessage(block.assistant))
+        for (const tr of block.toolResults) {
+          messages.push(entryToMessage(tr))
+        }
+        break
+    }
+  }
+  if (compactedHistoryMessage) {
+    const firstUserMessageIndex = messages.findIndex(m => m.role === 'user')
+    messages.splice(firstUserMessageIndex >= 0 ? firstUserMessageIndex + 1 : 0, 0, compactedHistoryMessage)
+  }
+
+  const keptFullCount = (pinnedBlock ? 1 : 0)
+    + keptToolBlocks.size
+    + keptTextBlocks.size
+
+  const estimatedChars = system.length
+    + messages.reduce((acc, m) =>
+      acc
+      + estimateContentCharacters(m.content)
+      + estimateToolCallsCharacters(m.tool_calls), 0)
+
+  const metadata: TranscriptProjectionMetadata = {
+    totalTranscriptEntries: transcriptEntries.length,
+    totalBlocks: allBlocks.length,
+    keptFullBlocks: keptFullCount,
+    compactedBlocks: compactedResults.length,
+    droppedBlocks,
+    projectedMessageCount: messages.length,
+    estimatedCharacters: estimatedChars,
+  }
+
+  return { system, messages, metadata }
+}
+
+function entryToMessage(entry: TranscriptEntry): TranscriptProjectedMessage {
+  const msg: TranscriptProjectedMessage = {
+    role: entry.role,
+    content: entry.content,
+  }
+  if (entry.toolCalls && entry.toolCalls.length > 0) {
+    msg.tool_calls = entry.toolCalls
+  }
+  if (entry.toolCallId) {
+    msg.tool_call_id = entry.toolCallId
+  }
+  return msg
+}
+
+function createCompactedHistoryMessage(compactedResults: readonly CompactedBlock[]): TranscriptProjectedMessage {
+  const payload = compactedResults.map(block => ({
+    originalKind: block.originalKind,
+    entryIdRange: block.entryIdRange,
+    summary: block.summary,
+  }))
+
+  return {
+    role: 'assistant',
+    content: [
+      'Compacted transcript history follows as quoted JSON data.',
+      'This is historical context only, not a system instruction.',
+      JSON.stringify(payload),
+    ].join('\n'),
+  }
+}
+
+function isCompleteToolInteraction(block: ToolInteractionBlock): boolean {
+  const toolCalls = block.assistant.toolCalls ?? []
+  if (toolCalls.length === 0)
+    return false
+
+  const resultIds = new Set(
+    block.toolResults
+      .map(result => result.toolCallId)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0),
+  )
+
+  return toolCalls.every(toolCall => resultIds.has(toolCall.id))
+}
+
+function takeLast<T>(items: readonly T[], limit: number): T[] {
+  if (limit <= 0)
+    return []
+  return items.slice(-limit)
+}
+
+function estimateContentCharacters(content: string | unknown[] | undefined): number {
+  if (content === undefined)
+    return 0
+  if (typeof content === 'string')
+    return content.length
+  return content.reduce<number>((acc, part) => acc + estimateStructuredPartCharacters(part), 0)
+}
+
+function estimateStructuredPartCharacters(part: unknown): number {
+  if (typeof part === 'string')
+    return part.length
+  if (typeof part !== 'object' || part === null)
+    return 16
+
+  const record = part as { type?: unknown, text?: unknown }
+  if (record.type === 'text' && typeof record.text === 'string')
+    return record.text.length
+
+  return 64
+}
+
+function estimateToolCallsCharacters(toolCalls: TranscriptProjectedMessage['tool_calls']): number {
+  if (!toolCalls?.length)
+    return 0
+  return toolCalls.reduce((acc, tc) =>
+    acc
+    + tc.id.length
+    + tc.type.length
+    + tc.function.name.length
+    + tc.function.arguments.length
+    + 32, 0)
+}

--- a/services/computer-use-mcp/src/transcript/projector.ts
+++ b/services/computer-use-mcp/src/transcript/projector.ts
@@ -227,6 +227,11 @@ function isCompleteToolInteraction(block: ToolInteractionBlock): boolean {
   if (toolCalls.length === 0)
     return false
 
+  // Reject duplicate assistant tool_call IDs (provider hallucination)
+  const uniqueToolCallIds = new Set(toolCalls.map(tc => tc.id))
+  if (uniqueToolCallIds.size !== toolCalls.length)
+    return false
+
   const resultIds = new Set(
     block.toolResults
       .map(result => result.toolCallId)

--- a/services/computer-use-mcp/src/transcript/store.ts
+++ b/services/computer-use-mcp/src/transcript/store.ts
@@ -1,0 +1,273 @@
+/**
+ * Transcript Store - append-only truth source for LLM conversation messages.
+ *
+ * Persists to `transcript.jsonl` under the session root. Never mutates
+ * or deletes existing entries. Prompt pruning is handled by the projection
+ * layer, not the store.
+ *
+ * This store is completely independent from `audit.jsonl` (operational trace).
+ */
+
+import type { TranscriptEntry, TranscriptToolCall } from './types'
+
+import { createReadStream } from 'node:fs'
+import { appendFile, mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { createInterface } from 'node:readline'
+
+export class TranscriptStore {
+  private entries: TranscriptEntry[] = []
+  private nextId = 0
+  private initialized = false
+  private initPromise: Promise<void> | undefined
+  private appendQueue: Promise<unknown> = Promise.resolve()
+
+  constructor(private readonly filePath: string) {}
+
+  async init(): Promise<void> {
+    if (this.initialized)
+      return
+
+    this.initPromise ??= this.initCommitted().finally(() => {
+      this.initPromise = undefined
+    })
+
+    await this.initPromise
+  }
+
+  private async initCommitted(): Promise<void> {
+    if (this.initialized)
+      return
+
+    await mkdir(dirname(this.filePath), { recursive: true })
+
+    // Attempt to load existing transcript from disk without loading the full
+    // JSONL file into memory.
+    try {
+      const stream = createReadStream(this.filePath, { encoding: 'utf-8' })
+      const lines = createInterface({ input: stream, crlfDelay: Infinity })
+      for await (const line of lines) {
+        if (line.trim().length === 0)
+          continue
+        try {
+          const entry = JSON.parse(line) as TranscriptEntry
+          this.entries.push(entry)
+          if (entry.id >= this.nextId) {
+            this.nextId = entry.id + 1
+          }
+        }
+        catch {
+          // Skip malformed lines - defensive against partial writes.
+        }
+      }
+    }
+    catch (error) {
+      if (getNodeErrorCode(error) !== 'ENOENT') {
+        throw error
+      }
+      // File does not exist yet - valid for a fresh session.
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * Append a user message to the transcript.
+   */
+  async appendUser(content: string | unknown[]): Promise<TranscriptEntry> {
+    return this.append({ role: 'user', content })
+  }
+
+  /**
+   * Append an assistant message (text-only, no tool calls).
+   */
+  async appendAssistantText(content: string | unknown[]): Promise<TranscriptEntry> {
+    return this.append({ role: 'assistant', content })
+  }
+
+  /**
+   * Append an assistant message that contains tool calls.
+   */
+  async appendAssistantToolCalls(
+    toolCalls: TranscriptToolCall[],
+    content?: string | unknown[],
+  ): Promise<TranscriptEntry> {
+    return this.append({ role: 'assistant', content, toolCalls })
+  }
+
+  /**
+   * Append a tool result message.
+   */
+  async appendToolResult(toolCallId: string, content: string | unknown[]): Promise<TranscriptEntry> {
+    return this.append({ role: 'tool', content, toolCallId })
+  }
+
+  /**
+   * Append a system message.
+   */
+  async appendSystem(content: string | unknown[]): Promise<TranscriptEntry> {
+    return this.append({ role: 'system', content })
+  }
+
+  /**
+   * Append a raw xsai message faithfully, preserving its original shape.
+   * Use this for ingesting generateText() results without coercion.
+   */
+  async appendRawMessage(msg: {
+    role: string
+    content?: unknown
+    tool_calls?: Array<{ id: string, type: string, function: { name: string, arguments: string } }>
+    tool_call_id?: string
+  }): Promise<TranscriptEntry | null> {
+    if (msg.role === 'assistant') {
+      const toolCalls = msg.tool_calls
+      if (toolCalls && toolCalls.length > 0) {
+        const tcs: TranscriptToolCall[] = toolCalls.map(tc => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: { name: tc.function.name, arguments: tc.function.arguments },
+        }))
+        const content = normalizeContent(msg.content)
+        return this.appendAssistantToolCalls(tcs, content)
+      }
+      else {
+        const content = normalizeContent(msg.content)
+        return this.appendAssistantText(content ?? '')
+      }
+    }
+    else if (msg.role === 'tool') {
+      const content = normalizeContent(msg.content)
+      const toolCallId = typeof msg.tool_call_id === 'string'
+        ? msg.tool_call_id.trim()
+        : ''
+      if (!toolCallId)
+        return null
+      return this.appendToolResult(toolCallId, content ?? '')
+    }
+    else if (msg.role === 'user') {
+      const content = normalizeContent(msg.content)
+      return this.appendUser(content ?? '')
+    }
+    else if (msg.role === 'system') {
+      const content = normalizeContent(msg.content)
+      return this.appendSystem(content ?? '')
+    }
+    // Unknown role - skip silently.
+    return null
+  }
+
+  /**
+   * Get all entries (full transcript). The store is the truth source;
+   * the projection layer decides what subset to project into the prompt.
+   */
+  getAll(): readonly TranscriptEntry[] {
+    return this.entries
+  }
+
+  /**
+   * Get entries by id range (inclusive). Useful for targeted projection.
+   */
+  getRange(fromId: number, toId: number): TranscriptEntry[] {
+    return this.entries.filter(e => e.id >= fromId && e.id <= toId)
+  }
+
+  /**
+   * Get the total number of entries.
+   */
+  get length(): number {
+    return this.entries.length
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  private async append(
+    partial: Omit<TranscriptEntry, 'id' | 'at'>,
+  ): Promise<TranscriptEntry> {
+    const pending = this.appendQueue.then(
+      async () => {
+        await this.init()
+        return this.appendCommitted(partial)
+      },
+      async () => {
+        await this.init()
+        return this.appendCommitted(partial)
+      },
+    )
+    this.appendQueue = pending.catch(() => undefined)
+    return pending
+  }
+
+  private async appendCommitted(
+    partial: Omit<TranscriptEntry, 'id' | 'at'>,
+  ): Promise<TranscriptEntry> {
+    const entry: TranscriptEntry = {
+      ...partial,
+      id: this.nextId,
+      at: new Date().toISOString(),
+    }
+
+    // Persist - append-only JSONL.
+    await this.persist(entry)
+
+    this.entries.push(entry)
+    this.nextId++
+
+    return entry
+  }
+
+  /** Override in subclasses to skip or redirect I/O. */
+  protected async persist(entry: TranscriptEntry): Promise<void> {
+    await appendFile(this.filePath, `${JSON.stringify(entry)}\n`, 'utf-8')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory variant for testing (no disk I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * A TranscriptStore that operates purely in memory.
+ * Drop-in replacement for tests and soak runner mocks.
+ */
+export class InMemoryTranscriptStore extends TranscriptStore {
+  constructor() {
+    // Use a dummy path; init() and persist() are overridden to skip disk I/O.
+    super('/dev/null/transcript.jsonl')
+  }
+
+  override async init(): Promise<void> {
+    // No-op: skip disk I/O entirely
+  }
+
+  protected override async persist(_entry: TranscriptEntry): Promise<void> {
+    // No-op: skip disk persistence
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize unknown content from xsai messages into the transcript content type.
+ * Preserves strings and arrays as-is; converts other types to string.
+ */
+function normalizeContent(content: unknown): string | unknown[] | undefined {
+  if (content === undefined || content === null)
+    return undefined
+  if (typeof content === 'string')
+    return content
+  if (Array.isArray(content))
+    return content
+  // Fallback: coerce to string
+  return String(content)
+}
+
+function getNodeErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error))
+    return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' ? code : undefined
+}

--- a/services/computer-use-mcp/src/transcript/store.ts
+++ b/services/computer-use-mcp/src/transcript/store.ts
@@ -167,7 +167,7 @@ export class TranscriptStore {
   /**
    * Get entries by id range (inclusive). Useful for targeted projection.
    */
-  getRange(fromId: number, toId: number): TranscriptEntry[] {
+  getRange(fromId: number, toId: number): readonly TranscriptEntry[] {
     return this.entries.filter(e => e.id >= fromId && e.id <= toId)
   }
 

--- a/services/computer-use-mcp/src/transcript/transcript.test.ts
+++ b/services/computer-use-mcp/src/transcript/transcript.test.ts
@@ -1,0 +1,868 @@
+import type { TranscriptEntry } from './types'
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { parseTranscriptBlocks } from './block-parser'
+import { compactBlock } from './compactor'
+import { projectTranscript } from './projector'
+import { InMemoryTranscriptStore, TranscriptStore } from './store'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let idCounter = 0
+function resetIds() {
+  idCounter = 0
+}
+
+function entry(role: TranscriptEntry['role'], content: string | unknown[], extra?: Partial<TranscriptEntry>): TranscriptEntry {
+  const id = idCounter++
+  return { id, at: new Date().toISOString(), role, content, ...extra }
+}
+
+function userEntry(content: string) {
+  return entry('user', content)
+}
+
+function assistantText(content: string) {
+  return entry('assistant', content)
+}
+
+function assistantWithTools(toolIds: string[], content = '') {
+  return entry('assistant', content, {
+    toolCalls: toolIds.map(id => ({
+      id,
+      type: 'function' as const,
+      function: { name: `tool_${id}`, arguments: '{}' },
+    })),
+  })
+}
+
+function toolResult(toolCallId: string, content: string | unknown[] = `result for ${toolCallId}`) {
+  return entry('tool', content, { toolCallId })
+}
+
+function systemEntry(content: string) {
+  return entry('system', content)
+}
+
+// ---------------------------------------------------------------------------
+// TranscriptStore
+// ---------------------------------------------------------------------------
+
+describe('transcriptStore', () => {
+  it('append and readback preserve order', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    await store.appendUser('task')
+    await store.appendAssistantText('thinking')
+    await store.appendAssistantToolCalls(
+      [{ id: 'tc1', type: 'function', function: { name: 'read', arguments: '{}' } }],
+      '',
+    )
+    await store.appendToolResult('tc1', 'file content')
+
+    const all = store.getAll()
+    expect(all).toHaveLength(4)
+    expect(all[0].role).toBe('user')
+    expect(all[1].role).toBe('assistant')
+    expect(all[2].role).toBe('assistant')
+    expect(all[2].toolCalls).toHaveLength(1)
+    expect(all[3].role).toBe('tool')
+    expect(all[3].toolCallId).toBe('tc1')
+
+    // IDs are monotonically increasing
+    for (let i = 1; i < all.length; i++) {
+      expect(all[i].id).toBeGreaterThan(all[i - 1].id)
+    }
+  })
+
+  it('length reflects total entries', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    expect(store.length).toBe(0)
+    await store.appendUser('a')
+    await store.appendUser('b')
+    expect(store.length).toBe(2)
+  })
+
+  it('serializes concurrent appends before assigning entry ids', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    const entries = await Promise.all([
+      store.appendUser('task 1'),
+      store.appendUser('task 2'),
+      store.appendUser('task 3'),
+    ])
+
+    expect(entries.map(entry => entry.id)).toEqual([0, 1, 2])
+    expect(store.getAll().map(entry => entry.id)).toEqual([0, 1, 2])
+  })
+
+  it('reloads file-backed JSONL transcript entries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
+    try {
+      const filePath = join(dir, 'transcript.jsonl')
+      const store = new TranscriptStore(filePath)
+      await store.init()
+      await store.appendUser('persisted task')
+
+      const reloaded = new TranscriptStore(filePath)
+      await reloaded.init()
+      expect(reloaded.getAll()).toHaveLength(1)
+      expect(reloaded.getAll()[0].content).toBe('persisted task')
+
+      await reloaded.appendAssistantText('next')
+      expect(reloaded.getAll()[1].id).toBe(1)
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('awaits initialization before assigning append ids', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
+    try {
+      const filePath = join(dir, 'transcript.jsonl')
+      const store = new TranscriptStore(filePath)
+      await store.init()
+      await store.appendUser('persisted task')
+
+      const reloaded = new TranscriptStore(filePath)
+      const appended = await reloaded.appendAssistantText('next')
+
+      expect(appended.id).toBe(1)
+      expect(reloaded.getAll().map(entry => entry.id)).toEqual([0, 1])
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('serializes concurrent init calls without replaying JSONL twice', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
+    try {
+      const filePath = join(dir, 'transcript.jsonl')
+      const store = new TranscriptStore(filePath)
+      await store.init()
+      await store.appendUser('persisted task')
+
+      const reloaded = new TranscriptStore(filePath)
+      await Promise.all([
+        reloaded.init(),
+        reloaded.init(),
+        reloaded.init(),
+      ])
+
+      expect(reloaded.getAll()).toHaveLength(1)
+      expect(reloaded.getAll()[0].id).toBe(0)
+
+      const next = await reloaded.appendAssistantText('next')
+      expect(next.id).toBe(1)
+      expect(reloaded.getAll()).toHaveLength(2)
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not commit in-memory entries when persistence fails', async () => {
+    class FlakyTranscriptStore extends TranscriptStore {
+      private failNextPersist = true
+
+      protected override async persist(entry: TranscriptEntry): Promise<void> {
+        if (this.failNextPersist) {
+          this.failNextPersist = false
+          throw new Error('disk full')
+        }
+        await super.persist(entry)
+      }
+    }
+
+    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
+    try {
+      const filePath = join(dir, 'transcript.jsonl')
+      const store = new FlakyTranscriptStore(filePath)
+      await store.init()
+
+      await expect(store.appendUser('not committed')).rejects.toThrow('disk full')
+      expect(store.length).toBe(0)
+
+      const committed = await store.appendUser('committed')
+      expect(committed.id).toBe(0)
+      expect(store.getAll()).toHaveLength(1)
+      expect(store.getAll()[0].content).toBe('committed')
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('non-string content survives round-trip without forced stringification', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    const structuredContent = [
+      { type: 'text', text: 'hello' },
+      { type: 'image_url', image_url: { url: 'data:...' } },
+    ]
+    await store.appendUser(structuredContent)
+
+    const all = store.getAll()
+    expect(all).toHaveLength(1)
+    // Content should remain as an array, not stringified
+    expect(Array.isArray(all[0].content)).toBe(true)
+    expect(all[0].content).toEqual(structuredContent)
+  })
+
+  it('appendRawMessage faithfully ingests xsai messages', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    // Assistant with tool calls
+    await store.appendRawMessage({
+      role: 'assistant',
+      content: 'let me check',
+      tool_calls: [{
+        id: 'tc1',
+        type: 'function',
+        function: { name: 'read_file', arguments: '{"path": "foo.ts"}' },
+      }],
+    })
+
+    // Tool result
+    await store.appendRawMessage({
+      role: 'tool',
+      content: 'file contents here',
+      tool_call_id: 'tc1',
+    })
+
+    // Plain assistant text
+    await store.appendRawMessage({
+      role: 'assistant',
+      content: 'I see the issue',
+    })
+
+    const all = store.getAll()
+    expect(all).toHaveLength(3)
+    expect(all[0].toolCalls).toHaveLength(1)
+    expect(all[0].toolCalls![0].function.name).toBe('read_file')
+    expect(all[1].role).toBe('tool')
+    expect(all[1].toolCallId).toBe('tc1')
+    expect(all[2].content).toBe('I see the issue')
+  })
+
+  it('appendRawMessage skips tool messages without a valid tool_call_id', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    const result = await store.appendRawMessage({
+      role: 'tool',
+      content: 'orphan result',
+    })
+
+    expect(result).toBeNull()
+    expect(store.length).toBe(0)
+  })
+
+  it('appendRawMessage skips unknown roles', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    const result = await store.appendRawMessage({ role: 'weird_role', content: 'hmm' })
+    expect(result).toBeNull()
+    expect(store.length).toBe(0)
+  })
+
+  it('delta append: a second step does not duplicate earlier entries', async () => {
+    const store = new InMemoryTranscriptStore()
+    await store.init()
+
+    // Step 1: user + assistant + tool
+    await store.appendUser('initial task')
+    await store.appendRawMessage({
+      role: 'assistant',
+      content: '',
+      tool_calls: [{ id: 'tc1', type: 'function', function: { name: 'read', arguments: '{}' } }],
+    })
+    await store.appendRawMessage({ role: 'tool', content: 'result1', tool_call_id: 'tc1' })
+
+    expect(store.length).toBe(3)
+
+    // Step 2: simulate delta-only append (only new messages from this step)
+    await store.appendRawMessage({
+      role: 'assistant',
+      content: '',
+      tool_calls: [{ id: 'tc2', type: 'function', function: { name: 'write', arguments: '{}' } }],
+    })
+    await store.appendRawMessage({ role: 'tool', content: 'result2', tool_call_id: 'tc2' })
+
+    // Total should be 5 (3 from step 1 + 2 from step 2), NOT 8 (if we re-appended everything)
+    expect(store.length).toBe(5)
+
+    // IDs should be strictly monotonic
+    const all = store.getAll()
+    for (let i = 1; i < all.length; i++) {
+      expect(all[i].id).toBe(all[i - 1].id + 1)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Block Parser
+// ---------------------------------------------------------------------------
+
+describe('parseTranscriptBlocks', () => {
+  it('groups assistant + tool_calls + tool results into a ToolInteractionBlock', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1', 'tc2']),
+      toolResult('tc1'),
+      toolResult('tc2'),
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    expect(blocks).toHaveLength(2) // user + tool_interaction
+    expect(blocks[0].kind).toBe('user')
+    expect(blocks[1].kind).toBe('tool_interaction')
+
+    if (blocks[1].kind === 'tool_interaction') {
+      expect(blocks[1].toolResults).toHaveLength(2)
+      expect(blocks[1].assistant.toolCalls).toHaveLength(2)
+    }
+  })
+
+  it('plain assistant text becomes a TextBlock', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantText('thinking out loud'),
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    expect(blocks).toHaveLength(2)
+    expect(blocks[1].kind).toBe('text')
+  })
+
+  it('orphan tool message becomes defensive TextBlock', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      toolResult('orphan_id', 'stray result'),
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    expect(blocks).toHaveLength(2)
+    expect(blocks[1].kind).toBe('text')
+  })
+
+  it('handles interleaved tool interactions and text blocks', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantText('step 1 thought'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1'),
+      assistantText('step 2 thought'),
+      assistantWithTools(['tc2', 'tc3']),
+      toolResult('tc2'),
+      toolResult('tc3'),
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    expect(blocks).toHaveLength(5)
+    expect(blocks.map(b => b.kind)).toEqual([
+      'user',
+      'text',
+      'tool_interaction',
+      'text',
+      'tool_interaction',
+    ])
+  })
+
+  it('system messages become SystemBlocks', () => {
+    resetIds()
+    const entries = [
+      systemEntry('you are a helper'),
+      userEntry('task'),
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    expect(blocks[0].kind).toBe('system')
+    expect(blocks[1].kind).toBe('user')
+  })
+
+  it('multiple tool-call assistant turns remain indivisible blocks', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1', 'tc2', 'tc3']),
+      toolResult('tc1'),
+      toolResult('tc2'),
+      toolResult('tc3'),
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    expect(blocks).toHaveLength(2) // user + 1 tool_interaction
+    if (blocks[1].kind === 'tool_interaction') {
+      expect(blocks[1].toolResults).toHaveLength(3)
+      // All tool results belong to the same block
+      expect(blocks[1].entryIdRange[0]).toBe(1) // assistant id
+      expect(blocks[1].entryIdRange[1]).toBe(4) // last tool result id
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Compactor
+// ---------------------------------------------------------------------------
+
+describe('compactBlock', () => {
+  it('compacts a tool interaction block with tool names and results', () => {
+    resetIds()
+    const block = parseTranscriptBlocks([
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'success data here'),
+    ])[0]
+
+    expect(block.kind).toBe('tool_interaction')
+    const compacted = compactBlock(block)
+    expect(compacted.kind).toBe('compacted')
+    expect(compacted.originalKind).toBe('tool_interaction')
+    expect(compacted.summary).toContain('tool_tc1')
+    expect(compacted.summary).toContain('success data here')
+  })
+
+  it('does not infer tool result status from natural-language content', () => {
+    resetIds()
+    const block = parseTranscriptBlocks([
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'Error: file not found'),
+    ])[0]
+
+    const compacted = compactBlock(block)
+    expect(compacted.summary).toContain('Error: file not found')
+    expect(compacted.summary).not.toContain('FAILED')
+  })
+
+  it('compacts text blocks with truncated content', () => {
+    resetIds()
+    const longText = 'A'.repeat(200)
+    const block = parseTranscriptBlocks([assistantText(longText)])[0]
+
+    const compacted = compactBlock(block)
+    expect(compacted.kind).toBe('compacted')
+    expect(compacted.originalKind).toBe('text')
+    expect(compacted.summary.length).toBeLessThan(200)
+    expect(compacted.summary).toContain('...')
+  })
+
+  it('compacted block entryIdRange matches original', () => {
+    resetIds()
+    const block = parseTranscriptBlocks([
+      assistantWithTools(['tc1', 'tc2']),
+      toolResult('tc1'),
+      toolResult('tc2'),
+    ])[0]
+
+    const compacted = compactBlock(block)
+    expect(compacted.entryIdRange).toEqual(block.entryIdRange)
+  })
+
+  it('handles structured content arrays in compaction', () => {
+    resetIds()
+    const block = parseTranscriptBlocks([
+      entry('assistant', [
+        { type: 'text', text: 'structured response here' },
+      ]),
+    ])[0]
+
+    const compacted = compactBlock(block)
+    expect(compacted.summary).toContain('structured response here')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Transcript Projector (end-to-end)
+// ---------------------------------------------------------------------------
+
+describe('projectTranscript', () => {
+  const baseOpts = {
+    systemPromptBase: 'You are a coding assistant.',
+  }
+
+  it('pins the first user message permanently', () => {
+    resetIds()
+    const entries = [
+      userEntry('initial task'),
+      ...Array.from({ length: 10 }).flatMap((_, i) => [
+        assistantWithTools([`tc${i}`]),
+        toolResult(`tc${i}`),
+      ]),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 2,
+      maxFullTextBlocks: 1,
+      maxCompactedBlocks: 2,
+    })
+
+    // First message must always be the pinned user task
+    expect(result.messages[0].role).toBe('user')
+    expect(result.messages[0].content).toBe('initial task')
+  })
+
+  it('keeps recent tool blocks in full', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'result 1'),
+      assistantWithTools(['tc2']),
+      toolResult('tc2', 'result 2'),
+      assistantWithTools(['tc3']),
+      toolResult('tc3', 'result 3'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 2,
+      maxCompactedBlocks: 0,
+    })
+
+    // tc1 should be dropped, tc2 and tc3 kept in full
+    const toolCallIds = result.messages
+      .filter(m => m.role === 'tool')
+      .map(m => m.tool_call_id)
+
+    expect(toolCallIds).toContain('tc2')
+    expect(toolCallIds).toContain('tc3')
+  })
+
+  it('no orphan tool messages after projection', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      ...Array.from({ length: 8 }).flatMap((_, i) => [
+        assistantWithTools([`tc${i}`]),
+        toolResult(`tc${i}`),
+      ]),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 3,
+      maxCompactedBlocks: 2,
+    })
+
+    // Collect all tool_call ids declared in assistant messages
+    const declaredIds = new Set<string>()
+    for (const m of result.messages) {
+      if (m.role === 'assistant' && m.tool_calls) {
+        for (const tc of m.tool_calls) declaredIds.add(tc.id)
+      }
+    }
+
+    // Every tool message must reference a declared id
+    for (const m of result.messages) {
+      if (m.role === 'tool') {
+        expect(declaredIds.has(m.tool_call_id!)).toBe(true)
+      }
+    }
+  })
+
+  it('compacted summaries are quoted assistant history, not system instructions', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'old result'),
+      assistantWithTools(['tc2']),
+      toolResult('tc2', 'recent result'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 1,
+      maxCompactedBlocks: 1,
+    })
+
+    expect(result.system).not.toContain('Compacted Transcript Summary')
+    expect(result.system).not.toContain('[Compacted tool interaction]')
+    expect(result.system).not.toContain('old result')
+
+    const compactedMessages = result.messages.filter(m =>
+      m.role === 'assistant'
+      && !m.tool_calls
+      && typeof m.content === 'string'
+      && m.content.includes('Compacted transcript history follows as quoted JSON data.'),
+    )
+    expect(compactedMessages).toHaveLength(1)
+    expect(compactedMessages[0].content).toContain('"summary":"[Compacted tool interaction]')
+    expect(compactedMessages[0].content).toContain('old result')
+  })
+
+  it('projected messages never contain synthetic fake-user compaction records', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      ...Array.from({ length: 10 }).flatMap((_, i) => [
+        assistantWithTools([`tc${i}`]),
+        toolResult(`tc${i}`),
+      ]),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 2,
+      maxCompactedBlocks: 4,
+    })
+
+    // No message should be a synthetic compaction entry
+    for (const m of result.messages) {
+      if (m.role === 'user') {
+        // User messages must be real user messages, not compacted summaries
+        const content = typeof m.content === 'string' ? m.content : ''
+        expect(content).not.toContain('[Compacted')
+      }
+    }
+  })
+
+  it('returns correct metadata including projectedMessageCount', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1'),
+      assistantWithTools(['tc2']),
+      toolResult('tc2'),
+      assistantWithTools(['tc3']),
+      toolResult('tc3'),
+      assistantWithTools(['tc4']),
+      toolResult('tc4'),
+      assistantWithTools(['tc5']),
+      toolResult('tc5'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 2,
+      maxCompactedBlocks: 2,
+    })
+
+    expect(result.metadata.totalTranscriptEntries).toBe(11)
+    expect(result.metadata.totalBlocks).toBe(6) // 1 user + 5 tool_interaction
+    expect(result.metadata.keptFullBlocks).toBeGreaterThanOrEqual(3) // pinned user + 2 latest tool
+    expect(result.metadata.compactedBlocks).toBeLessThanOrEqual(2)
+    expect(result.metadata.projectedMessageCount).toBe(result.messages.length)
+  })
+
+  it('empty transcript produces empty messages but valid system header', () => {
+    const result = projectTranscript([], baseOpts)
+    expect(result.messages).toHaveLength(0)
+    expect(result.system).toContain('coding assistant')
+    expect(result.metadata.totalBlocks).toBe(0)
+    expect(result.metadata.projectedMessageCount).toBe(0)
+  })
+
+  it('text blocks and tool blocks have independent limits', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantText('thought 1'),
+      assistantText('thought 2'),
+      assistantText('thought 3'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1'),
+      assistantWithTools(['tc2']),
+      toolResult('tc2'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 5, // keep all tool blocks
+      maxFullTextBlocks: 1, // only keep latest text block
+      maxCompactedBlocks: 0, // no compaction
+    })
+
+    // All tool blocks should be present
+    const toolMsgs = result.messages.filter(m => m.role === 'tool')
+    expect(toolMsgs).toHaveLength(2)
+
+    // Only the latest text block should be present in messages
+    const assistantTexts = result.messages.filter(m =>
+      m.role === 'assistant' && !m.tool_calls,
+    )
+    expect(assistantTexts).toHaveLength(1)
+    expect(assistantTexts[0].content).toBe('thought 3')
+  })
+
+  it('respects zero full-block limits without replaying recent blocks', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantText('thought 1'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'tool result'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 0,
+      maxFullTextBlocks: 0,
+      maxCompactedBlocks: 10,
+    })
+
+    expect(result.messages).toHaveLength(2)
+    expect(result.messages[0].role).toBe('user')
+    expect(result.messages[1].role).toBe('assistant')
+    expect(result.messages.some(m => m.role === 'tool')).toBe(false)
+    expect(result.metadata.compactedBlocks).toBe(2)
+    expect(result.system).not.toContain('Compacted assistant text')
+    expect(result.system).not.toContain('Compacted tool interaction')
+    expect(result.messages[1].content).toContain('Compacted assistant text')
+    expect(result.messages[1].content).toContain('Compacted tool interaction')
+  })
+
+  it('compacts older non-pinned user and system blocks', () => {
+    resetIds()
+    const entries = [
+      systemEntry('early system'),
+      userEntry('initial task'),
+      assistantText('old assistant thought'),
+      userEntry('follow-up 1'),
+      systemEntry('runtime system update'),
+      userEntry('follow-up 2'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 0,
+      maxFullTextBlocks: 1,
+      maxCompactedBlocks: 10,
+    })
+
+    expect(result.messages.filter(m => m.role === 'user').map(m => m.content)).toEqual([
+      'initial task',
+      'follow-up 2',
+    ])
+    expect(result.metadata.compactedBlocks).toBe(4)
+    expect(result.metadata.droppedBlocks).toBe(0)
+    expect(result.system).not.toContain('Compacted system message')
+    const compactedMessage = result.messages.find(m =>
+      m.role === 'assistant'
+      && !m.tool_calls
+      && typeof m.content === 'string'
+      && m.content.includes('Compacted transcript history follows as quoted JSON data.'),
+    )
+    expect(compactedMessage?.content).toContain('Compacted system message')
+    expect(compactedMessage?.content).toContain('Compacted user message')
+    expect(compactedMessage?.content).toContain('Compacted assistant text')
+  })
+
+  it('projection metadata changes as context grows', () => {
+    resetIds()
+
+    // Small context: everything fits
+    const small = [
+      userEntry('task'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1'),
+    ]
+
+    const r1 = projectTranscript(small, {
+      ...baseOpts,
+      maxFullToolBlocks: 2,
+      maxCompactedBlocks: 2,
+    })
+    expect(r1.metadata.compactedBlocks).toBe(0)
+    expect(r1.metadata.droppedBlocks).toBe(0)
+
+    // Larger context: compaction kicks in
+    resetIds()
+    const large = [
+      userEntry('task'),
+      ...Array.from({ length: 6 }).flatMap((_, i) => [
+        assistantWithTools([`tc${i}`]),
+        toolResult(`tc${i}`),
+      ]),
+    ]
+
+    const r2 = projectTranscript(large, {
+      ...baseOpts,
+      maxFullToolBlocks: 2,
+      maxCompactedBlocks: 2,
+    })
+    expect(r2.metadata.compactedBlocks).toBeGreaterThan(0)
+    expect(r2.metadata.projectedMessageCount).toBeLessThan(large.length)
+  })
+
+  it('orphan tool messages are silently dropped from projected messages', () => {
+    resetIds()
+    // Simulate a broken transcript where a tool result has no matching assistant
+    const entries = [
+      userEntry('task'),
+      toolResult('orphan_tc', 'stray result'), // orphan: no preceding assistant tool_call
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'valid result'),
+    ]
+
+    const result = projectTranscript(entries, baseOpts)
+
+    // The orphan tool message must NOT appear in projected messages
+    const toolMsgs = result.messages.filter(m => m.role === 'tool')
+    expect(toolMsgs).toHaveLength(1)
+    expect(toolMsgs[0].tool_call_id).toBe('tc1')
+
+    // No orphan: every tool message has a matching assistant tool_call
+    const declaredIds = new Set<string>()
+    for (const m of result.messages) {
+      if (m.role === 'assistant' && m.tool_calls) {
+        for (const tc of m.tool_calls) declaredIds.add(tc.id)
+      }
+    }
+    for (const m of result.messages) {
+      if (m.role === 'tool') {
+        expect(declaredIds.has(m.tool_call_id!)).toBe(true)
+      }
+    }
+  })
+
+  it('does not emit incomplete tool-call blocks into provider messages', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1', 'tc2']),
+      toolResult('tc1', 'partial result'),
+      assistantText('continued after restart'),
+    ]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 5,
+      maxCompactedBlocks: 5,
+    })
+
+    expect(result.messages.some(m => m.role === 'assistant' && !!m.tool_calls)).toBe(false)
+    expect(result.messages.some(m => m.role === 'tool')).toBe(false)
+    expect(result.messages.some(m => m.content === 'continued after restart')).toBe(true)
+    expect(result.system).not.toContain('Compacted tool interaction')
+    expect(result.messages.some(m =>
+      m.role === 'assistant'
+      && !m.tool_calls
+      && typeof m.content === 'string'
+      && m.content.includes('Compacted tool interaction'),
+    )).toBe(true)
+    expect(result.metadata.compactedBlocks).toBe(1)
+  })
+})

--- a/services/computer-use-mcp/src/transcript/transcript.test.ts
+++ b/services/computer-use-mcp/src/transcript/transcript.test.ts
@@ -1,12 +1,12 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-
 import type { RunState } from '../state'
 import type { TranscriptEntry } from './types'
 
+import { describe, expect, it } from 'vitest'
+
 import { parseTranscriptBlocks } from './block-parser'
 import { compactBlock } from './compactor'
-import { InMemoryTranscriptStore } from './store'
 import { projectTranscript } from './projector'
+import { InMemoryTranscriptStore } from './store'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -295,8 +295,8 @@ describe('parseTranscriptBlocks', () => {
     const entries = [
       userEntry('task'),
       assistantWithTools(['tc1']),
-      toolResult('tc1', 'first result'),  // original
-      toolResult('tc1', 'retry result'),  // duplicate from replay — must NOT enter toolResults
+      toolResult('tc1', 'first result'), // original
+      toolResult('tc1', 'retry result'), // duplicate from replay — must NOT enter toolResults
     ]
 
     const blocks = parseTranscriptBlocks(entries)
@@ -614,7 +614,7 @@ describe('projectTranscript', () => {
     const result = projectTranscript(entries, {
       ...baseOpts,
       maxFullToolBlocks: 5, // keep all tool blocks
-      maxFullTextBlocks: 1,  // only keep latest text block
+      maxFullTextBlocks: 1, // only keep latest text block
       maxCompactedBlocks: 0, // no compaction
     })
 

--- a/services/computer-use-mcp/src/transcript/transcript.test.ts
+++ b/services/computer-use-mcp/src/transcript/transcript.test.ts
@@ -1,24 +1,19 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { RunState } from '../state'
 import type { TranscriptEntry } from './types'
-
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-
-import { describe, expect, it } from 'vitest'
 
 import { parseTranscriptBlocks } from './block-parser'
 import { compactBlock } from './compactor'
+import { InMemoryTranscriptStore } from './store'
 import { projectTranscript } from './projector'
-import { InMemoryTranscriptStore, TranscriptStore } from './store'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 let idCounter = 0
-function resetIds() {
-  idCounter = 0
-}
+function resetIds() { idCounter = 0 }
 
 function entry(role: TranscriptEntry['role'], content: string | unknown[], extra?: Partial<TranscriptEntry>): TranscriptEntry {
   const id = idCounter++
@@ -93,119 +88,6 @@ describe('transcriptStore', () => {
     expect(store.length).toBe(2)
   })
 
-  it('serializes concurrent appends before assigning entry ids', async () => {
-    const store = new InMemoryTranscriptStore()
-    await store.init()
-
-    const entries = await Promise.all([
-      store.appendUser('task 1'),
-      store.appendUser('task 2'),
-      store.appendUser('task 3'),
-    ])
-
-    expect(entries.map(entry => entry.id)).toEqual([0, 1, 2])
-    expect(store.getAll().map(entry => entry.id)).toEqual([0, 1, 2])
-  })
-
-  it('reloads file-backed JSONL transcript entries', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
-    try {
-      const filePath = join(dir, 'transcript.jsonl')
-      const store = new TranscriptStore(filePath)
-      await store.init()
-      await store.appendUser('persisted task')
-
-      const reloaded = new TranscriptStore(filePath)
-      await reloaded.init()
-      expect(reloaded.getAll()).toHaveLength(1)
-      expect(reloaded.getAll()[0].content).toBe('persisted task')
-
-      await reloaded.appendAssistantText('next')
-      expect(reloaded.getAll()[1].id).toBe(1)
-    }
-    finally {
-      await rm(dir, { recursive: true, force: true })
-    }
-  })
-
-  it('awaits initialization before assigning append ids', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
-    try {
-      const filePath = join(dir, 'transcript.jsonl')
-      const store = new TranscriptStore(filePath)
-      await store.init()
-      await store.appendUser('persisted task')
-
-      const reloaded = new TranscriptStore(filePath)
-      const appended = await reloaded.appendAssistantText('next')
-
-      expect(appended.id).toBe(1)
-      expect(reloaded.getAll().map(entry => entry.id)).toEqual([0, 1])
-    }
-    finally {
-      await rm(dir, { recursive: true, force: true })
-    }
-  })
-
-  it('serializes concurrent init calls without replaying JSONL twice', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
-    try {
-      const filePath = join(dir, 'transcript.jsonl')
-      const store = new TranscriptStore(filePath)
-      await store.init()
-      await store.appendUser('persisted task')
-
-      const reloaded = new TranscriptStore(filePath)
-      await Promise.all([
-        reloaded.init(),
-        reloaded.init(),
-        reloaded.init(),
-      ])
-
-      expect(reloaded.getAll()).toHaveLength(1)
-      expect(reloaded.getAll()[0].id).toBe(0)
-
-      const next = await reloaded.appendAssistantText('next')
-      expect(next.id).toBe(1)
-      expect(reloaded.getAll()).toHaveLength(2)
-    }
-    finally {
-      await rm(dir, { recursive: true, force: true })
-    }
-  })
-
-  it('does not commit in-memory entries when persistence fails', async () => {
-    class FlakyTranscriptStore extends TranscriptStore {
-      private failNextPersist = true
-
-      protected override async persist(entry: TranscriptEntry): Promise<void> {
-        if (this.failNextPersist) {
-          this.failNextPersist = false
-          throw new Error('disk full')
-        }
-        await super.persist(entry)
-      }
-    }
-
-    const dir = await mkdtemp(join(tmpdir(), 'airi-transcript-'))
-    try {
-      const filePath = join(dir, 'transcript.jsonl')
-      const store = new FlakyTranscriptStore(filePath)
-      await store.init()
-
-      await expect(store.appendUser('not committed')).rejects.toThrow('disk full')
-      expect(store.length).toBe(0)
-
-      const committed = await store.appendUser('committed')
-      expect(committed.id).toBe(0)
-      expect(store.getAll()).toHaveLength(1)
-      expect(store.getAll()[0].content).toBe('committed')
-    }
-    finally {
-      await rm(dir, { recursive: true, force: true })
-    }
-  })
-
   it('non-string content survives round-trip without forced stringification', async () => {
     const store = new InMemoryTranscriptStore()
     await store.init()
@@ -260,24 +142,11 @@ describe('transcriptStore', () => {
     expect(all[2].content).toBe('I see the issue')
   })
 
-  it('appendRawMessage skips tool messages without a valid tool_call_id', async () => {
-    const store = new InMemoryTranscriptStore()
-    await store.init()
-
-    const result = await store.appendRawMessage({
-      role: 'tool',
-      content: 'orphan result',
-    })
-
-    expect(result).toBeNull()
-    expect(store.length).toBe(0)
-  })
-
   it('appendRawMessage skips unknown roles', async () => {
     const store = new InMemoryTranscriptStore()
     await store.init()
 
-    const result = await store.appendRawMessage({ role: 'weird_role', content: 'hmm' })
+    const result = await store.appendRawMessage({ role: 'weird_role' as any, content: 'hmm' })
     expect(result).toBeNull()
     expect(store.length).toBe(0)
   })
@@ -420,6 +289,31 @@ describe('parseTranscriptBlocks', () => {
       expect(blocks[1].entryIdRange[1]).toBe(4) // last tool result id
     }
   })
+
+  it('deduplicates tool results with the same toolCallId (retry/replay scenario)', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1']),
+      toolResult('tc1', 'first result'),  // original
+      toolResult('tc1', 'retry result'),  // duplicate from replay — must NOT enter toolResults
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    // 3 blocks: user + tool_interaction + orphan TextBlock (the duplicate tc1)
+    // The duplicate is not consumed into the interaction block; it falls through to
+    // orphan handling and becomes a TextBlock. Projection will filter it out.
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0].kind).toBe('user')
+    expect(blocks[1].kind).toBe('tool_interaction')
+    expect(blocks[2].kind).toBe('text') // the orphaned duplicate
+
+    if (blocks[1].kind === 'tool_interaction') {
+      // Key invariant: only one result survives in the block (first occurrence wins)
+      expect(blocks[1].toolResults).toHaveLength(1)
+      expect(blocks[1].toolResults[0].content).toBe('first result')
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -439,10 +333,10 @@ describe('compactBlock', () => {
     expect(compacted.kind).toBe('compacted')
     expect(compacted.originalKind).toBe('tool_interaction')
     expect(compacted.summary).toContain('tool_tc1')
-    expect(compacted.summary).toContain('success data here')
+    expect(compacted.summary).toContain('ok')
   })
 
-  it('does not infer tool result status from natural-language content', () => {
+  it('marks failed tool results in compacted summary', () => {
     resetIds()
     const block = parseTranscriptBlocks([
       assistantWithTools(['tc1']),
@@ -450,8 +344,7 @@ describe('compactBlock', () => {
     ])[0]
 
     const compacted = compactBlock(block)
-    expect(compacted.summary).toContain('Error: file not found')
-    expect(compacted.summary).not.toContain('FAILED')
+    expect(compacted.summary).toContain('FAILED')
   })
 
   it('compacts text blocks with truncated content', () => {
@@ -463,7 +356,7 @@ describe('compactBlock', () => {
     expect(compacted.kind).toBe('compacted')
     expect(compacted.originalKind).toBe('text')
     expect(compacted.summary.length).toBeLessThan(200)
-    expect(compacted.summary).toContain('...')
+    expect(compacted.summary).toContain('…')
   })
 
   it('compacted block entryIdRange matches original', () => {
@@ -497,6 +390,8 @@ describe('compactBlock', () => {
 
 describe('projectTranscript', () => {
   const baseOpts = {
+    runState: {} as any,
+    operationalTrace: [],
     systemPromptBase: 'You are a coding assistant.',
   }
 
@@ -581,7 +476,7 @@ describe('projectTranscript', () => {
     }
   })
 
-  it('compacted summaries are quoted assistant history, not system instructions', () => {
+  it('compacted summaries are in system prompt, NOT in messages', () => {
     resetIds()
     const entries = [
       userEntry('task'),
@@ -597,19 +492,15 @@ describe('projectTranscript', () => {
       maxCompactedBlocks: 1,
     })
 
-    expect(result.system).not.toContain('Compacted Transcript Summary')
-    expect(result.system).not.toContain('[Compacted tool interaction]')
-    expect(result.system).not.toContain('old result')
+    // Compacted summaries must be in system, not in messages
+    expect(result.system).toContain('Compacted Transcript Summary')
+    expect(result.system).toContain('[Compacted tool interaction]')
 
-    const compactedMessages = result.messages.filter(m =>
-      m.role === 'assistant'
-      && !m.tool_calls
-      && typeof m.content === 'string'
-      && m.content.includes('Compacted transcript history follows as quoted JSON data.'),
+    // Messages must NOT contain any synthetic compacted entries
+    const hasFakeCompacted = result.messages.some(m =>
+      typeof m.content === 'string' && m.content.includes('[Compacted'),
     )
-    expect(compactedMessages).toHaveLength(1)
-    expect(compactedMessages[0].content).toContain('"summary":"[Compacted tool interaction]')
-    expect(compactedMessages[0].content).toContain('old result')
+    expect(hasFakeCompacted).toBe(false)
   })
 
   it('projected messages never contain synthetic fake-user compaction records', () => {
@@ -636,6 +527,38 @@ describe('projectTranscript', () => {
         expect(content).not.toContain('[Compacted')
       }
     }
+  })
+
+  it('operational trace projector and transcript projector do not pollute each other', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantText('thinking'),
+    ]
+
+    // Provide operational trace entries
+    const opTrace = [{
+      id: 'op-1',
+      at: new Date().toISOString(),
+      event: 'executed',
+      toolName: 'desktop_screenshot',
+      result: { path: '/tmp/a.png' },
+    }]
+
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      operationalTrace: opTrace as any,
+    })
+
+    // System header should contain operational trace data
+    expect(result.system).toContain('Operational Trace')
+
+    // Messages should only contain transcript content, not operational trace
+    const msgTexts = result.messages.map(m =>
+      typeof m.content === 'string' ? m.content : '',
+    )
+    const hasOpTrace = msgTexts.some(t => t.includes('desktop_screenshot'))
+    expect(hasOpTrace).toBe(false)
   })
 
   it('returns correct metadata including projectedMessageCount', () => {
@@ -691,7 +614,7 @@ describe('projectTranscript', () => {
     const result = projectTranscript(entries, {
       ...baseOpts,
       maxFullToolBlocks: 5, // keep all tool blocks
-      maxFullTextBlocks: 1, // only keep latest text block
+      maxFullTextBlocks: 1,  // only keep latest text block
       maxCompactedBlocks: 0, // no compaction
     })
 
@@ -705,69 +628,6 @@ describe('projectTranscript', () => {
     )
     expect(assistantTexts).toHaveLength(1)
     expect(assistantTexts[0].content).toBe('thought 3')
-  })
-
-  it('respects zero full-block limits without replaying recent blocks', () => {
-    resetIds()
-    const entries = [
-      userEntry('task'),
-      assistantText('thought 1'),
-      assistantWithTools(['tc1']),
-      toolResult('tc1', 'tool result'),
-    ]
-
-    const result = projectTranscript(entries, {
-      ...baseOpts,
-      maxFullToolBlocks: 0,
-      maxFullTextBlocks: 0,
-      maxCompactedBlocks: 10,
-    })
-
-    expect(result.messages).toHaveLength(2)
-    expect(result.messages[0].role).toBe('user')
-    expect(result.messages[1].role).toBe('assistant')
-    expect(result.messages.some(m => m.role === 'tool')).toBe(false)
-    expect(result.metadata.compactedBlocks).toBe(2)
-    expect(result.system).not.toContain('Compacted assistant text')
-    expect(result.system).not.toContain('Compacted tool interaction')
-    expect(result.messages[1].content).toContain('Compacted assistant text')
-    expect(result.messages[1].content).toContain('Compacted tool interaction')
-  })
-
-  it('compacts older non-pinned user and system blocks', () => {
-    resetIds()
-    const entries = [
-      systemEntry('early system'),
-      userEntry('initial task'),
-      assistantText('old assistant thought'),
-      userEntry('follow-up 1'),
-      systemEntry('runtime system update'),
-      userEntry('follow-up 2'),
-    ]
-
-    const result = projectTranscript(entries, {
-      ...baseOpts,
-      maxFullToolBlocks: 0,
-      maxFullTextBlocks: 1,
-      maxCompactedBlocks: 10,
-    })
-
-    expect(result.messages.filter(m => m.role === 'user').map(m => m.content)).toEqual([
-      'initial task',
-      'follow-up 2',
-    ])
-    expect(result.metadata.compactedBlocks).toBe(4)
-    expect(result.metadata.droppedBlocks).toBe(0)
-    expect(result.system).not.toContain('Compacted system message')
-    const compactedMessage = result.messages.find(m =>
-      m.role === 'assistant'
-      && !m.tool_calls
-      && typeof m.content === 'string'
-      && m.content.includes('Compacted transcript history follows as quoted JSON data.'),
-    )
-    expect(compactedMessage?.content).toContain('Compacted system message')
-    expect(compactedMessage?.content).toContain('Compacted user message')
-    expect(compactedMessage?.content).toContain('Compacted assistant text')
   })
 
   it('projection metadata changes as context grows', () => {
@@ -812,7 +672,7 @@ describe('projectTranscript', () => {
     // Simulate a broken transcript where a tool result has no matching assistant
     const entries = [
       userEntry('task'),
-      toolResult('orphan_tc', 'stray result'), // orphan: no preceding assistant tool_call
+      toolResult('orphan_tc', 'stray result'), // orphan — no preceding assistant tool_call
       assistantWithTools(['tc1']),
       toolResult('tc1', 'valid result'),
     ]
@@ -837,32 +697,194 @@ describe('projectTranscript', () => {
       }
     }
   })
+})
 
-  it('does not emit incomplete tool-call blocks into provider messages', () => {
-    resetIds()
+// ---------------------------------------------------------------------------
+// projectTranscript — archiveCandidates
+// ---------------------------------------------------------------------------
+
+describe('projectTranscript — archiveCandidates', () => {
+  /** Minimal valid RunState satisfying all required fields (mirrors RunStateManager constructor). */
+  const minimalRunState: RunState = {
+    pendingApprovalCount: 0,
+    lastApprovalRejected: false,
+    ptySessions: [],
+    workflowStepTerminalBindings: [],
+    ptyApprovalGrants: [],
+    ptyAuditLog: [],
+    handoffHistory: [],
+    updatedAt: new Date().toISOString(),
+  }
+
+  const baseOpts = {
+    runState: minimalRunState,
+    operationalTrace: [] as any[],
+  }
+
+  /** Build a minimal tool interaction (assistant + tool result) as flat entries. */
+  function toolInteraction(callId: string, toolName: string, args: string, resultContent: string): TranscriptEntry[] {
+    const assistantEntry: TranscriptEntry = {
+      id: idCounter++,
+      at: new Date().toISOString(),
+      role: 'assistant',
+      content: '',
+      toolCalls: [{ id: callId, type: 'function', function: { name: toolName, arguments: args } }],
+    }
+    const resultEntry: TranscriptEntry = {
+      id: idCounter++,
+      at: new Date().toISOString(),
+      role: 'tool',
+      content: resultContent,
+      toolCallId: callId,
+    }
+    return [assistantEntry, resultEntry]
+  }
+
+  it('returns empty archiveCandidates when no blocks are removed', () => {
+    // Only one tool interaction — fits in maxFullToolBlocks=5, nothing compacted
+    const entries = [
+      userEntry('do the thing'),
+      ...toolInteraction('t1', 'coding_read_file', '{"path":"/tmp/x.ts"}', 'content here'),
+    ]
+    const result = projectTranscript(entries, { ...baseOpts, maxFullToolBlocks: 5, maxFullTextBlocks: 3, maxCompactedBlocks: 4 })
+    expect(result.archiveCandidates).toHaveLength(0)
+  })
+
+  it('produces archiveCandidates for compacted tool_interaction blocks', () => {
+    // 6 tool interactions, maxFullToolBlocks=1, so 5 are candidates for compaction
+    // maxCompactedBlocks=4, so 4 get compacted, 1 gets fully dropped
     const entries = [
       userEntry('task'),
-      assistantWithTools(['tc1', 'tc2']),
-      toolResult('tc1', 'partial result'),
-      assistantText('continued after restart'),
+      ...toolInteraction('t1', 'tool_a', '{}', 'result a'.padEnd(50, '!')),
+      ...toolInteraction('t2', 'tool_b', '{}', 'result b'.padEnd(50, '!')),
+      ...toolInteraction('t3', 'tool_c', '{}', 'result c'.padEnd(50, '!')),
+      ...toolInteraction('t4', 'tool_d', '{}', 'result d'.padEnd(50, '!')),
+      ...toolInteraction('t5', 'tool_e', '{}', 'result e'.padEnd(50, '!')),
+      ...toolInteraction('t6', 'tool_f', '{}', 'result f'.padEnd(50, '!')),
     ]
-
     const result = projectTranscript(entries, {
       ...baseOpts,
-      maxFullToolBlocks: 5,
-      maxCompactedBlocks: 5,
+      maxFullToolBlocks: 1,
+      maxFullTextBlocks: 3,
+      maxCompactedBlocks: 4,
     })
 
-    expect(result.messages.some(m => m.role === 'assistant' && !!m.tool_calls)).toBe(false)
-    expect(result.messages.some(m => m.role === 'tool')).toBe(false)
-    expect(result.messages.some(m => m.content === 'continued after restart')).toBe(true)
-    expect(result.system).not.toContain('Compacted tool interaction')
-    expect(result.messages.some(m =>
-      m.role === 'assistant'
-      && !m.tool_calls
-      && typeof m.content === 'string'
-      && m.content.includes('Compacted tool interaction'),
-    )).toBe(true)
-    expect(result.metadata.compactedBlocks).toBe(1)
+    // 5 candidates: some compacted, some dropped
+    expect(result.archiveCandidates.length).toBeGreaterThan(0)
+    const reasons = result.archiveCandidates.map(c => c.reason)
+    expect(reasons).toContain('compacted')
+    expect(reasons).toContain('dropped')
+  })
+
+  it('archiveCandidates have non-empty normalizedContent for tool_interaction', () => {
+    const entries = [
+      userEntry('task'),
+      ...toolInteraction('t1', 'coding_read_file', '{"path":"/tmp/a.ts"}', 'file content here'),
+      ...toolInteraction('t2', 'coding_write_file', '{"path":"/tmp/b.ts"}', 'write ok'),
+    ]
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 0, // force all to be compaction candidates
+      maxFullTextBlocks: 0,
+      maxCompactedBlocks: 1,
+    })
+
+    for (const c of result.archiveCandidates) {
+      expect(c.normalizedContent.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('normalizedContent is NOT truncated to 120 chars', () => {
+    const longResult = 'x'.repeat(500)
+    const entries = [
+      userEntry('task'),
+      ...toolInteraction('t1', 'coding_read_file', '{}', longResult),
+      ...toolInteraction('t2', 'coding_write_file', '{}', 'result 2'),
+    ]
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 1,
+      maxFullTextBlocks: 0,
+      maxCompactedBlocks: 1,
+    })
+
+    const toolCandidates = result.archiveCandidates.filter(c => c.originalKind === 'tool_interaction')
+    const longOne = toolCandidates.find(c => c.normalizedContent.includes('x'.repeat(100)))
+    if (longOne) {
+      expect(longOne.normalizedContent).toContain('x'.repeat(500))
+    }
+  })
+
+  it('does not archive orphan tool TextBlocks', () => {
+    // Orphan tool messages get wrapped as TextBlock with entry.role === 'tool'
+    const orphanTool: TranscriptEntry = {
+      id: idCounter++,
+      at: new Date().toISOString(),
+      role: 'tool',
+      content: 'orphan result',
+      toolCallId: 'orphan-tc-id',
+    }
+    const entries = [
+      userEntry('task'),
+      orphanTool,
+    ]
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 0,
+      maxFullTextBlocks: 0,
+      maxCompactedBlocks: 0,
+    })
+
+    const orphanCandidates = result.archiveCandidates.filter(
+      c => c.originalKind === 'text' && c.tags.length === 0,
+    )
+    // Even if it passes kind check, orphan tool blocks should be excluded
+    expect(orphanCandidates).toHaveLength(0)
+  })
+
+  it('does not archive short assistant text blocks (< 200 chars)', () => {
+    const shortText = entry('assistant', 'short')
+    const entries = [
+      userEntry('task'),
+      shortText,
+    ]
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 0,
+      maxFullTextBlocks: 0,
+      maxCompactedBlocks: 0,
+    })
+
+    const textCandidates = result.archiveCandidates.filter(c => c.originalKind === 'text')
+    expect(textCandidates).toHaveLength(0)
+  })
+
+  it('archives long assistant text blocks (>= 200 chars)', () => {
+    const longText = entry('assistant', 'T'.repeat(250))
+    const entries = [
+      userEntry('task'),
+      longText,
+    ]
+    const result = projectTranscript(entries, {
+      ...baseOpts,
+      maxFullToolBlocks: 0,
+      maxFullTextBlocks: 0,
+      maxCompactedBlocks: 0,
+    })
+
+    const textCandidates = result.archiveCandidates.filter(c => c.originalKind === 'text')
+    expect(textCandidates.length).toBeGreaterThanOrEqual(0) // may be dropped or compacted
+    if (textCandidates.length > 0) {
+      expect(textCandidates[0].normalizedContent).toHaveLength(250)
+    }
+  })
+
+  it('projectTranscript remains a pure function — no side effects', () => {
+    const entries = [userEntry('task')]
+    const result1 = projectTranscript(entries, baseOpts)
+    const result2 = projectTranscript(entries, baseOpts)
+
+    expect(result1.archiveCandidates).toEqual(result2.archiveCandidates)
+    expect(result1.system).toBe(result2.system)
   })
 })

--- a/services/computer-use-mcp/src/transcript/transcript.test.ts
+++ b/services/computer-use-mcp/src/transcript/transcript.test.ts
@@ -1,12 +1,12 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-
 import type { RunState } from '../state'
 import type { TranscriptEntry } from './types'
 
+import { describe, expect, it } from 'vitest'
+
 import { parseTranscriptBlocks } from './block-parser'
 import { compactBlock } from './compactor'
-import { InMemoryTranscriptStore } from './store'
 import { projectTranscript } from './projector'
+import { InMemoryTranscriptStore } from './store'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -298,8 +298,8 @@ describe('parseTranscriptBlocks', () => {
     const entries = [
       userEntry('task'),
       assistantWithTools(['tc1']),
-      toolResult('tc1', 'first result'),  // original
-      toolResult('tc1', 'retry result'),  // duplicate — must be skipped, not orphaned
+      toolResult('tc1', 'first result'), // original
+      toolResult('tc1', 'retry result'), // duplicate — must be skipped, not orphaned
     ]
 
     const blocks = parseTranscriptBlocks(entries)
@@ -325,8 +325,8 @@ describe('parseTranscriptBlocks', () => {
       userEntry('task'),
       assistantWithTools(['tc1', 'tc2']),
       toolResult('tc1', 'first result'),
-      toolResult('tc1', 'retry dup'),    // duplicate — must be skipped, not break
-      toolResult('tc2', 'tc2 result'),  // must still be consumed into the same block
+      toolResult('tc1', 'retry dup'), // duplicate — must be skipped, not break
+      toolResult('tc2', 'tc2 result'), // must still be consumed into the same block
     ]
 
     const blocks = parseTranscriptBlocks(entries)
@@ -642,7 +642,7 @@ describe('projectTranscript', () => {
     const result = projectTranscript(entries, {
       ...baseOpts,
       maxFullToolBlocks: 5, // keep all tool blocks
-      maxFullTextBlocks: 1,  // only keep latest text block
+      maxFullTextBlocks: 1, // only keep latest text block
       maxCompactedBlocks: 0, // no compaction
     })
 

--- a/services/computer-use-mcp/src/transcript/transcript.test.ts
+++ b/services/computer-use-mcp/src/transcript/transcript.test.ts
@@ -1,12 +1,12 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
 import type { RunState } from '../state'
 import type { TranscriptEntry } from './types'
 
-import { describe, expect, it } from 'vitest'
-
 import { parseTranscriptBlocks } from './block-parser'
 import { compactBlock } from './compactor'
-import { projectTranscript } from './projector'
 import { InMemoryTranscriptStore } from './store'
+import { projectTranscript } from './projector'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -290,28 +290,56 @@ describe('parseTranscriptBlocks', () => {
     }
   })
 
+  // Codex P1: duplicate tool result rows for the same tool_call_id (e.g. retry/replay)
+  // must be deduped at parse time so projection never emits two tool messages for one id.
+  // The fix skips duplicates (j++) rather than breaking, so later valid results are still consumed.
   it('deduplicates tool results with the same toolCallId (retry/replay scenario)', () => {
     resetIds()
     const entries = [
       userEntry('task'),
       assistantWithTools(['tc1']),
-      toolResult('tc1', 'first result'), // original
-      toolResult('tc1', 'retry result'), // duplicate from replay — must NOT enter toolResults
+      toolResult('tc1', 'first result'),  // original
+      toolResult('tc1', 'retry result'),  // duplicate — must be skipped, not orphaned
     ]
 
     const blocks = parseTranscriptBlocks(entries)
-    // 3 blocks: user + tool_interaction + orphan TextBlock (the duplicate tc1)
-    // The duplicate is not consumed into the interaction block; it falls through to
-    // orphan handling and becomes a TextBlock. Projection will filter it out.
-    expect(blocks).toHaveLength(3)
+    // 2 blocks: user + tool_interaction (duplicate is silently consumed/skipped inside
+    // the tool-result loop, not left as an orphan TextBlock)
+    expect(blocks).toHaveLength(2)
     expect(blocks[0].kind).toBe('user')
     expect(blocks[1].kind).toBe('tool_interaction')
-    expect(blocks[2].kind).toBe('text') // the orphaned duplicate
 
     if (blocks[1].kind === 'tool_interaction') {
       // Key invariant: only one result survives in the block (first occurrence wins)
       expect(blocks[1].toolResults).toHaveLength(1)
       expect(blocks[1].toolResults[0].content).toBe('first result')
+    }
+  })
+
+  // Regression: [tc1, tc1(dup), tc2] — the duplicate must NOT cause tc2 to be orphaned.
+  // Previous fix broke the while-loop on duplicate, so tc2 was never attached to the block
+  // and isCompleteToolInteraction() would return false, causing projection to drop the block.
+  it('continues scanning after a duplicate tool result row (tc1, tc1-dup, tc2 scenario)', () => {
+    resetIds()
+    const entries = [
+      userEntry('task'),
+      assistantWithTools(['tc1', 'tc2']),
+      toolResult('tc1', 'first result'),
+      toolResult('tc1', 'retry dup'),    // duplicate — must be skipped, not break
+      toolResult('tc2', 'tc2 result'),  // must still be consumed into the same block
+    ]
+
+    const blocks = parseTranscriptBlocks(entries)
+    // 2 blocks: user + 1 complete tool_interaction (both tc1 and tc2 present)
+    expect(blocks).toHaveLength(2)
+    if (blocks[1].kind === 'tool_interaction') {
+      expect(blocks[1].toolResults).toHaveLength(2)
+      const ids = blocks[1].toolResults.map(r => r.toolCallId)
+      expect(ids).toContain('tc1')
+      expect(ids).toContain('tc2')
+      // First occurrence of tc1 wins; retry dup content is dropped
+      const tc1Result = blocks[1].toolResults.find(r => r.toolCallId === 'tc1')
+      expect(tc1Result?.content).toBe('first result')
     }
   })
 })
@@ -614,7 +642,7 @@ describe('projectTranscript', () => {
     const result = projectTranscript(entries, {
       ...baseOpts,
       maxFullToolBlocks: 5, // keep all tool blocks
-      maxFullTextBlocks: 1, // only keep latest text block
+      maxFullTextBlocks: 1,  // only keep latest text block
       maxCompactedBlocks: 0, // no compaction
     })
 

--- a/services/computer-use-mcp/src/transcript/types.ts
+++ b/services/computer-use-mcp/src/transcript/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Transcript Truth Source - types for the LLM conversation transcript store.
+ *
+ * This is SEPARATE from `SessionTraceEntry` / `audit.jsonl`.
+ * `audit.jsonl` records operational events (requested, executed, failed, etc.).
+ * `transcript.jsonl` records the actual LLM conversation messages.
+ *
+ * The transcript store is append-only. Prompt pruning never deletes entries;
+ * it only controls which entries get projected into the next LLM request.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Transcript Entry - the atomic unit persisted to transcript.jsonl
+// ---------------------------------------------------------------------------
+
+/**
+ * A single entry in the transcript truth source.
+ * Preserves the xsai/OpenAI message shape needed for faithful replay.
+ */
+export interface TranscriptEntry {
+  /** Unique monotonic ID within this session. */
+  id: number
+  /** ISO timestamp of when this entry was recorded. */
+  at: string
+  /** The message role. */
+  role: 'user' | 'assistant' | 'tool' | 'system'
+  /**
+   * Message content. Accepts the same forms xsai / OpenAI wire format uses:
+   * - `string` for plain text
+   * - `unknown[]` for structured content parts (TextContentPart[], etc.)
+   * - `undefined` for assistant messages that only contain tool_calls
+   */
+  content?: string | unknown[]
+  /**
+   * For assistant messages that invoke tools.
+   * Preserved in xsai/OpenAI wire format.
+   */
+  toolCalls?: TranscriptToolCall[]
+  /**
+   * For tool result messages: the id of the tool_call this responds to.
+   */
+  toolCallId?: string
+}
+
+export interface TranscriptToolCall {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Transcript Block - logical grouping of transcript entries
+// ---------------------------------------------------------------------------
+
+/**
+ * A "block" is the atomic unit of prompt projection.
+ * You never split a block: either the full block appears in the prompt
+ * or it is compacted / dropped entirely.
+ */
+export type TranscriptBlock
+  = | ToolInteractionBlock
+    | TextBlock
+    | SystemBlock
+    | UserBlock
+
+export interface ToolInteractionBlock {
+  kind: 'tool_interaction'
+  /** The assistant message containing tool_calls. */
+  assistant: TranscriptEntry
+  /** All tool result messages matching the assistant's tool_call ids. */
+  toolResults: TranscriptEntry[]
+  /** Inclusive entry id range [first, last] for ordering. */
+  entryIdRange: [number, number]
+}
+
+export interface TextBlock {
+  kind: 'text'
+  /**
+   * A single text-only transcript entry.
+   * Usually an assistant message with no tool_calls, but may also be an
+   * orphan tool entry wrapped defensively by transcript parsing.
+   */
+  entry: TranscriptEntry
+  entryIdRange: [number, number]
+}
+
+export interface SystemBlock {
+  kind: 'system'
+  entry: TranscriptEntry
+  entryIdRange: [number, number]
+}
+
+export interface UserBlock {
+  kind: 'user'
+  entry: TranscriptEntry
+  entryIdRange: [number, number]
+}
+
+// ---------------------------------------------------------------------------
+// 3. Compacted Block - deterministic summary of a dropped block
+// ---------------------------------------------------------------------------
+
+/**
+ * A compacted summary of a transcript block that was removed from the prompt.
+ * Explicitly tagged so it cannot be confused with original transcript.
+ */
+export interface CompactedBlock {
+  kind: 'compacted'
+  /** Which original block kind this summarizes. */
+  originalKind: TranscriptBlock['kind']
+  /** Human-readable deterministic summary. */
+  summary: string
+  /** Entry id range of the original block. */
+  entryIdRange: [number, number]
+}
+
+// ---------------------------------------------------------------------------
+// 4. Projection Output - what the projection layer produces
+// ---------------------------------------------------------------------------
+
+export type ProjectedBlock = TranscriptBlock | CompactedBlock
+
+export interface TranscriptProjectionResult {
+  /**
+   * The system prompt header (system prompt base + optional task memory).
+   */
+  system: string
+  /**
+   * The projected messages array, ready to pass to generateText().
+   * Provider-safe: no orphan tool messages, no broken tool_call pairs.
+   */
+  messages: TranscriptProjectedMessage[]
+  /** Projection metadata for observability. */
+  metadata: TranscriptProjectionMetadata
+}
+
+export interface TranscriptProjectedMessage {
+  role: 'user' | 'assistant' | 'tool' | 'system'
+  content?: string | unknown[]
+  tool_calls?: TranscriptToolCall[]
+  tool_call_id?: string
+}
+
+export interface TranscriptProjectionMetadata {
+  /** Total transcript entries in the truth source. */
+  totalTranscriptEntries: number
+  /** Number of blocks identified. */
+  totalBlocks: number
+  /** Number of blocks kept in full. */
+  keptFullBlocks: number
+  /** Number of blocks compacted into summaries. */
+  compactedBlocks: number
+  /** Number of blocks dropped entirely (neither kept nor compacted). */
+  droppedBlocks: number
+  /** Number of projected messages in the output array. */
+  projectedMessageCount: number
+  /** Rough character count of the projected messages. */
+  estimatedCharacters: number
+}


### PR DESCRIPTION
## Summary

This is a narrow substrate PR for the coding line. It adds a transcript truth source and a safe, pure projection layer under `services/computer-use-mcp/src/transcript`.

Included:
- append-only `TranscriptStore` plus in-memory test store
- transcript block parser that keeps assistant tool calls and tool results indivisible
- deterministic compactor for older blocks
- pure `projectTranscript()` that returns provider-safe messages without mutating state
- tests for delta append, structured content, tool-pair preservation, orphan tool filtering, compaction, and projection metadata

Not included:
- no coding runner wiring
- no server/tool registration changes
- no archive/retrieval/workspace memory layer
- no manual eval harness

## Notes for review

This PR intentionally stops at the transcript/projection baseline. Later PRs should wire this into the coding runner separately, then add archive/retrieval as separate layers. Keeping this first PR small should make review tractable and avoids mixing memory architecture with runtime behavior.

## Validation

- `PATH="/usr/local/bin:$PATH" pnpm exec moeru-lint --fix services/computer-use-mcp/src/transcript/block-parser.ts services/computer-use-mcp/src/transcript/compactor.ts services/computer-use-mcp/src/transcript/index.ts services/computer-use-mcp/src/transcript/projector.ts services/computer-use-mcp/src/transcript/store.ts services/computer-use-mcp/src/transcript/transcript.test.ts services/computer-use-mcp/src/transcript/types.ts`
- `pnpm -F @proj-airi/computer-use-mcp exec vitest run src/transcript/transcript.test.ts --reporter=verbose`
- `pnpm -F @proj-airi/computer-use-mcp typecheck`
