### PR TITLE
Enable local-first desktop memory without putting LangMem on the chat path

### DIFF
--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -30,6 +30,7 @@ import { setupServerChannel } from './services/airi/channel-server'
 import { setupGodotStageManager } from './services/airi/godot-stage'
 import { setupBuiltInServer } from './services/airi/http-server'
 import { setupMcpStdioManager } from './services/airi/mcp-servers'
+import { createMemoryService, setupMemoryRepository, setupMemorySync } from './services/airi/memory'
 import { setupPluginHost } from './services/airi/plugins'
 import { setupArtistryBridge } from './services/airi/widgets/artistry-bridge'
 import { setupAutoUpdater } from './services/electron/auto-updater'
@@ -154,6 +155,14 @@ app.whenReady().then(async () => {
     build: ({ dependsOn }) => setupPluginHost(dependsOn),
   })
 
+  const memoryRepository = injeca.provide('modules:memory-repository', {
+    build: () => setupMemoryRepository(),
+  })
+
+  const memorySyncRuntime = injeca.provide('modules:memory-sync-runtime', {
+    build: () => setupMemorySync(),
+  })
+
   const windowAuthManager = injeca.provide('services:window-auth-manager', () => createWindowAuthManagerService())
 
   // BeatSync will create a background window to capture and process audio.
@@ -218,9 +227,26 @@ app.whenReady().then(async () => {
   }
 
   injeca.invoke({
-    dependsOn: { mainWindow, tray, serverChannel, airiHttpServer, godotStageManager, pluginHost, mcpStdioManager, onboardingWindow: onboardingWindowManager, widgetsWindow: widgetsManager, artistryConfig },
+    dependsOn: { mainWindow, tray, serverChannel, airiHttpServer, godotStageManager, pluginHost, mcpStdioManager, onboardingWindow: onboardingWindowManager, widgetsWindow: widgetsManager, artistryConfig, memoryRepository, memorySyncRuntime },
     callback: async (deps) => {
+      if (!app.isPackaged || env.MAIN_APP_DEBUG || env.APP_DEBUG) {
+        setTimeout(() => {
+          if (deps.mainWindow.isDestroyed()) {
+            return
+          }
+
+          deps.mainWindow.center()
+          deps.mainWindow.show()
+          deps.mainWindow.focus()
+        }, 1000)
+      }
+
       const { context } = createContext(ipcMain)
+      createMemoryService({
+        context,
+        repository: deps.memoryRepository,
+        runtime: deps.memorySyncRuntime,
+      })
       await setupArtistryBridge({
         widgetsManager: deps.widgetsWindow,
         context,

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/index.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/index.test.ts
@@ -1,0 +1,262 @@
+import type { createContext } from '@moeru/eventa/adapters/electron/main'
+
+import type { MemoryRepository } from './repository'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const defineInvokeHandlerMock = vi.hoisted(() => vi.fn())
+const repositoryFactoryMock = vi.hoisted(() => vi.fn())
+const onAppBeforeQuitMock = vi.hoisted(() => vi.fn())
+const appMock = vi.hoisted(() => ({
+  getPath: vi.fn((name: string) => `/tmp/airi/${name}`),
+}))
+
+vi.mock('@moeru/eventa', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@moeru/eventa')>()
+  return {
+    ...actual,
+    defineInvokeHandler: defineInvokeHandlerMock,
+  }
+})
+
+vi.mock('electron', () => ({
+  app: appMock,
+}))
+
+vi.mock('../../../libs/bootkit/lifecycle', () => ({
+  onAppBeforeQuit: onAppBeforeQuitMock,
+}))
+
+vi.mock('./repository', () => ({
+  createMemoryRepository: repositoryFactoryMock,
+}))
+
+type MainContext = ReturnType<typeof createContext>['context']
+
+describe('memory service wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('registers the three memory invoke handlers', async () => {
+    const context = { key: 'test-context' } as unknown as MainContext
+    const repository = {
+      appendTurn: vi.fn(),
+      close: vi.fn(),
+      getSyncState: vi.fn(),
+      initialize: vi.fn(),
+      readPromptContext: vi.fn(),
+      replaceProfileSummary: vi.fn(),
+      upsertStableFact: vi.fn(),
+    } as unknown as MemoryRepository
+    const {
+      electronMemoryAppendTurn,
+      electronMemoryGetSyncState,
+      electronMemoryReadPromptContext,
+    } = await import('../../../../shared/eventa/memory')
+    const { createMemoryService } = await import('./index')
+
+    createMemoryService({ context, repository })
+
+    expect(defineInvokeHandlerMock).toHaveBeenCalledTimes(3)
+    expect(defineInvokeHandlerMock).toHaveBeenNthCalledWith(1, context, electronMemoryReadPromptContext, expect.any(Function))
+    expect(defineInvokeHandlerMock).toHaveBeenNthCalledWith(2, context, electronMemoryAppendTurn, expect.any(Function))
+    expect(defineInvokeHandlerMock).toHaveBeenNthCalledWith(3, context, electronMemoryGetSyncState, expect.any(Function))
+  })
+
+  it('append-turn handler forwards payload to the repository and returns its result shape', async () => {
+    const context = { key: 'test-context' } as unknown as MainContext
+    const appendResult = {
+      createdAt: 1000,
+      role: 'user' as const,
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'hello',
+      turnId: 'turn-1',
+      updatedAt: 1000,
+      version: 1,
+    }
+    const repository = {
+      appendTurn: vi.fn(() => appendResult),
+      close: vi.fn(),
+      getSyncState: vi.fn(),
+      initialize: vi.fn(),
+      readPromptContext: vi.fn(),
+      replaceProfileSummary: vi.fn(),
+      upsertStableFact: vi.fn(),
+    } as unknown as MemoryRepository
+    const { createMemoryService } = await import('./index')
+
+    createMemoryService({ context, repository })
+
+    const appendHandler = defineInvokeHandlerMock.mock.calls[1]?.[2] as (payload: unknown) => Promise<unknown>
+    const payload = {
+      createdAt: 1000,
+      rawPayload: { content: 'hello' },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'hello',
+      turnId: 'turn-1',
+    }
+
+    await expect(appendHandler(payload)).resolves.toEqual({
+      schemaVersion: 1,
+      storedTurnId: 'turn-1',
+      syncCheckpoint: 0,
+    })
+    expect(repository.appendTurn).toHaveBeenCalledWith(payload)
+  })
+
+  it('read-prompt-context and get-sync-state handlers return repository results', async () => {
+    const context = { key: 'test-context' } as unknown as MainContext
+    const promptContext = {
+      profileSummary: {
+        confidence: 0.8,
+        createdAt: 1000,
+        generatedFromTurnId: 'turn-summary',
+        id: 'summary-1',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryMarkdown: 'Summary',
+        supersededBy: null,
+        updatedAt: 1000,
+        version: 1,
+      },
+      recentTurns: [
+        {
+          createdAt: 1000,
+          role: 'user' as const,
+          scope: {
+            characterId: 'character-a',
+            sessionId: 'session-a',
+            userId: 'user-a',
+          },
+          text: 'hello',
+          turnId: 'turn-1',
+          updatedAt: 1000,
+          version: 1,
+        },
+      ],
+      stableFacts: [
+        {
+          confidence: 0.7,
+          createdAt: 1000,
+          factKey: 'name',
+          factValue: 'Airi',
+          generatedFromTurnId: 'turn-fact',
+          id: 'fact-1',
+          scope: {
+            characterId: 'character-a',
+            sessionId: 'session-a',
+            userId: 'user-a',
+          },
+          supersededBy: null,
+          updatedAt: 1000,
+          version: 1,
+        },
+      ],
+    }
+    const syncState = null
+    const repository = {
+      appendTurn: vi.fn(),
+      close: vi.fn(),
+      getSyncState: vi.fn(() => syncState),
+      initialize: vi.fn(),
+      readPromptContext: vi.fn(() => promptContext),
+      replaceProfileSummary: vi.fn(),
+      upsertStableFact: vi.fn(),
+    } as unknown as MemoryRepository
+    const { createMemoryService } = await import('./index')
+
+    createMemoryService({ context, repository })
+
+    const readPromptContextHandler = defineInvokeHandlerMock.mock.calls[0]?.[2] as (payload: unknown) => Promise<unknown>
+    const getSyncStateHandler = defineInvokeHandlerMock.mock.calls[2]?.[2] as (payload: unknown) => Promise<unknown>
+    const request = {
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    }
+
+    await expect(readPromptContextHandler(request)).resolves.toEqual({
+      memoryCards: [],
+      profileSummary: 'Summary',
+      recentTurns: [
+        {
+          createdAt: 1000,
+          role: 'user',
+          text: 'hello',
+          turnId: 'turn-1',
+        },
+      ],
+      schemaVersion: 1,
+      scope: request.scope,
+      stableFacts: [
+        {
+          confidence: 0.7,
+          id: 'fact-1',
+          key: 'name',
+          value: 'Airi',
+        },
+      ],
+    })
+    await expect(getSyncStateHandler(request)).resolves.toEqual({
+      runtimeMode: 'desktop-local-sqlite',
+      schemaVersion: 1,
+      scope: request.scope,
+      syncMode: 'enabled',
+      syncModeReason: null,
+      syncState: null,
+    })
+    expect(repository.readPromptContext).toHaveBeenCalledWith(request)
+    expect(repository.getSyncState).toHaveBeenCalledWith(request)
+  })
+
+  it('setupMemoryRepository creates one singleton repository and initializes it only once', async () => {
+    const close = vi.fn()
+    const initialize = vi.fn()
+    const repository = {
+      appendTurn: vi.fn(),
+      close,
+      getSyncState: vi.fn(),
+      initialize,
+      readPromptContext: vi.fn(),
+      replaceProfileSummary: vi.fn(),
+      upsertStableFact: vi.fn(),
+    } as unknown as MemoryRepository
+
+    repositoryFactoryMock.mockReturnValue(repository)
+
+    const { setupMemoryRepository } = await import('./index')
+
+    const firstRepository = setupMemoryRepository()
+    const secondRepository = setupMemoryRepository()
+
+    expect(firstRepository).toBe(repository)
+    expect(secondRepository).toBe(repository)
+    expect(repositoryFactoryMock).toHaveBeenCalledTimes(1)
+    expect(repositoryFactoryMock).toHaveBeenCalledWith({
+      databasePath: '/tmp/airi/userData/memory.sqlite',
+    })
+    expect(initialize).toHaveBeenCalledTimes(1)
+    expect(onAppBeforeQuitMock).toHaveBeenCalledTimes(1)
+
+    const cleanup = onAppBeforeQuitMock.mock.calls[0]?.[0] as (() => void) | undefined
+    cleanup?.()
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/index.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/index.ts
@@ -1,0 +1,186 @@
+import type { createContext } from '@moeru/eventa/adapters/electron/main'
+
+import type { ElectronMemoryGetSyncStateResponse, ElectronMemoryScope } from '../../../../shared/eventa/memory'
+import type { MemoryRepository } from './repository'
+import type { MemorySyncRuntime } from './runtime'
+import type { MemoryPromptContext, MemoryRecentTurnRecord, MemoryStableFactRecord } from './types'
+
+import { join } from 'node:path'
+
+import { defineInvokeHandler } from '@moeru/eventa'
+import { app } from 'electron'
+
+import {
+  electronMemoryAppendTurn,
+  electronMemoryGetSyncState,
+  electronMemoryReadPromptContext,
+} from '../../../../shared/eventa/memory'
+import { onAppBeforeQuit } from '../../../libs/bootkit/lifecycle'
+import { createMemoryRepository } from './repository'
+import { setupMemorySyncRuntime } from './runtime'
+import { MEMORY_SCHEMA_V1_VERSION } from './schema'
+
+let singletonRepository: MemoryRepository | null = null
+let repositoryInitialized = false
+let repositoryCleanupRegistered = false
+let singletonSyncRuntime: MemorySyncRuntime | null = null
+
+function mapStableFact(record: MemoryStableFactRecord) {
+  return {
+    confidence: record.confidence,
+    id: record.id,
+    key: record.factKey,
+    value: record.factValue,
+  }
+}
+
+function mapRecentTurn(record: MemoryRecentTurnRecord) {
+  return {
+    createdAt: record.createdAt,
+    role: record.role,
+    text: record.text,
+    turnId: record.turnId,
+  }
+}
+
+function mapPromptContext(scope: ElectronMemoryScope, promptContext: MemoryPromptContext) {
+  return {
+    memoryCards: [],
+    profileSummary: promptContext.profileSummary?.summaryMarkdown ?? null,
+    recentTurns: promptContext.recentTurns.map(mapRecentTurn),
+    schemaVersion: MEMORY_SCHEMA_V1_VERSION,
+    scope,
+    stableFacts: promptContext.stableFacts.map(mapStableFact),
+  }
+}
+
+function mapSyncState(scope: ElectronMemoryScope, syncState: ReturnType<MemoryRepository['getSyncState']>, runtime?: MemorySyncRuntime): ElectronMemoryGetSyncStateResponse {
+  const runtimeStatus = runtime?.getStatus()
+  let syncMode: ElectronMemoryGetSyncStateResponse['syncMode'] = 'enabled'
+  let syncModeReason: string | null = null
+
+  if (runtimeStatus?.uploader.mode === 'disabled' && runtimeStatus.patch.mode === 'disabled') {
+    syncMode = 'disabled'
+    syncModeReason = runtimeStatus.uploader.reason ?? runtimeStatus.patch.reason ?? 'memory background sync disabled'
+  }
+
+  return {
+    runtimeMode: 'desktop-local-sqlite' as const,
+    schemaVersion: MEMORY_SCHEMA_V1_VERSION,
+    scope,
+    syncMode,
+    syncModeReason,
+    syncState: syncState
+      ? {
+          lastAppliedSummaryVersion: syncState.lastAppliedSummaryVersion,
+          lastError: syncState.lastError ?? null,
+          lastLocalTurnCheckpoint: syncState.lastLocalTurnCheckpoint,
+          lastPullAt: syncState.lastPullAt ?? null,
+          lastSyncedAt: syncState.lastSyncedAt ?? null,
+          lastUploadAt: syncState.lastUploadAt ?? null,
+          pendingTurnCount: syncState.pendingTurnCount,
+          remoteCheckpoint: syncState.remoteCheckpoint ?? null,
+          state: syncState.state as 'idle' | 'syncing' | 'error',
+          syncCheckpoint: syncState.syncCheckpoint,
+        }
+      : null,
+  }
+}
+
+/**
+ * Creates the desktop memory repository singleton and initializes it once.
+ *
+ * Use when:
+ * - Main-process services need one shared local SQLite memory repository
+ * - App lifecycle should close the repository through the standard bootkit hook
+ *
+ * Expects:
+ * - Electron `app.getPath('userData')` resolves to a writable directory
+ *
+ * Returns:
+ * - The shared memory repository instance
+ */
+export function setupMemoryRepository(): MemoryRepository {
+  if (!singletonRepository) {
+    singletonRepository = createMemoryRepository({
+      databasePath: join(app.getPath('userData'), 'memory.sqlite'),
+    })
+  }
+
+  if (!repositoryInitialized) {
+    singletonRepository.initialize()
+    repositoryInitialized = true
+  }
+
+  if (!repositoryCleanupRegistered) {
+    onAppBeforeQuit(() => {
+      singletonRepository?.close()
+    })
+    repositoryCleanupRegistered = true
+  }
+
+  return singletonRepository
+}
+
+/**
+ * Creates the desktop memory sync runtime singleton and wires it into app lifecycle once.
+ *
+ * Use when:
+ * - The main process should automatically scan and upload pending raw turns
+ * - Sync runtime status should stay centralized inside the memory service boundary
+ *
+ * Expects:
+ * - The memory repository singleton is already available or can be created on demand
+ *
+ * Returns:
+ * - The shared memory sync runtime instance
+ */
+export function setupMemorySync(): MemorySyncRuntime {
+  if (!singletonSyncRuntime) {
+    singletonSyncRuntime = setupMemorySyncRuntime({
+      repository: setupMemoryRepository(),
+    })
+  }
+
+  return singletonSyncRuntime
+}
+
+/**
+ * Registers desktop local-memory Eventa invoke handlers on a main-process context.
+ *
+ * Use when:
+ * - A shared main-process Eventa context should expose local-memory capabilities
+ * - Phase 3 needs handler wiring without renderer/store integration
+ *
+ * Expects:
+ * - `repository` is the singleton repository created by {@link setupMemoryRepository}
+ * - `context` is a main-process Eventa context ready for invoke registration
+ *
+ * Returns:
+ * - Registers handlers on the provided context and does not return a value
+ */
+export function createMemoryService(params: {
+  context: ReturnType<typeof createContext>['context']
+  repository: MemoryRepository
+  runtime?: MemorySyncRuntime
+}) {
+  defineInvokeHandler(params.context, electronMemoryReadPromptContext, async (payload) => {
+    const promptContext = params.repository.readPromptContext(payload)
+
+    return mapPromptContext(payload.scope, promptContext)
+  })
+
+  defineInvokeHandler(params.context, electronMemoryAppendTurn, async (payload) => {
+    const record = params.repository.appendTurn(payload)
+
+    return {
+      schemaVersion: MEMORY_SCHEMA_V1_VERSION,
+      storedTurnId: record.turnId,
+      syncCheckpoint: 0,
+    }
+  })
+
+  defineInvokeHandler(params.context, electronMemoryGetSyncState, async (payload) => {
+    return mapSyncState(payload.scope, params.repository.getSyncState(payload), params.runtime)
+  })
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/patch-client.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/patch-client.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMemoryPatchPullRuntime } from './patch-client'
+
+describe('memory patch pull runtime', () => {
+  it('enters disabled no-op mode when patch config is missing', async () => {
+    const runtime = createMemoryPatchPullRuntime({
+      config: {
+        enabled: true,
+        endpointUrl: null,
+        authToken: null,
+        pullIntervalMs: 15_000,
+        requestTimeoutMs: 10_000,
+        retryDelayMs: 30_000,
+      },
+    })
+
+    expect(runtime.getStatus()).toEqual({
+      mode: 'disabled',
+      reason: 'memory patch pull is missing endpoint or auth token',
+    })
+
+    await expect(runtime.client.fetchMemoryPatch({
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }, null)).resolves.toBeNull()
+  })
+
+  it('fetches one memory patch through the active runtime adapter', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      json: async () => ({
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          generatedFromTurnId: 'turn-2',
+          summaryMarkdown: 'Cloud summary',
+          summaryVersion: 2,
+        },
+      }),
+      ok: true,
+      status: 200,
+    }))
+
+    const runtime = createMemoryPatchPullRuntime({
+      config: {
+        authToken: 'token',
+        enabled: true,
+        endpointUrl: 'https://example.com/memory/patch',
+        pullIntervalMs: 15_000,
+        requestTimeoutMs: 10_000,
+        retryDelayMs: 30_000,
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    const result = await runtime.client.fetchMemoryPatch({
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }, null)
+
+    expect(runtime.getStatus()).toEqual({
+      endpointUrl: 'https://example.com/memory/patch',
+      mode: 'active',
+    })
+    expect(result).toEqual({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      summaryPatch: {
+        generatedFromTurnId: 'turn-2',
+        summaryMarkdown: 'Cloud summary',
+        summaryVersion: 2,
+      },
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.com/memory/patch', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Authorization': 'Bearer token',
+        'Content-Type': 'application/json',
+      }),
+      method: 'POST',
+    }))
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/patch-client.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/patch-client.ts
@@ -1,0 +1,103 @@
+import type {
+  MemoryPatchPullClient,
+  MemoryPatchPullConfig,
+  MemoryPatchPullStatus,
+} from './sync-types'
+import type { MemoryRepositoryScope, MemorySyncStateRecord } from './types'
+
+export interface MemoryPatchPullRuntime {
+  client: MemoryPatchPullClient
+  getStatus: () => MemoryPatchPullStatus
+}
+
+interface CreateMemoryPatchPullRuntimeOptions {
+  config: MemoryPatchPullConfig
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Creates the runtime adapter for pulling incremental memory patches.
+ *
+ * Use when:
+ * - The desktop sync runtime wants a concrete patch-pull client
+ * - App startup must degrade cleanly when remote patch config is absent
+ *
+ * Expects:
+ * - `config` is already resolved from one centralized runtime config source
+ * - `fetchImpl` behaves like the standard Fetch API
+ *
+ * Returns:
+ * - An active patch-pull runtime, or a disabled no-op runtime with an explicit status
+ */
+export function createMemoryPatchPullRuntime(options: CreateMemoryPatchPullRuntimeOptions): MemoryPatchPullRuntime {
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  if (!options.config.enabled) {
+    return {
+      client: {
+        async fetchMemoryPatch() {
+          return null
+        },
+      },
+      getStatus: () => ({
+        mode: 'disabled',
+        reason: 'memory patch pull is disabled',
+      }),
+    }
+  }
+
+  if (!options.config.endpointUrl || !options.config.authToken) {
+    return {
+      client: {
+        async fetchMemoryPatch() {
+          return null
+        },
+      },
+      getStatus: () => ({
+        mode: 'disabled',
+        reason: 'memory patch pull is missing endpoint or auth token',
+      }),
+    }
+  }
+
+  return {
+    client: {
+      async fetchMemoryPatch(scope: MemoryRepositoryScope, state: MemorySyncStateRecord | null) {
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), options.config.requestTimeoutMs)
+
+        try {
+          const response = await fetchImpl(options.config.endpointUrl!, {
+            body: JSON.stringify({
+              scope,
+              state,
+            }),
+            headers: {
+              'Authorization': `Bearer ${options.config.authToken}`,
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+            signal: controller.signal,
+          })
+
+          if (response.status === 204) {
+            return null
+          }
+
+          if (!response.ok) {
+            throw new Error(`memory patch pull failed (${response.status})`)
+          }
+
+          return await response.json()
+        }
+        finally {
+          clearTimeout(timeoutId)
+        }
+      },
+    },
+    getStatus: () => ({
+      endpointUrl: options.config.endpointUrl,
+      mode: 'active',
+    }),
+  }
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/repository.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/repository.test.ts
@@ -621,6 +621,99 @@ describe('memory repository', () => {
     repository.close()
   })
 
+  it('rolls back a patch transaction when a later write fails', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { text: 'source' },
+      role: 'user',
+      scope,
+      text: 'source',
+      turnId: 'turn-source',
+    })
+
+    expect(() => repository.applyMemoryPatch({
+      nextPullAt: 3_000,
+      patch: {
+        factsPatch: [
+          {
+            confidence: 1,
+            factKey: null as unknown as string,
+            factValue: 'invalid',
+            generatedFromTurnId: 'turn-source',
+          },
+        ],
+        scope,
+        summaryPatch: {
+          confidence: 1,
+          generatedFromTurnId: 'turn-source',
+          summaryMarkdown: 'Should roll back',
+          summaryVersion: 1,
+        },
+      },
+      pulledAt: 2_000,
+    })).toThrow()
+
+    const promptContext = repository.readPromptContext({ scope })
+    expect(promptContext.profileSummary).toBeNull()
+    expect(promptContext.stableFacts).toEqual([])
+    expect(repository.getSyncState({ scope })?.lastPullAt ?? null).toBeNull()
+
+    repository.close()
+  })
+
+  it('clears nullable sync error fields when a later update passes null explicitly', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { text: 'source' },
+      role: 'user',
+      scope,
+      text: 'source',
+      turnId: 'turn-source',
+    })
+    repository.recordRawTurnUploadFailure({
+      error: 'upload failed',
+      failedAt: 2_000,
+      nextRetryAt: 3_000,
+      scope,
+    })
+
+    expect(repository.getSyncState({ scope })?.lastError).toBe('upload failed')
+
+    repository.applyMemoryPatch({
+      nextPullAt: 5_000,
+      patch: { scope },
+      pulledAt: 4_000,
+    })
+
+    const syncState = repository.getSyncState({ scope })
+    expect(syncState?.lastError).toBeNull()
+    expect(syncState?.nextRetryAt).toBe(3_000)
+
+    repository.close()
+  })
+
   it('applies a newer memory patch and updates summary, facts, memory cards, and sync state', () => {
     const tempDatabase = createTempDatabasePath()
     cleanupCallbacks.push(tempDatabase.cleanup)

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/repository.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/repository.test.ts
@@ -1,0 +1,1054 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createMemoryRepository } from './repository'
+
+function createTempDatabasePath() {
+  // NOTICE:
+  // Tests use a real file-backed SQLite database so we can verify persisted rows
+  // through a second connection without exposing repository internals.
+  // Root cause: Phase 2 requires validating table state, supersede chains, and
+  // transaction side effects directly in SQLite.
+  // Source/context: node:sqlite DatabaseSync supports file-backed paths and
+  // synchronous access in the current Node runtime.
+  // Removal condition: Safe to remove if repository tests no longer need direct
+  // SQLite inspection or if a dedicated test helper becomes available.
+  const directoryPath = mkdtempSync(join(tmpdir(), 'airi-memory-repository-'))
+
+  return {
+    cleanup: () => rmSync(directoryPath, { force: true, recursive: true }),
+    databasePath: join(directoryPath, 'memory.sqlite'),
+  }
+}
+
+describe('memory repository', () => {
+  const cleanupCallbacks: Array<() => void> = []
+
+  afterEach(() => {
+    for (const cleanup of cleanupCallbacks.splice(0)) {
+      cleanup()
+    }
+  })
+
+  it('initializes the Phase 2 SQLite schema successfully', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+    repository.close()
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const tables = database.prepare(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name IN ('profile_summary', 'stable_facts', 'recent_turns', 'raw_turn_log', 'memory_cards', 'sync_state')
+      ORDER BY name
+    `).all() as Array<{ name: string }>
+
+    const rawTurnLogColumns = database.prepare('PRAGMA table_info(raw_turn_log)').all() as Array<{ name: string }>
+
+    expect(tables).toEqual([
+      { name: 'memory_cards' },
+      { name: 'profile_summary' },
+      { name: 'raw_turn_log' },
+      { name: 'recent_turns' },
+      { name: 'stable_facts' },
+      { name: 'sync_state' },
+    ])
+    expect(rawTurnLogColumns.some(column => column.name === 'sync_status')).toBe(true)
+
+    database.close()
+  })
+
+  it('appends one turn into raw_turn_log and recent_turns with pending sync status', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { content: 'hello', role: 'user' },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'hello',
+      turnId: 'turn-1',
+    })
+    repository.close()
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const rawTurnRow = database.prepare(`
+      SELECT turn_id, role, raw_payload_json, sync_status
+      FROM raw_turn_log
+      WHERE turn_id = ?
+    `).get('turn-1') as {
+      raw_payload_json: string
+      role: string
+      sync_status: string
+      turn_id: string
+    }
+    const recentTurnRow = database.prepare(`
+      SELECT turn_id, role, turn_text
+      FROM recent_turns
+      WHERE turn_id = ?
+    `).get('turn-1') as {
+      role: string
+      turn_id: string
+      turn_text: string
+    }
+
+    expect(rawTurnRow.turn_id).toBe('turn-1')
+    expect(rawTurnRow.role).toBe('user')
+    expect(rawTurnRow.sync_status).toBe('pending')
+    expect(JSON.parse(rawTurnRow.raw_payload_json)).toEqual({ content: 'hello', role: 'user' })
+    expect(recentTurnRow).toEqual({
+      role: 'user',
+      turn_id: 'turn-1',
+      turn_text: 'hello',
+    })
+
+    database.close()
+  })
+
+  it('replaces the current profile summary for the same user and character', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    const firstSummary = repository.replaceProfileSummary({
+      confidence: 0.4,
+      generatedFromTurnId: 'turn-1',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      summaryMarkdown: 'First summary',
+      updatedAt: 1_000,
+    })
+    const secondSummary = repository.replaceProfileSummary({
+      confidence: 0.9,
+      generatedFromTurnId: 'turn-2',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-b',
+        userId: 'user-a',
+      },
+      summaryMarkdown: 'Second summary',
+      updatedAt: 2_000,
+    })
+
+    const promptContext = repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-b',
+        userId: 'user-a',
+      },
+    })
+    repository.close()
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const summaryRows = database.prepare(`
+      SELECT id, summary_markdown, superseded_by, version
+      FROM profile_summary
+      ORDER BY created_at ASC
+    `).all() as Array<{
+      id: string
+      summary_markdown: string
+      superseded_by: string | null
+      version: number
+    }>
+
+    expect(promptContext.profileSummary?.id).toBe(secondSummary.id)
+    expect(promptContext.profileSummary?.summaryMarkdown).toBe('Second summary')
+    expect(summaryRows).toEqual([
+      {
+        id: firstSummary.id,
+        summary_markdown: 'First summary',
+        superseded_by: secondSummary.id,
+        version: 1,
+      },
+      {
+        id: secondSummary.id,
+        summary_markdown: 'Second summary',
+        superseded_by: null,
+        version: 2,
+      },
+    ])
+
+    database.close()
+  })
+
+  it('supersedes the previous stable fact for the same scoped fact key', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    const firstFact = repository.upsertStableFact({
+      confidence: 0.3,
+      factKey: 'favorite-color',
+      factValue: 'blue',
+      generatedFromTurnId: 'turn-1',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      updatedAt: 1_000,
+    })
+    const secondFact = repository.upsertStableFact({
+      confidence: 0.8,
+      factKey: 'favorite-color',
+      factValue: 'green',
+      generatedFromTurnId: 'turn-2',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      updatedAt: 2_000,
+    })
+
+    const promptContext = repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })
+    repository.close()
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const factRows = database.prepare(`
+      SELECT id, fact_key, fact_value, superseded_by, version
+      FROM stable_facts
+      ORDER BY created_at ASC
+    `).all() as Array<{
+      fact_key: string
+      fact_value: string
+      id: string
+      superseded_by: string | null
+      version: number
+    }>
+
+    expect(promptContext.stableFacts).toEqual([
+      expect.objectContaining({
+        factKey: 'favorite-color',
+        factValue: 'green',
+        id: secondFact.id,
+      }),
+    ])
+    expect(factRows).toEqual([
+      {
+        fact_key: 'favorite-color',
+        fact_value: 'blue',
+        id: firstFact.id,
+        superseded_by: secondFact.id,
+        version: 1,
+      },
+      {
+        fact_key: 'favorite-color',
+        fact_value: 'green',
+        id: secondFact.id,
+        superseded_by: null,
+        version: 2,
+      },
+    ])
+
+    database.close()
+  })
+
+  it('reads prompt context with current summary, unsuperseded stable facts, and the latest 24 turns in ascending order', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.replaceProfileSummary({
+      confidence: 1,
+      generatedFromTurnId: 'turn-summary',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      summaryMarkdown: 'Current summary',
+      updatedAt: 500,
+    })
+
+    repository.upsertStableFact({
+      confidence: 0.4,
+      factKey: 'location',
+      factValue: 'tokyo',
+      generatedFromTurnId: 'turn-fact-1',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      updatedAt: 600,
+    })
+    repository.upsertStableFact({
+      confidence: 0.9,
+      factKey: 'location',
+      factValue: 'kyoto',
+      generatedFromTurnId: 'turn-fact-2',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      updatedAt: 700,
+    })
+    repository.upsertStableFact({
+      confidence: 0.8,
+      factKey: 'hobby',
+      factValue: 'music',
+      generatedFromTurnId: 'turn-fact-3',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      updatedAt: 800,
+    })
+    repository.upsertStableFact({
+      confidence: 1,
+      factKey: 'ignored-other-scope',
+      factValue: 'ignore-me',
+      generatedFromTurnId: 'turn-fact-4',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-b',
+        userId: 'user-a',
+      },
+      updatedAt: 900,
+    })
+
+    for (let turnNumber = 1; turnNumber <= 26; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 100,
+        rawPayload: { order: turnNumber },
+        role: turnNumber % 2 === 0 ? 'assistant' : 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    repository.appendTurn({
+      createdAt: 99_999,
+      rawPayload: { order: 'other-scope' },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-b',
+        userId: 'user-a',
+      },
+      text: 'ignore-other-scope',
+      turnId: 'turn-other-scope',
+    })
+
+    const promptContext = repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })
+    repository.close()
+
+    expect(promptContext.profileSummary?.summaryMarkdown).toBe('Current summary')
+    expect(promptContext.stableFacts.map(fact => `${fact.factKey}:${fact.factValue}`)).toEqual([
+      'hobby:music',
+      'location:kyoto',
+    ])
+    expect(promptContext.recentTurns).toHaveLength(24)
+    expect(promptContext.recentTurns[0]?.turnId).toBe('turn-3')
+    expect(promptContext.recentTurns[0]?.text).toBe('turn-3')
+    expect(promptContext.recentTurns[23]?.turnId).toBe('turn-26')
+    expect(promptContext.recentTurns.map(turn => turn.turnId)).toEqual(
+      Array.from({ length: 24 }, (_, index) => `turn-${index + 3}`),
+    )
+  })
+
+  it('returns null sync state when no row exists for the scope', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toBeNull()
+
+    repository.close()
+  })
+
+  it('lists pending raw turns ordered by time and filtered by scope', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'first',
+      turnId: 'turn-1',
+    })
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { order: 2 },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'second',
+      turnId: 'turn-2',
+    })
+    repository.appendTurn({
+      createdAt: 3_000,
+      rawPayload: { order: 3 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-b',
+        userId: 'user-a',
+      },
+      text: 'other-scope',
+      turnId: 'turn-3',
+    })
+
+    repository.markRawTurnsUploaded({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      turnIds: ['turn-2'],
+      uploadedAt: 5_000,
+    })
+
+    expect(repository.listPendingRawTurnScopes()).toEqual([
+      {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      {
+        characterId: 'character-a',
+        sessionId: 'session-b',
+        userId: 'user-a',
+      },
+    ])
+    expect(repository.listPendingRawTurns({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual([
+      expect.objectContaining({
+        rawPayload: { order: 1 },
+        role: 'user',
+        syncStatus: 'pending',
+        text: 'first',
+        turnId: 'turn-1',
+      }),
+    ])
+
+    repository.close()
+  })
+
+  it('prunes only uploaded turns older than the configurable retention window and keeps long-term memory', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { state: 'pending-old' },
+      role: 'user',
+      scope,
+      text: 'pending old',
+      turnId: 'turn-pending-old',
+    })
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { state: 'uploaded-old' },
+      role: 'assistant',
+      scope,
+      text: 'uploaded old',
+      turnId: 'turn-uploaded-old',
+    })
+    repository.appendTurn({
+      createdAt: 9_000,
+      rawPayload: { state: 'uploaded-new' },
+      role: 'user',
+      scope,
+      text: 'uploaded new',
+      turnId: 'turn-uploaded-new',
+    })
+    repository.markRawTurnsUploaded({
+      scope,
+      turnIds: ['turn-uploaded-old', 'turn-uploaded-new'],
+      uploadedAt: 10_000,
+    })
+    repository.replaceProfileSummary({
+      scope,
+      summaryMarkdown: 'Keep summary',
+      updatedAt: 11_000,
+    })
+    repository.upsertStableFact({
+      factKey: 'keep',
+      factValue: 'fact',
+      scope,
+      updatedAt: 11_000,
+    })
+    repository.applyMemoryPatch({
+      nextPullAt: 20_000,
+      patch: {
+        memoryCards: [
+          {
+            content: 'Keep card',
+            id: 'card-keep',
+            title: 'Keep Card',
+          },
+        ],
+        scope,
+      },
+      pulledAt: 11_000,
+    })
+
+    const pruneResult = repository.pruneUploadedTurns({
+      now: 12_000,
+      retentionWindowMs: 5_000,
+      scope,
+    })
+
+    expect(pruneResult).toEqual({
+      prunedRawTurnCount: 1,
+      prunedRecentTurnCount: 1,
+    })
+    expect(repository.listPendingRawTurns({ scope }).map(turn => turn.turnId)).toEqual([
+      'turn-pending-old',
+    ])
+    expect(repository.readPromptContext({ scope }).recentTurns.map(turn => turn.turnId)).toEqual([
+      'turn-pending-old',
+      'turn-uploaded-new',
+    ])
+    expect(repository.readPromptContext({ scope })).toEqual(expect.objectContaining({
+      profileSummary: expect.objectContaining({
+        summaryMarkdown: 'Keep summary',
+      }),
+      stableFacts: [
+        expect.objectContaining({
+          factKey: 'keep',
+          factValue: 'fact',
+        }),
+      ],
+    }))
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const memoryCardCount = (database.prepare(`
+      SELECT COUNT(*) AS count
+      FROM memory_cards
+    `).get() as { count: number }).count
+    const rawTurnRows = database.prepare(`
+      SELECT turn_id, sync_status
+      FROM raw_turn_log
+      ORDER BY created_at ASC
+    `).all() as Array<{ sync_status: string, turn_id: string }>
+    const recentTurnRows = database.prepare(`
+      SELECT turn_id
+      FROM recent_turns
+      ORDER BY created_at ASC
+    `).all() as Array<{ turn_id: string }>
+
+    expect(memoryCardCount).toBe(1)
+    expect(rawTurnRows).toEqual([
+      { sync_status: 'pending', turn_id: 'turn-pending-old' },
+      { sync_status: 'uploaded', turn_id: 'turn-uploaded-new' },
+    ])
+    expect(recentTurnRows).toEqual([
+      { turn_id: 'turn-pending-old' },
+      { turn_id: 'turn-uploaded-new' },
+    ])
+
+    database.close()
+    repository.close()
+  })
+
+  it('applies a newer memory patch and updates summary, facts, memory cards, and sync state', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-1',
+      turnId: 'turn-1',
+    })
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { order: 2 },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-2',
+      turnId: 'turn-2',
+    })
+
+    const applyResult = repository.applyMemoryPatch({
+      nextPullAt: 9_000,
+      patch: {
+        factsPatch: [
+          {
+            confidence: 0.8,
+            factKey: 'location',
+            factValue: 'kyoto',
+            generatedFromTurnId: 'turn-2',
+          },
+        ],
+        memoryCards: [
+          {
+            confidence: 0.7,
+            content: 'card body',
+            id: 'card-1',
+            title: 'Card One',
+          },
+        ],
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          confidence: 0.9,
+          generatedFromTurnId: 'turn-2',
+          summaryMarkdown: 'Cloud summary',
+          summaryVersion: 2,
+        },
+      },
+      pulledAt: 5_000,
+    })
+
+    expect(applyResult).toEqual({
+      appliedFactsCount: 1,
+      appliedMemoryCardCount: 1,
+      appliedSummary: true,
+      rejectedSummaryReason: null,
+    })
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      profileSummary: expect.objectContaining({
+        summaryMarkdown: 'Cloud summary',
+        version: 2,
+      }),
+      stableFacts: [
+        expect.objectContaining({
+          factKey: 'location',
+          factValue: 'kyoto',
+        }),
+      ],
+    }))
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      lastAppliedGeneratedFromTurnId: 'turn-2',
+      lastAppliedSummaryVersion: 2,
+      lastAppliedTurnCheckpoint: 2_000,
+      lastPullAt: 5_000,
+      nextPullAt: 9_000,
+    }))
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const memoryCards = database.prepare(`
+      SELECT id, title, content
+      FROM memory_cards
+      ORDER BY id ASC
+    `).all() as Array<{ content: string, id: string, title: string }>
+
+    expect(memoryCards).toEqual([
+      {
+        content: 'card body',
+        id: 'card-1',
+        title: 'Card One',
+      },
+    ])
+
+    database.close()
+    repository.close()
+  })
+
+  it('rejects an older summary version patch without overwriting newer state', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { order: 2 },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-2',
+      turnId: 'turn-2',
+    })
+
+    repository.applyMemoryPatch({
+      nextPullAt: 9_000,
+      patch: {
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          confidence: 0.9,
+          generatedFromTurnId: 'turn-2',
+          summaryMarkdown: 'Newer summary',
+          summaryVersion: 3,
+        },
+      },
+      pulledAt: 5_000,
+    })
+
+    const applyResult = repository.applyMemoryPatch({
+      nextPullAt: 10_000,
+      patch: {
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          confidence: 0.5,
+          generatedFromTurnId: 'turn-2',
+          summaryMarkdown: 'Older summary',
+          summaryVersion: 2,
+        },
+      },
+      pulledAt: 6_000,
+    })
+
+    expect(applyResult).toEqual({
+      appliedFactsCount: 0,
+      appliedMemoryCardCount: 0,
+      appliedSummary: false,
+      rejectedSummaryReason: 'outdated-summary-version',
+    })
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    }).profileSummary?.summaryMarkdown).toBe('Newer summary')
+
+    repository.close()
+  })
+
+  it('rejects a summary patch generated from an older turn than the applied checkpoint', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-1',
+      turnId: 'turn-1',
+    })
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { order: 2 },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-2',
+      turnId: 'turn-2',
+    })
+
+    repository.applyMemoryPatch({
+      nextPullAt: 9_000,
+      patch: {
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          confidence: 0.9,
+          generatedFromTurnId: 'turn-2',
+          summaryMarkdown: 'Current summary',
+          summaryVersion: 3,
+        },
+      },
+      pulledAt: 5_000,
+    })
+
+    const applyResult = repository.applyMemoryPatch({
+      nextPullAt: 10_000,
+      patch: {
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          confidence: 1,
+          generatedFromTurnId: 'turn-1',
+          summaryMarkdown: 'Stale turn summary',
+          summaryVersion: 4,
+        },
+      },
+      pulledAt: 6_000,
+    })
+
+    expect(applyResult).toEqual({
+      appliedFactsCount: 0,
+      appliedMemoryCardCount: 0,
+      appliedSummary: false,
+      rejectedSummaryReason: 'outdated-generated-from-turn',
+    })
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    }).profileSummary?.summaryMarkdown).toBe('Current summary')
+
+    repository.close()
+  })
+
+  it('merges patched facts through supersede chains and upserts memory cards', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-1',
+      turnId: 'turn-1',
+    })
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { order: 2 },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-2',
+      turnId: 'turn-2',
+    })
+
+    repository.upsertStableFact({
+      confidence: 0.5,
+      factKey: 'favorite-color',
+      factValue: 'blue',
+      generatedFromTurnId: 'turn-1',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      updatedAt: 1_500,
+    })
+
+    repository.applyMemoryPatch({
+      nextPullAt: 9_000,
+      patch: {
+        factsPatch: [
+          {
+            confidence: 0.9,
+            factKey: 'favorite-color',
+            factValue: 'green',
+            generatedFromTurnId: 'turn-2',
+          },
+        ],
+        memoryCards: [
+          {
+            confidence: 0.4,
+            content: 'old card body',
+            id: 'card-1',
+            title: 'Old Card',
+          },
+        ],
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+      },
+      pulledAt: 5_000,
+    })
+
+    const applyResult = repository.applyMemoryPatch({
+      nextPullAt: 10_000,
+      patch: {
+        factsPatch: [
+          {
+            confidence: 1,
+            factKey: 'favorite-color',
+            factValue: 'red',
+            generatedFromTurnId: 'turn-2',
+          },
+        ],
+        memoryCards: [
+          {
+            confidence: 0.8,
+            content: 'new card body',
+            id: 'card-1',
+            title: 'New Card',
+          },
+        ],
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+      },
+      pulledAt: 6_000,
+    })
+
+    expect(applyResult).toEqual({
+      appliedFactsCount: 1,
+      appliedMemoryCardCount: 1,
+      appliedSummary: false,
+      rejectedSummaryReason: null,
+    })
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    }).stableFacts).toEqual([
+      expect.objectContaining({
+        factKey: 'favorite-color',
+        factValue: 'red',
+      }),
+    ])
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const stableFacts = database.prepare(`
+      SELECT fact_value, superseded_by
+      FROM stable_facts
+      WHERE fact_key = 'favorite-color'
+      ORDER BY created_at ASC
+    `).all() as Array<{ fact_value: string, superseded_by: string | null }>
+    const memoryCards = database.prepare(`
+      SELECT id, title, content
+      FROM memory_cards
+      ORDER BY id ASC
+    `).all() as Array<{ content: string, id: string, title: string }>
+
+    expect(stableFacts.at(-1)).toEqual({
+      fact_value: 'red',
+      superseded_by: null,
+    })
+    expect(stableFacts[0]?.superseded_by).not.toBeNull()
+    expect(memoryCards).toEqual([
+      {
+        content: 'new card body',
+        id: 'card-1',
+        title: 'New Card',
+      },
+    ])
+
+    database.close()
+    repository.close()
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/repository.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/repository.ts
@@ -1,0 +1,1454 @@
+import type { StatementSync } from 'node:sqlite'
+
+import type {
+  ApplyMemoryPatchResult,
+  MemoryPatchPayload,
+  MemoryStableFactPatch,
+} from './sync-types'
+import type {
+  MemoryAppendTurnInput,
+  MemoryGetSyncStateInput,
+  MemoryProfileSummaryRecord,
+  MemoryPromptContext,
+  MemoryRawTurnRecord,
+  MemoryReadPromptContextInput,
+  MemoryRecentTurnRecord,
+  MemoryReplaceProfileSummaryInput,
+  MemoryRepositoryScope,
+  MemoryStableFactRecord,
+  MemorySyncStateRecord,
+  MemoryUpsertStableFactInput,
+} from './types'
+
+import { randomUUID } from 'node:crypto'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { memorySchemaV1Sql } from './schema'
+
+interface MemoryRepositoryOptions {
+  /** Absolute or relative SQLite database path. Use `:memory:` for in-memory tests. */
+  databasePath: string
+}
+
+/**
+ * Input for deleting uploaded local raw/recent turns after cloud confirmation.
+ */
+export interface MemoryPruneUploadedTurnsInput {
+  /** Scope whose short-term turn rows should be considered for pruning. */
+  scope: MemoryRepositoryScope
+  /** Current Unix timestamp in milliseconds used to compute the retention cutoff. */
+  now: number
+  /** Configurable retention window in milliseconds. Rows newer than this window are kept. */
+  retentionWindowMs: number
+}
+
+/**
+ * Result of one uploaded-turn pruning pass.
+ */
+export interface MemoryPruneUploadedTurnsResult {
+  /** Number of rows deleted from `raw_turn_log`. */
+  prunedRawTurnCount: number
+  /** Number of rows deleted from `recent_turns`. */
+  prunedRecentTurnCount: number
+}
+
+/**
+ * Synchronous local-first SQLite repository for desktop memory.
+ */
+export interface MemoryRepository {
+  initialize: () => void
+  appendTurn: (input: MemoryAppendTurnInput) => MemoryRecentTurnRecord
+  replaceProfileSummary: (input: MemoryReplaceProfileSummaryInput) => MemoryProfileSummaryRecord
+  upsertStableFact: (input: MemoryUpsertStableFactInput) => MemoryStableFactRecord
+  readPromptContext: (input: MemoryReadPromptContextInput) => MemoryPromptContext
+  getSyncState: (input: MemoryGetSyncStateInput) => MemorySyncStateRecord | null
+  listPendingRawTurnScopes: () => MemoryRepositoryScope[]
+  listPendingRawTurns: (input: MemoryGetSyncStateInput) => MemoryRawTurnRecord[]
+  listSyncScopes: () => MemoryRepositoryScope[]
+  markRawTurnsUploaded: (input: { scope: MemoryRepositoryScope, turnIds: string[], uploadedAt: number }) => void
+  pruneUploadedTurns: (input: MemoryPruneUploadedTurnsInput) => MemoryPruneUploadedTurnsResult
+  recordRawTurnUploadFailure: (input: { scope: MemoryRepositoryScope, error: string, failedAt: number, nextRetryAt: number }) => void
+  applyMemoryPatch: (input: { patch: MemoryPatchPayload, pulledAt: number, nextPullAt: number }) => ApplyMemoryPatchResult
+  recordMemoryPatchPullFailure: (input: { scope: MemoryRepositoryScope, error: string, failedAt: number, nextPullAt: number }) => void
+  close: () => void
+}
+
+interface ScopeBoundValues {
+  sessionId: string | null
+  userId: string
+  characterId: string
+}
+
+interface ProfileSummaryRow {
+  id: string
+  scope_user_id: string
+  scope_character_id: string
+  scope_session_id: string | null
+  version: number
+  summary_markdown: string
+  generated_from_turn_id: string | null
+  confidence: number
+  superseded_by: string | null
+  created_at: number
+  updated_at: number
+}
+
+interface StableFactRow {
+  id: string
+  scope_user_id: string
+  scope_character_id: string
+  scope_session_id: string | null
+  version: number
+  fact_key: string
+  fact_value: string
+  generated_from_turn_id: string | null
+  confidence: number
+  superseded_by: string | null
+  created_at: number
+  updated_at: number
+}
+
+interface RecentTurnRow {
+  turn_id: string
+  scope_user_id: string
+  scope_character_id: string
+  scope_session_id: string | null
+  version: number
+  role: MemoryRecentTurnRecord['role']
+  turn_text: string
+  created_at: number
+  updated_at: number
+}
+
+interface RawTurnRow {
+  turn_id: string
+  scope_user_id: string
+  scope_character_id: string
+  scope_session_id: string | null
+  version: number
+  role: MemoryRecentTurnRecord['role']
+  raw_payload_json: string
+  sync_status: 'pending' | 'uploaded'
+  turn_text: string
+  created_at: number
+  updated_at: number
+}
+
+interface SyncStateRow {
+  id: string
+  scope_user_id: string
+  scope_character_id: string
+  scope_session_id: string | null
+  version: number
+  generated_from_turn_id: string | null
+  confidence: number
+  superseded_by: string | null
+  sync_checkpoint: number
+  last_local_turn_checkpoint: number
+  remote_checkpoint: string | null
+  last_synced_turn_id: string | null
+  last_synced_at: number | null
+  last_uploaded_turn_id: string | null
+  last_upload_at: number | null
+  last_applied_summary_version: number
+  last_applied_generated_from_turn_id: string | null
+  last_applied_turn_checkpoint: number
+  last_pull_at: number | null
+  next_pull_at: number | null
+  pending_turn_count: number
+  retry_count: number
+  next_retry_at: number | null
+  sync_state: string
+  last_error: string | null
+  created_at: number
+  updated_at: number
+}
+
+interface MemoryRepositoryStatements {
+  insertProfileSummaryStatement: StatementSync
+  insertRawTurnStatement: StatementSync
+  insertRecentTurnStatement: StatementSync
+  insertStableFactStatement: StatementSync
+  insertSyncStateStatement: StatementSync
+  selectCurrentProfileSummaryStatement: StatementSync
+  selectCurrentStableFactStatement: StatementSync
+  selectCurrentSyncStateStatement: StatementSync
+  selectLastRawTurnCheckpointStatement: StatementSync
+  selectPendingRawTurnCountStatement: StatementSync
+  selectPendingRawTurnScopesStatement: StatementSync
+  selectPendingRawTurnsStatement: StatementSync
+  selectRecentTurnsForPromptContextStatement: StatementSync
+  selectStableFactsForPromptContextStatement: StatementSync
+  selectSyncScopesStatement: StatementSync
+  selectTurnCheckpointByTurnIdStatement: StatementSync
+  supersedeProfileSummaryStatement: StatementSync
+  supersedeStableFactStatement: StatementSync
+  updateSyncStateStatement: StatementSync
+  upsertMemoryCardStatement: StatementSync
+}
+
+function isInMemoryDatabasePath(databasePath: string) {
+  return databasePath === ':memory:'
+    || databasePath.startsWith('file::memory:')
+}
+
+function ensureDatabaseDirectory(databasePath: string) {
+  if (isInMemoryDatabasePath(databasePath)) {
+    return
+  }
+
+  // SQLite will create the file itself, but the parent directory must exist first.
+  mkdirSync(dirname(databasePath), { recursive: true })
+}
+
+function toScopeBoundValues(scope: MemoryRepositoryScope): ScopeBoundValues {
+  return {
+    characterId: scope.characterId,
+    sessionId: scope.sessionId ?? null,
+    userId: scope.userId,
+  }
+}
+
+function mapScope(row: { scope_user_id: string, scope_character_id: string, scope_session_id: string | null }): MemoryRepositoryScope {
+  return {
+    characterId: row.scope_character_id,
+    sessionId: row.scope_session_id,
+    userId: row.scope_user_id,
+  }
+}
+
+function mapProfileSummaryRow(row: ProfileSummaryRow): MemoryProfileSummaryRecord {
+  return {
+    confidence: row.confidence,
+    createdAt: row.created_at,
+    generatedFromTurnId: row.generated_from_turn_id,
+    id: row.id,
+    scope: mapScope(row),
+    summaryMarkdown: row.summary_markdown,
+    supersededBy: row.superseded_by,
+    updatedAt: row.updated_at,
+    version: row.version,
+  }
+}
+
+function mapStableFactRow(row: StableFactRow): MemoryStableFactRecord {
+  return {
+    confidence: row.confidence,
+    createdAt: row.created_at,
+    factKey: row.fact_key,
+    factValue: row.fact_value,
+    generatedFromTurnId: row.generated_from_turn_id,
+    id: row.id,
+    scope: mapScope(row),
+    supersededBy: row.superseded_by,
+    updatedAt: row.updated_at,
+    version: row.version,
+  }
+}
+
+function mapRecentTurnRow(row: RecentTurnRow): MemoryRecentTurnRecord {
+  return {
+    createdAt: row.created_at,
+    role: row.role,
+    scope: mapScope(row),
+    text: row.turn_text,
+    turnId: row.turn_id,
+    updatedAt: row.updated_at,
+    version: row.version,
+  }
+}
+
+function mapRawTurnRow(row: RawTurnRow): MemoryRawTurnRecord {
+  return {
+    createdAt: row.created_at,
+    rawPayload: JSON.parse(row.raw_payload_json) as Record<string, unknown> | null,
+    role: row.role,
+    scope: mapScope(row),
+    syncStatus: row.sync_status,
+    text: row.turn_text,
+    turnId: row.turn_id,
+    updatedAt: row.updated_at,
+    version: row.version,
+  }
+}
+
+function mapSyncStateRow(row: SyncStateRow): MemorySyncStateRecord {
+  return {
+    confidence: row.confidence,
+    createdAt: row.created_at,
+    generatedFromTurnId: row.generated_from_turn_id,
+    id: row.id,
+    lastAppliedGeneratedFromTurnId: row.last_applied_generated_from_turn_id,
+    lastAppliedSummaryVersion: row.last_applied_summary_version,
+    lastAppliedTurnCheckpoint: row.last_applied_turn_checkpoint,
+    lastError: row.last_error,
+    lastLocalTurnCheckpoint: row.last_local_turn_checkpoint,
+    lastPullAt: row.last_pull_at,
+    lastSyncedAt: row.last_synced_at,
+    lastSyncedTurnId: row.last_synced_turn_id,
+    lastUploadAt: row.last_upload_at,
+    lastUploadedTurnId: row.last_uploaded_turn_id,
+    nextPullAt: row.next_pull_at,
+    nextRetryAt: row.next_retry_at,
+    pendingTurnCount: row.pending_turn_count,
+    remoteCheckpoint: row.remote_checkpoint,
+    retryCount: row.retry_count,
+    scope: mapScope(row),
+    state: row.sync_state,
+    supersededBy: row.superseded_by,
+    syncCheckpoint: row.sync_checkpoint,
+    updatedAt: row.updated_at,
+    version: row.version,
+  }
+}
+
+function runInTransaction<T>(database: DatabaseSync, work: () => T): T {
+  database.exec('BEGIN IMMEDIATE')
+
+  try {
+    const result = work()
+    database.exec('COMMIT')
+    return result
+  }
+  catch (error) {
+    if (database.isTransaction) {
+      database.exec('ROLLBACK')
+    }
+
+    throw error
+  }
+}
+
+/**
+ * Creates the local SQLite repository for desktop memory, sync upload, and patch merge workflows.
+ *
+ * Use when:
+ * - Desktop main-process services need one concrete local-first memory implementation
+ * - Tests need real SQLite-backed reads, writes, sync bookkeeping, and patch merge behavior
+ *
+ * Expects:
+ * - `databasePath` points to a writable file location or `:memory:`
+ * - Callers invoke `initialize()` before repository reads or writes
+ *
+ * Returns:
+ * - A synchronous repository covering prompt reads, turn writes, sync status, and patch application
+ */
+export function createMemoryRepository(options: MemoryRepositoryOptions): MemoryRepository {
+  ensureDatabaseDirectory(options.databasePath)
+
+  const database = new DatabaseSync(options.databasePath)
+  let statements: MemoryRepositoryStatements | null = null
+
+  function prepareStatements(): MemoryRepositoryStatements {
+    return {
+      insertProfileSummaryStatement: database.prepare(`
+        INSERT INTO profile_summary (
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          summary_markdown,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertRawTurnStatement: database.prepare(`
+        INSERT INTO raw_turn_log (
+          turn_id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          role,
+          raw_payload_json,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          sync_checkpoint,
+          sync_status,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertRecentTurnStatement: database.prepare(`
+        INSERT INTO recent_turns (
+          turn_id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          role,
+          turn_text,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertStableFactStatement: database.prepare(`
+        INSERT INTO stable_facts (
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          fact_key,
+          fact_value,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      insertSyncStateStatement: database.prepare(`
+        INSERT INTO sync_state (
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          sync_checkpoint,
+          last_local_turn_checkpoint,
+          remote_checkpoint,
+          last_synced_turn_id,
+          last_synced_at,
+          last_uploaded_turn_id,
+          last_upload_at,
+          last_applied_summary_version,
+          last_applied_generated_from_turn_id,
+          last_applied_turn_checkpoint,
+          last_pull_at,
+          next_pull_at,
+          pending_turn_count,
+          retry_count,
+          next_retry_at,
+          sync_state,
+          last_error,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `),
+      selectCurrentProfileSummaryStatement: database.prepare(`
+        SELECT
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          summary_markdown,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        FROM profile_summary
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND superseded_by IS NULL
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT 1
+      `),
+      selectCurrentStableFactStatement: database.prepare(`
+        SELECT
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          fact_key,
+          fact_value,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        FROM stable_facts
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+          AND fact_key = ?
+          AND superseded_by IS NULL
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT 1
+      `),
+      selectCurrentSyncStateStatement: database.prepare(`
+        SELECT
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          sync_checkpoint,
+          last_local_turn_checkpoint,
+          remote_checkpoint,
+          last_synced_turn_id,
+          last_synced_at,
+          last_uploaded_turn_id,
+          last_upload_at,
+          last_applied_summary_version,
+          last_applied_generated_from_turn_id,
+          last_applied_turn_checkpoint,
+          last_pull_at,
+          next_pull_at,
+          pending_turn_count,
+          retry_count,
+          next_retry_at,
+          sync_state,
+          last_error,
+          created_at,
+          updated_at
+        FROM sync_state
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+          AND superseded_by IS NULL
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT 1
+      `),
+      selectLastRawTurnCheckpointStatement: database.prepare(`
+        SELECT COALESCE(MAX(created_at), 0) AS checkpoint
+        FROM raw_turn_log
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+      `),
+      selectPendingRawTurnCountStatement: database.prepare(`
+        SELECT COUNT(*) AS count
+        FROM raw_turn_log
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+          AND sync_status = 'pending'
+      `),
+      selectPendingRawTurnScopesStatement: database.prepare(`
+        SELECT
+          scope_user_id,
+          scope_character_id,
+          scope_session_id
+        FROM raw_turn_log
+        WHERE sync_status = 'pending'
+        GROUP BY scope_user_id, scope_character_id, scope_session_id
+        ORDER BY MIN(created_at) ASC
+      `),
+      selectPendingRawTurnsStatement: database.prepare(`
+        SELECT
+          raw_turn_log.turn_id,
+          raw_turn_log.scope_user_id,
+          raw_turn_log.scope_character_id,
+          raw_turn_log.scope_session_id,
+          raw_turn_log.version,
+          raw_turn_log.role,
+          raw_turn_log.raw_payload_json,
+          raw_turn_log.sync_status,
+          COALESCE(recent_turns.turn_text, '') AS turn_text,
+          raw_turn_log.created_at,
+          raw_turn_log.updated_at
+        FROM raw_turn_log
+        LEFT JOIN recent_turns
+          ON recent_turns.turn_id = raw_turn_log.turn_id
+        WHERE raw_turn_log.scope_user_id = ?
+          AND raw_turn_log.scope_character_id = ?
+          AND ((? IS NULL AND raw_turn_log.scope_session_id IS NULL) OR raw_turn_log.scope_session_id = ?)
+          AND raw_turn_log.sync_status = 'pending'
+        ORDER BY raw_turn_log.created_at ASC, raw_turn_log.turn_id ASC
+      `),
+      selectRecentTurnsForPromptContextStatement: database.prepare(`
+        SELECT
+          turn_id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          role,
+          turn_text,
+          created_at,
+          updated_at
+        FROM (
+          SELECT
+            turn_id,
+            scope_user_id,
+            scope_character_id,
+            scope_session_id,
+            version,
+            role,
+            turn_text,
+            created_at,
+            updated_at
+          FROM recent_turns
+          WHERE scope_user_id = ?
+            AND scope_character_id = ?
+            AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+            AND superseded_by IS NULL
+          ORDER BY created_at DESC, turn_id DESC
+          LIMIT 24
+        )
+        ORDER BY created_at ASC, turn_id ASC
+      `),
+      selectStableFactsForPromptContextStatement: database.prepare(`
+        SELECT
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          fact_key,
+          fact_value,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        FROM stable_facts
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+          AND superseded_by IS NULL
+        ORDER BY fact_key ASC, created_at ASC
+      `),
+      selectSyncScopesStatement: database.prepare(`
+        SELECT
+          scope_user_id,
+          scope_character_id,
+          scope_session_id
+        FROM sync_state
+        WHERE superseded_by IS NULL
+        ORDER BY updated_at ASC
+      `),
+      selectTurnCheckpointByTurnIdStatement: database.prepare(`
+        SELECT created_at AS checkpoint
+        FROM raw_turn_log
+        WHERE turn_id = ?
+          AND scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+        LIMIT 1
+      `),
+      supersedeProfileSummaryStatement: database.prepare(`
+        UPDATE profile_summary
+        SET superseded_by = ?, updated_at = ?
+        WHERE id = ?
+      `),
+      supersedeStableFactStatement: database.prepare(`
+        UPDATE stable_facts
+        SET superseded_by = ?, updated_at = ?
+        WHERE id = ?
+      `),
+      updateSyncStateStatement: database.prepare(`
+        UPDATE sync_state
+        SET version = ?,
+            generated_from_turn_id = ?,
+            sync_checkpoint = ?,
+            last_local_turn_checkpoint = ?,
+            last_synced_turn_id = ?,
+            last_synced_at = ?,
+            last_uploaded_turn_id = ?,
+            last_upload_at = ?,
+            last_applied_summary_version = ?,
+            last_applied_generated_from_turn_id = ?,
+            last_applied_turn_checkpoint = ?,
+            last_pull_at = ?,
+            next_pull_at = ?,
+            pending_turn_count = ?,
+            retry_count = ?,
+            next_retry_at = ?,
+            sync_state = ?,
+            last_error = ?,
+            updated_at = ?
+        WHERE id = ?
+      `),
+      upsertMemoryCardStatement: database.prepare(`
+        INSERT INTO memory_cards (
+          id,
+          scope_user_id,
+          scope_character_id,
+          scope_session_id,
+          version,
+          title,
+          content,
+          generated_from_turn_id,
+          confidence,
+          superseded_by,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          scope_user_id = excluded.scope_user_id,
+          scope_character_id = excluded.scope_character_id,
+          scope_session_id = excluded.scope_session_id,
+          version = memory_cards.version + 1,
+          title = excluded.title,
+          content = excluded.content,
+          generated_from_turn_id = excluded.generated_from_turn_id,
+          confidence = excluded.confidence,
+          updated_at = excluded.updated_at
+      `),
+    }
+  }
+
+  function getStatements(): MemoryRepositoryStatements {
+    if (!statements) {
+      throw new Error('Memory repository schema is not initialized. Call initialize() before using repository methods.')
+    }
+
+    return statements
+  }
+
+  function getPendingTurnCount(scope: ScopeBoundValues) {
+    const preparedStatements = getStatements()
+    const row = preparedStatements.selectPendingRawTurnCountStatement.get(
+      scope.userId,
+      scope.characterId,
+      scope.sessionId,
+      scope.sessionId,
+    ) as { count: number } | undefined
+
+    return row?.count ?? 0
+  }
+
+  function getLastRawTurnCheckpoint(scope: ScopeBoundValues) {
+    const preparedStatements = getStatements()
+    const row = preparedStatements.selectLastRawTurnCheckpointStatement.get(
+      scope.userId,
+      scope.characterId,
+      scope.sessionId,
+      scope.sessionId,
+    ) as { checkpoint: number | null } | undefined
+
+    return row?.checkpoint ?? 0
+  }
+
+  function selectCurrentSyncState(scope: ScopeBoundValues) {
+    const preparedStatements = getStatements()
+    return preparedStatements.selectCurrentSyncStateStatement.get(
+      scope.userId,
+      scope.characterId,
+      scope.sessionId,
+      scope.sessionId,
+    ) as SyncStateRow | undefined
+  }
+
+  function resolveTurnCheckpoint(scope: ScopeBoundValues, turnId: string | null | undefined) {
+    if (!turnId) {
+      return null
+    }
+
+    const preparedStatements = getStatements()
+    const row = preparedStatements.selectTurnCheckpointByTurnIdStatement.get(
+      turnId,
+      scope.userId,
+      scope.characterId,
+      scope.sessionId,
+      scope.sessionId,
+    ) as { checkpoint: number | null } | undefined
+
+    return row?.checkpoint ?? null
+  }
+
+  function upsertSyncState(params: {
+    scope: ScopeBoundValues
+    updatedAt: number
+    lastUploadedTurnId?: string | null
+    lastUploadAt?: number | null
+    lastSyncedTurnId?: string | null
+    lastSyncedAt?: number | null
+    lastAppliedSummaryVersion?: number
+    lastAppliedGeneratedFromTurnId?: string | null
+    lastAppliedTurnCheckpoint?: number
+    lastPullAt?: number | null
+    nextPullAt?: number | null
+    pendingTurnCount: number
+    retryCount: number
+    nextRetryAt?: number | null
+    state: string
+    lastError?: string | null
+    syncCheckpoint: number
+    lastLocalTurnCheckpoint: number
+    generatedFromTurnId?: string | null
+  }) {
+    const preparedStatements = getStatements()
+    const currentRow = selectCurrentSyncState(params.scope)
+
+    if (!currentRow) {
+      preparedStatements.insertSyncStateStatement.run(
+        randomUUID(),
+        params.scope.userId,
+        params.scope.characterId,
+        params.scope.sessionId,
+        1,
+        params.generatedFromTurnId ?? null,
+        1,
+        null,
+        params.syncCheckpoint,
+        params.lastLocalTurnCheckpoint,
+        null,
+        params.lastSyncedTurnId ?? null,
+        params.lastSyncedAt ?? null,
+        params.lastUploadedTurnId ?? null,
+        params.lastUploadAt ?? null,
+        params.lastAppliedSummaryVersion ?? 0,
+        params.lastAppliedGeneratedFromTurnId ?? null,
+        params.lastAppliedTurnCheckpoint ?? 0,
+        params.lastPullAt ?? null,
+        params.nextPullAt ?? null,
+        params.pendingTurnCount,
+        params.retryCount,
+        params.nextRetryAt ?? null,
+        params.state,
+        params.lastError ?? null,
+        params.updatedAt,
+        params.updatedAt,
+      )
+      return
+    }
+
+    preparedStatements.updateSyncStateStatement.run(
+      currentRow.version + 1,
+      params.generatedFromTurnId ?? currentRow.generated_from_turn_id,
+      params.syncCheckpoint,
+      params.lastLocalTurnCheckpoint,
+      params.lastSyncedTurnId ?? currentRow.last_synced_turn_id,
+      params.lastSyncedAt ?? currentRow.last_synced_at,
+      params.lastUploadedTurnId ?? currentRow.last_uploaded_turn_id,
+      params.lastUploadAt ?? currentRow.last_upload_at,
+      params.lastAppliedSummaryVersion ?? currentRow.last_applied_summary_version,
+      params.lastAppliedGeneratedFromTurnId ?? currentRow.last_applied_generated_from_turn_id,
+      params.lastAppliedTurnCheckpoint ?? currentRow.last_applied_turn_checkpoint,
+      params.lastPullAt ?? currentRow.last_pull_at,
+      params.nextPullAt ?? currentRow.next_pull_at,
+      params.pendingTurnCount,
+      params.retryCount,
+      params.nextRetryAt ?? currentRow.next_retry_at,
+      params.state,
+      params.lastError ?? currentRow.last_error,
+      params.updatedAt,
+      currentRow.id,
+    )
+  }
+
+  function applyFactPatch(params: {
+    scope: ScopeBoundValues
+    factPatch: MemoryStableFactPatch
+    updatedAt: number
+  }) {
+    const preparedStatements = getStatements()
+    const currentRow = preparedStatements.selectCurrentStableFactStatement.get(
+      params.scope.userId,
+      params.scope.characterId,
+      params.scope.sessionId,
+      params.scope.sessionId,
+      params.factPatch.factKey,
+    ) as StableFactRow | undefined
+    const nextId = randomUUID()
+    const nextVersion = (currentRow?.version ?? 0) + 1
+
+    if (currentRow) {
+      preparedStatements.supersedeStableFactStatement.run(nextId, params.updatedAt, currentRow.id)
+    }
+
+    preparedStatements.insertStableFactStatement.run(
+      nextId,
+      params.scope.userId,
+      params.scope.characterId,
+      params.scope.sessionId,
+      nextVersion,
+      params.factPatch.factKey,
+      params.factPatch.factValue,
+      params.factPatch.generatedFromTurnId,
+      params.factPatch.confidence ?? 1,
+      null,
+      params.updatedAt,
+      params.updatedAt,
+    )
+  }
+
+  return {
+    appendTurn(input) {
+      const preparedStatements = getStatements()
+      const scope = toScopeBoundValues(input.scope)
+      const rawPayloadJson = JSON.stringify(input.rawPayload ?? null)
+
+      runInTransaction(database, () => {
+        preparedStatements.insertRawTurnStatement.run(
+          input.turnId,
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          1,
+          input.role,
+          rawPayloadJson,
+          null,
+          1,
+          null,
+          0,
+          'pending',
+          input.createdAt,
+          input.createdAt,
+        )
+        preparedStatements.insertRecentTurnStatement.run(
+          input.turnId,
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          1,
+          input.role,
+          input.text,
+          null,
+          1,
+          null,
+          input.createdAt,
+          input.createdAt,
+        )
+      })
+
+      return {
+        createdAt: input.createdAt,
+        role: input.role,
+        scope: input.scope,
+        text: input.text,
+        turnId: input.turnId,
+        updatedAt: input.createdAt,
+        version: 1,
+      }
+    },
+
+    close() {
+      database.close()
+    },
+
+    getSyncState(input) {
+      const scope = toScopeBoundValues(input.scope)
+      const row = selectCurrentSyncState(scope)
+
+      return row ? mapSyncStateRow(row) : null
+    },
+
+    initialize() {
+      database.exec(memorySchemaV1Sql)
+      statements ??= prepareStatements()
+    },
+
+    listPendingRawTurnScopes() {
+      const preparedStatements = getStatements()
+      const rows = preparedStatements.selectPendingRawTurnScopesStatement.all() as Array<{
+        scope_user_id: string
+        scope_character_id: string
+        scope_session_id: string | null
+      }>
+
+      return rows.map(mapScope)
+    },
+
+    listPendingRawTurns(input) {
+      const preparedStatements = getStatements()
+      const scope = toScopeBoundValues(input.scope)
+      const rows = preparedStatements.selectPendingRawTurnsStatement.all(
+        scope.userId,
+        scope.characterId,
+        scope.sessionId,
+        scope.sessionId,
+      ) as unknown as RawTurnRow[]
+
+      return rows.map(mapRawTurnRow)
+    },
+
+    listSyncScopes() {
+      const preparedStatements = getStatements()
+      const rows = preparedStatements.selectSyncScopesStatement.all() as Array<{
+        scope_user_id: string
+        scope_character_id: string
+        scope_session_id: string | null
+      }>
+
+      return rows.map(mapScope)
+    },
+
+    markRawTurnsUploaded(input) {
+      const scope = toScopeBoundValues(input.scope)
+      if (input.turnIds.length === 0) {
+        return
+      }
+
+      runInTransaction(database, () => {
+        const placeholders = input.turnIds.map(() => '?').join(', ')
+        database.prepare(`
+          UPDATE raw_turn_log
+          SET sync_status = 'uploaded',
+              sync_checkpoint = ?,
+              updated_at = ?
+          WHERE scope_user_id = ?
+            AND scope_character_id = ?
+            AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+            AND turn_id IN (${placeholders})
+        `).run(
+          input.uploadedAt,
+          input.uploadedAt,
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          scope.sessionId,
+          ...input.turnIds,
+        )
+
+        const currentState = this.getSyncState({ scope: input.scope })
+
+        upsertSyncState({
+          generatedFromTurnId: input.turnIds.at(-1) ?? null,
+          lastAppliedGeneratedFromTurnId: currentState?.lastAppliedGeneratedFromTurnId ?? null,
+          lastAppliedSummaryVersion: currentState?.lastAppliedSummaryVersion ?? 0,
+          lastAppliedTurnCheckpoint: currentState?.lastAppliedTurnCheckpoint ?? 0,
+          lastLocalTurnCheckpoint: getLastRawTurnCheckpoint(scope),
+          lastPullAt: currentState?.lastPullAt ?? null,
+          lastSyncedAt: input.uploadedAt,
+          lastSyncedTurnId: input.turnIds.at(-1) ?? null,
+          lastUploadAt: input.uploadedAt,
+          lastUploadedTurnId: input.turnIds.at(-1) ?? null,
+          nextPullAt: input.uploadedAt,
+          pendingTurnCount: getPendingTurnCount(scope),
+          retryCount: 0,
+          scope,
+          state: 'idle',
+          syncCheckpoint: input.uploadedAt,
+          updatedAt: input.uploadedAt,
+        })
+      })
+    },
+
+    readPromptContext(input) {
+      const preparedStatements = getStatements()
+      const scope = toScopeBoundValues(input.scope)
+      const profileSummaryRow = preparedStatements.selectCurrentProfileSummaryStatement.get(
+        scope.userId,
+        scope.characterId,
+      ) as ProfileSummaryRow | undefined
+      const stableFactRows = preparedStatements.selectStableFactsForPromptContextStatement.all(
+        scope.userId,
+        scope.characterId,
+        scope.sessionId,
+        scope.sessionId,
+      ) as unknown as StableFactRow[]
+      const recentTurnRows = preparedStatements.selectRecentTurnsForPromptContextStatement.all(
+        scope.userId,
+        scope.characterId,
+        scope.sessionId,
+        scope.sessionId,
+      ) as unknown as RecentTurnRow[]
+
+      return {
+        profileSummary: profileSummaryRow ? mapProfileSummaryRow(profileSummaryRow) : null,
+        recentTurns: recentTurnRows.map(mapRecentTurnRow),
+        stableFacts: stableFactRows.map(mapStableFactRow),
+      } satisfies MemoryPromptContext
+    },
+
+    pruneUploadedTurns(input) {
+      if (!Number.isFinite(input.retentionWindowMs) || input.retentionWindowMs < 0) {
+        throw new Error('Memory retention window must be a non-negative finite number.')
+      }
+
+      const scope = toScopeBoundValues(input.scope)
+      const pruneBefore = input.now - input.retentionWindowMs
+      const staleTurnRows = database.prepare(`
+        SELECT turn_id
+        FROM raw_turn_log
+        WHERE scope_user_id = ?
+          AND scope_character_id = ?
+          AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+          AND sync_status = 'uploaded'
+          AND created_at < ?
+        ORDER BY created_at ASC, turn_id ASC
+      `).all(
+        scope.userId,
+        scope.characterId,
+        scope.sessionId,
+        scope.sessionId,
+        pruneBefore,
+      ) as Array<{ turn_id: string }>
+      const staleTurnIds = staleTurnRows.map(row => row.turn_id)
+
+      if (staleTurnIds.length === 0) {
+        return {
+          prunedRawTurnCount: 0,
+          prunedRecentTurnCount: 0,
+        }
+      }
+
+      return runInTransaction(database, () => {
+        const placeholders = staleTurnIds.map(() => '?').join(', ')
+        const recentDeleteResult = database.prepare(`
+          DELETE FROM recent_turns
+          WHERE scope_user_id = ?
+            AND scope_character_id = ?
+            AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+            AND turn_id IN (${placeholders})
+        `).run(
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          scope.sessionId,
+          ...staleTurnIds,
+        ) as { changes: number }
+        const rawDeleteResult = database.prepare(`
+          DELETE FROM raw_turn_log
+          WHERE scope_user_id = ?
+            AND scope_character_id = ?
+            AND ((? IS NULL AND scope_session_id IS NULL) OR scope_session_id = ?)
+            AND sync_status = 'uploaded'
+            AND turn_id IN (${placeholders})
+        `).run(
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          scope.sessionId,
+          ...staleTurnIds,
+        ) as { changes: number }
+
+        return {
+          prunedRawTurnCount: rawDeleteResult.changes,
+          prunedRecentTurnCount: recentDeleteResult.changes,
+        }
+      })
+    },
+
+    recordRawTurnUploadFailure(input) {
+      const scope = toScopeBoundValues(input.scope)
+
+      runInTransaction(database, () => {
+        const currentState = this.getSyncState({ scope: input.scope })
+
+        upsertSyncState({
+          generatedFromTurnId: currentState?.generatedFromTurnId ?? null,
+          lastAppliedGeneratedFromTurnId: currentState?.lastAppliedGeneratedFromTurnId ?? null,
+          lastAppliedSummaryVersion: currentState?.lastAppliedSummaryVersion ?? 0,
+          lastAppliedTurnCheckpoint: currentState?.lastAppliedTurnCheckpoint ?? 0,
+          lastError: input.error,
+          lastLocalTurnCheckpoint: getLastRawTurnCheckpoint(scope),
+          lastPullAt: currentState?.lastPullAt ?? null,
+          lastSyncedAt: currentState?.lastSyncedAt ?? null,
+          lastSyncedTurnId: currentState?.lastSyncedTurnId ?? null,
+          lastUploadAt: currentState?.lastUploadAt ?? null,
+          lastUploadedTurnId: currentState?.lastUploadedTurnId ?? null,
+          nextPullAt: currentState?.nextPullAt ?? null,
+          nextRetryAt: input.nextRetryAt,
+          pendingTurnCount: getPendingTurnCount(scope),
+          retryCount: (currentState?.retryCount ?? 0) + 1,
+          scope,
+          state: 'error',
+          syncCheckpoint: currentState?.syncCheckpoint ?? 0,
+          updatedAt: input.failedAt,
+        })
+      })
+    },
+
+    applyMemoryPatch(input) {
+      const scope = toScopeBoundValues(input.patch.scope)
+
+      return runInTransaction(database, () => {
+        const preparedStatements = getStatements()
+        const currentState = this.getSyncState({ scope: input.patch.scope })
+        const currentSummary = this.readPromptContext({ scope: input.patch.scope }).profileSummary
+        let appliedSummary = false
+        let rejectedSummaryReason: ApplyMemoryPatchResult['rejectedSummaryReason'] = null
+        let appliedFactsCount = 0
+        let appliedMemoryCardCount = 0
+        const currentAppliedCheckpoint = currentState?.lastAppliedTurnCheckpoint ?? 0
+        const currentSummaryVersion = currentState?.lastAppliedSummaryVersion
+          ?? currentSummary?.version
+          ?? 0
+        const patchGeneratedTurnIds = [
+          input.patch.summaryPatch?.generatedFromTurnId ?? null,
+          ...(input.patch.factsPatch ?? []).map(fact => fact.generatedFromTurnId),
+          ...(input.patch.memoryCards ?? []).map(card => card.generatedFromTurnId ?? null),
+        ].filter((turnId): turnId is string => !!turnId)
+        const patchGeneratedCheckpoints = patchGeneratedTurnIds
+          .map(turnId => resolveTurnCheckpoint(scope, turnId))
+          .filter((checkpoint): checkpoint is number => checkpoint !== null)
+        const latestPatchCheckpoint = patchGeneratedCheckpoints.length > 0
+          ? Math.max(...patchGeneratedCheckpoints)
+          : null
+
+        const summaryPatch = input.patch.summaryPatch ?? null
+        const isPatchIdempotentNoop = latestPatchCheckpoint !== null
+          && latestPatchCheckpoint <= currentAppliedCheckpoint
+          && (!summaryPatch || summaryPatch.summaryVersion <= currentSummaryVersion)
+
+        if (isPatchIdempotentNoop) {
+          upsertSyncState({
+            generatedFromTurnId: currentState?.generatedFromTurnId ?? null,
+            lastAppliedGeneratedFromTurnId: currentState?.lastAppliedGeneratedFromTurnId ?? null,
+            lastAppliedSummaryVersion: currentState?.lastAppliedSummaryVersion ?? 0,
+            lastAppliedTurnCheckpoint: currentAppliedCheckpoint,
+            lastError: null,
+            lastLocalTurnCheckpoint: getLastRawTurnCheckpoint(scope),
+            lastPullAt: input.pulledAt,
+            lastSyncedAt: currentState?.lastSyncedAt ?? null,
+            lastSyncedTurnId: currentState?.lastSyncedTurnId ?? null,
+            lastUploadAt: currentState?.lastUploadAt ?? null,
+            lastUploadedTurnId: currentState?.lastUploadedTurnId ?? null,
+            nextPullAt: input.nextPullAt,
+            nextRetryAt: currentState?.nextRetryAt ?? null,
+            pendingTurnCount: getPendingTurnCount(scope),
+            retryCount: 0,
+            scope,
+            state: 'idle',
+            syncCheckpoint: currentState?.syncCheckpoint ?? 0,
+            updatedAt: input.pulledAt,
+          })
+
+          return {
+            appliedFactsCount: 0,
+            appliedMemoryCardCount: 0,
+            appliedSummary: false,
+            rejectedSummaryReason: summaryPatch
+              ? (summaryPatch.summaryVersion <= currentSummaryVersion
+                  ? 'outdated-summary-version'
+                  : 'outdated-generated-from-turn')
+              : null,
+          } satisfies ApplyMemoryPatchResult
+        }
+
+        if (summaryPatch) {
+          const generatedCheckpoint = resolveTurnCheckpoint(scope, summaryPatch.generatedFromTurnId)
+
+          if (summaryPatch.summaryVersion <= currentSummaryVersion) {
+            rejectedSummaryReason = 'outdated-summary-version'
+          }
+          else if (generatedCheckpoint !== null && generatedCheckpoint < currentAppliedCheckpoint) {
+            rejectedSummaryReason = 'outdated-generated-from-turn'
+          }
+          else {
+            const currentSummaryRow = preparedStatements.selectCurrentProfileSummaryStatement.get(
+              scope.userId,
+              scope.characterId,
+            ) as ProfileSummaryRow | undefined
+            const nextId = randomUUID()
+
+            if (currentSummaryRow) {
+              preparedStatements.supersedeProfileSummaryStatement.run(nextId, input.pulledAt, currentSummaryRow.id)
+            }
+
+            preparedStatements.insertProfileSummaryStatement.run(
+              nextId,
+              scope.userId,
+              scope.characterId,
+              scope.sessionId,
+              summaryPatch.summaryVersion,
+              summaryPatch.summaryMarkdown,
+              summaryPatch.generatedFromTurnId,
+              summaryPatch.confidence ?? 1,
+              null,
+              input.pulledAt,
+              input.pulledAt,
+            )
+            appliedSummary = true
+          }
+        }
+
+        for (const factPatch of input.patch.factsPatch ?? []) {
+          applyFactPatch({
+            factPatch,
+            scope,
+            updatedAt: input.pulledAt,
+          })
+          appliedFactsCount += 1
+        }
+
+        for (const memoryCardPatch of input.patch.memoryCards ?? []) {
+          preparedStatements.upsertMemoryCardStatement.run(
+            memoryCardPatch.id,
+            scope.userId,
+            scope.characterId,
+            scope.sessionId,
+            1,
+            memoryCardPatch.title,
+            memoryCardPatch.content,
+            memoryCardPatch.generatedFromTurnId ?? null,
+            memoryCardPatch.confidence ?? 1,
+            null,
+            input.pulledAt,
+            input.pulledAt,
+          )
+          appliedMemoryCardCount += 1
+        }
+
+        const summaryGeneratedTurnId = summaryPatch?.generatedFromTurnId ?? currentState?.lastAppliedGeneratedFromTurnId ?? null
+        const summaryGeneratedCheckpoint = appliedSummary
+          ? (resolveTurnCheckpoint(scope, summaryPatch?.generatedFromTurnId) ?? currentAppliedCheckpoint)
+          : currentAppliedCheckpoint
+
+        upsertSyncState({
+          generatedFromTurnId: currentState?.generatedFromTurnId ?? null,
+          lastAppliedGeneratedFromTurnId: summaryGeneratedTurnId,
+          lastAppliedSummaryVersion: appliedSummary
+            ? (summaryPatch?.summaryVersion ?? currentState?.lastAppliedSummaryVersion ?? 0)
+            : (currentState?.lastAppliedSummaryVersion ?? 0),
+          lastAppliedTurnCheckpoint: summaryGeneratedCheckpoint,
+          lastError: rejectedSummaryReason || null,
+          lastLocalTurnCheckpoint: getLastRawTurnCheckpoint(scope),
+          lastPullAt: input.pulledAt,
+          lastSyncedAt: currentState?.lastSyncedAt ?? null,
+          lastSyncedTurnId: currentState?.lastSyncedTurnId ?? null,
+          lastUploadAt: currentState?.lastUploadAt ?? null,
+          lastUploadedTurnId: currentState?.lastUploadedTurnId ?? null,
+          nextPullAt: input.nextPullAt,
+          nextRetryAt: currentState?.nextRetryAt ?? null,
+          pendingTurnCount: getPendingTurnCount(scope),
+          retryCount: 0,
+          scope,
+          state: 'idle',
+          syncCheckpoint: currentState?.syncCheckpoint ?? 0,
+          updatedAt: input.pulledAt,
+        })
+
+        return {
+          appliedFactsCount,
+          appliedMemoryCardCount,
+          appliedSummary,
+          rejectedSummaryReason,
+        } satisfies ApplyMemoryPatchResult
+      })
+    },
+
+    recordMemoryPatchPullFailure(input) {
+      const scope = toScopeBoundValues(input.scope)
+
+      runInTransaction(database, () => {
+        const currentState = this.getSyncState({ scope: input.scope })
+
+        upsertSyncState({
+          generatedFromTurnId: currentState?.generatedFromTurnId ?? null,
+          lastAppliedGeneratedFromTurnId: currentState?.lastAppliedGeneratedFromTurnId ?? null,
+          lastAppliedSummaryVersion: currentState?.lastAppliedSummaryVersion ?? 0,
+          lastAppliedTurnCheckpoint: currentState?.lastAppliedTurnCheckpoint ?? 0,
+          lastError: input.error,
+          lastLocalTurnCheckpoint: getLastRawTurnCheckpoint(scope),
+          lastPullAt: currentState?.lastPullAt ?? null,
+          lastSyncedAt: currentState?.lastSyncedAt ?? null,
+          lastSyncedTurnId: currentState?.lastSyncedTurnId ?? null,
+          lastUploadAt: currentState?.lastUploadAt ?? null,
+          lastUploadedTurnId: currentState?.lastUploadedTurnId ?? null,
+          nextPullAt: input.nextPullAt,
+          nextRetryAt: currentState?.nextRetryAt ?? null,
+          pendingTurnCount: getPendingTurnCount(scope),
+          retryCount: currentState?.retryCount ?? 0,
+          scope,
+          state: 'error',
+          syncCheckpoint: currentState?.syncCheckpoint ?? 0,
+          updatedAt: input.failedAt,
+        })
+      })
+    },
+
+    replaceProfileSummary(input) {
+      const preparedStatements = getStatements()
+      const scope = toScopeBoundValues(input.scope)
+      const currentRow = preparedStatements.selectCurrentProfileSummaryStatement.get(
+        scope.userId,
+        scope.characterId,
+      ) as ProfileSummaryRow | undefined
+      const nextId = randomUUID()
+      const nextVersion = (currentRow?.version ?? 0) + 1
+
+      runInTransaction(database, () => {
+        if (currentRow) {
+          preparedStatements.supersedeProfileSummaryStatement.run(nextId, input.updatedAt, currentRow.id)
+        }
+
+        preparedStatements.insertProfileSummaryStatement.run(
+          nextId,
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          nextVersion,
+          input.summaryMarkdown,
+          input.generatedFromTurnId ?? null,
+          input.confidence ?? 1,
+          null,
+          input.updatedAt,
+          input.updatedAt,
+        )
+      })
+
+      return {
+        confidence: input.confidence ?? 1,
+        createdAt: input.updatedAt,
+        generatedFromTurnId: input.generatedFromTurnId ?? null,
+        id: nextId,
+        scope: {
+          characterId: scope.characterId,
+          sessionId: scope.sessionId,
+          userId: scope.userId,
+        },
+        summaryMarkdown: input.summaryMarkdown,
+        supersededBy: null,
+        updatedAt: input.updatedAt,
+        version: nextVersion,
+      }
+    },
+
+    upsertStableFact(input) {
+      const preparedStatements = getStatements()
+      const scope = toScopeBoundValues(input.scope)
+      const currentRow = preparedStatements.selectCurrentStableFactStatement.get(
+        scope.userId,
+        scope.characterId,
+        scope.sessionId,
+        scope.sessionId,
+        input.factKey,
+      ) as StableFactRow | undefined
+      const nextId = randomUUID()
+      const nextVersion = (currentRow?.version ?? 0) + 1
+
+      runInTransaction(database, () => {
+        if (currentRow) {
+          preparedStatements.supersedeStableFactStatement.run(nextId, input.updatedAt, currentRow.id)
+        }
+
+        preparedStatements.insertStableFactStatement.run(
+          nextId,
+          scope.userId,
+          scope.characterId,
+          scope.sessionId,
+          nextVersion,
+          input.factKey,
+          input.factValue,
+          input.generatedFromTurnId ?? null,
+          input.confidence ?? 1,
+          null,
+          input.updatedAt,
+          input.updatedAt,
+        )
+      })
+
+      return {
+        confidence: input.confidence ?? 1,
+        createdAt: input.updatedAt,
+        factKey: input.factKey,
+        factValue: input.factValue,
+        generatedFromTurnId: input.generatedFromTurnId ?? null,
+        id: nextId,
+        scope: {
+          characterId: scope.characterId,
+          sessionId: scope.sessionId,
+          userId: scope.userId,
+        },
+        supersededBy: null,
+        updatedAt: input.updatedAt,
+        version: nextVersion,
+      }
+    },
+  }
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/repository.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/repository.ts
@@ -313,12 +313,14 @@ function runInTransaction<T>(database: DatabaseSync, work: () => T): T {
     return result
   }
   catch (error) {
-    if (database.isTransaction) {
-      database.exec('ROLLBACK')
-    }
+    database.exec('ROLLBACK')
 
     throw error
   }
+}
+
+function useExistingWhenUndefined<T>(nextValue: T | undefined, existingValue: T): T {
+  return nextValue === undefined ? existingValue : nextValue
 }
 
 /**
@@ -817,23 +819,23 @@ export function createMemoryRepository(options: MemoryRepositoryOptions): Memory
 
     preparedStatements.updateSyncStateStatement.run(
       currentRow.version + 1,
-      params.generatedFromTurnId ?? currentRow.generated_from_turn_id,
+      useExistingWhenUndefined(params.generatedFromTurnId, currentRow.generated_from_turn_id),
       params.syncCheckpoint,
       params.lastLocalTurnCheckpoint,
-      params.lastSyncedTurnId ?? currentRow.last_synced_turn_id,
-      params.lastSyncedAt ?? currentRow.last_synced_at,
-      params.lastUploadedTurnId ?? currentRow.last_uploaded_turn_id,
-      params.lastUploadAt ?? currentRow.last_upload_at,
+      useExistingWhenUndefined(params.lastSyncedTurnId, currentRow.last_synced_turn_id),
+      useExistingWhenUndefined(params.lastSyncedAt, currentRow.last_synced_at),
+      useExistingWhenUndefined(params.lastUploadedTurnId, currentRow.last_uploaded_turn_id),
+      useExistingWhenUndefined(params.lastUploadAt, currentRow.last_upload_at),
       params.lastAppliedSummaryVersion ?? currentRow.last_applied_summary_version,
-      params.lastAppliedGeneratedFromTurnId ?? currentRow.last_applied_generated_from_turn_id,
+      useExistingWhenUndefined(params.lastAppliedGeneratedFromTurnId, currentRow.last_applied_generated_from_turn_id),
       params.lastAppliedTurnCheckpoint ?? currentRow.last_applied_turn_checkpoint,
-      params.lastPullAt ?? currentRow.last_pull_at,
-      params.nextPullAt ?? currentRow.next_pull_at,
+      useExistingWhenUndefined(params.lastPullAt, currentRow.last_pull_at),
+      useExistingWhenUndefined(params.nextPullAt, currentRow.next_pull_at),
       params.pendingTurnCount,
       params.retryCount,
-      params.nextRetryAt ?? currentRow.next_retry_at,
+      useExistingWhenUndefined(params.nextRetryAt, currentRow.next_retry_at),
       params.state,
-      params.lastError ?? currentRow.last_error,
+      useExistingWhenUndefined(params.lastError, currentRow.last_error),
       params.updatedAt,
       currentRow.id,
     )

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
@@ -153,6 +153,75 @@ describe('memory sync runtime', () => {
     repository.close()
   })
 
+  it('does not start overlapping automatic ticks while a previous tick is still running', async () => {
+    vi.useFakeTimers()
+
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    for (let turnNumber = 1; turnNumber <= 4; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 1_000,
+        rawPayload: { order: turnNumber },
+        role: 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    let resolveUpload: ((response: Response) => void) | undefined
+    const fetchImpl = vi.fn(() => new Promise<Response>((resolve) => {
+      resolveUpload = resolve
+    }))
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        pollIntervalMs: 1_000,
+        uploader: {
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/raw-turns',
+          authToken: 'token',
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => 10_000,
+      repository,
+    })
+
+    const startHook = onAppReadyMock.mock.calls[0]?.[0] as (() => void) | undefined
+
+    startHook?.()
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(runtime.getStatus().running).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+
+    resolveUpload?.({
+      ok: true,
+      status: 200,
+    } as Response)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })?.lastUploadedTurnId).toBe('turn-4')
+
+    runtime.stop()
+    repository.close()
+  })
+
   it('idle-driven periodic ticks can upload small pending batches', async () => {
     vi.useFakeTimers()
 

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
@@ -469,4 +469,72 @@ describe('memory sync runtime', () => {
 
     repository.close()
   })
+
+  it('respects patch retry delay after the first pull failure', async () => {
+    vi.useFakeTimers()
+
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-1',
+      turnId: 'turn-1',
+    })
+    repository.markRawTurnsUploaded({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      turnIds: ['turn-1'],
+      uploadedAt: 5_000,
+    })
+
+    let currentTime = 10_000
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('pull failed')
+    })
+
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        patch: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/patch',
+          pullIntervalMs: 1_000,
+          requestTimeoutMs: 10_000,
+          retryDelayMs: 30_000,
+        },
+        uploader: {
+          authToken: null,
+          enabled: false,
+          endpointUrl: null,
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    await runtime.tick()
+    currentTime = 20_000
+    await runtime.tick()
+    currentTime = 40_000
+    await runtime.tick()
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+
+    repository.close()
+  })
 })

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
@@ -1,0 +1,403 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createMemoryRepository } from './repository'
+import { setupMemorySyncRuntime } from './runtime'
+
+const onAppReadyMock = vi.hoisted(() => vi.fn())
+const onAppBeforeQuitMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../libs/bootkit/lifecycle', () => ({
+  onAppBeforeQuit: onAppBeforeQuitMock,
+  onAppReady: onAppReadyMock,
+}))
+
+function createTempDatabasePath() {
+  const directoryPath = mkdtempSync(join(tmpdir(), 'airi-memory-sync-runtime-'))
+
+  return {
+    cleanup: () => rmSync(directoryPath, { force: true, recursive: true }),
+    databasePath: join(directoryPath, 'memory.sqlite'),
+  }
+}
+
+describe('memory sync runtime', () => {
+  const cleanupCallbacks: Array<() => void> = []
+
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    for (const cleanup of cleanupCallbacks.splice(0)) {
+      cleanup()
+    }
+  })
+
+  it('stays disabled and does not crash when uploader config is missing', () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        uploader: {
+          enabled: true,
+          endpointUrl: null,
+          authToken: null,
+          requestTimeoutMs: 10_000,
+        },
+      },
+      repository,
+    })
+
+    expect(runtime.getStatus()).toEqual({
+      patch: {
+        mode: 'disabled',
+        reason: 'memory patch pull is disabled',
+      },
+      running: false,
+      uploader: {
+        mode: 'disabled',
+        reason: 'memory sync upload is missing endpoint or auth token',
+      },
+    })
+
+    const startHook = onAppReadyMock.mock.calls[0]?.[0] as (() => void) | undefined
+    startHook?.()
+
+    expect(runtime.getStatus().running).toBe(false)
+
+    repository.close()
+  })
+
+  it('starts automatic ticking on app ready and stops on app shutdown', async () => {
+    vi.useFakeTimers()
+
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    for (let turnNumber = 1; turnNumber <= 4; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 1_000,
+        rawPayload: { order: turnNumber },
+        role: 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    let currentTime = 10_000
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+    }))
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        pollIntervalMs: 1_000,
+        uploader: {
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/raw-turns',
+          authToken: 'token',
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    const startHook = onAppReadyMock.mock.calls[0]?.[0] as (() => void) | undefined
+    const stopHook = onAppBeforeQuitMock.mock.calls[0]?.[0] as (() => void) | undefined
+
+    startHook?.()
+    expect(runtime.getStatus().running).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      lastUploadedTurnId: 'turn-4',
+      lastUploadAt: 10_000,
+      pendingTurnCount: 0,
+      state: 'idle',
+    }))
+
+    currentTime = 20_000
+    stopHook?.()
+
+    expect(runtime.getStatus().running).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+
+    repository.close()
+  })
+
+  it('idle-driven periodic ticks can upload small pending batches', async () => {
+    vi.useFakeTimers()
+
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'short',
+      turnId: 'turn-1',
+    })
+
+    const currentTime = 10_000
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+    }))
+    setupMemorySyncRuntime({
+      config: {
+        idleAfterMs: 8_000,
+        pollIntervalMs: 1_000,
+        uploader: {
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/raw-turns',
+          authToken: 'token',
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    const startHook = onAppReadyMock.mock.calls[0]?.[0] as (() => void) | undefined
+    startHook?.()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+
+    repository.close()
+  })
+
+  it('completes one upload then pull cycle and updates local summary and facts', async () => {
+    vi.useFakeTimers()
+
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    for (let turnNumber = 1; turnNumber <= 4; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 1_000,
+        rawPayload: { order: turnNumber },
+        role: 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    const currentTime = 10_000
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('/raw-turns')) {
+        return { ok: true, status: 200 }
+      }
+
+      return {
+        json: async () => ({
+          factsPatch: [
+            {
+              confidence: 0.8,
+              factKey: 'location',
+              factValue: 'kyoto',
+              generatedFromTurnId: 'turn-4',
+            },
+          ],
+          scope: {
+            characterId: 'character-a',
+            sessionId: 'session-a',
+            userId: 'user-a',
+          },
+          summaryPatch: {
+            confidence: 0.9,
+            generatedFromTurnId: 'turn-4',
+            summaryMarkdown: 'Pulled summary',
+            summaryVersion: 2,
+          },
+        }),
+        ok: true,
+        status: 200,
+      }
+    })
+
+    setupMemorySyncRuntime({
+      config: {
+        patch: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/patch',
+          pullIntervalMs: 15_000,
+          requestTimeoutMs: 10_000,
+          retryDelayMs: 30_000,
+        },
+        uploader: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/raw-turns',
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    const startHook = onAppReadyMock.mock.calls[0]?.[0] as (() => void) | undefined
+    startHook?.()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      profileSummary: expect.objectContaining({
+        summaryMarkdown: 'Pulled summary',
+      }),
+      stableFacts: [
+        expect.objectContaining({
+          factKey: 'location',
+          factValue: 'kyoto',
+        }),
+      ],
+    }))
+
+    repository.close()
+  })
+
+  it('records pull failure without polluting existing local summary state', async () => {
+    vi.useFakeTimers()
+
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'turn-1',
+      turnId: 'turn-1',
+    })
+    repository.applyMemoryPatch({
+      nextPullAt: 9_000,
+      patch: {
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        summaryPatch: {
+          confidence: 1,
+          generatedFromTurnId: 'turn-1',
+          summaryMarkdown: 'Local summary',
+          summaryVersion: 2,
+        },
+      },
+      pulledAt: 5_000,
+    })
+
+    const currentTime = 10_000
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('pull failed')
+    })
+
+    setupMemorySyncRuntime({
+      config: {
+        patch: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/patch',
+          pullIntervalMs: 1_000,
+          requestTimeoutMs: 10_000,
+          retryDelayMs: 30_000,
+        },
+        uploader: {
+          authToken: null,
+          enabled: false,
+          endpointUrl: null,
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    const startHook = onAppReadyMock.mock.calls[0]?.[0] as (() => void) | undefined
+    startHook?.()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    }).profileSummary?.summaryMarkdown).toBe('Local summary')
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      lastError: 'pull failed',
+      nextPullAt: 40_000,
+    }))
+
+    repository.close()
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.test.ts
@@ -274,6 +274,67 @@ describe('memory sync runtime', () => {
     repository.close()
   })
 
+  it('does not mark raw turns uploaded when uploader is disabled in patch-only mode', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+
+    for (let turnNumber = 1; turnNumber <= 4; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 1_000,
+        rawPayload: { order: turnNumber },
+        role: 'user',
+        scope,
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        patch: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/patch',
+          pullIntervalMs: 1_000,
+          requestTimeoutMs: 10_000,
+          retryDelayMs: 30_000,
+        },
+        uploader: {
+          authToken: null,
+          enabled: false,
+          endpointUrl: null,
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: vi.fn(async () => ({
+        json: async () => ({ scope }),
+        ok: true,
+        status: 200,
+      })) as unknown as typeof fetch,
+      now: () => 10_000,
+      repository,
+    })
+
+    await runtime.tick()
+
+    expect(repository.listPendingRawTurns({ scope }).map(turn => turn.turnId)).toEqual([
+      'turn-1',
+      'turn-2',
+      'turn-3',
+      'turn-4',
+    ])
+
+    repository.close()
+  })
+
   it('completes one upload then pull cycle and updates local summary and facts', async () => {
     vi.useFakeTimers()
 

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
@@ -170,7 +170,9 @@ export function setupMemorySyncRuntime(options: SetupMemorySyncRuntimeOptions): 
   async function tick() {
     const currentTime = options.now ? options.now() : Date.now()
     uploadedScopeKeys.clear()
-    await agent.tick()
+    if (uploadRuntime.getStatus().mode !== 'disabled') {
+      await agent.tick()
+    }
     await pullEligiblePatches(currentTime)
     pruneUploadedTurnsBeyondRetention(currentTime)
   }

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
@@ -131,8 +131,7 @@ export function setupMemorySyncRuntime(options: SetupMemorySyncRuntimeOptions): 
       const scopeKey = createScopeKey(scope)
       const syncState = options.repository.getSyncState({ scope })
       const shouldPull = uploadedScopeKeys.has(scopeKey)
-        || !syncState?.lastPullAt
-        || ((syncState.nextPullAt ?? 0) <= currentTime)
+        || ((syncState?.nextPullAt ?? 0) <= currentTime)
 
       if (!shouldPull) {
         continue

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
@@ -1,0 +1,221 @@
+import type { MemoryRepository } from './repository'
+import type { MemoryRawTurnSyncAgent } from './sync-agent'
+import type {
+  MemoryPatchPullStatus,
+  MemoryRawTurnSyncRuntimeConfig,
+  MemoryRawTurnUploaderStatus,
+} from './sync-types'
+
+import process from 'node:process'
+
+import { onAppBeforeQuit, onAppReady } from '../../../libs/bootkit/lifecycle'
+import { createMemoryPatchPullRuntime } from './patch-client'
+import { createMemoryRawTurnSyncAgent } from './sync-agent'
+import { createMemoryRawTurnUploadRuntime } from './uploader'
+
+const defaultMemoryRawTurnSyncRuntimeConfig: MemoryRawTurnSyncRuntimeConfig = {
+  charThreshold: 2_000,
+  idleAfterMs: 8_000,
+  oldestPendingAgeMs: 90_000,
+  pollIntervalMs: 1_000,
+  rawTurnRetentionWindowMs: Number(
+    import.meta.env.VITE_MEMORY_RAW_TURN_RETENTION_WINDOW_MS
+      || process.env.AIRI_MEMORY_RAW_TURN_RETENTION_WINDOW_MS
+      || 30 * 24 * 60 * 60 * 1000,
+  ),
+  retryDelayMs: 30_000,
+  turnCountThreshold: 4,
+  patch: {
+    authToken: import.meta.env.VITE_MEMORY_PATCH_AUTH_TOKEN || process.env.AIRI_MEMORY_PATCH_AUTH_TOKEN || null,
+    enabled: (import.meta.env.VITE_MEMORY_PATCH_ENABLED || process.env.AIRI_MEMORY_PATCH_ENABLED || '') === '1',
+    endpointUrl: import.meta.env.VITE_MEMORY_PATCH_ENDPOINT_URL || process.env.AIRI_MEMORY_PATCH_ENDPOINT_URL || null,
+    pullIntervalMs: Number(import.meta.env.VITE_MEMORY_PATCH_PULL_INTERVAL_MS || process.env.AIRI_MEMORY_PATCH_PULL_INTERVAL_MS || 15_000),
+    requestTimeoutMs: Number(import.meta.env.VITE_MEMORY_PATCH_REQUEST_TIMEOUT_MS || process.env.AIRI_MEMORY_PATCH_REQUEST_TIMEOUT_MS || 10_000),
+    retryDelayMs: Number(import.meta.env.VITE_MEMORY_PATCH_RETRY_DELAY_MS || process.env.AIRI_MEMORY_PATCH_RETRY_DELAY_MS || 30_000),
+  },
+  uploader: {
+    authToken: import.meta.env.VITE_MEMORY_SYNC_AUTH_TOKEN || process.env.AIRI_MEMORY_SYNC_AUTH_TOKEN || null,
+    enabled: (import.meta.env.VITE_MEMORY_SYNC_ENABLED || process.env.AIRI_MEMORY_SYNC_ENABLED || '') === '1',
+    endpointUrl: import.meta.env.VITE_MEMORY_SYNC_ENDPOINT_URL || process.env.AIRI_MEMORY_SYNC_ENDPOINT_URL || null,
+    requestTimeoutMs: Number(import.meta.env.VITE_MEMORY_SYNC_REQUEST_TIMEOUT_MS || process.env.AIRI_MEMORY_SYNC_REQUEST_TIMEOUT_MS || 10_000),
+  },
+}
+
+export interface MemorySyncRuntimeStatus {
+  patch: MemoryPatchPullStatus
+  uploader: MemoryRawTurnUploaderStatus
+  running: boolean
+}
+
+export interface MemorySyncRuntime {
+  tick: () => Promise<void>
+  start: () => void
+  stop: () => void
+  getStatus: () => MemorySyncRuntimeStatus
+  agent: MemoryRawTurnSyncAgent
+}
+
+interface SetupMemorySyncRuntimeOptions {
+  repository: MemoryRepository
+  config?: Partial<MemoryRawTurnSyncRuntimeConfig>
+  now?: () => number
+  fetchImpl?: typeof fetch
+}
+
+function mergeMemorySyncRuntimeConfig(config?: Partial<MemoryRawTurnSyncRuntimeConfig>): MemoryRawTurnSyncRuntimeConfig {
+  return {
+    ...defaultMemoryRawTurnSyncRuntimeConfig,
+    ...config,
+    patch: {
+      ...defaultMemoryRawTurnSyncRuntimeConfig.patch,
+      ...config?.patch,
+    },
+    uploader: {
+      ...defaultMemoryRawTurnSyncRuntimeConfig.uploader,
+      ...config?.uploader,
+    },
+  }
+}
+
+/**
+ * Sets up the live desktop raw-turn sync runtime and hooks it into app lifecycle.
+ *
+ * Use when:
+ * - The main process should automatically scan and upload pending raw turns
+ * - Startup and shutdown must control the sync agent without blocking the app
+ *
+ * Expects:
+ * - Repository is already initialized
+ * - Config is resolved from one centralized runtime config source
+ *
+ * Returns:
+ * - A runtime wrapper exposing current uploader status plus start/stop/tick controls
+ */
+export function setupMemorySyncRuntime(options: SetupMemorySyncRuntimeOptions): MemorySyncRuntime {
+  const config = mergeMemorySyncRuntimeConfig(options.config)
+  const uploadRuntime = createMemoryRawTurnUploadRuntime({
+    config: config.uploader,
+    fetchImpl: options.fetchImpl,
+  })
+  const patchRuntime = createMemoryPatchPullRuntime({
+    config: config.patch,
+    fetchImpl: options.fetchImpl,
+  })
+  const uploadedScopeKeys = new Set<string>()
+  const agent = createMemoryRawTurnSyncAgent({
+    config,
+    now: options.now,
+    repository: options.repository,
+    uploadClient: {
+      async uploadRawTurns(request) {
+        await uploadRuntime.client.uploadRawTurns(request)
+        uploadedScopeKeys.add(`${request.scope.userId}::${request.scope.characterId}::${request.scope.sessionId ?? ''}`)
+      },
+    },
+  })
+
+  let intervalHandle: ReturnType<typeof setInterval> | undefined
+
+  function createScopeKey(scope: { userId: string, characterId: string, sessionId?: string | null }) {
+    return `${scope.userId}::${scope.characterId}::${scope.sessionId ?? ''}`
+  }
+
+  async function pullEligiblePatches(currentTime: number) {
+    if (patchRuntime.getStatus().mode === 'disabled') {
+      return
+    }
+
+    const syncScopes = options.repository.listSyncScopes()
+    for (const scope of syncScopes) {
+      const scopeKey = createScopeKey(scope)
+      const syncState = options.repository.getSyncState({ scope })
+      const shouldPull = uploadedScopeKeys.has(scopeKey)
+        || !syncState?.lastPullAt
+        || ((syncState.nextPullAt ?? 0) <= currentTime)
+
+      if (!shouldPull) {
+        continue
+      }
+
+      try {
+        const patch = await patchRuntime.client.fetchMemoryPatch(scope, syncState)
+        options.repository.applyMemoryPatch({
+          nextPullAt: currentTime + config.patch.pullIntervalMs,
+          patch: patch ?? { scope },
+          pulledAt: currentTime,
+        })
+      }
+      catch (error) {
+        options.repository.recordMemoryPatchPullFailure({
+          error: error instanceof Error ? error.message : String(error),
+          failedAt: currentTime,
+          nextPullAt: currentTime + config.patch.retryDelayMs,
+          scope,
+        })
+      }
+    }
+  }
+
+  function pruneUploadedTurnsBeyondRetention(currentTime: number) {
+    const syncScopes = options.repository.listSyncScopes()
+    for (const scope of syncScopes) {
+      options.repository.pruneUploadedTurns({
+        now: currentTime,
+        retentionWindowMs: config.rawTurnRetentionWindowMs,
+        scope,
+      })
+    }
+  }
+
+  async function tick() {
+    const currentTime = options.now ? options.now() : Date.now()
+    uploadedScopeKeys.clear()
+    await agent.tick()
+    await pullEligiblePatches(currentTime)
+    pruneUploadedTurnsBeyondRetention(currentTime)
+  }
+
+  function start() {
+    if (intervalHandle) {
+      return
+    }
+    if (uploadRuntime.getStatus().mode === 'disabled' && patchRuntime.getStatus().mode === 'disabled') {
+      return
+    }
+
+    intervalHandle = setInterval(() => {
+      void tick()
+    }, config.pollIntervalMs)
+  }
+
+  function stop() {
+    if (!intervalHandle) {
+      return
+    }
+
+    clearInterval(intervalHandle)
+    intervalHandle = undefined
+  }
+
+  onAppReady(() => {
+    start()
+  })
+
+  onAppBeforeQuit(() => {
+    stop()
+  })
+
+  return {
+    agent,
+    getStatus() {
+      return {
+        patch: patchRuntime.getStatus(),
+        running: !!intervalHandle,
+        uploader: uploadRuntime.getStatus(),
+      }
+    },
+    tick,
+    start,
+    stop,
+  }
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/runtime.ts
@@ -114,7 +114,8 @@ export function setupMemorySyncRuntime(options: SetupMemorySyncRuntimeOptions): 
     },
   })
 
-  let intervalHandle: ReturnType<typeof setInterval> | undefined
+  let isRunning = false
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
 
   function createScopeKey(scope: { userId: string, characterId: string, sessionId?: string | null }) {
     return `${scope.userId}::${scope.characterId}::${scope.sessionId ?? ''}`
@@ -175,26 +176,48 @@ export function setupMemorySyncRuntime(options: SetupMemorySyncRuntimeOptions): 
     pruneUploadedTurnsBeyondRetention(currentTime)
   }
 
+  function scheduleNextTick() {
+    if (!isRunning) {
+      return
+    }
+
+    timeoutHandle = setTimeout(() => {
+      timeoutHandle = undefined
+      void runScheduledTick()
+    }, config.pollIntervalMs)
+  }
+
+  async function runScheduledTick() {
+    try {
+      await tick()
+    }
+    finally {
+      scheduleNextTick()
+    }
+  }
+
   function start() {
-    if (intervalHandle) {
+    if (isRunning) {
       return
     }
     if (uploadRuntime.getStatus().mode === 'disabled' && patchRuntime.getStatus().mode === 'disabled') {
       return
     }
 
-    intervalHandle = setInterval(() => {
-      void tick()
-    }, config.pollIntervalMs)
+    isRunning = true
+    scheduleNextTick()
   }
 
   function stop() {
-    if (!intervalHandle) {
+    if (!isRunning && !timeoutHandle) {
       return
     }
 
-    clearInterval(intervalHandle)
-    intervalHandle = undefined
+    isRunning = false
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle)
+      timeoutHandle = undefined
+    }
   }
 
   onAppReady(() => {
@@ -210,7 +233,7 @@ export function setupMemorySyncRuntime(options: SetupMemorySyncRuntimeOptions): 
     getStatus() {
       return {
         patch: patchRuntime.getStatus(),
-        running: !!intervalHandle,
+        running: isRunning,
         uploader: uploadRuntime.getStatus(),
       }
     },

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/schema.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { MEMORY_V1_TABLE_NAMES, memorySchemaV1Sql } from './schema'
+
+/**
+ * Verifies the Phase 1 local-first memory schema skeleton is present.
+ *
+ * @example
+ * describe('memory schema V1', () => {
+ *   expect(memorySchemaV1Sql).toContain('CREATE TABLE IF NOT EXISTS profile_summary')
+ * })
+ */
+describe('memory schema V1', () => {
+  /**
+   * Keeps the schema bootstrap anchored to the six Phase 1 tables.
+   *
+   * @example
+   * it('contains the six required Phase 1 tables', () => {
+   *   expect(MEMORY_V1_TABLE_NAMES).toHaveLength(6)
+   * })
+   */
+  it('contains the six required Phase 1 tables', () => {
+    expect(MEMORY_V1_TABLE_NAMES).toEqual([
+      'profile_summary',
+      'stable_facts',
+      'recent_turns',
+      'raw_turn_log',
+      'memory_cards',
+      'sync_state',
+    ])
+
+    for (const tableName of MEMORY_V1_TABLE_NAMES) {
+      expect(memorySchemaV1Sql).toContain(`CREATE TABLE IF NOT EXISTS ${tableName}`)
+    }
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/schema.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/schema.ts
@@ -1,0 +1,165 @@
+/**
+ * Fixed Phase 1 SQLite table names for desktop local-first memory.
+ */
+export const MEMORY_V1_TABLE_NAMES = [
+  'profile_summary',
+  'stable_facts',
+  'recent_turns',
+  'raw_turn_log',
+  'memory_cards',
+  'sync_state',
+] as const
+
+/**
+ * Current Phase 1 schema version for desktop local-first memory.
+ */
+export const MEMORY_SCHEMA_V1_VERSION = 1
+
+/**
+ * Bootstrap SQL for the Phase 1 desktop local-first memory schema.
+ *
+ * Use when:
+ * - Initializing the local SQLite database for desktop memory
+ * - Verifying the shared schema skeleton before repository work begins
+ *
+ * Expects:
+ * - SQLite-compatible execution in declaration order
+ * - Future migrations to append V2+ changes instead of mutating this snapshot
+ *
+ * Returns:
+ * - One SQL script containing the six Phase 1 `CREATE TABLE IF NOT EXISTS` statements
+ */
+export const memorySchemaV1Sql = `
+CREATE TABLE IF NOT EXISTS profile_summary (
+  id TEXT PRIMARY KEY,
+  scope_user_id TEXT NOT NULL,
+  scope_character_id TEXT NOT NULL,
+  scope_session_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  summary_markdown TEXT NOT NULL,
+  generated_from_turn_id TEXT,
+  confidence REAL NOT NULL DEFAULT 0.5 CHECK (confidence >= 0 AND confidence <= 1),
+  superseded_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (superseded_by) REFERENCES profile_summary(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS stable_facts (
+  id TEXT PRIMARY KEY,
+  scope_user_id TEXT NOT NULL,
+  scope_character_id TEXT NOT NULL,
+  scope_session_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  fact_key TEXT NOT NULL,
+  fact_value TEXT NOT NULL,
+  generated_from_turn_id TEXT,
+  confidence REAL NOT NULL DEFAULT 0.5 CHECK (confidence >= 0 AND confidence <= 1),
+  superseded_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (superseded_by) REFERENCES stable_facts(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS recent_turns (
+  turn_id TEXT PRIMARY KEY,
+  scope_user_id TEXT NOT NULL,
+  scope_character_id TEXT NOT NULL,
+  scope_session_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  role TEXT NOT NULL,
+  turn_text TEXT NOT NULL,
+  generated_from_turn_id TEXT,
+  confidence REAL NOT NULL DEFAULT 1 CHECK (confidence >= 0 AND confidence <= 1),
+  superseded_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (superseded_by) REFERENCES recent_turns(turn_id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS raw_turn_log (
+  turn_id TEXT PRIMARY KEY,
+  scope_user_id TEXT NOT NULL,
+  scope_character_id TEXT NOT NULL,
+  scope_session_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  role TEXT NOT NULL,
+  raw_payload_json TEXT NOT NULL,
+  generated_from_turn_id TEXT,
+  confidence REAL NOT NULL DEFAULT 1 CHECK (confidence >= 0 AND confidence <= 1),
+  superseded_by TEXT,
+  sync_checkpoint INTEGER NOT NULL DEFAULT 0,
+  sync_status TEXT NOT NULL DEFAULT 'pending',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (superseded_by) REFERENCES raw_turn_log(turn_id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS memory_cards (
+  id TEXT PRIMARY KEY,
+  scope_user_id TEXT NOT NULL,
+  scope_character_id TEXT NOT NULL,
+  scope_session_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  generated_from_turn_id TEXT,
+  confidence REAL NOT NULL DEFAULT 0.5 CHECK (confidence >= 0 AND confidence <= 1),
+  superseded_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (superseded_by) REFERENCES memory_cards(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE IF NOT EXISTS sync_state (
+  id TEXT PRIMARY KEY,
+  scope_user_id TEXT NOT NULL,
+  scope_character_id TEXT NOT NULL,
+  scope_session_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  generated_from_turn_id TEXT,
+  confidence REAL NOT NULL DEFAULT 1 CHECK (confidence >= 0 AND confidence <= 1),
+  superseded_by TEXT,
+  sync_checkpoint INTEGER NOT NULL DEFAULT 0,
+  last_local_turn_checkpoint INTEGER NOT NULL DEFAULT 0,
+  remote_checkpoint TEXT,
+  last_synced_turn_id TEXT,
+  last_synced_at INTEGER,
+  last_uploaded_turn_id TEXT,
+  last_upload_at INTEGER,
+  last_applied_summary_version INTEGER NOT NULL DEFAULT 0,
+  last_applied_generated_from_turn_id TEXT,
+  last_applied_turn_checkpoint INTEGER NOT NULL DEFAULT 0,
+  last_pull_at INTEGER,
+  next_pull_at INTEGER,
+  pending_turn_count INTEGER NOT NULL DEFAULT 0,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  next_retry_at INTEGER,
+  sync_state TEXT NOT NULL DEFAULT 'idle',
+  last_error TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (superseded_by) REFERENCES sync_state(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS profile_summary_current_scope_unique
+  ON profile_summary (scope_user_id, scope_character_id)
+  WHERE superseded_by IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS stable_facts_current_scope_key_unique
+  ON stable_facts (scope_user_id, scope_character_id, COALESCE(scope_session_id, ''), fact_key)
+  WHERE superseded_by IS NULL;
+
+CREATE INDEX IF NOT EXISTS recent_turns_scope_created_at_index
+  ON recent_turns (scope_user_id, scope_character_id, COALESCE(scope_session_id, ''), created_at);
+
+CREATE INDEX IF NOT EXISTS sync_state_scope_lookup_index
+  ON sync_state (scope_user_id, scope_character_id, COALESCE(scope_session_id, ''), updated_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sync_state_current_scope_unique
+  ON sync_state (scope_user_id, scope_character_id, COALESCE(scope_session_id, ''))
+  WHERE superseded_by IS NULL;
+
+CREATE INDEX IF NOT EXISTS raw_turn_log_pending_scope_created_at_index
+  ON raw_turn_log (scope_user_id, scope_character_id, COALESCE(scope_session_id, ''), sync_status, created_at);
+`.trim()

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/sync-agent.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/sync-agent.test.ts
@@ -1,0 +1,300 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createMemoryRepository } from './repository'
+import {
+  createMemoryRawTurnSyncAgent,
+  evaluateRawTurnSyncTrigger,
+} from './sync-agent'
+
+function createTempDatabasePath() {
+  const directoryPath = mkdtempSync(join(tmpdir(), 'airi-memory-sync-agent-'))
+
+  return {
+    cleanup: () => rmSync(directoryPath, { force: true, recursive: true }),
+    databasePath: join(directoryPath, 'memory.sqlite'),
+  }
+}
+
+describe('memory raw turn sync agent', () => {
+  const cleanupCallbacks: Array<() => void> = []
+
+  afterEach(() => {
+    for (const cleanup of cleanupCallbacks.splice(0)) {
+      cleanup()
+    }
+  })
+
+  it('evaluates the four upload trigger conditions', () => {
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+
+    expect(evaluateRawTurnSyncTrigger({
+      config: {
+        charThreshold: 2000,
+        idleAfterMs: 8_000,
+        oldestPendingAgeMs: 90_000,
+        turnCountThreshold: 4,
+      },
+      now: 10_000,
+      pendingTurns: Array.from({ length: 4 }, (_, index) => ({
+        createdAt: 1_000 + index,
+        rawPayload: null,
+        role: 'user' as const,
+        scope,
+        syncStatus: 'pending' as const,
+        text: `turn-${index + 1}`,
+        turnId: `turn-${index + 1}`,
+        updatedAt: 1_000 + index,
+        version: 1,
+      })),
+    })?.type).toBe('turn-count-threshold')
+
+    expect(evaluateRawTurnSyncTrigger({
+      config: {
+        charThreshold: 10,
+        idleAfterMs: 8_000,
+        oldestPendingAgeMs: 90_000,
+        turnCountThreshold: 4,
+      },
+      now: 10_000,
+      pendingTurns: [
+        {
+          createdAt: 1_000,
+          rawPayload: null,
+          role: 'user',
+          scope,
+          syncStatus: 'pending',
+          text: '01234567890',
+          turnId: 'turn-1',
+          updatedAt: 1_000,
+          version: 1,
+        },
+      ],
+    })?.type).toBe('character-threshold')
+
+    expect(evaluateRawTurnSyncTrigger({
+      config: {
+        charThreshold: 2000,
+        idleAfterMs: 8_000,
+        oldestPendingAgeMs: 90_000,
+        turnCountThreshold: 4,
+      },
+      now: 100_000,
+      pendingTurns: [
+        {
+          createdAt: 1_000,
+          rawPayload: null,
+          role: 'user',
+          scope,
+          syncStatus: 'pending',
+          text: 'old',
+          turnId: 'turn-1',
+          updatedAt: 1_000,
+          version: 1,
+        },
+      ],
+    })?.type).toBe('oldest-turn-age-threshold')
+
+    expect(evaluateRawTurnSyncTrigger({
+      config: {
+        charThreshold: 2000,
+        idleAfterMs: 8_000,
+        oldestPendingAgeMs: 90_000,
+        turnCountThreshold: 4,
+      },
+      now: 20_000,
+      pendingTurns: [
+        {
+          createdAt: 10_000,
+          rawPayload: null,
+          role: 'user',
+          scope,
+          syncStatus: 'pending',
+          text: 'idle',
+          turnId: 'turn-1',
+          updatedAt: 10_000,
+          version: 1,
+        },
+      ],
+    })?.type).toBe('idle-threshold')
+  })
+
+  it('uploads incremental pending raw turns when a trigger fires and marks them uploaded', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    for (let turnNumber = 1; turnNumber <= 4; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 1_000,
+        rawPayload: { order: turnNumber },
+        role: turnNumber % 2 === 0 ? 'assistant' : 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    const uploadRawTurns = vi.fn(async () => {})
+    const agent = createMemoryRawTurnSyncAgent({
+      now: () => 10_000,
+      repository,
+      uploadClient: { uploadRawTurns },
+    })
+
+    await agent.tick()
+
+    expect(uploadRawTurns).toHaveBeenCalledTimes(1)
+    expect(uploadRawTurns).toHaveBeenCalledWith(expect.objectContaining({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      trigger: expect.objectContaining({
+        type: 'turn-count-threshold',
+      }),
+      turns: [
+        expect.objectContaining({ turnId: 'turn-1', text: 'turn-1', rawPayload: { order: 1 } }),
+        expect.objectContaining({ turnId: 'turn-2', text: 'turn-2', rawPayload: { order: 2 } }),
+        expect.objectContaining({ turnId: 'turn-3', text: 'turn-3', rawPayload: { order: 3 } }),
+        expect.objectContaining({ turnId: 'turn-4', text: 'turn-4', rawPayload: { order: 4 } }),
+      ],
+    }))
+    expect(repository.listPendingRawTurns({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual([])
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      lastUploadedTurnId: 'turn-4',
+      lastUploadAt: 10_000,
+      pendingTurnCount: 0,
+      state: 'idle',
+    }))
+
+    repository.close()
+  })
+
+  it('keeps turns pending and records retry state when upload fails', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { order: 1 },
+      role: 'user',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      text: 'x'.repeat(2_500),
+      turnId: 'turn-1',
+    })
+
+    const uploadRawTurns = vi.fn(async () => {
+      throw new Error('upload failed')
+    })
+    const agent = createMemoryRawTurnSyncAgent({
+      now: () => 10_000,
+      repository,
+      uploadClient: { uploadRawTurns },
+      config: {
+        charThreshold: 2_000,
+        idleAfterMs: 8_000,
+        oldestPendingAgeMs: 90_000,
+        pollIntervalMs: 1_000,
+        retryDelayMs: 30_000,
+        turnCountThreshold: 4,
+      },
+    })
+
+    await agent.tick()
+
+    expect(uploadRawTurns).toHaveBeenCalledTimes(1)
+    expect(repository.listPendingRawTurns({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toHaveLength(1)
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).toEqual(expect.objectContaining({
+      lastError: 'upload failed',
+      nextRetryAt: 40_000,
+      pendingTurnCount: 1,
+      retryCount: 1,
+      state: 'error',
+    }))
+
+    repository.close()
+  })
+
+  it('does not re-upload a batch after it has already been marked uploaded', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    for (let turnNumber = 1; turnNumber <= 4; turnNumber += 1) {
+      repository.appendTurn({
+        createdAt: turnNumber * 1_000,
+        rawPayload: { order: turnNumber },
+        role: 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: `turn-${turnNumber}`,
+        turnId: `turn-${turnNumber}`,
+      })
+    }
+
+    const uploadRawTurns = vi.fn(async () => {})
+    const agent = createMemoryRawTurnSyncAgent({
+      now: () => 10_000,
+      repository,
+      uploadClient: { uploadRawTurns },
+    })
+
+    await agent.tick()
+    await agent.tick()
+
+    expect(uploadRawTurns).toHaveBeenCalledTimes(1)
+
+    repository.close()
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/sync-agent.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/sync-agent.ts
@@ -1,0 +1,221 @@
+import type { MemoryRepository } from './repository'
+import type {
+  MemoryRawTurnSyncConfig,
+  MemoryRawTurnSyncTrigger,
+  MemoryRawTurnUploadClient,
+} from './sync-types'
+import type { MemoryRawTurnRecord, MemoryRepositoryScope } from './types'
+
+import { errorMessageFrom } from '@moeru/std'
+
+const defaultMemoryRawTurnSyncConfig: MemoryRawTurnSyncConfig = {
+  charThreshold: 2_000,
+  idleAfterMs: 8_000,
+  oldestPendingAgeMs: 90_000,
+  pollIntervalMs: 1_000,
+  retryDelayMs: 30_000,
+  turnCountThreshold: 4,
+}
+
+interface CreateMemoryRawTurnSyncAgentOptions {
+  repository: MemoryRepository
+  uploadClient: MemoryRawTurnUploadClient
+  config?: Partial<MemoryRawTurnSyncConfig>
+  now?: () => number
+}
+
+export interface MemoryRawTurnSyncAgent {
+  tick: () => Promise<void>
+  start: () => void
+  stop: () => void
+  isRunning: () => boolean
+}
+
+function createScopeKey(scope: MemoryRepositoryScope) {
+  return `${scope.userId}::${scope.characterId}::${scope.sessionId ?? ''}`
+}
+
+function getPendingCharacterCount(pendingTurns: MemoryRawTurnRecord[]) {
+  return pendingTurns.reduce((total, turn) => total + turn.text.length, 0)
+}
+
+/**
+ * Evaluates whether a pending raw-turn batch should be uploaded.
+ *
+ * Use when:
+ * - The raw-turn sync agent wants a pure local trigger decision
+ * - Tests need deterministic threshold coverage without invoking uploads
+ *
+ * Expects:
+ * - `pendingTurns` are ordered by ascending creation time
+ * - `now` is a Unix timestamp in milliseconds
+ *
+ * Returns:
+ * - `null` when no upload should run yet
+ * - Otherwise a structured trigger reason with local batch metrics
+ */
+export function evaluateRawTurnSyncTrigger(params: {
+  pendingTurns: MemoryRawTurnRecord[]
+  now: number
+  config: Pick<MemoryRawTurnSyncConfig, 'turnCountThreshold' | 'charThreshold' | 'oldestPendingAgeMs' | 'idleAfterMs'>
+}): MemoryRawTurnSyncTrigger | null {
+  const oldestPendingTurn = params.pendingTurns[0]
+  const newestPendingTurn = params.pendingTurns.at(-1)
+
+  if (!oldestPendingTurn || !newestPendingTurn) {
+    return null
+  }
+
+  const pendingTurnCount = params.pendingTurns.length
+  const pendingCharacterCount = getPendingCharacterCount(params.pendingTurns)
+  const oldestPendingTurnAgeMs = params.now - oldestPendingTurn.createdAt
+  const idleDurationMs = params.now - newestPendingTurn.createdAt
+
+  if (pendingTurnCount >= params.config.turnCountThreshold) {
+    return {
+      idleDurationMs,
+      oldestPendingTurnAgeMs,
+      pendingCharacterCount,
+      pendingTurnCount,
+      type: 'turn-count-threshold',
+    }
+  }
+
+  if (pendingCharacterCount >= params.config.charThreshold) {
+    return {
+      idleDurationMs,
+      oldestPendingTurnAgeMs,
+      pendingCharacterCount,
+      pendingTurnCount,
+      type: 'character-threshold',
+    }
+  }
+
+  if (oldestPendingTurnAgeMs >= params.config.oldestPendingAgeMs) {
+    return {
+      idleDurationMs,
+      oldestPendingTurnAgeMs,
+      pendingCharacterCount,
+      pendingTurnCount,
+      type: 'oldest-turn-age-threshold',
+    }
+  }
+
+  if (idleDurationMs >= params.config.idleAfterMs) {
+    return {
+      idleDurationMs,
+      oldestPendingTurnAgeMs,
+      pendingCharacterCount,
+      pendingTurnCount,
+      type: 'idle-threshold',
+    }
+  }
+
+  return null
+}
+
+/**
+ * Creates the desktop raw-turn background sync agent skeleton.
+ *
+ * Use when:
+ * - Main-process memory should convert pending local turns into upload batches
+ * - A later phase will attach a real uploader without changing local trigger logic
+ *
+ * Expects:
+ * - The repository has already been initialized
+ * - The upload client performs only the remote side effect and throws on failure
+ *
+ * Returns:
+ * - An agent with `tick`, `start`, and `stop` controls for local background sync
+ */
+export function createMemoryRawTurnSyncAgent(options: CreateMemoryRawTurnSyncAgentOptions): MemoryRawTurnSyncAgent {
+  const config: MemoryRawTurnSyncConfig = {
+    ...defaultMemoryRawTurnSyncConfig,
+    ...options.config,
+  }
+  const now = options.now ?? (() => Date.now())
+  const inFlightScopeKeys = new Set<string>()
+
+  let intervalHandle: ReturnType<typeof setInterval> | undefined
+
+  async function tickScope(scope: MemoryRepositoryScope) {
+    const scopeKey = createScopeKey(scope)
+    if (inFlightScopeKeys.has(scopeKey)) {
+      return
+    }
+
+    const currentTime = now()
+    const syncState = options.repository.getSyncState({ scope })
+    if (syncState?.nextRetryAt && syncState.nextRetryAt > currentTime) {
+      return
+    }
+
+    const pendingTurns = options.repository.listPendingRawTurns({ scope })
+    const trigger = evaluateRawTurnSyncTrigger({
+      config,
+      now: currentTime,
+      pendingTurns,
+    })
+
+    if (!trigger) {
+      return
+    }
+
+    inFlightScopeKeys.add(scopeKey)
+
+    try {
+      await options.uploadClient.uploadRawTurns({
+        scope,
+        trigger,
+        turns: pendingTurns,
+      })
+
+      options.repository.markRawTurnsUploaded({
+        scope,
+        turnIds: pendingTurns.map(turn => turn.turnId),
+        uploadedAt: currentTime,
+      })
+    }
+    catch (error) {
+      options.repository.recordRawTurnUploadFailure({
+        error: errorMessageFrom(error) ?? String(error),
+        failedAt: currentTime,
+        nextRetryAt: currentTime + config.retryDelayMs,
+        scope,
+      })
+    }
+    finally {
+      inFlightScopeKeys.delete(scopeKey)
+    }
+  }
+
+  return {
+    isRunning() {
+      return !!intervalHandle
+    },
+    async tick() {
+      const scopes = options.repository.listPendingRawTurnScopes()
+
+      for (const scope of scopes) {
+        await tickScope(scope)
+      }
+    },
+    start() {
+      if (intervalHandle) {
+        return
+      }
+
+      intervalHandle = setInterval(() => {
+        void this.tick()
+      }, config.pollIntervalMs)
+    },
+    stop() {
+      if (!intervalHandle) {
+        return
+      }
+
+      clearInterval(intervalHandle)
+      intervalHandle = undefined
+    },
+  }
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/sync-types.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/sync-types.ts
@@ -1,0 +1,205 @@
+import type { MemoryRawTurnRecord, MemoryRepositoryScope, MemorySyncStateRecord } from './types'
+
+/**
+ * One local trigger decision for uploading pending raw turns.
+ */
+export interface MemoryRawTurnSyncTrigger {
+  /** Why the pending batch is eligible for upload. */
+  type: 'turn-count-threshold' | 'character-threshold' | 'oldest-turn-age-threshold' | 'idle-threshold'
+  /** Pending turn count observed at decision time. */
+  pendingTurnCount: number
+  /** Total pending text length observed at decision time. */
+  pendingCharacterCount: number
+  /** Age in milliseconds of the oldest pending turn. */
+  oldestPendingTurnAgeMs: number
+  /** Idle duration in milliseconds since the most recent pending turn. */
+  idleDurationMs: number
+}
+
+/**
+ * Configurable local thresholds for raw-turn upload decisions.
+ */
+export interface MemoryRawTurnSyncConfig {
+  /** Upload after this many pending turns. @default 4 */
+  turnCountThreshold: number
+  /** Upload after this many pending text characters. @default 2000 */
+  charThreshold: number
+  /** Upload once the oldest pending turn reaches this age in ms. @default 90000 */
+  oldestPendingAgeMs: number
+  /** Upload once no new pending turn has arrived for this long in ms. @default 8000 */
+  idleAfterMs: number
+  /** Background polling cadence in ms when the agent is started. @default 1000 */
+  pollIntervalMs: number
+  /** Local retry backoff in ms after a failed upload. @default 30000 */
+  retryDelayMs: number
+}
+
+/**
+ * Upload request passed to the abstract raw-turn upload client.
+ */
+export interface MemoryRawTurnUploadRequest {
+  /** Scope that owns the incremental turn batch. */
+  scope: MemoryRepositoryScope
+  /** Incremental pending turns selected for upload. */
+  turns: MemoryRawTurnRecord[]
+  /** Local trigger that caused the upload to run. */
+  trigger: MemoryRawTurnSyncTrigger
+}
+
+/**
+ * Abstract upload client for raw-turn sync.
+ */
+export interface MemoryRawTurnUploadClient {
+  /**
+   * Uploads one incremental batch of raw turns.
+   */
+  uploadRawTurns: (request: MemoryRawTurnUploadRequest) => Promise<void>
+}
+
+/**
+ * Runtime config for the raw-turn upload adapter.
+ */
+export interface MemoryRawTurnUploaderConfig {
+  /** Whether remote raw-turn upload is enabled. */
+  enabled: boolean
+  /** Remote upload endpoint URL. */
+  endpointUrl?: string | null
+  /** Bearer token or API key used by the uploader. */
+  authToken?: string | null
+  /** Request timeout in milliseconds for one upload attempt. */
+  requestTimeoutMs: number
+}
+
+/**
+ * Visible uploader runtime status for diagnostics and tests.
+ */
+export interface MemoryRawTurnUploaderStatus {
+  /** Whether the uploader is active or a disabled no-op. */
+  mode: 'active' | 'disabled'
+  /** Human-readable reason when disabled. */
+  reason?: string
+  /** Resolved endpoint URL when active. */
+  endpointUrl?: string | null
+}
+
+/**
+ * One remote profile-summary patch.
+ */
+export interface MemoryProfileSummaryPatch {
+  /** Monotonic remote summary version. */
+  summaryVersion: number
+  /** Renderable markdown summary content. */
+  summaryMarkdown: string
+  /** Source turn that generated the summary. */
+  generatedFromTurnId: string
+  /** Confidence score normalized to 0..1. */
+  confidence?: number
+}
+
+/**
+ * One remote stable-fact patch item.
+ */
+export interface MemoryStableFactPatch {
+  /** Stable fact key used for supersede merge. */
+  factKey: string
+  /** Stable fact value. */
+  factValue: string
+  /** Source turn that generated the fact. */
+  generatedFromTurnId: string
+  /** Confidence score normalized to 0..1. */
+  confidence?: number
+}
+
+/**
+ * One remote memory-card patch item.
+ */
+export interface MemoryCardPatch {
+  /** Stable memory-card identifier. */
+  id: string
+  /** Card title or label. */
+  title: string
+  /** Card content body. */
+  content: string
+  /** Source turn that generated the card, when available. */
+  generatedFromTurnId?: string | null
+  /** Confidence score normalized to 0..1. */
+  confidence?: number
+}
+
+/**
+ * One incremental memory patch payload fetched from the cloud.
+ */
+export interface MemoryPatchPayload {
+  /** Scope the patch applies to. */
+  scope: MemoryRepositoryScope
+  /** Optional summary patch for the scope. */
+  summaryPatch?: MemoryProfileSummaryPatch | null
+  /** Optional stable-fact patch batch. */
+  factsPatch?: MemoryStableFactPatch[]
+  /** Optional memory-card upsert batch. */
+  memoryCards?: MemoryCardPatch[]
+}
+
+/**
+ * Result of applying one fetched memory patch locally.
+ */
+export interface ApplyMemoryPatchResult {
+  /** Whether the summary patch was applied. */
+  appliedSummary: boolean
+  /** Number of fact rows applied. */
+  appliedFactsCount: number
+  /** Number of memory-card rows upserted. */
+  appliedMemoryCardCount: number
+  /** Explicit summary rejection reason, if one occurred. */
+  rejectedSummaryReason: null | 'outdated-summary-version' | 'outdated-generated-from-turn'
+}
+
+/**
+ * Abstract pull client for incremental memory patches.
+ */
+export interface MemoryPatchPullClient {
+  /**
+   * Fetches one incremental memory patch for a scope and current local state.
+   */
+  fetchMemoryPatch: (scope: MemoryRepositoryScope, state: MemorySyncStateRecord | null) => Promise<MemoryPatchPayload | null>
+}
+
+/**
+ * Runtime config for the memory patch pull adapter.
+ */
+export interface MemoryPatchPullConfig {
+  /** Whether remote patch pulling is enabled. */
+  enabled: boolean
+  /** Remote patch endpoint URL. */
+  endpointUrl?: string | null
+  /** Bearer token or API key used by the patch puller. */
+  authToken?: string | null
+  /** Request timeout in milliseconds for one patch fetch. */
+  requestTimeoutMs: number
+  /** Periodic pull interval in milliseconds. */
+  pullIntervalMs: number
+  /** Local retry backoff in milliseconds after a failed pull. */
+  retryDelayMs: number
+}
+
+/**
+ * Visible patch-pull runtime status for diagnostics and tests.
+ */
+export interface MemoryPatchPullStatus {
+  /** Whether the patch puller is active or a disabled no-op. */
+  mode: 'active' | 'disabled'
+  /** Human-readable reason when disabled. */
+  reason?: string
+  /** Resolved endpoint URL when active. */
+  endpointUrl?: string | null
+}
+
+/**
+ * Combined memory sync runtime config.
+ */
+export interface MemoryRawTurnSyncRuntimeConfig extends MemoryRawTurnSyncConfig {
+  /** Local raw/recent turn retention window in ms after successful upload confirmation. */
+  rawTurnRetentionWindowMs: number
+  uploader: MemoryRawTurnUploaderConfig
+  patch: MemoryPatchPullConfig
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/types.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/types.ts
@@ -1,0 +1,241 @@
+/**
+ * Local-first memory scope resolved inside the desktop SQLite repository.
+ */
+export interface MemoryRepositoryScope {
+  /** Stable user identifier owning the memory slice. */
+  userId: string
+  /** Character identifier associated with the slice. */
+  characterId: string
+  /** Optional session identifier for session-local records. */
+  sessionId?: string | null
+}
+
+/**
+ * Current profile summary row returned by the repository.
+ */
+export interface MemoryProfileSummaryRecord {
+  /** Stable summary identifier. */
+  id: string
+  /** Scope that owns the summary. */
+  scope: MemoryRepositoryScope
+  /** Monotonic summary version within the user/character pair. */
+  version: number
+  /** Renderable markdown summary content. */
+  summaryMarkdown: string
+  /** Source turn that generated the summary, when available. */
+  generatedFromTurnId?: string | null
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+  /** Newer row that superseded this one, if any. */
+  supersededBy?: string | null
+  /** Unix timestamp in milliseconds when the row was created. */
+  createdAt: number
+  /** Unix timestamp in milliseconds when the row was last updated. */
+  updatedAt: number
+}
+
+/**
+ * Current stable fact row returned by the repository.
+ */
+export interface MemoryStableFactRecord {
+  /** Stable fact identifier. */
+  id: string
+  /** Scope that owns the fact. */
+  scope: MemoryRepositoryScope
+  /** Monotonic fact version within the scoped fact key. */
+  version: number
+  /** Stable fact key used for upserts and recall. */
+  factKey: string
+  /** Stable fact value surfaced to prompt assembly. */
+  factValue: string
+  /** Source turn that generated the fact, when available. */
+  generatedFromTurnId?: string | null
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+  /** Newer row that superseded this one, if any. */
+  supersededBy?: string | null
+  /** Unix timestamp in milliseconds when the row was created. */
+  createdAt: number
+  /** Unix timestamp in milliseconds when the row was last updated. */
+  updatedAt: number
+}
+
+/**
+ * Recent conversational turn returned by the repository.
+ */
+export interface MemoryRecentTurnRecord {
+  /** Stable turn identifier. */
+  turnId: string
+  /** Scope that owns the turn. */
+  scope: MemoryRepositoryScope
+  /** Row version for future mutable turn workflows. */
+  version: number
+  /** Speaker role recorded for the turn. */
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  /** Plain-text content used for prompt assembly. */
+  text: string
+  /** Unix timestamp in milliseconds when the turn was created. */
+  createdAt: number
+  /** Unix timestamp in milliseconds when the row was last updated. */
+  updatedAt: number
+}
+
+/**
+ * Raw turn row returned by the repository for sync/upload workflows.
+ */
+export interface MemoryRawTurnRecord {
+  /** Stable turn identifier. */
+  turnId: string
+  /** Scope that owns the turn. */
+  scope: MemoryRepositoryScope
+  /** Row version for sync bookkeeping. */
+  version: number
+  /** Speaker role recorded for the turn. */
+  role: MemoryRecentTurnRecord['role']
+  /** Plain-text content paired from `recent_turns` for thresholds and uploads. */
+  text: string
+  /** Structured raw payload parsed from the raw-turn log. */
+  rawPayload?: Record<string, unknown> | null
+  /** Current raw-turn sync status. */
+  syncStatus: 'pending' | 'uploaded'
+  /** Unix timestamp in milliseconds when the row was created. */
+  createdAt: number
+  /** Unix timestamp in milliseconds when the row was last updated. */
+  updatedAt: number
+}
+
+/**
+ * Sync-state row returned by the repository.
+ */
+export interface MemorySyncStateRecord {
+  /** Stable sync-state identifier. */
+  id: string
+  /** Scope that owns the sync-state row. */
+  scope: MemoryRepositoryScope
+  /** Row version for future migration-safe updates. */
+  version: number
+  /** Source turn that produced the current checkpoint, when available. */
+  generatedFromTurnId?: string | null
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+  /** Newer row that superseded this one, if any. */
+  supersededBy?: string | null
+  /** Current local sync checkpoint. */
+  syncCheckpoint: number
+  /** Latest local raw-turn checkpoint. */
+  lastLocalTurnCheckpoint: number
+  /** Remote checkpoint cursor when the scope has synced before. */
+  remoteCheckpoint?: string | null
+  /** Last synced turn identifier, when available. */
+  lastSyncedTurnId?: string | null
+  /** Unix timestamp in milliseconds of the last successful sync. */
+  lastSyncedAt?: number | null
+  /** Last successfully uploaded raw-turn identifier, when available. */
+  lastUploadedTurnId?: string | null
+  /** Unix timestamp in milliseconds of the last successful raw-turn upload. */
+  lastUploadAt?: number | null
+  /** Last successfully applied summary version from remote patches. */
+  lastAppliedSummaryVersion: number
+  /** Generated-from turn id of the latest applied remote patch checkpoint. */
+  lastAppliedGeneratedFromTurnId?: string | null
+  /** Numeric checkpoint of the latest applied remote patch turn. */
+  lastAppliedTurnCheckpoint: number
+  /** Unix timestamp in milliseconds of the last successful patch pull. */
+  lastPullAt?: number | null
+  /** Next scheduled pull timestamp in milliseconds. */
+  nextPullAt?: number | null
+  /** Current number of pending raw turns for the scope. */
+  pendingTurnCount: number
+  /** Current upload retry count for the scope. */
+  retryCount: number
+  /** Next retry timestamp in milliseconds, when backoff is active. */
+  nextRetryAt?: number | null
+  /** Current sync lifecycle state. */
+  state: string
+  /** Last sync error summary, when available. */
+  lastError?: string | null
+  /** Unix timestamp in milliseconds when the row was created. */
+  createdAt: number
+  /** Unix timestamp in milliseconds when the row was last updated. */
+  updatedAt: number
+}
+
+/**
+ * Input for appending one raw and recent turn in the same transaction.
+ */
+export interface MemoryAppendTurnInput {
+  /** Scope that owns the turn. */
+  scope: MemoryRepositoryScope
+  /** Stable turn identifier. */
+  turnId: string
+  /** Speaker role recorded for the turn. */
+  role: MemoryRecentTurnRecord['role']
+  /** Plain-text form used for prompt assembly. */
+  text: string
+  /** Structured raw payload persisted into the raw-turn log. */
+  rawPayload?: Record<string, unknown> | null
+  /** Unix timestamp in milliseconds for both created_at and updated_at. */
+  createdAt: number
+}
+
+/**
+ * Input for replacing the current user/character profile summary.
+ */
+export interface MemoryReplaceProfileSummaryInput {
+  /** Scope that owns the summary. Session is stored but not part of current-summary uniqueness. */
+  scope: MemoryRepositoryScope
+  /** Renderable markdown summary content. */
+  summaryMarkdown: string
+  /** Source turn that generated the summary, when available. */
+  generatedFromTurnId?: string | null
+  /** Confidence score normalized to 0..1. @default 1 */
+  confidence?: number
+  /** Unix timestamp in milliseconds for both created_at and updated_at. */
+  updatedAt: number
+}
+
+/**
+ * Input for upserting one stable fact inside a scope.
+ */
+export interface MemoryUpsertStableFactInput {
+  /** Scope that owns the fact. */
+  scope: MemoryRepositoryScope
+  /** Stable fact key used to locate the current fact row. */
+  factKey: string
+  /** Stable fact value to persist as the new current row. */
+  factValue: string
+  /** Source turn that generated the fact, when available. */
+  generatedFromTurnId?: string | null
+  /** Confidence score normalized to 0..1. @default 1 */
+  confidence?: number
+  /** Unix timestamp in milliseconds for both created_at and updated_at. */
+  updatedAt: number
+}
+
+/**
+ * Input for reading the current prompt context from local SQLite memory.
+ */
+export interface MemoryReadPromptContextInput {
+  /** Scope used to resolve stable facts and recent turns. */
+  scope: MemoryRepositoryScope
+}
+
+/**
+ * Repository result for prompt-context assembly.
+ */
+export interface MemoryPromptContext {
+  /** Current profile summary for the user/character pair, if one exists. */
+  profileSummary: MemoryProfileSummaryRecord | null
+  /** Current unsuperseded stable facts for the scope. */
+  stableFacts: MemoryStableFactRecord[]
+  /** Latest 24 turns for the scope, ordered by time ascending. */
+  recentTurns: MemoryRecentTurnRecord[]
+}
+
+/**
+ * Input for reading sync-state rows from local SQLite memory.
+ */
+export interface MemoryGetSyncStateInput {
+  /** Scope used to resolve the sync-state row. */
+  scope: MemoryRepositoryScope
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/uploader.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/uploader.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMemoryRawTurnUploadRuntime } from './uploader'
+
+describe('memory raw-turn uploader runtime', () => {
+  it('enters disabled no-op mode when config is missing', async () => {
+    const runtime = createMemoryRawTurnUploadRuntime({
+      config: {
+        enabled: true,
+        endpointUrl: null,
+        authToken: null,
+        requestTimeoutMs: 10_000,
+      },
+    })
+
+    expect(runtime.getStatus()).toEqual({
+      mode: 'disabled',
+      reason: 'memory sync upload is missing endpoint or auth token',
+    })
+
+    await expect(runtime.client.uploadRawTurns({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      trigger: {
+        idleDurationMs: 9_000,
+        oldestPendingTurnAgeMs: 9_000,
+        pendingCharacterCount: 10,
+        pendingTurnCount: 1,
+        type: 'idle-threshold',
+      },
+      turns: [],
+    })).resolves.toBeUndefined()
+  })
+
+  it('posts uploaded raw turns through the active runtime adapter', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+    }))
+    const runtime = createMemoryRawTurnUploadRuntime({
+      config: {
+        enabled: true,
+        endpointUrl: 'https://example.com/memory/raw-turns',
+        authToken: 'secret-token',
+        requestTimeoutMs: 10_000,
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    await runtime.client.uploadRawTurns({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      trigger: {
+        idleDurationMs: 9_000,
+        oldestPendingTurnAgeMs: 9_000,
+        pendingCharacterCount: 10,
+        pendingTurnCount: 1,
+        type: 'idle-threshold',
+      },
+      turns: [
+        {
+          createdAt: 1_000,
+          rawPayload: { content: 'hello' },
+          role: 'user',
+          scope: {
+            characterId: 'character-a',
+            sessionId: 'session-a',
+            userId: 'user-a',
+          },
+          syncStatus: 'pending',
+          text: 'hello',
+          turnId: 'turn-1',
+          updatedAt: 1_000,
+          version: 1,
+        },
+      ],
+    })
+
+    expect(runtime.getStatus()).toEqual({
+      endpointUrl: 'https://example.com/memory/raw-turns',
+      mode: 'active',
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.com/memory/raw-turns', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Authorization': 'Bearer secret-token',
+        'Content-Type': 'application/json',
+      }),
+      method: 'POST',
+    }))
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/memory/uploader.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/memory/uploader.ts
@@ -1,0 +1,95 @@
+import type {
+  MemoryRawTurnUploadClient,
+  MemoryRawTurnUploaderConfig,
+  MemoryRawTurnUploaderStatus,
+} from './sync-types'
+
+export interface MemoryRawTurnUploadRuntime {
+  client: MemoryRawTurnUploadClient
+  getStatus: () => MemoryRawTurnUploaderStatus
+}
+
+interface CreateMemoryRawTurnUploadRuntimeOptions {
+  config: MemoryRawTurnUploaderConfig
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Creates the runtime upload adapter for raw-turn sync.
+ *
+ * Use when:
+ * - The raw-turn sync agent needs a concrete upload client for desktop runtime
+ * - App startup must degrade cleanly when upload configuration is absent
+ *
+ * Expects:
+ * - `config` is already resolved from one centralized config source
+ * - `fetchImpl` behaves like the standard Fetch API
+ *
+ * Returns:
+ * - An active uploader runtime, or a disabled no-op runtime with an explicit status
+ */
+export function createMemoryRawTurnUploadRuntime(options: CreateMemoryRawTurnUploadRuntimeOptions): MemoryRawTurnUploadRuntime {
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  if (!options.config.enabled) {
+    return {
+      client: {
+        async uploadRawTurns() {
+        },
+      },
+      getStatus: () => ({
+        mode: 'disabled',
+        reason: 'memory sync upload is disabled',
+      }),
+    }
+  }
+
+  if (!options.config.endpointUrl || !options.config.authToken) {
+    return {
+      client: {
+        async uploadRawTurns() {
+        },
+      },
+      getStatus: () => ({
+        mode: 'disabled',
+        reason: 'memory sync upload is missing endpoint or auth token',
+      }),
+    }
+  }
+
+  return {
+    client: {
+      async uploadRawTurns(request) {
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), options.config.requestTimeoutMs)
+
+        try {
+          const response = await fetchImpl(options.config.endpointUrl!, {
+            body: JSON.stringify({
+              scope: request.scope,
+              trigger: request.trigger,
+              turns: request.turns,
+            }),
+            headers: {
+              'Authorization': `Bearer ${options.config.authToken}`,
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+            signal: controller.signal,
+          })
+
+          if (!response.ok) {
+            throw new Error(`memory raw-turn upload failed (${response.status})`)
+          }
+        }
+        finally {
+          clearTimeout(timeoutId)
+        }
+      },
+    },
+    getStatus: () => ({
+      endpointUrl: options.config.endpointUrl,
+      mode: 'active',
+    }),
+  }
+}

--- a/apps/stage-tamagotchi/src/main/windows/beat-sync/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/beat-sync/index.ts
@@ -15,7 +15,16 @@ export async function setupBeatSync() {
     },
   })
 
-  await load(window, baseUrl(resolve(getElectronMainDirname(), '..', 'renderer'), 'beat-sync.html'))
+  // NOTICE:
+  // BeatSync is a background helper window and must not block desktop app boot.
+  // In local development we have seen `load(...)` for the hidden BeatSync page hang
+  // long enough to prevent `windows:main` from ever being created, leaving the app
+  // process alive with zero visible windows.
+  // We therefore start loading the page in the background and only log failures here,
+  // so the main AIRI window can still open while BeatSync initializes independently.
+  void load(window, baseUrl(resolve(getElectronMainDirname(), '..', 'renderer'), 'beat-sync.html')).catch((error) => {
+    console.error('[beat-sync] failed to load background window:', error)
+  })
 
   initScreenCaptureForWindow(window)
 

--- a/apps/stage-tamagotchi/src/main/windows/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/main/index.ts
@@ -170,13 +170,15 @@ export async function setupMainWindow(params: {
     window.setWindowButtonVisibility(false)
   }
 
-  window.on('ready-to-show', () => window!.show())
+  let shownByFallback = false
+  window.on('ready-to-show', () => {
+    shownByFallback = true
+    window.show()
+  })
   window.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }
   })
-
-  await load(window, baseUrl(resolve(getElectronMainDirname(), '..', 'renderer')))
 
   await setupMainWindowElectronInvokes({
     window,
@@ -192,6 +194,26 @@ export async function setupMainWindow(params: {
     onboardingWindowManager: params.onboardingWindowManager,
     windowAuthManager: params.windowAuthManager,
   })
+
+  // NOTICE:
+  // The main AIRI window must not block app boot on renderer navigation resolution.
+  // In development we have observed `load(...)` remain pending long enough that
+  // no visible windows are ever created, even though the renderer dev server is up.
+  // Start navigation in the background, keep the normal `ready-to-show` path, and
+  // add a fallback `show()` in development so the app is still inspectable.
+  void load(window, baseUrl(resolve(getElectronMainDirname(), '..', 'renderer'))).catch((error) => {
+    console.error('[main-window] failed to load renderer:', error)
+  })
+
+  if (is.dev || env.MAIN_APP_DEBUG || env.APP_DEBUG) {
+    setTimeout(() => {
+      if (shownByFallback || window.isDestroyed() || window.isVisible())
+        return
+
+      shownByFallback = true
+      window.show()
+    }, 3000)
+  }
 
   /**
    * This is a know issue (or expected behavior maybe) to Electron.

--- a/apps/stage-tamagotchi/src/shared/eventa/index.ts
+++ b/apps/stage-tamagotchi/src/shared/eventa/index.ts
@@ -46,6 +46,7 @@ export interface ElectronUpdaterPreferences {
 export const electronGetUpdaterPreferences = defineInvokeEventa<ElectronUpdaterPreferences>('eventa:invoke:electron:auto-updater:get-preferences')
 export const electronSetUpdaterPreferences = defineInvokeEventa<ElectronUpdaterPreferences, ElectronUpdaterPreferences>('eventa:invoke:electron:auto-updater:set-preferences')
 
+export * from './memory'
 export * from './plugin/assets'
 export * from './plugin/capabilities'
 export * from './plugin/host'

--- a/apps/stage-tamagotchi/src/shared/eventa/memory.test.ts
+++ b/apps/stage-tamagotchi/src/shared/eventa/memory.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  electronMemoryAppendTurn as electronMemoryAppendTurnFromMemory,
+  electronMemoryGetSyncState as electronMemoryGetSyncStateFromMemory,
+  electronMemoryReadPromptContext as electronMemoryReadPromptContextFromMemory,
+} from './memory'
+
+/**
+ * Verifies the memory Eventa contracts stay sourced from the dedicated memory module.
+ *
+ * @example
+ * describe('memory Eventa contracts', () => {
+ *   expect(electronMemoryReadPromptContext).toBe(electronMemoryReadPromptContextFromMemory)
+ * })
+ */
+describe('memory Eventa contracts', () => {
+  /**
+   * Keeps the dedicated memory contract module wired into the shared Eventa barrel.
+   *
+   * @example
+   * it('exports the memory domain through the shared Eventa barrel', () => {
+   *   expect(indexSource).toContain(`export * from './memory'`)
+   * })
+   */
+  it('exports the memory domain through the shared Eventa barrel', () => {
+    const indexSource = readFileSync(new URL('./index.ts', import.meta.url), 'utf8')
+
+    expect(indexSource).toContain(`export * from './memory'`)
+    expect(electronMemoryReadPromptContextFromMemory).toBeDefined()
+    expect(electronMemoryAppendTurnFromMemory).toBeDefined()
+    expect(electronMemoryGetSyncStateFromMemory).toBeDefined()
+  })
+})

--- a/apps/stage-tamagotchi/src/shared/eventa/memory.ts
+++ b/apps/stage-tamagotchi/src/shared/eventa/memory.ts
@@ -1,0 +1,184 @@
+import { defineInvokeEventa } from '@moeru/eventa'
+
+/**
+ * Shared scope identity for local-first desktop memory records.
+ */
+export interface ElectronMemoryScope {
+  /** Stable user identifier owning the memory slice. */
+  userId: string
+  /** Character identifier associated with the slice. */
+  characterId: string
+  /** Session identifier for session-local memory views. */
+  sessionId?: string | null
+}
+
+/**
+ * One recent conversational turn used to assemble prompt context.
+ */
+export interface ElectronMemoryRecentTurnSnapshot {
+  /** Stable turn identifier. */
+  turnId: string
+  /** Speaker role recorded for the turn. */
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  /** Plain-text form used for prompt assembly. */
+  text: string
+  /** Unix timestamp in milliseconds. */
+  createdAt: number
+}
+
+/**
+ * One stable fact recalled into the prompt context.
+ */
+export interface ElectronMemoryStableFactSnapshot {
+  /** Stable fact identifier. */
+  id: string
+  /** Fact key or short label. */
+  key: string
+  /** Human-readable fact value. */
+  value: string
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+}
+
+/**
+ * One higher-level memory card assembled for later retrieval.
+ */
+export interface ElectronMemoryCardSnapshot {
+  /** Stable card identifier. */
+  id: string
+  /** Card title or label. */
+  title: string
+  /** Card body that can be injected into prompts. */
+  content: string
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+}
+
+/**
+ * One sync status snapshot for the scoped local memory slice.
+ */
+export interface ElectronMemorySyncStateSnapshot {
+  /** Monotonic local checkpoint that marks the latest synced boundary. */
+  syncCheckpoint: number
+  /** Latest raw turn checkpoint seen locally. */
+  lastLocalTurnCheckpoint: number
+  /** Opaque remote cursor or checkpoint identifier if available. */
+  remoteCheckpoint?: string | null
+  /** Unix timestamp in milliseconds of the last successful sync attempt. */
+  lastSyncedAt?: number | null
+  /** Unix timestamp in milliseconds of the last successful raw-turn upload. */
+  lastUploadAt?: number | null
+  /** Unix timestamp in milliseconds of the last successful patch pull. */
+  lastPullAt?: number | null
+  /** Current number of pending raw turns for the scope. */
+  pendingTurnCount?: number
+  /** Last successfully applied summary version. */
+  lastAppliedSummaryVersion?: number | null
+  /** Human-readable state for future sync orchestration. */
+  state: 'idle' | 'syncing' | 'error'
+  /** Optional last sync error summary. */
+  lastError?: string | null
+}
+
+/**
+ * Request payload for assembling prompt context from desktop local memory.
+ */
+export interface ElectronMemoryReadPromptContextRequest {
+  /** Scope selecting the local-first memory slice. */
+  scope: ElectronMemoryScope
+  /** Maximum recent conversational turns to include. */
+  recentTurnLimit?: number
+  /** Maximum stable facts to include. */
+  stableFactLimit?: number
+  /** Maximum memory cards to include. */
+  memoryCardLimit?: number
+}
+
+/**
+ * Response payload for prompt-context reads.
+ */
+export interface ElectronMemoryReadPromptContextResponse {
+  /** Current schema version used by the local memory layer. */
+  schemaVersion: number
+  /** Scope used to resolve the prompt context. */
+  scope: ElectronMemoryScope
+  /** Optional profile summary for the scope. */
+  profileSummary?: string | null
+  /** Stable facts selected for prompt assembly. */
+  stableFacts: ElectronMemoryStableFactSnapshot[]
+  /** Recent turns selected for prompt assembly. */
+  recentTurns: ElectronMemoryRecentTurnSnapshot[]
+  /** Memory cards selected for prompt assembly. */
+  memoryCards: ElectronMemoryCardSnapshot[]
+}
+
+/**
+ * Request payload for appending one turn into the local memory log.
+ */
+export interface ElectronMemoryAppendTurnRequest {
+  /** Scope selecting the local-first memory slice. */
+  scope: ElectronMemoryScope
+  /** Stable turn identifier to append. */
+  turnId: string
+  /** Speaker role recorded for the turn. */
+  role: ElectronMemoryRecentTurnSnapshot['role']
+  /** Plain-text turn content. */
+  text: string
+  /** Optional structured raw payload for future replay or sync. */
+  rawPayload?: Record<string, unknown> | null
+  /** Unix timestamp in milliseconds. */
+  createdAt: number
+}
+
+/**
+ * Response payload for local turn append requests.
+ */
+export interface ElectronMemoryAppendTurnResponse {
+  /** Current schema version used by the local memory layer. */
+  schemaVersion: number
+  /** Turn identifier accepted by the local memory layer. */
+  storedTurnId: string
+  /** Updated sync checkpoint after the append. */
+  syncCheckpoint: number
+}
+
+/**
+ * Request payload for reading sync state without mutating local memory.
+ */
+export interface ElectronMemoryGetSyncStateRequest {
+  /** Scope selecting the local-first memory slice. */
+  scope: ElectronMemoryScope
+}
+
+/**
+ * Response payload for sync-state reads.
+ */
+export interface ElectronMemoryGetSyncStateResponse {
+  /** Current schema version used by the local memory layer. */
+  schemaVersion: number
+  /** Scope used to resolve the sync state. */
+  scope: ElectronMemoryScope
+  /** Runtime mode surfaced to renderer consumers. */
+  runtimeMode?: 'desktop-local-sqlite' | 'web-stub'
+  /** Whether background sync is enabled, disabled, or unavailable. */
+  syncMode?: 'enabled' | 'disabled' | 'unavailable'
+  /** Human-readable sync mode detail. */
+  syncModeReason?: string | null
+  /** Current sync state snapshot, if the scope has been initialized. */
+  syncState?: ElectronMemorySyncStateSnapshot | null
+}
+
+export const electronMemoryReadPromptContext = defineInvokeEventa<
+  ElectronMemoryReadPromptContextResponse,
+  ElectronMemoryReadPromptContextRequest
+>('eventa:invoke:electron:memory:read-prompt-context')
+
+export const electronMemoryAppendTurn = defineInvokeEventa<
+  ElectronMemoryAppendTurnResponse,
+  ElectronMemoryAppendTurnRequest
+>('eventa:invoke:electron:memory:append-turn')
+
+export const electronMemoryGetSyncState = defineInvokeEventa<
+  ElectronMemoryGetSyncStateResponse,
+  ElectronMemoryGetSyncStateRequest
+>('eventa:invoke:electron:memory:get-sync-state')

--- a/docs/superpowers/specs/2026-04-26-airi-local-first-memory-design.md
+++ b/docs/superpowers/specs/2026-04-26-airi-local-first-memory-design.md
@@ -1,0 +1,296 @@
+# AIRI Local-First Memory Design
+
+**Status:** Approved for implementation planning
+
+**Goal:** Make AIRI read realtime memory from local SQLite during chat, keep only a bounded local short-term raw-memory window, and let cloud LangMem turn the full uploaded experience stream into long-term memory patches that are cached back into SQLite.
+
+**Scope assumption:** V1 targets the Electron desktop runtime in `apps/stage-tamagotchi` as the first-class SQLite host. Shared stage UI code will consume a runtime-agnostic memory gateway, and web/mobile can keep their current local storage path until a later adapter is added.
+
+## Why This Design
+
+The current repository has three partial memory directions:
+
+- local IndexedDB persistence for sessions and local-first app data
+- a DuckDB proof-of-concept that is not in the realtime chat path
+- Telegram-side pgvector retrieval that lives in a server/service lane
+
+That means AIRI does not yet have one unified memory path for realtime interaction. This design makes the desktop app use local SQLite as the realtime memory source, while cloud LangMem is the long-term memory formation system. The local store keeps short-term raw detail plus the latest cloud-consolidated memory copy; it is not expected to keep every raw turn forever.
+
+## Design Principles
+
+- Realtime chat must never wait on cloud memory work.
+- Every turn must be durable locally before any background sync starts.
+- The local store is the interaction-time source of truth.
+- Cloud LangMem is the long-term memory compression and consolidation source.
+- Local raw turns are retained as a configurable short-term window, not as infinite local history.
+- Cloud output is a memory patch that refreshes the local long-term memory copy.
+- Recent turns outrank summaries when prompt budget is tight.
+- Long-term memory should be merged incrementally and versioned defensively.
+
+## Final Architecture Summary
+
+AIRI's realtime chat path reads memory only from local SQLite. The local database contains two prompt-visible memory layers:
+
+1. A bounded short-term memory window, such as the most recent N days of raw or prompt-ready turns.
+2. A local copy of long-term memory distilled by cloud LangMem, such as `profile_summary`, `stable_facts`, and `memory_cards`.
+
+The full experience stream is uploaded from local `raw_turn_log` in the background. Cloud LangMem slowly summarizes, extracts stable facts, and creates memory cards from that uploaded stream. The desktop app later pulls a memory patch and merges the distilled result back into SQLite.
+
+In one sentence:
+
+> AIRI keeps short-term experience and long-term memory essence locally for fast chat, while cloud LangMem compresses the complete uploaded experience stream into long-term memory patches.
+
+The prompt-critical read model is:
+
+```txt
+local_runtime_memory_context =
+  local_short_term_recent_window
+  + local_copy_of_cloud_consolidated_memory
+```
+
+The important invariant is:
+
+> Cloud creates consolidated long-term memory; local SQLite serves it on the live chat path.
+
+## High-Level Architecture
+
+The V1 architecture has four moving parts:
+
+1. A local SQLite memory database owned by the desktop runtime.
+2. A renderer-facing memory gateway for reads, writes, and sync state.
+3. A background sync agent that uploads raw turn deltas and safely prunes local raw turns after retention rules allow it.
+4. A cloud LangMem worker that summarizes, extracts facts, creates memory cards, and returns memory patches.
+
+The realtime chat path is:
+
+1. User submits input.
+2. AIRI reads local memory context from SQLite: recent local window plus cloud-consolidated long-term memory copy.
+3. AIRI writes the user turn to local SQLite.
+4. AIRI calls the LLM.
+5. AIRI writes the assistant turn to local SQLite.
+6. AIRI marks new raw turns as pending for background sync.
+
+The cloud path is:
+
+1. Local sync agent batches unsynced raw turns from the short-term raw log.
+2. Cloud LangMem ingests the uploaded experience stream and generates consolidated memory patches.
+3. Desktop pulls the newest patch set by version or cursor.
+4. Local merge logic updates summary, facts, and memory cards in SQLite.
+5. Local cleanup prunes raw turns outside the configured retention window only after upload acknowledgement.
+
+## Local Memory Model
+
+V1 keeps five primary memory content buckets plus one sync state table.
+
+### `profile_summary`
+
+Purpose:
+Compressed user and relationship summary used first in prompt assembly.
+
+Properties:
+- scoped by `user_id` and `character_id`
+- single current active summary row per scope
+- includes `summary_version`
+- includes `generated_from_turn_id`
+- includes `updated_at`
+
+### `stable_facts`
+
+Purpose:
+Persistent facts that should outlive recent chat windows.
+
+Properties:
+- scoped by `user_id` and `character_id`
+- includes `fact_key`, `fact_value`, `confidence`
+- includes `updated_at`
+- includes `superseded_by`
+- supports soft replacement rather than destructive overwrite
+
+### `recent_turns`
+
+Purpose:
+Fast prompt-ready rolling short-term conversation memory.
+
+Properties:
+- scoped by `user_id`, `character_id`, and `session_id`
+- contains the latest prompt-eligible turns inside the configured local retention window
+- pruned by turn count and age after the raw source has been durably handled
+- optimized for direct prompt assembly without extra transformation
+
+### `raw_turn_log`
+
+Purpose:
+Local short-term raw turn buffer for upload, retry, and recent-detail recall.
+
+Properties:
+- scoped by `user_id`, `character_id`, and `session_id`
+- contains user and assistant turns that are still inside the configured local retention or sync safety window
+- each row has a unique `turn_id`
+- tracks `sync_status`
+- is uploaded to cloud LangMem as the source stream for long-term memory formation
+- is not retained forever locally
+- is never used directly as the default prompt source
+
+### `memory_cards`
+
+Purpose:
+Cloud-consolidated long-term memory essence cached locally for optional recall.
+
+Properties:
+- scoped by `user_id` and `character_id`
+- stores short cloud-generated digests or recall cards
+- includes tags, entities, salience, and source turn range
+- can later support SQLite FTS5 without entering the default fast path
+
+### `sync_state`
+
+Purpose:
+Track upload, patch pull, merge, and retention progress safely.
+
+Properties:
+- scoped by `user_id` and `character_id`
+- stores `last_uploaded_turn_id`
+- stores `last_applied_summary_version`
+- stores cloud acknowledgement or cursor data needed before pruning local raw turns
+- stores last sync timestamps and retry counters
+
+## Realtime Read Order
+
+Default prompt read order is:
+
+1. `profile_summary`
+2. `stable_facts`
+3. `recent_turns`
+
+Optional enhancement:
+
+- `memory_cards` are read only when a recall trigger is detected
+- examples: "你还记得吗", "我之前说过", clear cross-session references, or explicit reflective prompts
+
+`recent_turns` must outrank `profile_summary` and `stable_facts` when there is tension between recent corrections and older summarized state. Recent raw detail is the short-term working memory; cloud-consolidated data is the long-term memory essence.
+
+## Realtime Write Policy
+
+Realtime writes must stay intentionally lightweight.
+
+On user input:
+
+- append a `raw_turn_log` row
+- update `recent_turns`
+- mark sync state dirty
+
+On assistant completion:
+
+- append a `raw_turn_log` row
+- update `recent_turns`
+- mark sync state dirty
+
+V1 does not do any of the following in the critical path:
+
+- cloud upload
+- embedding generation
+- vector retrieval
+- summarization
+- fact extraction
+- patch merging
+
+## Background Upload Policy
+
+The local client should upload raw turn log deltas asynchronously when any trigger fires:
+
+- 4 new conversation turns
+- around 2000 new CJK characters of text
+- 90 seconds since the last upload
+- 8 seconds of user idle time after a completed exchange
+
+These values are V1 defaults and must be configurable.
+
+## Local Retention Policy
+
+Local raw memory retention is a product parameter. Examples include "recent 7 days" or "recent 30 days", but the architecture treats this as a configurable policy rather than a fixed truth.
+
+The retention window applies to short-term raw or prompt-ready turn data:
+
+- `raw_turn_log`
+- `recent_turns`
+
+The retention window does not apply to cloud-consolidated long-term memory:
+
+- `profile_summary`
+- `stable_facts`
+- `memory_cards`
+
+Raw turns may be pruned only when both conditions are true:
+
+1. The turn is outside the configured local retention window.
+2. The cloud sync layer has acknowledged receiving the turn, or an equivalent upload cursor proves that the turn is safe to remove locally.
+
+This prevents offline or failed-sync periods from silently deleting experiences that cloud LangMem never received.
+
+## Cloud Summarization Policy
+
+Cloud LangMem should summarize less frequently than upload.
+
+Suggested default triggers:
+
+- 12 new conversation turns
+- around 8000 new CJK characters
+- 15 minutes since the last summarization run
+
+Cloud output should include:
+
+- `summary_patch`
+- `facts_patch`
+- `memory_cards`
+- `summary_version`
+- `generated_from_turn_id`
+- an acknowledgement cursor or processed source range that lets the desktop decide which raw turns are safe to prune
+
+## Merge Rules
+
+Local merge logic must be deterministic and defensive.
+
+- Never apply a patch with an older `summary_version`.
+- Never apply a patch whose `generated_from_turn_id` is behind the latest applied checkpoint for that scope.
+- Facts must be superseded, not blindly overwritten.
+- Recent turns are always local-source-of-truth for the current active session.
+- Cloud patches may improve long-term context, but they cannot rewrite the meaning of the latest local session turns.
+- Patch merge must not depend on retaining old raw turns locally after they have been acknowledged and pruned.
+
+## Runtime Boundaries
+
+V1 runtime ownership:
+
+- SQLite file lives in Electron main process storage.
+- renderer accesses memory through Eventa contracts
+- shared `packages/stage-ui` code talks to a memory gateway interface, not directly to Node SQLite APIs
+
+This boundary keeps desktop-specific persistence inside Electron while preserving shared UI/store logic.
+
+## Rollout Strategy
+
+V1 should ship in three slices:
+
+1. Replace the current desktop chat session persistence path with a local SQLite-backed memory gateway for prompt-critical data.
+2. Add background raw turn sync and patch application plumbing without turning on cloud summarization-dependent prompt reads.
+3. Add retention-window pruning for uploaded raw turns and optional `memory_cards` local recall triggers after the fast path is stable.
+
+## Non-Goals For V1
+
+- no cloud dependency in prompt assembly
+- no realtime vector retrieval in the default path
+- no cross-platform SQLite parity for web/mobile in the first slice
+- no emotional scoring, forgetting curve, or autonomous dream processing in V1
+- no promise that local raw turn history is retained forever
+
+## Success Criteria
+
+The design is successful when:
+
+- desktop AIRI can restart without losing prompt-critical memory
+- prompt assembly reads only local memory during realtime chat
+- cloud downtime does not block interaction
+- old cloud summaries cannot overwrite newer local state
+- sync happens in the background without user-visible chat stalls
+- raw turns outside the local retention window are pruned only after upload acknowledgement
+- chat reads the recent local window plus cloud-consolidated long-term memory copy

--- a/packages/stage-pages/src/pages/settings/memory/index.vue
+++ b/packages/stage-pages/src/pages/settings/memory/index.vue
@@ -1,9 +1,111 @@
 <script setup lang="ts">
-import { WIP } from '@proj-airi/stage-ui/components'
+import { isStageTamagotchi } from '@proj-airi/stage-shared'
+import { createMemoryGateway } from '@proj-airi/stage-ui/services/memory/gateway'
+import { readMemoryStatusSnapshot } from '@proj-airi/stage-ui/services/memory/status'
+import { useAuthStore } from '@proj-airi/stage-ui/stores/auth'
+import { useChatSessionStore } from '@proj-airi/stage-ui/stores/chat/session-store'
+import { useAiriCardStore } from '@proj-airi/stage-ui/stores/modules/airi-card'
+import { onMounted, shallowRef } from 'vue'
+
+const authStore = useAuthStore()
+const chatSessionStore = useChatSessionStore()
+const cardStore = useAiriCardStore()
+
+const status = shallowRef<{
+  runtimeMode: string
+  runtimeLabel: string
+  syncMode: string
+  syncMessage: string
+  lastUploadAt: number | null
+  lastPullAt: number | null
+  pendingTurnCount: number
+  lastAppliedSummaryVersion: number | null
+  lastError: string | null
+} | null>(null)
+
+function formatTime(value: number | null) {
+  if (!value)
+    return 'Never'
+
+  return new Date(value).toLocaleString()
+}
+
+onMounted(async () => {
+  const runtime = isStageTamagotchi() ? 'desktop' : 'web'
+  const gateway = createMemoryGateway({ runtime })
+
+  status.value = await readMemoryStatusSnapshot({
+    gateway,
+    runtime,
+    scope: {
+      characterId: cardStore.activeCardId || 'default',
+      sessionId: chatSessionStore.activeSessionId || null,
+      userId: authStore.userId || 'local',
+    },
+  })
+})
 </script>
 
 <template>
-  <WIP />
+  <div :class="['flex flex-col gap-4 pb-4']">
+    <section :class="['rounded-2xl border border-black/10 bg-white/70 p-4 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-black/20']">
+      <div :class="['flex flex-col gap-2']">
+        <div :class="['text-base font-semibold']">
+          {{ status?.runtimeLabel ?? 'Local-First Memory' }}
+        </div>
+        <div :class="['text-sm opacity-80']">
+          {{ status?.syncMessage ?? 'Loading memory status...' }}
+        </div>
+        <div :class="['font-mono text-xs opacity-70']">
+          {{ status?.runtimeMode ?? 'unknown' }}
+        </div>
+      </div>
+    </section>
+
+    <section :class="['rounded-2xl border border-black/10 bg-white/70 p-4 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-black/20']">
+      <div :class="['mb-3 text-base font-semibold']">
+        Status
+      </div>
+      <dl :class="['grid grid-cols-1 gap-3 text-sm md:grid-cols-2']" aria-label="memory-status">
+        <div>
+          <dt :class="['opacity-70']">
+            Mode
+          </dt>
+          <dd>{{ status?.syncMode ?? 'unknown' }}</dd>
+        </div>
+        <div>
+          <dt :class="['opacity-70']">
+            Pending turns
+          </dt>
+          <dd>{{ status?.pendingTurnCount ?? 0 }}</dd>
+        </div>
+        <div>
+          <dt :class="['opacity-70']">
+            Last upload
+          </dt>
+          <dd>{{ formatTime(status?.lastUploadAt ?? null) }}</dd>
+        </div>
+        <div>
+          <dt :class="['opacity-70']">
+            Last pull
+          </dt>
+          <dd>{{ formatTime(status?.lastPullAt ?? null) }}</dd>
+        </div>
+        <div>
+          <dt :class="['opacity-70']">
+            Applied summary version
+          </dt>
+          <dd>{{ status?.lastAppliedSummaryVersion ?? 'None' }}</dd>
+        </div>
+        <div>
+          <dt :class="['opacity-70']">
+            Recent error
+          </dt>
+          <dd>{{ status?.lastError ?? 'None' }}</dd>
+        </div>
+      </dl>
+    </section>
+  </div>
 </template>
 
 <route lang="yaml">

--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -29,6 +29,8 @@
     "./libs/inference": "./src/libs/inference/index.ts",
     "./libs/*": "./src/libs/*.ts",
     "./libs": "./src/libs/index.ts",
+    "./services/memory/*": "./src/services/memory/*.ts",
+    "./services/memory": "./src/services/memory/gateway.ts",
     "./tools/mcp": "./src/tools/mcp.ts",
     "./stores/providers/aliyun": "./src/stores/providers/aliyun/index.ts",
     "./stores/analytics": "./src/stores/analytics/index.ts",

--- a/packages/stage-ui/src/services/memory/desktop-gateway.ts
+++ b/packages/stage-ui/src/services/memory/desktop-gateway.ts
@@ -1,0 +1,93 @@
+import type {
+  CreateMemoryGatewayOptions,
+  MemoryAppendTurnResult,
+  MemoryGateway,
+  MemoryPromptContext,
+  MemorySyncStateResult,
+} from './types'
+
+import { defineInvoke } from '@moeru/eventa'
+import { createContext } from '@moeru/eventa/adapters/electron/renderer'
+
+import {
+  electronMemoryAppendTurn,
+  electronMemoryGetSyncState,
+  electronMemoryReadPromptContext,
+} from '../../../../../apps/stage-tamagotchi/src/shared/eventa/memory'
+
+function getDesktopIpcRenderer(override?: CreateMemoryGatewayOptions['ipcRenderer']) {
+  if (override)
+    return override
+
+  const win = globalThis.window as undefined | { electron?: { ipcRenderer?: unknown } }
+  return win?.electron?.ipcRenderer
+}
+
+function normalizePromptContext(result: Partial<MemoryPromptContext> & Pick<MemoryPromptContext, 'schemaVersion' | 'scope'>): MemoryPromptContext {
+  return {
+    memoryCards: result.memoryCards ?? [],
+    profileSummary: result.profileSummary ?? null,
+    recentTurns: result.recentTurns ?? [],
+    schemaVersion: result.schemaVersion,
+    scope: result.scope,
+    stableFacts: result.stableFacts ?? [],
+  }
+}
+
+function normalizeAppendTurnResult(result: Partial<MemoryAppendTurnResult> & Pick<MemoryAppendTurnResult, 'schemaVersion' | 'storedTurnId' | 'syncCheckpoint'>): MemoryAppendTurnResult {
+  return {
+    schemaVersion: result.schemaVersion,
+    storedTurnId: result.storedTurnId,
+    syncCheckpoint: result.syncCheckpoint,
+  }
+}
+
+function normalizeSyncStateResult(result: Partial<MemorySyncStateResult> & Pick<MemorySyncStateResult, 'schemaVersion' | 'scope'>): MemorySyncStateResult {
+  return {
+    runtimeMode: result.runtimeMode ?? 'desktop-local-sqlite',
+    schemaVersion: result.schemaVersion,
+    scope: result.scope,
+    syncMode: result.syncMode ?? 'enabled',
+    syncModeReason: result.syncModeReason ?? null,
+    syncState: result.syncState ?? null,
+  }
+}
+
+/**
+ * Creates the desktop memory gateway backed by Electron renderer Eventa invokes.
+ *
+ * Use when:
+ * - stage-ui runs inside the desktop renderer and needs access to main-process memory
+ * - callers want a shared memory interface without coupling to raw Eventa invoke contracts
+ *
+ * Expects:
+ * - Electron `ipcRenderer` is available either through `options.ipcRenderer` or `window.electron.ipcRenderer`
+ *
+ * Returns:
+ * - A shared `MemoryGateway` that forwards to the desktop memory invoke contracts
+ */
+export function createDesktopMemoryGateway(options: Pick<CreateMemoryGatewayOptions, 'ipcRenderer'> = {}): MemoryGateway {
+  const ipcRenderer = getDesktopIpcRenderer(options.ipcRenderer)
+
+  if (!ipcRenderer) {
+    throw new Error('Desktop memory gateway requires an Electron ipcRenderer transport.')
+  }
+
+  const { context } = createContext(ipcRenderer as never)
+
+  const readPromptContextInvoke = defineInvoke(context, electronMemoryReadPromptContext)
+  const appendTurnInvoke = defineInvoke(context, electronMemoryAppendTurn)
+  const getSyncStateInvoke = defineInvoke(context, electronMemoryGetSyncState)
+
+  return {
+    async appendTurn(input) {
+      return normalizeAppendTurnResult(await appendTurnInvoke(input) as MemoryAppendTurnResult)
+    },
+    async getSyncState(input) {
+      return normalizeSyncStateResult(await getSyncStateInvoke(input) as MemorySyncStateResult)
+    },
+    async readPromptContext(input) {
+      return normalizePromptContext(await readPromptContextInvoke(input) as MemoryPromptContext)
+    },
+  }
+}

--- a/packages/stage-ui/src/services/memory/gateway.test.ts
+++ b/packages/stage-ui/src/services/memory/gateway.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const defineInvokeMock = vi.hoisted(() => vi.fn())
+const createContextMock = vi.hoisted(() => vi.fn(() => ({ context: { key: 'desktop-context' } })))
+
+const memoryContractsMock = vi.hoisted(() => ({
+  electronMemoryAppendTurn: { name: 'append-turn-contract' },
+  electronMemoryGetSyncState: { name: 'get-sync-state-contract' },
+  electronMemoryReadPromptContext: { name: 'read-prompt-context-contract' },
+}))
+
+vi.mock('@moeru/eventa', () => ({
+  defineInvoke: defineInvokeMock,
+}))
+
+vi.mock('@moeru/eventa/adapters/electron/renderer', () => ({
+  createContext: createContextMock,
+}))
+
+vi.mock('../../../../../apps/stage-tamagotchi/src/shared/eventa/memory', () => memoryContractsMock)
+
+describe('memory gateway', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('desktop gateway calls the three existing memory contracts with passthrough payloads', async () => {
+    const readPromptContextInvoke = vi.fn(async payload => ({
+      memoryCards: undefined,
+      profileSummary: undefined,
+      recentTurns: undefined,
+      schemaVersion: 1,
+      scope: payload.scope,
+      stableFacts: undefined,
+    }))
+    const appendTurnInvoke = vi.fn(async payload => ({
+      schemaVersion: 1,
+      storedTurnId: payload.turnId,
+      syncCheckpoint: 12,
+    }))
+    const getSyncStateInvoke = vi.fn(async payload => ({
+      runtimeMode: 'desktop-local-sqlite',
+      schemaVersion: 1,
+      scope: payload.scope,
+      syncMode: 'enabled',
+      syncModeReason: null,
+      syncState: undefined,
+    }))
+
+    defineInvokeMock.mockImplementation((_context, contract) => {
+      if (contract === memoryContractsMock.electronMemoryReadPromptContext)
+        return readPromptContextInvoke
+      if (contract === memoryContractsMock.electronMemoryAppendTurn)
+        return appendTurnInvoke
+      if (contract === memoryContractsMock.electronMemoryGetSyncState)
+        return getSyncStateInvoke
+      throw new Error(`Unexpected contract: ${String((contract as { name?: string })?.name)}`)
+    })
+
+    const { createDesktopMemoryGateway } = await import('./desktop-gateway')
+
+    const ipcRenderer = { key: 'ipc-renderer' }
+    const gateway = createDesktopMemoryGateway({ ipcRenderer })
+    const readRequest = {
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    }
+    const appendRequest = {
+      createdAt: 1000,
+      rawPayload: { content: 'hello' },
+      role: 'user' as const,
+      scope: readRequest.scope,
+      text: 'hello',
+      turnId: 'turn-1',
+    }
+
+    const promptContext = await gateway.readPromptContext(readRequest)
+    const appendResult = await gateway.appendTurn(appendRequest)
+    const syncStateResult = await gateway.getSyncState(readRequest)
+
+    expect(createContextMock).toHaveBeenCalledTimes(1)
+    expect(createContextMock).toHaveBeenCalledWith(ipcRenderer)
+    expect(defineInvokeMock).toHaveBeenCalledTimes(3)
+    expect(readPromptContextInvoke).toHaveBeenCalledWith(readRequest)
+    expect(appendTurnInvoke).toHaveBeenCalledWith(appendRequest)
+    expect(getSyncStateInvoke).toHaveBeenCalledWith(readRequest)
+    expect(promptContext).toEqual({
+      memoryCards: [],
+      profileSummary: null,
+      recentTurns: [],
+      schemaVersion: 1,
+      scope: readRequest.scope,
+      stableFacts: [],
+    })
+    expect(appendResult).toEqual({
+      schemaVersion: 1,
+      storedTurnId: 'turn-1',
+      syncCheckpoint: 12,
+    })
+    expect(syncStateResult).toEqual({
+      runtimeMode: 'desktop-local-sqlite',
+      schemaVersion: 1,
+      scope: readRequest.scope,
+      syncMode: 'enabled',
+      syncModeReason: null,
+      syncState: null,
+    })
+  })
+
+  it('desktop gateway normalizes returned shared memory values', async () => {
+    defineInvokeMock.mockImplementation((_context, contract) => {
+      if (contract === memoryContractsMock.electronMemoryReadPromptContext) {
+        return async () => ({
+          memoryCards: [
+            {
+              confidence: 0.6,
+              content: 'card-content',
+              id: 'card-1',
+              title: 'Card One',
+            },
+          ],
+          profileSummary: 'Summary',
+          recentTurns: [
+            {
+              createdAt: 1000,
+              role: 'assistant',
+              text: 'hello back',
+              turnId: 'turn-2',
+            },
+          ],
+          schemaVersion: 2,
+          scope: {
+            characterId: 'character-a',
+            sessionId: 'session-a',
+            userId: 'user-a',
+          },
+          stableFacts: [
+            {
+              confidence: 0.9,
+              id: 'fact-1',
+              key: 'name',
+              value: 'Airi',
+            },
+          ],
+        })
+      }
+
+      if (contract === memoryContractsMock.electronMemoryAppendTurn)
+        return async () => ({ schemaVersion: 1, storedTurnId: 'turn-1', syncCheckpoint: 5 })
+
+      if (contract === memoryContractsMock.electronMemoryGetSyncState) {
+        return async () => ({
+          schemaVersion: 3,
+          scope: {
+            characterId: 'character-a',
+            sessionId: 'session-a',
+            userId: 'user-a',
+          },
+          syncState: {
+            lastAppliedSummaryVersion: 4,
+            lastError: null,
+            lastLocalTurnCheckpoint: 8,
+            lastPullAt: 3000,
+            lastSyncedAt: 2000,
+            lastUploadAt: 1000,
+            pendingTurnCount: 2,
+            remoteCheckpoint: 'remote-1',
+            state: 'idle',
+            syncCheckpoint: 9,
+          },
+          syncMode: 'disabled',
+          syncModeReason: 'memory sync upload is missing endpoint or auth token',
+        })
+      }
+
+      throw new Error('Unexpected contract')
+    })
+
+    const { createDesktopMemoryGateway } = await import('./desktop-gateway')
+    const gateway = createDesktopMemoryGateway({ ipcRenderer: { key: 'ipc-renderer' } })
+
+    await expect(gateway.readPromptContext({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).resolves.toEqual({
+      memoryCards: [
+        {
+          confidence: 0.6,
+          content: 'card-content',
+          id: 'card-1',
+          title: 'Card One',
+        },
+      ],
+      profileSummary: 'Summary',
+      recentTurns: [
+        {
+          createdAt: 1000,
+          role: 'assistant',
+          text: 'hello back',
+          turnId: 'turn-2',
+        },
+      ],
+      schemaVersion: 2,
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      stableFacts: [
+        {
+          confidence: 0.9,
+          id: 'fact-1',
+          key: 'name',
+          value: 'Airi',
+        },
+      ],
+    })
+
+    await expect(gateway.getSyncState({
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).resolves.toEqual({
+      runtimeMode: 'desktop-local-sqlite',
+      schemaVersion: 3,
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+      syncMode: 'disabled',
+      syncModeReason: 'memory sync upload is missing endpoint or auth token',
+      syncState: {
+        lastAppliedSummaryVersion: 4,
+        lastError: null,
+        lastLocalTurnCheckpoint: 8,
+        lastPullAt: 3000,
+        lastSyncedAt: 2000,
+        lastUploadAt: 1000,
+        pendingTurnCount: 2,
+        remoteCheckpoint: 'remote-1',
+        state: 'idle',
+        syncCheckpoint: 9,
+      },
+    })
+  })
+
+  it('web stub is stable and does not throw', async () => {
+    const { createMemoryGateway } = await import('./gateway')
+
+    const gateway = createMemoryGateway({ runtime: 'web' })
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+
+    await expect(gateway.readPromptContext({ scope })).resolves.toEqual({
+      memoryCards: [],
+      profileSummary: null,
+      recentTurns: [],
+      schemaVersion: 0,
+      scope,
+      stableFacts: [],
+    })
+    await expect(gateway.appendTurn({
+      createdAt: 1000,
+      rawPayload: { content: 'hello' },
+      role: 'user',
+      scope,
+      text: 'hello',
+      turnId: 'turn-1',
+    })).resolves.toEqual({
+      schemaVersion: 0,
+      storedTurnId: 'turn-1',
+      syncCheckpoint: 0,
+    })
+    await expect(gateway.getSyncState({ scope })).resolves.toEqual({
+      runtimeMode: 'web-stub',
+      schemaVersion: 0,
+      scope,
+      syncMode: 'unavailable',
+      syncModeReason: 'memory background sync unavailable',
+      syncState: null,
+    })
+  })
+})

--- a/packages/stage-ui/src/services/memory/gateway.ts
+++ b/packages/stage-ui/src/services/memory/gateway.ts
@@ -1,0 +1,77 @@
+import type {
+  CreateMemoryGatewayOptions,
+  MemoryAppendTurnInput,
+  MemoryAppendTurnResult,
+  MemoryGateway,
+  MemoryPromptContext,
+  MemorySyncStateResult,
+} from './types'
+
+import { createDesktopMemoryGateway } from './desktop-gateway'
+
+function createWebMemoryGateway(): MemoryGateway {
+  return {
+    async appendTurn(input: MemoryAppendTurnInput): Promise<MemoryAppendTurnResult> {
+      return {
+        schemaVersion: 0,
+        storedTurnId: input.turnId,
+        syncCheckpoint: 0,
+      }
+    },
+    async getSyncState(input): Promise<MemorySyncStateResult> {
+      return {
+        runtimeMode: 'web-stub',
+        schemaVersion: 0,
+        scope: input.scope,
+        syncMode: 'unavailable',
+        syncModeReason: 'memory background sync unavailable',
+        syncState: null,
+      }
+    },
+    async readPromptContext(input): Promise<MemoryPromptContext> {
+      return {
+        memoryCards: [],
+        profileSummary: null,
+        recentTurns: [],
+        schemaVersion: 0,
+        scope: input.scope,
+        stableFacts: [],
+      }
+    },
+  }
+}
+
+/**
+ * Creates the shared stage-ui memory gateway for the requested runtime.
+ *
+ * Use when:
+ * - stage-ui needs one stable memory interface across desktop and web runtimes
+ * - callers want desktop invokes hidden behind a shared gateway contract
+ *
+ * Expects:
+ * - `runtime` selects either the desktop Eventa adapter or the web stub
+ *
+ * Returns:
+ * - A runtime-specific `MemoryGateway`
+ */
+export function createMemoryGateway(options: CreateMemoryGatewayOptions): MemoryGateway {
+  if (options.runtime === 'desktop') {
+    return createDesktopMemoryGateway({ ipcRenderer: options.ipcRenderer })
+  }
+
+  return createWebMemoryGateway()
+}
+
+export type {
+  CreateMemoryGatewayOptions,
+  MemoryAppendTurnInput,
+  MemoryAppendTurnResult,
+  MemoryCard,
+  MemoryGateway,
+  MemoryPromptContext,
+  MemoryRecentTurn,
+  MemoryScope,
+  MemoryStableFact,
+  MemorySyncState,
+  MemorySyncStateResult,
+} from './types'

--- a/packages/stage-ui/src/services/memory/status.test.ts
+++ b/packages/stage-ui/src/services/memory/status.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMemoryGateway } from './gateway'
+import { readMemoryStatusSnapshot } from './status'
+
+describe('memory status snapshot', () => {
+  it('maps desktop sync state into a stable read-only status shape', async () => {
+    const gateway = {
+      appendTurn: async () => ({ schemaVersion: 1, storedTurnId: 'turn-1', syncCheckpoint: 1 }),
+      getSyncState: async () => ({
+        runtimeMode: 'desktop-local-sqlite' as const,
+        schemaVersion: 1,
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        syncMode: 'disabled' as const,
+        syncModeReason: 'memory sync upload is missing endpoint or auth token',
+        syncState: {
+          lastAppliedSummaryVersion: 3,
+          lastError: 'patch pull failed',
+          lastLocalTurnCheckpoint: 10,
+          lastPullAt: 2_000,
+          lastSyncedAt: 1_500,
+          lastUploadAt: 1_000,
+          pendingTurnCount: 2,
+          remoteCheckpoint: 'remote-1',
+          state: 'error' as const,
+          syncCheckpoint: 10,
+        },
+      }),
+      readPromptContext: async () => ({
+        memoryCards: [],
+        profileSummary: null,
+        recentTurns: [],
+        schemaVersion: 1,
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        stableFacts: [],
+      }),
+    }
+
+    await expect(readMemoryStatusSnapshot({
+      gateway,
+      runtime: 'desktop',
+      scope: {
+        characterId: 'character-a',
+        sessionId: 'session-a',
+        userId: 'user-a',
+      },
+    })).resolves.toEqual({
+      lastAppliedSummaryVersion: 3,
+      lastError: 'patch pull failed',
+      lastPullAt: 2_000,
+      lastUploadAt: 1_000,
+      pendingTurnCount: 2,
+      runtimeLabel: 'Local-First Memory',
+      runtimeMode: 'desktop-local-sqlite',
+      syncMessage: 'memory sync upload is missing endpoint or auth token',
+      syncMode: 'disabled',
+    })
+  })
+
+  it('keeps the web stub stable and unavailable', async () => {
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+    const gateway = createMemoryGateway({ runtime: 'web' })
+
+    await expect(readMemoryStatusSnapshot({
+      gateway,
+      runtime: 'web',
+      scope,
+    })).resolves.toEqual({
+      lastAppliedSummaryVersion: null,
+      lastError: null,
+      lastPullAt: null,
+      lastUploadAt: null,
+      pendingTurnCount: 0,
+      runtimeLabel: 'Memory unavailable',
+      runtimeMode: 'web-stub',
+      syncMessage: 'memory background sync unavailable',
+      syncMode: 'unavailable',
+    })
+  })
+})

--- a/packages/stage-ui/src/services/memory/status.ts
+++ b/packages/stage-ui/src/services/memory/status.ts
@@ -1,0 +1,66 @@
+import type { MemoryGateway, MemoryScope, MemorySyncStateResult } from './gateway'
+
+import { isStageTamagotchi } from '@proj-airi/stage-shared'
+
+import { createMemoryGateway } from './gateway'
+
+export interface MemoryStatusSnapshot {
+  runtimeMode: 'desktop-local-sqlite' | 'web-stub'
+  runtimeLabel: string
+  syncMode: 'enabled' | 'disabled' | 'unavailable'
+  syncMessage: string
+  lastUploadAt: number | null
+  lastPullAt: number | null
+  pendingTurnCount: number
+  lastAppliedSummaryVersion: number | null
+  lastError: string | null
+}
+
+function buildMemoryStatusSnapshot(result: MemorySyncStateResult): MemoryStatusSnapshot {
+  const runtimeMode = result.runtimeMode ?? 'desktop-local-sqlite'
+  const syncMode = result.syncMode ?? (runtimeMode === 'web-stub' ? 'unavailable' : 'enabled')
+  const syncMessage = result.syncModeReason
+    ?? (syncMode === 'enabled'
+      ? 'Background sync active'
+      : syncMode === 'disabled'
+        ? 'Background sync disabled'
+        : 'Memory background sync unavailable')
+
+  return {
+    lastAppliedSummaryVersion: result.syncState?.lastAppliedSummaryVersion ?? null,
+    lastError: result.syncState?.lastError ?? null,
+    lastPullAt: result.syncState?.lastPullAt ?? null,
+    lastUploadAt: result.syncState?.lastUploadAt ?? null,
+    pendingTurnCount: result.syncState?.pendingTurnCount ?? 0,
+    runtimeLabel: runtimeMode === 'desktop-local-sqlite' ? 'Local-First Memory' : 'Memory unavailable',
+    runtimeMode,
+    syncMessage,
+    syncMode,
+  }
+}
+
+/**
+ * Reads and normalizes memory sync status for read-only UI surfaces.
+ *
+ * Use when:
+ * - A settings page or diagnostic surface needs a stable memory status snapshot
+ * - Callers want one normalized shape across desktop and web stub runtimes
+ *
+ * Expects:
+ * - `scope` is stable enough for the current UI surface
+ * - `gateway.getSyncState()` may legitimately return `null` nested state
+ *
+ * Returns:
+ * - A normalized read-only status snapshot suitable for direct rendering
+ */
+export async function readMemoryStatusSnapshot(params: {
+  scope: MemoryScope
+  gateway?: MemoryGateway
+  runtime?: 'desktop' | 'web'
+}) {
+  const runtime = params.runtime ?? (isStageTamagotchi() ? 'desktop' : 'web')
+  const gateway = params.gateway ?? createMemoryGateway({ runtime })
+  const result = await gateway.getSyncState({ scope: params.scope })
+
+  return buildMemoryStatusSnapshot(result)
+}

--- a/packages/stage-ui/src/services/memory/types.ts
+++ b/packages/stage-ui/src/services/memory/types.ts
@@ -1,0 +1,173 @@
+/**
+ * Shared memory scope consumed by stage-ui runtime adapters.
+ */
+export interface MemoryScope {
+  /** Stable user identifier owning the memory slice. */
+  userId: string
+  /** Character identifier associated with the slice. */
+  characterId: string
+  /** Optional session identifier for session-local context. */
+  sessionId?: string | null
+}
+
+/**
+ * One stable fact exposed through the shared memory gateway.
+ */
+export interface MemoryStableFact {
+  /** Stable fact identifier. */
+  id: string
+  /** Stable fact key used for prompt assembly. */
+  key: string
+  /** Human-readable fact value. */
+  value: string
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+}
+
+/**
+ * One recent conversational turn exposed through the shared memory gateway.
+ */
+export interface MemoryRecentTurn {
+  /** Stable turn identifier. */
+  turnId: string
+  /** Speaker role recorded for the turn. */
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  /** Plain-text turn content. */
+  text: string
+  /** Unix timestamp in milliseconds. */
+  createdAt: number
+}
+
+/**
+ * One memory card exposed through the shared memory gateway.
+ */
+export interface MemoryCard {
+  /** Stable card identifier. */
+  id: string
+  /** Card title or label. */
+  title: string
+  /** Card content used for prompt injection or later recall. */
+  content: string
+  /** Confidence score normalized to 0..1. */
+  confidence: number
+}
+
+/**
+ * Shared prompt-context snapshot returned by the memory gateway.
+ */
+export interface MemoryPromptContext {
+  /** Schema version reported by the active runtime adapter. */
+  schemaVersion: number
+  /** Scope used to resolve the prompt context. */
+  scope: MemoryScope
+  /** Current profile summary string, or `null` when none exists. */
+  profileSummary: string | null
+  /** Current unsuperseded stable facts. */
+  stableFacts: MemoryStableFact[]
+  /** Latest recent turns ordered for prompt consumption. */
+  recentTurns: MemoryRecentTurn[]
+  /** Memory cards available for prompt enrichment. */
+  memoryCards: MemoryCard[]
+}
+
+/**
+ * Shared append-turn input consumed by stage-ui runtime adapters.
+ */
+export interface MemoryAppendTurnInput {
+  /** Scope selecting the local memory slice. */
+  scope: MemoryScope
+  /** Stable turn identifier to append. */
+  turnId: string
+  /** Speaker role recorded for the turn. */
+  role: MemoryRecentTurn['role']
+  /** Plain-text turn content. */
+  text: string
+  /** Optional structured raw payload for replay or sync. */
+  rawPayload?: Record<string, unknown> | null
+  /** Unix timestamp in milliseconds. */
+  createdAt: number
+}
+
+/**
+ * Shared append-turn result exposed by the memory gateway.
+ */
+export interface MemoryAppendTurnResult {
+  /** Schema version reported by the active runtime adapter. */
+  schemaVersion: number
+  /** Stable turn identifier accepted by the runtime adapter. */
+  storedTurnId: string
+  /** Updated sync checkpoint after the append. */
+  syncCheckpoint: number
+}
+
+/**
+ * Shared sync-state snapshot returned by the memory gateway.
+ */
+export interface MemorySyncState {
+  /** Current local sync checkpoint. */
+  syncCheckpoint: number
+  /** Latest local raw-turn checkpoint. */
+  lastLocalTurnCheckpoint: number
+  /** Opaque remote checkpoint cursor when one exists. */
+  remoteCheckpoint?: string | null
+  /** Unix timestamp in milliseconds of the last successful sync. */
+  lastSyncedAt?: number | null
+  /** Unix timestamp in milliseconds of the last successful raw-turn upload. */
+  lastUploadAt?: number | null
+  /** Unix timestamp in milliseconds of the last successful patch pull. */
+  lastPullAt?: number | null
+  /** Current number of pending raw turns. */
+  pendingTurnCount?: number
+  /** Last successfully applied summary version. */
+  lastAppliedSummaryVersion?: number | null
+  /** Current sync lifecycle state. */
+  state: 'idle' | 'syncing' | 'error'
+  /** Optional last sync error summary. */
+  lastError?: string | null
+}
+
+/**
+ * Shared sync-state result exposed by the memory gateway.
+ */
+export interface MemorySyncStateResult {
+  /** Schema version reported by the active runtime adapter. */
+  schemaVersion: number
+  /** Scope used to resolve the sync-state row. */
+  scope: MemoryScope
+  /** Runtime mode surfaced by the active memory adapter. */
+  runtimeMode?: 'desktop-local-sqlite' | 'web-stub'
+  /** Whether background sync is enabled, disabled, or unavailable. */
+  syncMode?: 'enabled' | 'disabled' | 'unavailable'
+  /** Human-readable sync mode detail. */
+  syncModeReason?: string | null
+  /** Current sync-state snapshot, or `null` when not initialized. */
+  syncState: MemorySyncState | null
+}
+
+/**
+ * Stable shared memory interface consumed by stage-ui.
+ */
+export interface MemoryGateway {
+  /**
+   * Reads the current prompt context for one scope.
+   */
+  readPromptContext: (input: { scope: MemoryScope }) => Promise<MemoryPromptContext>
+  /**
+   * Appends one turn into the current runtime memory implementation.
+   */
+  appendTurn: (input: MemoryAppendTurnInput) => Promise<MemoryAppendTurnResult>
+  /**
+   * Reads the current sync-state snapshot for one scope.
+   */
+  getSyncState: (input: { scope: MemoryScope }) => Promise<MemorySyncStateResult>
+}
+
+/**
+ * Runtime options for creating a stage-ui memory gateway.
+ */
+export interface CreateMemoryGatewayOptions {
+  /** Which runtime adapter to build. */
+  runtime: 'desktop' | 'web'
+  /** Optional Electron renderer IPC transport override for desktop tests or custom hosts. */
+  ipcRenderer?: unknown
+}

--- a/packages/stage-ui/src/stores/chat.contract.test.ts
+++ b/packages/stage-ui/src/stores/chat.contract.test.ts
@@ -22,6 +22,8 @@ const appendTurnMock = vi.fn()
 const createMemoryGatewayMock = vi.hoisted(() => vi.fn())
 
 const activeSessionIdRef = ref('session-1')
+const activeCardIdRef = ref('character-1')
+const userIdRef = ref('user-1')
 const streamingMessageRef = ref<any>({ role: 'assistant', content: '', slices: [], tool_results: [] })
 const sessionMessages: Record<string, any[]> = {}
 let currentGeneration = 1
@@ -184,7 +186,7 @@ vi.mock('./chat/stream-store', () => ({
 vi.mock('./modules/airi-card', () => ({
   useAiriCardStore: () => ({
     activeCard: undefined,
-    activeCardId: ref('character-1'),
+    activeCardId: activeCardIdRef,
   }),
 }))
 
@@ -196,7 +198,7 @@ vi.mock('./modules/artistry-autonomous', () => ({
 
 vi.mock('./auth', () => ({
   useAuthStore: () => ({
-    userId: ref('user-1'),
+    userId: userIdRef,
   }),
 }))
 
@@ -234,6 +236,8 @@ describe('chat orchestrator contract', () => {
     appendTurnMock.mockReset()
     createMemoryGatewayMock.mockReset()
     activeSessionIdRef.value = 'session-1'
+    activeCardIdRef.value = 'character-1'
+    userIdRef.value = 'user-1'
     streamingMessageRef.value = { role: 'assistant', content: '', slices: [], tool_results: [] }
     currentGeneration = 1
 
@@ -510,6 +514,56 @@ describe('chat orchestrator contract', () => {
     )
 
     consoleErrorSpy.mockRestore()
+  })
+
+  it('does not persist a stale assistant generation into memory', async () => {
+    getContextsSnapshotMock.mockReturnValue({})
+    llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, _messages: Message[], options: any) => {
+      await options.onStreamEvent({ type: 'text-delta', text: 'stale reply' })
+      currentGeneration = 2
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+
+    await store.ingest('hello from user', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(appendTurnMock).toHaveBeenCalledTimes(1)
+    expect(appendTurnMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      role: 'user',
+      text: 'hello from user',
+    }))
+  })
+
+  it('persists assistant memory with the same scope captured for the user turn', async () => {
+    getContextsSnapshotMock.mockReturnValue({})
+    llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, _messages: Message[], options: any) => {
+      activeCardIdRef.value = 'character-switched'
+      userIdRef.value = 'user-switched'
+      await options.onStreamEvent({ type: 'text-delta', text: 'scoped reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+
+    await store.ingest('hello from user', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(appendTurnMock).toHaveBeenCalledTimes(2)
+    expect(appendTurnMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      role: 'assistant',
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      text: 'scoped reply',
+    }))
   })
 
   it('rejects cancelled queued sends before they start', async () => {

--- a/packages/stage-ui/src/stores/chat.contract.test.ts
+++ b/packages/stage-ui/src/stores/chat.contract.test.ts
@@ -17,6 +17,9 @@ const forkSessionMock = vi.fn()
 const ensureSessionMock = vi.fn()
 const parserConsumeMock = vi.fn()
 const parserEndMock = vi.fn()
+const readPromptContextMock = vi.fn()
+const appendTurnMock = vi.fn()
+const createMemoryGatewayMock = vi.hoisted(() => vi.fn())
 
 const activeSessionIdRef = ref('session-1')
 const streamingMessageRef = ref<any>({ role: 'assistant', content: '', slices: [], tool_results: [] })
@@ -69,6 +72,10 @@ vi.mock('../composables', () => ({
   useAnalytics: () => ({
     trackFirstMessage: trackFirstMessageMock,
   }),
+}))
+
+vi.mock('../services/memory/gateway', () => ({
+  createMemoryGateway: createMemoryGatewayMock,
 }))
 
 vi.mock('../composables/llm-marker-parser', () => ({
@@ -129,9 +136,67 @@ vi.mock('./chat/session-store', () => ({
   }),
 }))
 
+vi.mock('./chat/hooks', () => ({
+  createChatHooks: () => {
+    const beforeMessageComposed: Array<(message: string, context: any) => Promise<void> | void> = []
+    const afterMessageComposed: Array<(message: string, context: any) => Promise<void> | void> = []
+    const beforeSend: Array<(message: string, context: any) => Promise<void> | void> = []
+    const afterSend: Array<(message: string, context: any) => Promise<void> | void> = []
+    const tokenLiteral: Array<(literal: string, context: any) => Promise<void> | void> = []
+    const tokenSpecial: Array<(special: string, context: any) => Promise<void> | void> = []
+    const streamEnd: Array<(context: any) => Promise<void> | void> = []
+    const assistantResponseEnd: Array<(fullText: string, context: any) => Promise<void> | void> = []
+    const assistantMessage: Array<(message: any, fullText: string, context: any) => Promise<void> | void> = []
+    const chatTurnComplete: Array<(turn: any, context: any) => Promise<void> | void> = []
+
+    return {
+      clearHooks: vi.fn(),
+      emitBeforeMessageComposedHooks: async (message: string, context: any) => { for (const hook of beforeMessageComposed) await hook(message, context) },
+      emitAfterMessageComposedHooks: async (message: string, context: any) => { for (const hook of afterMessageComposed) await hook(message, context) },
+      emitBeforeSendHooks: async (message: string, context: any) => { for (const hook of beforeSend) await hook(message, context) },
+      emitAfterSendHooks: async (message: string, context: any) => { for (const hook of afterSend) await hook(message, context) },
+      emitTokenLiteralHooks: async (literal: string, context: any) => { for (const hook of tokenLiteral) await hook(literal, context) },
+      emitTokenSpecialHooks: async (special: string, context: any) => { for (const hook of tokenSpecial) await hook(special, context) },
+      emitStreamEndHooks: async (context: any) => { for (const hook of streamEnd) await hook(context) },
+      emitAssistantResponseEndHooks: async (fullText: string, context: any) => { for (const hook of assistantResponseEnd) await hook(fullText, context) },
+      emitAssistantMessageHooks: async (message: any, fullText: string, context: any) => { for (const hook of assistantMessage) await hook(message, fullText, context) },
+      emitChatTurnCompleteHooks: async (turn: any, context: any) => { for (const hook of chatTurnComplete) await hook(turn, context) },
+      onBeforeMessageComposed: (hook: any) => beforeMessageComposed.push(hook),
+      onAfterMessageComposed: (hook: any) => afterMessageComposed.push(hook),
+      onBeforeSend: (hook: any) => beforeSend.push(hook),
+      onAfterSend: (hook: any) => afterSend.push(hook),
+      onTokenLiteral: (hook: any) => tokenLiteral.push(hook),
+      onTokenSpecial: (hook: any) => tokenSpecial.push(hook),
+      onStreamEnd: (hook: any) => streamEnd.push(hook),
+      onAssistantResponseEnd: (hook: any) => assistantResponseEnd.push(hook),
+      onAssistantMessage: (hook: any) => assistantMessage.push(hook),
+      onChatTurnComplete: (hook: any) => chatTurnComplete.push(hook),
+    }
+  },
+}))
+
 vi.mock('./chat/stream-store', () => ({
   useChatStreamStore: () => ({
     streamingMessage: streamingMessageRef,
+  }),
+}))
+
+vi.mock('./modules/airi-card', () => ({
+  useAiriCardStore: () => ({
+    activeCard: undefined,
+    activeCardId: ref('character-1'),
+  }),
+}))
+
+vi.mock('./modules/artistry-autonomous', () => ({
+  useAutonomousArtistryStore: () => ({
+    runArtistTask: vi.fn(),
+  }),
+}))
+
+vi.mock('./auth', () => ({
+  useAuthStore: () => ({
+    userId: ref('user-1'),
   }),
 }))
 
@@ -165,6 +230,9 @@ describe('chat orchestrator contract', () => {
     ensureSessionMock.mockReset()
     parserConsumeMock.mockReset()
     parserEndMock.mockReset()
+    readPromptContextMock.mockReset()
+    appendTurnMock.mockReset()
+    createMemoryGatewayMock.mockReset()
     activeSessionIdRef.value = 'session-1'
     streamingMessageRef.value = { role: 'assistant', content: '', slices: [], tool_results: [] }
     currentGeneration = 1
@@ -174,6 +242,28 @@ describe('chat orchestrator contract', () => {
     }
 
     sessionMessages['session-1'] = [{ role: 'system', content: 'system prompt', createdAt: 1, id: 'system' }]
+    createMemoryGatewayMock.mockReturnValue({
+      appendTurn: appendTurnMock,
+      getSyncState: vi.fn(),
+      readPromptContext: readPromptContextMock,
+    })
+    appendTurnMock.mockResolvedValue({
+      schemaVersion: 1,
+      storedTurnId: 'ignored',
+      syncCheckpoint: 0,
+    })
+    readPromptContextMock.mockResolvedValue({
+      memoryCards: [],
+      profileSummary: null,
+      recentTurns: [],
+      schemaVersion: 0,
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      stableFacts: [],
+    })
   })
 
   it('keeps hook order and composes context prompt after system message', async () => {
@@ -190,10 +280,58 @@ describe('chat orchestrator contract', () => {
     }
 
     getContextsSnapshotMock.mockReturnValue(contextsSnapshot)
+    readPromptContextMock.mockResolvedValue({
+      memoryCards: [],
+      profileSummary: 'AIRI knows the user prefers concise replies.',
+      recentTurns: [
+        {
+          createdAt: 10,
+          role: 'user',
+          text: 'Earlier question',
+          turnId: 'turn-earlier-user',
+        },
+        {
+          createdAt: 11,
+          role: 'assistant',
+          text: 'Earlier answer',
+          turnId: 'turn-earlier-assistant',
+        },
+      ],
+      schemaVersion: 1,
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      stableFacts: [
+        {
+          confidence: 0.9,
+          id: 'fact-1',
+          key: 'preference',
+          value: 'concise',
+        },
+      ],
+    })
 
     let composedMessages: Message[] = []
     llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, messages: Message[], options: any) => {
       composedMessages = messages
+      expect(readPromptContextMock).toHaveBeenCalledWith({
+        scope: {
+          characterId: 'character-1',
+          sessionId: 'session-1',
+          userId: 'user-1',
+        },
+      })
+      expect(appendTurnMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        role: 'user',
+        scope: {
+          characterId: 'character-1',
+          sessionId: 'session-1',
+          userId: 'user-1',
+        },
+        text: 'hello from user',
+      }))
       expect(options.waitForTools).toBe(true)
 
       await options.onStreamEvent({ type: 'text-delta', text: 'hello' })
@@ -247,6 +385,16 @@ describe('chat orchestrator contract', () => {
     expect(persistSessionMessagesMock).not.toHaveBeenCalled()
     expect(parserConsumeMock).toHaveBeenCalledWith('hello')
     expect(parserEndMock).toHaveBeenCalledTimes(1)
+    expect(appendTurnMock).toHaveBeenCalledTimes(2)
+    expect(appendTurnMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      role: 'assistant',
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      text: 'hello',
+    }))
     expect(hookOrder).toEqual([
       'before-compose',
       'after-compose',
@@ -279,11 +427,89 @@ describe('chat orchestrator contract', () => {
     const userMessageContent = (composedMessages[1] as any).content
     expect(userMessageContent[0].text).toMatch(/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] hello from user$/)
 
-    const syntheticContextText = userMessageContent[1].text
+    const memoryText = userMessageContent[1].text
+    expect(memoryText).toContain('[Memory]')
+    expect(memoryText.indexOf('[Profile Summary]')).toBeLessThan(memoryText.indexOf('[Stable Facts]'))
+    expect(memoryText.indexOf('[Stable Facts]')).toBeLessThan(memoryText.indexOf('[Recent Turns]'))
+    expect(memoryText).toContain('AIRI knows the user prefers concise replies.')
+    expect(memoryText).toContain('- preference: concise')
+    expect(memoryText).toContain('- user: Earlier question')
+    expect(memoryText).toContain('- assistant: Earlier answer')
+
+    const syntheticContextText = userMessageContent[2].text
     expect(syntheticContextText).not.toContain('<context>')
     expect(syntheticContextText).not.toContain('<module ')
     expect(syntheticContextText).toContain('[Context]')
     expect(syntheticContextText).toContain('- system:weather: sunny')
+  })
+
+  it('keeps sending stable when memory summary, facts, and turns are empty', async () => {
+    getContextsSnapshotMock.mockReturnValue({})
+    readPromptContextMock.mockResolvedValue({
+      memoryCards: [],
+      profileSummary: null,
+      recentTurns: [],
+      schemaVersion: 0,
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      stableFacts: [],
+    })
+
+    llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, messages: Message[], options: any) => {
+      expect(messages).toHaveLength(2)
+      const userMessageContent = (messages[1] as any).content
+      expect(typeof userMessageContent === 'string' || Array.isArray(userMessageContent)).toBe(true)
+      await options.onStreamEvent({ type: 'text-delta', text: 'ok' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+
+    await expect(store.ingest('hello from user', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })).resolves.toBeUndefined()
+  })
+
+  it('continues the chat flow when appendTurn fails and logs a clear error branch', async () => {
+    getContextsSnapshotMock.mockReturnValue({})
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    appendTurnMock
+      .mockRejectedValueOnce(new Error('user append failed'))
+      .mockRejectedValueOnce(new Error('assistant append failed'))
+
+    llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, _messages: Message[], options: any) => {
+      await options.onStreamEvent({ type: 'text-delta', text: 'ok' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+
+    await expect(store.ingest('hello from user', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })).resolves.toBeUndefined()
+
+    expect(llmStreamMock).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[memory-turn-write] Failed to append turn to local memory:',
+      expect.objectContaining({
+        error: expect.any(Error),
+        payload: expect.objectContaining({ role: 'user' }),
+      }),
+    )
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[memory-turn-write] Failed to append turn to local memory:',
+      expect.objectContaining({
+        error: expect.any(Error),
+        payload: expect.objectContaining({ role: 'assistant' }),
+      }),
+    )
+
+    consoleErrorSpy.mockRestore()
   })
 
   it('rejects cancelled queued sends before they start', async () => {

--- a/packages/stage-ui/src/stores/chat.memory.integration.test.ts
+++ b/packages/stage-ui/src/stores/chat.memory.integration.test.ts
@@ -1,0 +1,684 @@
+import type { ChatProvider } from '@xsai-ext/providers/utils'
+import type { Message } from '@xsai/shared-chat'
+
+import type { MemoryGateway } from '../services/memory/gateway'
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { createMemoryRepository } from '../../../../apps/stage-tamagotchi/src/main/services/airi/memory/repository'
+import { setupMemorySyncRuntime } from '../../../../apps/stage-tamagotchi/src/main/services/airi/memory/runtime'
+import { readMemoryStatusSnapshot } from '../services/memory/status'
+import { useChatOrchestratorStore } from './chat'
+
+const llmStreamMock = vi.fn()
+const trackFirstMessageMock = vi.fn()
+const ingestContextMessageMock = vi.fn()
+const getContextsSnapshotMock = vi.fn()
+const createMinecraftContextMock = vi.fn()
+const persistSessionMessagesMock = vi.fn()
+const forkSessionMock = vi.fn()
+const ensureSessionMock = vi.fn()
+const parserConsumeMock = vi.fn()
+const parserEndMock = vi.fn()
+const createMemoryGatewayMock = vi.hoisted(() => vi.fn())
+
+const activeSessionIdRef = ref('session-1')
+const streamingMessageRef = ref<any>({ role: 'assistant', content: '', slices: [], tool_results: [] })
+const sessionMessages: Record<string, any[]> = {}
+let currentGeneration = 1
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual<typeof import('pinia')>('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store: any) => store,
+  }
+})
+
+vi.mock('@proj-airi/stream-kit', () => ({
+  createQueue: ({ handlers }: { handlers: Array<(ctx: { data: any }) => Promise<void> | void> }) => {
+    const enqueueListeners: Array<(data: any) => void> = []
+    const dequeueListeners: Array<(data: any) => void> = []
+
+    return {
+      enqueue(data: any) {
+        for (const listener of enqueueListeners)
+          listener(data)
+
+        queueMicrotask(async () => {
+          try {
+            for (const handler of handlers) {
+              await handler({ data })
+            }
+          }
+          finally {
+            for (const listener of dequeueListeners)
+              listener(data)
+          }
+        })
+      },
+      on(event: 'enqueue' | 'dequeue', listener: (data: any) => void) {
+        if (event === 'enqueue') {
+          enqueueListeners.push(listener)
+          return
+        }
+
+        dequeueListeners.push(listener)
+      },
+    }
+  },
+}))
+
+vi.mock('../composables', () => ({
+  useAnalytics: () => ({
+    trackFirstMessage: trackFirstMessageMock,
+  }),
+}))
+
+vi.mock('../services/memory/gateway', () => ({
+  createMemoryGateway: createMemoryGatewayMock,
+}))
+
+vi.mock('../composables/llm-marker-parser', () => ({
+  useLlmmarkerParser: (options: { onLiteral?: (literal: string) => Promise<void>, onEnd?: (fullText: string) => Promise<void> }) => {
+    let fullText = ''
+    return {
+      consume: async (textPart: string) => {
+        parserConsumeMock(textPart)
+        fullText += textPart
+        await options.onLiteral?.(textPart)
+      },
+      end: async () => {
+        parserEndMock()
+        await options.onEnd?.(fullText)
+      },
+    }
+  },
+}))
+
+vi.mock('../composables/response-categoriser', () => ({
+  createStreamingCategorizer: () => ({
+    consume: vi.fn(),
+    filterToSpeech: (literal: string) => literal,
+  }),
+  categorizeResponse: (fullText: string) => ({
+    speech: fullText,
+    reasoning: '',
+  }),
+}))
+
+vi.mock('./chat/context-providers', () => ({
+  createMinecraftContext: () => createMinecraftContextMock(),
+}))
+
+vi.mock('./chat/context-store', () => ({
+  useChatContextStore: () => ({
+    ingestContextMessage: ingestContextMessageMock,
+    getContextsSnapshot: getContextsSnapshotMock,
+  }),
+}))
+
+vi.mock('./chat/session-store', () => ({
+  useChatSessionStore: () => ({
+    activeSessionId: activeSessionIdRef,
+    sessionMessages,
+    ensureSession: (sessionId: string) => {
+      ensureSessionMock(sessionId)
+      sessionMessages[sessionId] ??= [{ role: 'system', content: 'system prompt', createdAt: 1, id: 'system' }]
+    },
+    appendSessionMessage: (sessionId: string, message: any) => {
+      sessionMessages[sessionId] ??= []
+      sessionMessages[sessionId].push(message)
+    },
+    getSessionMessages: (sessionId: string) => sessionMessages[sessionId] ?? [],
+    persistSessionMessages: persistSessionMessagesMock,
+    getSessionGeneration: () => currentGeneration,
+    forkSession: forkSessionMock,
+  }),
+}))
+
+vi.mock('./chat/hooks', () => ({
+  createChatHooks: () => {
+    const beforeMessageComposed: Array<(message: string, context: any) => Promise<void> | void> = []
+    const afterMessageComposed: Array<(message: string, context: any) => Promise<void> | void> = []
+    const beforeSend: Array<(message: string, context: any) => Promise<void> | void> = []
+    const afterSend: Array<(message: string, context: any) => Promise<void> | void> = []
+    const tokenLiteral: Array<(literal: string, context: any) => Promise<void> | void> = []
+    const tokenSpecial: Array<(special: string, context: any) => Promise<void> | void> = []
+    const streamEnd: Array<(context: any) => Promise<void> | void> = []
+    const assistantResponseEnd: Array<(fullText: string, context: any) => Promise<void> | void> = []
+    const assistantMessage: Array<(message: any, fullText: string, context: any) => Promise<void> | void> = []
+    const chatTurnComplete: Array<(turn: any, context: any) => Promise<void> | void> = []
+
+    return {
+      clearHooks: vi.fn(),
+      emitBeforeMessageComposedHooks: async (message: string, context: any) => { for (const hook of beforeMessageComposed) await hook(message, context) },
+      emitAfterMessageComposedHooks: async (message: string, context: any) => { for (const hook of afterMessageComposed) await hook(message, context) },
+      emitBeforeSendHooks: async (message: string, context: any) => { for (const hook of beforeSend) await hook(message, context) },
+      emitAfterSendHooks: async (message: string, context: any) => { for (const hook of afterSend) await hook(message, context) },
+      emitTokenLiteralHooks: async (literal: string, context: any) => { for (const hook of tokenLiteral) await hook(literal, context) },
+      emitTokenSpecialHooks: async (special: string, context: any) => { for (const hook of tokenSpecial) await hook(special, context) },
+      emitStreamEndHooks: async (context: any) => { for (const hook of streamEnd) await hook(context) },
+      emitAssistantResponseEndHooks: async (fullText: string, context: any) => { for (const hook of assistantResponseEnd) await hook(fullText, context) },
+      emitAssistantMessageHooks: async (message: any, fullText: string, context: any) => { for (const hook of assistantMessage) await hook(message, fullText, context) },
+      emitChatTurnCompleteHooks: async (turn: any, context: any) => { for (const hook of chatTurnComplete) await hook(turn, context) },
+      onBeforeMessageComposed: (hook: any) => beforeMessageComposed.push(hook),
+      onAfterMessageComposed: (hook: any) => afterMessageComposed.push(hook),
+      onBeforeSend: (hook: any) => beforeSend.push(hook),
+      onAfterSend: (hook: any) => afterSend.push(hook),
+      onTokenLiteral: (hook: any) => tokenLiteral.push(hook),
+      onTokenSpecial: (hook: any) => tokenSpecial.push(hook),
+      onStreamEnd: (hook: any) => streamEnd.push(hook),
+      onAssistantResponseEnd: (hook: any) => assistantResponseEnd.push(hook),
+      onAssistantMessage: (hook: any) => assistantMessage.push(hook),
+      onChatTurnComplete: (hook: any) => chatTurnComplete.push(hook),
+    }
+  },
+}))
+
+vi.mock('./chat/stream-store', () => ({
+  useChatStreamStore: () => ({
+    streamingMessage: streamingMessageRef,
+  }),
+}))
+
+vi.mock('./modules/airi-card', () => ({
+  useAiriCardStore: () => ({
+    activeCard: undefined,
+    activeCardId: ref('character-1'),
+  }),
+}))
+
+vi.mock('./modules/artistry-autonomous', () => ({
+  useAutonomousArtistryStore: () => ({
+    runArtistTask: vi.fn(),
+  }),
+}))
+
+vi.mock('./auth', () => ({
+  useAuthStore: () => ({
+    userId: ref('user-1'),
+  }),
+}))
+
+vi.mock('./llm', () => ({
+  useLLM: () => ({
+    stream: llmStreamMock,
+  }),
+}))
+
+vi.mock('./modules/consciousness', () => ({
+  useConsciousnessStore: () => ({
+    activeProvider: ref('mock-provider'),
+  }),
+}))
+
+const provider = {
+  chat: () => ({ baseURL: 'https://example.com/' }),
+} as unknown as ChatProvider
+
+function createTempDatabasePath() {
+  const directoryPath = mkdtempSync(join(tmpdir(), 'airi-chat-memory-integration-'))
+
+  return {
+    cleanup: () => rmSync(directoryPath, { force: true, recursive: true }),
+    databasePath: join(directoryPath, 'memory.sqlite'),
+  }
+}
+
+function createIntegrationGateway(repository: ReturnType<typeof createMemoryRepository>, runtime: ReturnType<typeof setupMemorySyncRuntime>): MemoryGateway {
+  return {
+    async appendTurn(input) {
+      const record = repository.appendTurn(input)
+      return {
+        schemaVersion: 1,
+        storedTurnId: record.turnId,
+        syncCheckpoint: 0,
+      }
+    },
+    async getSyncState(input) {
+      const syncState = repository.getSyncState(input)
+      const runtimeStatus = runtime.getStatus()
+
+      return {
+        runtimeMode: 'desktop-local-sqlite' as const,
+        schemaVersion: 1,
+        scope: input.scope,
+        syncMode: runtimeStatus.uploader.mode === 'disabled' && runtimeStatus.patch.mode === 'disabled'
+          ? 'disabled'
+          : 'enabled',
+        syncModeReason: runtimeStatus.uploader.mode === 'disabled' && runtimeStatus.patch.mode === 'disabled'
+          ? runtimeStatus.uploader.reason ?? runtimeStatus.patch.reason ?? null
+          : null,
+        syncState: syncState
+          ? {
+              lastAppliedSummaryVersion: syncState.lastAppliedSummaryVersion,
+              lastError: syncState.lastError ?? null,
+              lastLocalTurnCheckpoint: syncState.lastLocalTurnCheckpoint,
+              lastPullAt: syncState.lastPullAt ?? null,
+              lastSyncedAt: syncState.lastSyncedAt ?? null,
+              lastUploadAt: syncState.lastUploadAt ?? null,
+              pendingTurnCount: syncState.pendingTurnCount,
+              remoteCheckpoint: syncState.remoteCheckpoint ?? null,
+              state: syncState.state as 'idle' | 'syncing' | 'error',
+              syncCheckpoint: syncState.syncCheckpoint,
+            }
+          : null,
+      }
+    },
+    async readPromptContext(input) {
+      const promptContext = repository.readPromptContext(input)
+      return {
+        memoryCards: [],
+        profileSummary: promptContext.profileSummary?.summaryMarkdown ?? null,
+        recentTurns: promptContext.recentTurns.map(turn => ({
+          createdAt: turn.createdAt,
+          role: turn.role,
+          text: turn.text,
+          turnId: turn.turnId,
+        })),
+        schemaVersion: 1,
+        scope: input.scope,
+        stableFacts: promptContext.stableFacts.map(fact => ({
+          confidence: fact.confidence,
+          id: fact.id,
+          key: fact.factKey,
+          value: fact.factValue,
+        })),
+      }
+    },
+  }
+}
+
+describe('chat memory integration', () => {
+  const cleanupCallbacks: Array<() => void> = []
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    activeSessionIdRef.value = 'session-1'
+    streamingMessageRef.value = { role: 'assistant', content: '', slices: [], tool_results: [] }
+    currentGeneration = 1
+
+    for (const key of Object.keys(sessionMessages)) {
+      delete sessionMessages[key]
+    }
+
+    sessionMessages['session-1'] = [{ role: 'system', content: 'system prompt', createdAt: 1, id: 'system' }]
+    getContextsSnapshotMock.mockReturnValue({})
+    createMinecraftContextMock.mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    for (const cleanup of cleanupCallbacks.splice(0)) {
+      cleanup()
+    }
+  })
+
+  it('writes user and assistant turns locally, reads local memory into the prompt, and reflects merged sync status', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { content: 'earlier user' },
+      role: 'user',
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      text: 'earlier user',
+      turnId: 'turn-earlier-user',
+    })
+    repository.appendTurn({
+      createdAt: 2_000,
+      rawPayload: { content: 'earlier assistant' },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      text: 'earlier assistant',
+      turnId: 'turn-earlier-assistant',
+    })
+    repository.markRawTurnsUploaded({
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      turnIds: ['turn-earlier-user', 'turn-earlier-assistant'],
+      uploadedAt: 3_000,
+    })
+    repository.applyMemoryPatch({
+      nextPullAt: 9_000,
+      patch: {
+        factsPatch: [
+          {
+            confidence: 0.9,
+            factKey: 'preference',
+            factValue: 'concise',
+            generatedFromTurnId: 'turn-earlier-assistant',
+          },
+        ],
+        scope: {
+          characterId: 'character-1',
+          sessionId: 'session-1',
+          userId: 'user-1',
+        },
+        summaryPatch: {
+          confidence: 0.8,
+          generatedFromTurnId: 'turn-earlier-assistant',
+          summaryMarkdown: 'Existing summary',
+          summaryVersion: 2,
+        },
+      },
+      pulledAt: 4_000,
+    })
+
+    const currentTime = 10_000
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes('/raw-turns')) {
+        return {
+          ok: true,
+          status: 200,
+        }
+      }
+
+      return {
+        json: async () => ({
+          factsPatch: [
+            {
+              confidence: 1,
+              factKey: 'location',
+              factValue: 'kyoto',
+              generatedFromTurnId: 'assistant-current',
+            },
+          ],
+          scope: {
+            characterId: 'character-1',
+            sessionId: 'session-1',
+            userId: 'user-1',
+          },
+          summaryPatch: {
+            confidence: 0.95,
+            generatedFromTurnId: 'assistant-current',
+            summaryMarkdown: 'Merged summary',
+            summaryVersion: 3,
+          },
+        }),
+        ok: true,
+        status: 200,
+      }
+    })
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        patch: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/patch',
+          pullIntervalMs: 15_000,
+          requestTimeoutMs: 10_000,
+          retryDelayMs: 30_000,
+        },
+        turnCountThreshold: 2,
+        uploader: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/raw-turns',
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    const gateway = createIntegrationGateway(repository, runtime)
+
+    createMemoryGatewayMock.mockReturnValue(gateway)
+
+    let composedMessages: Message[] = []
+    llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, messages: Message[], options: any) => {
+      composedMessages = messages
+      await options.onStreamEvent({ type: 'text-delta', text: 'assistant final' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+
+    await store.ingest('current user', {
+      chatProvider: provider,
+      model: 'gpt-test',
+    })
+
+    expect(repository.listPendingRawTurns({
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+    }).map(turn => `${turn.role}:${turn.text}`)).toEqual([
+      'user:current user',
+      'assistant:assistant final',
+    ])
+
+    const userMessageContent = (composedMessages[1] as any).content
+    const memoryTextPart = Array.isArray(userMessageContent) ? userMessageContent.find((part: any) => String(part.text).includes('[Memory]'))?.text : userMessageContent
+
+    expect(memoryTextPart).toContain('Existing summary')
+    expect(memoryTextPart).toContain('- preference: concise')
+    expect(memoryTextPart).toContain('- user: earlier user')
+    expect(memoryTextPart).toContain('- assistant: earlier assistant')
+    expect(memoryTextPart).not.toContain('current user')
+    expect(memoryTextPart).not.toContain('card')
+
+    await runtime.tick()
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(repository.readPromptContext({
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+    })).toEqual(expect.objectContaining({
+      profileSummary: expect.objectContaining({
+        summaryMarkdown: 'Merged summary',
+        version: 3,
+      }),
+      stableFacts: expect.arrayContaining([
+        expect.objectContaining({
+          factKey: 'location',
+          factValue: 'kyoto',
+        }),
+      ]),
+    }))
+
+    await expect(readMemoryStatusSnapshot({
+      gateway,
+      runtime: 'desktop',
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+    })).resolves.toEqual(expect.objectContaining({
+      lastAppliedSummaryVersion: 3,
+      pendingTurnCount: 0,
+      runtimeMode: 'desktop-local-sqlite',
+      syncMode: 'enabled',
+    }))
+
+    repository.close()
+  })
+
+  it('reads memory before appending the current turn, while the next turn can recall the previous turn pair', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+    const runtime = setupMemorySyncRuntime({
+      repository,
+    })
+    const gateway = createIntegrationGateway(repository, runtime)
+
+    createMemoryGatewayMock.mockReturnValue(gateway)
+
+    const composedMessagesByTurn: Message[][] = []
+    llmStreamMock.mockImplementation(async (_model: string, _chatProvider: ChatProvider, messages: Message[], options: any) => {
+      composedMessagesByTurn.push(messages)
+      const responseText = composedMessagesByTurn.length === 1 ? 'first assistant memory' : 'second assistant memory'
+      await options.onStreamEvent({ type: 'text-delta', text: responseText })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+
+    await store.ingest('first user memory', {
+      chatProvider: provider,
+      model: 'gpt-test',
+    })
+    await store.ingest('second user memory', {
+      chatProvider: provider,
+      model: 'gpt-test',
+    })
+
+    expect(composedMessagesByTurn).toHaveLength(2)
+
+    const firstComposedMessages = composedMessagesByTurn[0]!
+    const secondComposedMessages = composedMessagesByTurn[1]!
+    const firstUserMessageContent = (firstComposedMessages[1] as any).content
+    const firstMemoryTextPart = Array.isArray(firstUserMessageContent)
+      ? firstUserMessageContent.find((part: any) => String(part.text).includes('[Memory]'))?.text
+      : undefined
+    const secondUserMessageContent = (secondComposedMessages.at(-1) as any).content
+    const secondMemoryTextPart = Array.isArray(secondUserMessageContent)
+      ? secondUserMessageContent.find((part: any) => String(part.text).includes('[Memory]'))?.text
+      : secondUserMessageContent
+
+    expect(firstMemoryTextPart).toBeUndefined()
+    expect(secondMemoryTextPart).toContain('- user: first user memory')
+    expect(secondMemoryTextPart).toContain('- assistant: first assistant memory')
+    expect(secondMemoryTextPart).not.toContain('second user memory')
+
+    repository.close()
+  })
+
+  it('does not pollute local state when the same patch is applied twice through runtime pull', async () => {
+    const tempDatabase = createTempDatabasePath()
+    cleanupCallbacks.push(tempDatabase.cleanup)
+
+    const repository = createMemoryRepository({ databasePath: tempDatabase.databasePath })
+    repository.initialize()
+
+    repository.appendTurn({
+      createdAt: 1_000,
+      rawPayload: { content: 'seed' },
+      role: 'assistant',
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      text: 'seed',
+      turnId: 'turn-seed',
+    })
+    repository.markRawTurnsUploaded({
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+      turnIds: ['turn-seed'],
+      uploadedAt: 2_000,
+    })
+
+    let currentTime = 10_000
+    const fetchImpl = vi.fn(async () => ({
+      json: async () => ({
+        factsPatch: [
+          {
+            confidence: 1,
+            factKey: 'location',
+            factValue: 'kyoto',
+            generatedFromTurnId: 'turn-seed',
+          },
+        ],
+        scope: {
+          characterId: 'character-1',
+          sessionId: 'session-1',
+          userId: 'user-1',
+        },
+        summaryPatch: {
+          confidence: 1,
+          generatedFromTurnId: 'turn-seed',
+          summaryMarkdown: 'Merged summary',
+          summaryVersion: 2,
+        },
+      }),
+      ok: true,
+      status: 200,
+    }))
+    const runtime = setupMemorySyncRuntime({
+      config: {
+        patch: {
+          authToken: 'token',
+          enabled: true,
+          endpointUrl: 'https://example.com/memory/patch',
+          pullIntervalMs: 5_000,
+          requestTimeoutMs: 10_000,
+          retryDelayMs: 30_000,
+        },
+        uploader: {
+          authToken: null,
+          enabled: false,
+          endpointUrl: null,
+          requestTimeoutMs: 10_000,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => currentTime,
+      repository,
+    })
+
+    await runtime.tick()
+
+    const database = new DatabaseSync(tempDatabase.databasePath)
+    const firstSummaryCount = (database.prepare(`SELECT COUNT(*) AS count FROM profile_summary`).get() as { count: number }).count
+    const firstFactCount = (database.prepare(`SELECT COUNT(*) AS count FROM stable_facts`).get() as { count: number }).count
+
+    currentTime = 20_000
+    await runtime.tick()
+
+    const secondSummaryCount = (database.prepare(`SELECT COUNT(*) AS count FROM profile_summary`).get() as { count: number }).count
+    const secondFactCount = (database.prepare(`SELECT COUNT(*) AS count FROM stable_facts`).get() as { count: number }).count
+
+    expect(secondSummaryCount).toBe(firstSummaryCount)
+    expect(secondFactCount).toBe(firstFactCount)
+    expect(repository.getSyncState({
+      scope: {
+        characterId: 'character-1',
+        sessionId: 'session-1',
+        userId: 'user-1',
+      },
+    })).toEqual(expect.objectContaining({
+      lastAppliedSummaryVersion: 2,
+    }))
+
+    database.close()
+    repository.close()
+  })
+})

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -540,25 +540,22 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
 
       await parser.end()
 
-      if (!isStaleGeneration() && buildingMessage.slices.length > 0) {
+      const shouldPersistAssistantTurn = !isStaleGeneration() && buildingMessage.slices.length > 0
+      if (shouldPersistAssistantTurn) {
         chatSession.appendSessionMessage(sessionId, toRaw(buildingMessage))
-      }
 
-      await appendMemoryTurnSafely({
-        gateway: memoryGateway,
-        payload: {
-          createdAt: buildingMessage.createdAt ?? Date.now(),
-          rawPayload: null,
-          role: 'assistant',
-          scope: {
-            characterId: activeCardId.value || 'default',
-            sessionId,
-            userId: userId.value || 'local',
+        await appendMemoryTurnSafely({
+          gateway: memoryGateway,
+          payload: {
+            createdAt: buildingMessage.createdAt ?? Date.now(),
+            rawPayload: null,
+            role: 'assistant',
+            scope: memoryScope,
+            text: fullText,
+            turnId: buildingMessage.id ?? nanoid(),
           },
-          text: fullText,
-          turnId: buildingMessage.id ?? nanoid(),
-        },
-      })
+        })
+      }
 
       await hooks.emitStreamEndHooks(streamingMessageContext)
       await hooks.emitAssistantResponseEndHooks(fullText, streamingMessageContext)

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -5,7 +5,7 @@ import type { CommonContentPart, Message, ToolMessage } from '@xsai/shared-chat'
 import type { ChatAssistantMessage, ChatSlices, ChatStreamEventContext, StreamingAssistantMessage } from '../types/chat'
 import type { StreamEvent, StreamOptions } from './llm'
 
-import { IOAttributes, IOEvents, IOSpanNames, IOSubsystems } from '@proj-airi/stage-shared'
+import { IOAttributes, IOEvents, IOSpanNames, IOSubsystems, isStageTamagotchi } from '@proj-airi/stage-shared'
 import { createQueue } from '@proj-airi/stream-kit'
 import { nanoid } from 'nanoid'
 import { defineStore, storeToRefs } from 'pinia'
@@ -15,13 +15,17 @@ import { useAnalytics } from '../composables'
 import { useLlmmarkerParser } from '../composables/llm-marker-parser'
 import { categorizeResponse, createStreamingCategorizer } from '../composables/response-categoriser'
 import { activeTurnSpan, startSpan } from '../composables/use-io-tracer'
+import { createMemoryGateway } from '../services/memory/gateway'
+import { useAuthStore } from './auth'
 import { formatContextPromptText } from './chat/context-prompt'
 import { createMinecraftContext } from './chat/context-providers'
 import { useChatContextStore } from './chat/context-store'
 import { formatTimePrefix } from './chat/datetime-prefix'
 import { createChatHooks } from './chat/hooks'
+import { readMemoryPromptText } from './chat/prompt-memory'
 import { useChatSessionStore } from './chat/session-store'
 import { useChatStreamStore } from './chat/stream-store'
+import { appendMemoryTurnSafely } from './chat/turn-memory'
 import { useContextObservabilityStore } from './devtools/context-observability'
 import { useLLM } from './llm'
 import { useAiriCardStore } from './modules/airi-card'
@@ -104,6 +108,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
   const llmStore = useLLM()
   const consciousnessStore = useConsciousnessStore()
   const artistryAutonomousStore = useAutonomousArtistryStore()
+  const authStore = useAuthStore()
   const { activeProvider } = storeToRefs(consciousnessStore)
   const { trackFirstMessage } = useAnalytics()
 
@@ -114,11 +119,16 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
   const contextObservability = useContextObservabilityStore()
   const { activeSessionId } = storeToRefs(chatSession)
   const { streamingMessage } = storeToRefs(chatStream)
+  const { userId } = storeToRefs(authStore)
+  const { activeCardId } = storeToRefs(cardStore)
 
   const sending = ref(false)
   const pendingQueuedSends = ref<QueuedSend[]>([])
   const pendingQueuedSendCount = computed(() => pendingQueuedSends.value.length)
   const hooks = createChatHooks()
+  const memoryGateway = createMemoryGateway({
+    runtime: isStageTamagotchi() ? 'desktop' : 'web',
+  })
 
   const sendQueue = createQueue<QueuedSend>({
     handlers: [
@@ -243,11 +253,37 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       if (shouldAbort())
         return
 
+      const userMessageId = nanoid()
+      const memoryScope = {
+        characterId: activeCardId.value || 'default',
+        sessionId,
+        userId: userId.value || 'local',
+      }
+      const { promptText: memoryPromptText } = await readMemoryPromptText({
+        gateway: memoryGateway,
+        scope: memoryScope,
+      })
+
+      if (shouldAbort())
+        return
+
+      await appendMemoryTurnSafely({
+        gateway: memoryGateway,
+        payload: {
+          createdAt: sendingCreatedAt,
+          rawPayload: streamingMessageContext.input?.data as unknown as Record<string, unknown> | null | undefined,
+          role: 'user',
+          scope: memoryScope,
+          text: sendingMessage,
+          turnId: userMessageId,
+        },
+      })
+
       chatSession.appendSessionMessage(sessionId, {
         role: 'user',
         content: finalContent,
         createdAt: sendingCreatedAt,
-        id: nanoid(),
+        id: userMessageId,
       })
       const sessionMessagesForSend = chatSession.getSessionMessages(sessionId)
 
@@ -360,6 +396,19 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
 
       const contextsSnapshot = chatContext.getContextsSnapshot()
       const contextPromptText = formatContextPromptText(contextsSnapshot)
+      if (memoryPromptText) {
+        const lastMessage = newMessages.at(-1)
+        if (lastMessage && lastMessage.role === 'user') {
+          const existingParts = typeof lastMessage.content === 'string'
+            ? [{ type: 'text' as const, text: lastMessage.content }]
+            : lastMessage.content
+
+          lastMessage.content = [
+            ...existingParts,
+            { type: 'text' as const, text: `\n${memoryPromptText}` },
+          ]
+        }
+      }
       if (contextPromptText) {
         // Merge context into the latest user message instead of inserting a
         // separate user message, which would create consecutive same-role
@@ -494,6 +543,22 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       if (!isStaleGeneration() && buildingMessage.slices.length > 0) {
         chatSession.appendSessionMessage(sessionId, toRaw(buildingMessage))
       }
+
+      await appendMemoryTurnSafely({
+        gateway: memoryGateway,
+        payload: {
+          createdAt: buildingMessage.createdAt ?? Date.now(),
+          rawPayload: null,
+          role: 'assistant',
+          scope: {
+            characterId: activeCardId.value || 'default',
+            sessionId,
+            userId: userId.value || 'local',
+          },
+          text: fullText,
+          turnId: buildingMessage.id ?? nanoid(),
+        },
+      })
 
       await hooks.emitStreamEndHooks(streamingMessageContext)
       await hooks.emitAssistantResponseEndHooks(fullText, streamingMessageContext)

--- a/packages/stage-ui/src/stores/chat/prompt-memory.test.ts
+++ b/packages/stage-ui/src/stores/chat/prompt-memory.test.ts
@@ -1,0 +1,111 @@
+import type { MemoryPromptContext } from '../../services/memory/gateway'
+
+import { describe, expect, it } from 'vitest'
+
+import { createMemoryGateway } from '../../services/memory/gateway'
+import { formatMemoryPromptText, readMemoryPromptText } from './prompt-memory'
+
+function createPromptContext(overrides: Partial<MemoryPromptContext> = {}): MemoryPromptContext {
+  return {
+    memoryCards: [],
+    profileSummary: 'Summary line',
+    recentTurns: [
+      {
+        createdAt: 1000,
+        role: 'user',
+        text: 'hello',
+        turnId: 'turn-1',
+      },
+      {
+        createdAt: 2000,
+        role: 'assistant',
+        text: 'hi there',
+        turnId: 'turn-2',
+      },
+    ],
+    schemaVersion: 1,
+    scope: {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    },
+    stableFacts: [
+      {
+        confidence: 0.8,
+        id: 'fact-1',
+        key: 'name',
+        value: 'Airi',
+      },
+      {
+        confidence: 0.7,
+        id: 'fact-2',
+        key: 'hobby',
+        value: 'music',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('memory prompt helper', () => {
+  it('formats memory sections in fixed order: profile summary, stable facts, recent turns', () => {
+    const text = formatMemoryPromptText(createPromptContext())
+
+    expect(text.startsWith('[Memory]')).toBe(true)
+    expect(text.indexOf('[Profile Summary]')).toBeLessThan(text.indexOf('[Stable Facts]'))
+    expect(text.indexOf('[Stable Facts]')).toBeLessThan(text.indexOf('[Recent Turns]'))
+    expect(text).toContain('Summary line')
+    expect(text).toContain('- name: Airi')
+    expect(text).toContain('- hobby: music')
+    expect(text).toContain('- user: hello')
+    expect(text).toContain('- assistant: hi there')
+  })
+
+  it('stays stable when summary, facts, or turns are empty', async () => {
+    const gateway = {
+      appendTurn: async () => ({ schemaVersion: 1, storedTurnId: 'turn-1', syncCheckpoint: 0 }),
+      getSyncState: async () => ({ schemaVersion: 1, scope: createPromptContext().scope, syncState: null }),
+      readPromptContext: async () => createPromptContext({
+        profileSummary: null,
+        recentTurns: [],
+        stableFacts: [],
+      }),
+    }
+
+    await expect(readMemoryPromptText({
+      gateway,
+      scope: createPromptContext().scope,
+    })).resolves.toEqual({
+      promptContext: createPromptContext({
+        profileSummary: null,
+        recentTurns: [],
+        stableFacts: [],
+      }),
+      promptText: '',
+    })
+  })
+
+  it('web stub remains safe through the prompt-memory reader', async () => {
+    const scope = {
+      characterId: 'character-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    }
+    const gateway = createMemoryGateway({ runtime: 'web' })
+
+    await expect(readMemoryPromptText({
+      gateway,
+      scope,
+    })).resolves.toEqual({
+      promptContext: {
+        memoryCards: [],
+        profileSummary: null,
+        recentTurns: [],
+        schemaVersion: 0,
+        scope,
+        stableFacts: [],
+      },
+      promptText: '',
+    })
+  })
+})

--- a/packages/stage-ui/src/stores/chat/prompt-memory.ts
+++ b/packages/stage-ui/src/stores/chat/prompt-memory.ts
@@ -1,0 +1,100 @@
+import type { MemoryGateway, MemoryPromptContext, MemoryScope } from '../../services/memory/gateway'
+
+// NOTICE:
+// Realtime chat reads local memory only through the local memory gateway
+// (desktop SQLite, web stub). LangMem is cloud background consolidation only:
+// prompt assembly must not wait for raw-turn upload, patch pull, runtime ticks,
+// fetch, or any LangMem response. Local long-term tables are patched from cloud
+// memory output; they are not generated in the realtime chat path.
+
+/**
+ * Renders local memory prompt context into a compact, deterministic text block.
+ *
+ * Use when:
+ * - The chat orchestrator wants to attach local memory to the latest user turn
+ * - Prompt assembly must keep a stable section order for cache friendliness
+ *
+ * Expects:
+ * - `profileSummary`, `stableFacts`, and `recentTurns` may each be empty
+ * - Memory cards are intentionally ignored in Phase 5
+ *
+ * Returns:
+ * - Empty string when no supported memory content exists
+ * - Otherwise a `[Memory]` block with sections ordered as profile summary,
+ *   stable facts, then recent turns
+ */
+export function formatMemoryPromptText(promptContext: MemoryPromptContext) {
+  const sections: string[] = []
+
+  if (promptContext.profileSummary) {
+    sections.push([
+      '[Profile Summary]',
+      promptContext.profileSummary,
+    ].join('\n'))
+  }
+
+  if (promptContext.stableFacts.length > 0) {
+    sections.push([
+      '[Stable Facts]',
+      ...promptContext.stableFacts.map(fact => `- ${fact.key}: ${fact.value}`),
+    ].join('\n'))
+  }
+
+  if (promptContext.recentTurns.length > 0) {
+    sections.push([
+      '[Recent Turns]',
+      ...promptContext.recentTurns.map(turn => `- ${turn.role}: ${turn.text}`),
+    ].join('\n'))
+  }
+
+  if (sections.length === 0)
+    return ''
+
+  return ['[Memory]', ...sections].join('\n\n')
+}
+
+/**
+ * Reads local memory prompt context and returns both the raw snapshot and formatted text.
+ *
+ * Use when:
+ * - The chat store needs a safe pre-LLM memory read path
+ * - Runtime adapters may legitimately return empty prompt context
+ *
+ * Expects:
+ * - `gateway.readPromptContext` should be resilient, but any thrown error is treated
+ *   as an empty-memory fallback in Phase 5
+ *
+ * Returns:
+ * - The prompt context plus a formatted text block
+ * - On failure, a stable empty snapshot and empty prompt text
+ */
+export async function readMemoryPromptText(params: {
+  gateway: MemoryGateway
+  scope: MemoryScope
+}) {
+  try {
+    const promptContext = await params.gateway.readPromptContext({
+      scope: params.scope,
+    })
+
+    return {
+      promptContext,
+      promptText: formatMemoryPromptText(promptContext),
+    }
+  }
+  catch {
+    const promptContext: MemoryPromptContext = {
+      memoryCards: [],
+      profileSummary: null,
+      recentTurns: [],
+      schemaVersion: 0,
+      scope: params.scope,
+      stableFacts: [],
+    }
+
+    return {
+      promptContext,
+      promptText: '',
+    }
+  }
+}

--- a/packages/stage-ui/src/stores/chat/turn-memory.test.ts
+++ b/packages/stage-ui/src/stores/chat/turn-memory.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMemoryGateway } from '../../services/memory/gateway'
+import { appendMemoryTurnSafely } from './turn-memory'
+
+describe('appendMemoryTurnSafely', () => {
+  it('does not throw when using the web stub gateway', async () => {
+    const gateway = createMemoryGateway({ runtime: 'web' })
+
+    await expect(appendMemoryTurnSafely({
+      gateway,
+      payload: {
+        createdAt: 1000,
+        rawPayload: { content: 'hello' },
+        role: 'user',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: 'hello',
+        turnId: 'turn-1',
+      },
+    })).resolves.toBeUndefined()
+  })
+
+  it('logs a clear error and continues when appendTurn fails', async () => {
+    const gateway = {
+      appendTurn: vi.fn(async () => {
+        throw new Error('append failed')
+      }),
+      getSyncState: vi.fn(),
+      readPromptContext: vi.fn(),
+    }
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(appendMemoryTurnSafely({
+      gateway: gateway as any,
+      payload: {
+        createdAt: 1000,
+        rawPayload: { content: 'hello' },
+        role: 'assistant',
+        scope: {
+          characterId: 'character-a',
+          sessionId: 'session-a',
+          userId: 'user-a',
+        },
+        text: 'hello back',
+        turnId: 'turn-2',
+      },
+    })).resolves.toBeUndefined()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[memory-turn-write] Failed to append turn to local memory:',
+      expect.objectContaining({
+        error: expect.any(Error),
+        payload: expect.objectContaining({
+          role: 'assistant',
+          text: 'hello back',
+          turnId: 'turn-2',
+        }),
+      }),
+    )
+
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/packages/stage-ui/src/stores/chat/turn-memory.ts
+++ b/packages/stage-ui/src/stores/chat/turn-memory.ts
@@ -1,0 +1,30 @@
+import type { MemoryAppendTurnInput, MemoryGateway } from '../../services/memory/gateway'
+
+/**
+ * Appends one chat turn into the local memory gateway without breaking the chat flow.
+ *
+ * Use when:
+ * - The chat orchestrator wants best-effort local turn persistence
+ * - Memory append failures should degrade gracefully instead of aborting the LLM turn
+ *
+ * Expects:
+ * - `gateway.appendTurn` may reject for runtime-specific reasons
+ * - Callers provide a fully populated append-turn payload
+ *
+ * Returns:
+ * - Resolves once the append attempt completes or is downgraded after logging
+ */
+export async function appendMemoryTurnSafely(params: {
+  gateway: MemoryGateway
+  payload: MemoryAppendTurnInput
+}) {
+  try {
+    await params.gateway.appendTurn(params.payload)
+  }
+  catch (error) {
+    console.error('[memory-turn-write] Failed to append turn to local memory:', {
+      error,
+      payload: params.payload,
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Electron-owned local SQLite memory storage and Eventa memory invokes for desktop realtime memory.
- Adds stage-ui memory gateway/status helpers and chat integration.
- Reads local memory before appending the current user turn, preventing same-turn self-injection into `[Memory] -> [Recent Turns]`.
- Adds background raw-turn upload / patch-pull runtime that is disabled-safe when cloud config is absent.
- Adds retention pruning for uploaded raw/recent turns only, gated by configurable retention window.
- Adds memory settings status surface and reviewer-facing architecture spec.

## Architecture Invariant
LangMem is not in the realtime chat path; realtime prompt assembly reads only local memory gateway / SQLite.

Realtime chat must not wait for upload, patch pull, runtime tick, or memory consolidation. LangMem remains the cloud background long-term memory consolidation layer that produces patches later.

## Verification
- Targeted memory/chat Vitest passed: 14 files / 50 tests.
- `pnpm -F @proj-airi/stage-ui typecheck` passed.
- `pnpm -F @proj-airi/stage-tamagotchi typecheck` passed.
- Electron smoke passed: mock LLM wrote pending user/assistant turns and opened memory settings page.
- `pnpm lint` exits 0, but prints unrelated existing repo lint findings outside this PR scope.

## Known Issues / Out of Scope
- P1 patch contract delete semantics, tombstones, remote cursor, out-of-order delivery, and cloud LangMem worker are intentionally out of scope.
- Existing unrelated repo lint findings are not fixed in this PR.