### PR TITLE
fix: resolve provider validation and CORS issues in dev mode

### DIFF
--- a/apps/stage-tamagotchi/src/main/windows/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/main/index.ts
@@ -88,6 +88,8 @@ export async function setupMainWindow(params: {
     webPreferences: {
       preload: join(dirname(fileURLToPath(import.meta.url)), '../preload/index.mjs'),
       sandbox: false,
+      // Disable webSecurity in development to avoid CORS issues
+      webSecurity: !is.dev,
     },
     // Thanks to [@HeartArmy](https://github.com/HeartArmy) for the tip implementation.
     //

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2072,6 +2072,10 @@ export const useProvidersStore = defineStore('providers', () => {
       if (!providerMetadata[providerId] || intervalMs <= 0)
         continue
 
+      // Only start periodic validation for providers that have been explicitly added
+      if (!addedProviders.value[providerId])
+        continue
+
       if (providerRevalidationLoops.has(providerId)) {
         continue
       }
@@ -2087,8 +2091,8 @@ export const useProvidersStore = defineStore('providers', () => {
   // Update configuration status for all configured providers
   async function updateConfigurationStatus() {
     await Promise.all(Object.entries(providerMetadata)
-      // TODO: ignore un-configured provider
-      // .filter(([_, provider]) => provider.configured)
+      // Only validate providers that have been explicitly added by the user
+      .filter(([providerId]) => addedProviders.value[providerId])
       .map(async ([providerId]) => {
         try {
           if (providerRuntimeState.value[providerId]) {
@@ -2107,6 +2111,23 @@ export const useProvidersStore = defineStore('providers', () => {
   // Call initially and watch for changes
   watch(providerCredentials, updateConfigurationStatus, { deep: true, immediate: true })
   startPeriodicRuntimeValidation()
+
+  // Watch for newly added providers and start their periodic validation
+  watch(addedProviders, (newAdded, oldAdded) => {
+    for (const providerId of Object.keys(newAdded)) {
+      if (newAdded[providerId] && !oldAdded?.[providerId]) {
+        // Provider was just added, start its periodic validation if configured
+        const intervalMs = providerValidationIntervalMsById.get(providerId)
+        if (intervalMs && intervalMs > 0 && !providerRevalidationLoops.has(providerId)) {
+          const loop = useIntervalFn(() => {
+            void validateProvider(providerId, { force: true })
+          }, intervalMs, { immediate: false, immediateCallback: false })
+          loop.resume()
+          providerRevalidationLoops.set(providerId, loop)
+        }
+      }
+    }
+  }, { deep: true })
 
   watch(() => authState.isAuthenticated, updateConfigurationStatus)
 


### PR DESCRIPTION
- Only validate explicitly added providers to prevent unnecessary connection attempts
- Start periodic validation only for added providers
- Watch for newly added providers and start their validation
- Disable webSecurity in development mode to fix CORS errors with external APIs

Fixes connection refused errors for Ollama/LM Studio when not running locally. Fixes CORS errors when using OpenAI-compatible APIs in development mode.

## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
