### PR TITLE
fix(stage-tamagotchi): add xwayland dev script for Wayland Electron deadlock

### DIFF
--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -17,6 +17,7 @@
     "app:dev": "pnpm run dev",
     "app:build": "pnpm run build",
     "start": "electron-vite preview",
+    "start:xwayland": "electron-vite preview -- --ozone-platform=x11",
     "dev": "electron-vite dev",
     "dev:xwayland": "electron-vite dev -- --ozone-platform=x11",
     "build": "electron-vite build",

--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -18,6 +18,7 @@
     "app:build": "pnpm run build",
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
+    "dev:xwayland": "electron-vite dev -- --ozone-platform=x11",
     "build": "electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "pnpm run build && electron-builder --dir",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:pocket:android": "pnpm -rF @proj-airi/stage-pocket run dev:android",
     "dev:server": "pnpm -rF @proj-airi/server-runtime run dev",
     "dev:tamagotchi": "pnpm -rF @proj-airi/stage-tamagotchi run dev",
+    "dev:tamagotchi:xwayland": "pnpm -rF @proj-airi/stage-tamagotchi run dev:xwayland",
     "dev:apps": "pnpm -rF=\"./apps/*\" run --parallel dev",
     "dev:packages": "pnpm -rF=\"./packages/*\" --parallel run dev",
     "build": "turbo run build -F=\"./packages/*\" -F=\"./apps/*\"",


### PR DESCRIPTION
## Context

`pnpm dev:tamagotchi` can fail to start or behave incorrectly on some native Wayland sessions (KDE Plasma 6, Hyprland, etc.) due to known Electron/Chromium Ozone issues on Wayland.

I've had deadlocks on startup, crashes and more recently, ui glitches which all go away when using xWayland.

## Change

Adds an opt-in `pnpm dev:tamagotchi:xwayland` that routes the dev session through XWayland by passing `--ozone-platform=x11` to Electron at launch. Default `dev:tamagotchi` is unchanged.