### PR TITLE
fix(chat): strip echoed datetime prefixes from streamed model output

### DIFF
--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -18,6 +18,7 @@
     "app:build": "pnpm run build",
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
+    "dev:xwayland": "electron-vite dev -- --ozone-platform=x11",
     "build": "electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "pnpm run build && electron-builder --dir",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:pocket:android": "pnpm -rF @proj-airi/stage-pocket run dev:android",
     "dev:server": "pnpm -rF @proj-airi/server-runtime run dev",
     "dev:tamagotchi": "pnpm -rF @proj-airi/stage-tamagotchi run dev",
+    "dev:tamagotchi:xwayland": "pnpm -rF @proj-airi/stage-tamagotchi run dev:xwayland",
     "dev:apps": "pnpm -rF=\"./apps/*\" run --parallel dev",
     "dev:packages": "pnpm -rF=\"./packages/*\" --parallel run dev",
     "build": "turbo run build -F=\"./packages/*\" -F=\"./apps/*\"",

--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -3,6 +3,7 @@ import type { CommonContentPart, CompletionToolCall, CompletionToolResult, Messa
 
 export type StreamEvent
   = | { type: 'text-delta', text: string }
+    | { type: 'reasoning-delta', text: string }
     | ({ type: 'finish' } & any)
     | ({ type: 'tool-call' } & CompletionToolCall)
     | (CompletionToolResult & { type: 'tool-error' })

--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -17,6 +17,7 @@ withDefaults(defineProps<{
 
   paused?: boolean
   mouthOpenSize?: number
+  isSpeaking?: boolean
   focusAt?: { x: number, y: number }
   disableFocusAt?: boolean
   scale?: number
@@ -33,6 +34,7 @@ withDefaults(defineProps<{
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
   mouthOpenSize: 0,
+  isSpeaking: false,
   scale: 1,
   themeColorsHue: 220.44,
   themeColorsHueDynamic: false,
@@ -88,6 +90,7 @@ defineExpose({
         :model-id="modelId"
         :app="app"
         :mouth-open-size="mouthOpenSize"
+        :is-speaking="isSpeaking"
         :width="width"
         :height="height"
         :paused="paused"

--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -17,7 +17,7 @@ withDefaults(defineProps<{
 
   paused?: boolean
   mouthOpenSize?: number
-  isSpeaking?: boolean
+  nowSpeaking?: boolean
   focusAt?: { x: number, y: number }
   disableFocusAt?: boolean
   scale?: number
@@ -34,7 +34,7 @@ withDefaults(defineProps<{
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
   mouthOpenSize: 0,
-  isSpeaking: false,
+  nowSpeaking: false,
   scale: 1,
   themeColorsHue: 220.44,
   themeColorsHueDynamic: false,
@@ -90,7 +90,7 @@ defineExpose({
         :model-id="modelId"
         :app="app"
         :mouth-open-size="mouthOpenSize"
-        :is-speaking="isSpeaking"
+        :now-speaking="nowSpeaking"
         :width="width"
         :height="height"
         :paused="paused"

--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
@@ -35,6 +35,7 @@ const props = withDefaults(defineProps<{
 
   app?: Application
   mouthOpenSize?: number
+  isSpeaking?: boolean
   width: number
   height: number
   paused?: boolean
@@ -52,6 +53,7 @@ const props = withDefaults(defineProps<{
   live2dShadowEnabled?: boolean
 }>(), {
   mouthOpenSize: 0,
+  isSpeaking: false,
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
   disableFocusAt: false,
@@ -106,6 +108,7 @@ const model = ref<Live2DModel<PixiLive2DInternalModel>>()
 const initialModelWidth = ref<number>(0)
 const initialModelHeight = ref<number>(0)
 const mouthOpenSize = computed(() => Math.max(0, Math.min(100, props.mouthOpenSize)))
+const isSpeaking = toRef(() => props.isSpeaking)
 const lastUpdateTime = ref(0)
 
 const { isDark: dark } = useTheme()
@@ -117,10 +120,6 @@ const dropShadowFilter = shallowRef(new DropShadowFilter({
   distance: 20,
   rotation: 45,
 }))
-
-function getCoreModel() {
-  return model.value!.internalModel.coreModel as any
-}
 
 let resizeAnimation: ReturnType<typeof animate> | undefined
 
@@ -379,7 +378,7 @@ async function loadModel() {
     // This ensures blink respects expression state (0 × blinkFactor = 0).
     motionManagerUpdate.register(useMotionUpdatePluginExpression(expressionController), 'final')
     motionManagerUpdate.register(useMotionUpdatePluginAutoEyeBlink(live2dExpressionEnabled), 'final')
-    motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize), 'final')
+    motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize, isSpeaking), 'final')
 
     const hookedUpdate = motionManager.update as (model: PixiLive2DInternalModel['coreModel'], now: number) => boolean
     motionManager.update = function (model: PixiLive2DInternalModel['coreModel'], now: number) {
@@ -575,7 +574,6 @@ watch([themeColorsHueDynamic, live2dShadowEnabled], ([dynamic, shadowEnabled]) =
   }
 }, { immediate: true })
 
-watch(mouthOpenSize, value => getCoreModel().setParameterValueById('ParamMouthOpenY', value))
 watch(currentMotion, value => setMotion(value.group, value.index))
 watch(paused, value => value ? pixiApp.value?.stop() : pixiApp.value?.start())
 

--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
@@ -24,6 +24,7 @@ import {
   useMotionUpdatePluginExpression,
   useMotionUpdatePluginIdleDisable,
   useMotionUpdatePluginIdleFocus,
+  useMotionUpdatePluginLipSync,
 } from '../../../composables/live2d'
 import { Emotion, EmotionNeutralMotionName } from '../../../constants/emotions'
 import { useLive2d } from '../../../stores/live2d'
@@ -378,6 +379,7 @@ async function loadModel() {
     // This ensures blink respects expression state (0 × blinkFactor = 0).
     motionManagerUpdate.register(useMotionUpdatePluginExpression(expressionController), 'final')
     motionManagerUpdate.register(useMotionUpdatePluginAutoEyeBlink(live2dExpressionEnabled), 'final')
+    motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize), 'final')
 
     const hookedUpdate = motionManager.update as (model: PixiLive2DInternalModel['coreModel'], now: number) => boolean
     motionManager.update = function (model: PixiLive2DInternalModel['coreModel'], now: number) {

--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
@@ -35,7 +35,7 @@ const props = withDefaults(defineProps<{
 
   app?: Application
   mouthOpenSize?: number
-  isSpeaking?: boolean
+  nowSpeaking?: boolean
   width: number
   height: number
   paused?: boolean
@@ -53,7 +53,7 @@ const props = withDefaults(defineProps<{
   live2dShadowEnabled?: boolean
 }>(), {
   mouthOpenSize: 0,
-  isSpeaking: false,
+  nowSpeaking: false,
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
   disableFocusAt: false,
@@ -108,7 +108,7 @@ const model = ref<Live2DModel<PixiLive2DInternalModel>>()
 const initialModelWidth = ref<number>(0)
 const initialModelHeight = ref<number>(0)
 const mouthOpenSize = computed(() => Math.max(0, Math.min(100, props.mouthOpenSize)))
-const isSpeaking = toRef(() => props.isSpeaking)
+const nowSpeaking = toRef(() => props.nowSpeaking)
 const lastUpdateTime = ref(0)
 
 const { isDark: dark } = useTheme()
@@ -378,7 +378,7 @@ async function loadModel() {
     // This ensures blink respects expression state (0 × blinkFactor = 0).
     motionManagerUpdate.register(useMotionUpdatePluginExpression(expressionController), 'final')
     motionManagerUpdate.register(useMotionUpdatePluginAutoEyeBlink(live2dExpressionEnabled), 'final')
-    motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize, isSpeaking), 'final')
+    motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize, nowSpeaking), 'final')
 
     const hookedUpdate = motionManager.update as (model: PixiLive2DInternalModel['coreModel'], now: number) => boolean
     motionManager.update = function (model: PixiLive2DInternalModel['coreModel'], now: number) {

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -442,12 +442,12 @@ export function useMotionUpdatePluginExpression(
  * Final-phase plugin that owns ParamMouthOpenY while speech is active and
  * smoothly cross-fades back to the motion-driven value when speech ends.
  *
- * `isSpeaking` (not `mouthOpenSize > 0`) is the speech boundary, so silent
+ * `nowSpeaking` (not `mouthOpenSize > 0`) is the speech boundary, so silent
  * gaps between phonemes write 0 directly instead of triggering the release.
  */
 export function useMotionUpdatePluginLipSync(
   mouthOpenSize: Ref<number>,
-  isSpeaking: Ref<boolean>,
+  nowSpeaking: Ref<boolean>,
 ): MotionManagerPlugin {
   const RELEASE_DURATION_MS = 200
 
@@ -457,7 +457,7 @@ export function useMotionUpdatePluginLipSync(
   const smoothstep = (t: number) => t * t * (3 - 2 * t)
 
   return (ctx) => {
-    if (isSpeaking.value) {
+    if (nowSpeaking.value) {
       lastForcedValue = mouthOpenSize.value
       releaseRemainingMs = RELEASE_DURATION_MS
       ctx.model.setParameterValueById('ParamMouthOpenY', mouthOpenSize.value)

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -437,3 +437,18 @@ export function useMotionUpdatePluginExpression(
     controller.applyExpressions(ctx.model)
   }
 }
+
+/**
+ * Final-phase plugin that overrides ParamMouthOpenY with the lip sync value.
+ * Runs AFTER motion curves and expression overrides so the lip sync always
+ * has the last word on mouth position during speech.
+ */
+export function useMotionUpdatePluginLipSync(
+  mouthOpenSize: Ref<number>,
+): MotionManagerPlugin {
+  return (ctx) => {
+    if (mouthOpenSize.value <= 0)
+      return
+    ctx.model.setParameterValueById('ParamMouthOpenY', mouthOpenSize.value)
+  }
+}

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -439,16 +439,45 @@ export function useMotionUpdatePluginExpression(
 }
 
 /**
- * Final-phase plugin that overrides ParamMouthOpenY with the lip sync value.
- * Runs AFTER motion curves and expression overrides so the lip sync always
- * has the last word on mouth position during speech.
+ * Final-phase plugin that owns ParamMouthOpenY while speech is active and
+ * smoothly cross-fades back to the motion-driven value when speech ends.
+ *
+ * `isSpeaking` (not `mouthOpenSize > 0`) is the speech boundary, so silent
+ * gaps between phonemes write 0 directly instead of triggering the release.
  */
 export function useMotionUpdatePluginLipSync(
   mouthOpenSize: Ref<number>,
+  isSpeaking: Ref<boolean>,
 ): MotionManagerPlugin {
+  const RELEASE_DURATION_MS = 200
+
+  let releaseRemainingMs = 0
+  let lastForcedValue = 0
+
+  const smoothstep = (t: number) => t * t * (3 - 2 * t)
+
   return (ctx) => {
-    if (mouthOpenSize.value <= 0)
+    if (isSpeaking.value) {
+      lastForcedValue = mouthOpenSize.value
+      releaseRemainingMs = RELEASE_DURATION_MS
+      ctx.model.setParameterValueById('ParamMouthOpenY', mouthOpenSize.value)
       return
-    ctx.model.setParameterValueById('ParamMouthOpenY', mouthOpenSize.value)
+    }
+
+    if (releaseRemainingMs <= 0)
+      return
+
+    // timeDelta is usually ms but can arrive in seconds; mirror useMotionUpdatePluginAutoEyeBlink.
+    const rawDelta = Math.max(ctx.timeDelta ?? 0, 0)
+    const dtMs = rawDelta < 5 ? rawDelta * 1000 : rawDelta
+
+    releaseRemainingMs = Math.max(0, releaseRemainingMs - dtMs)
+    const blend = smoothstep(1 - releaseRemainingMs / RELEASE_DURATION_MS)
+
+    // ParamMouthOpenY was already written by motion + expression plugins this frame.
+    const motionValue = ctx.model.getParameterValueById('ParamMouthOpenY') as number
+    const blended = lastForcedValue * (1 - blend) + motionValue * blend
+
+    ctx.model.setParameterValueById('ParamMouthOpenY', blended)
   }
 }

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -651,7 +651,7 @@ defineExpose({
         :model-id="stageModelSelected"
         :focus-at="focusAt"
         :mouth-open-size="mouthOpenSize"
-        :is-speaking="nowSpeaking"
+        :now-speaking="nowSpeaking"
         :paused="paused"
         :x-offset="xOffset"
         :y-offset="yOffset"

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -109,7 +109,7 @@ viewUpdateCleanups.push(live2dStore.onShouldUpdateView(async () => {
 }))
 
 const audioAnalyser = ref<AnalyserNode>()
-const isSpeaking = ref(false)
+const nowSpeaking = ref(false)
 const lipSyncStarted = ref(false)
 const lipSyncLoopId = ref<number>()
 const live2dLipSync = ref<Live2DLipSync>()
@@ -338,12 +338,12 @@ playbackManager.onEnd(({ item }) => {
   if (item.special)
     playSpecialToken(item.special)
 
-  isSpeaking.value = false
+  nowSpeaking.value = false
   mouthOpenSize.value = 0
 })
 
 playbackManager.onStart(({ item }) => {
-  isSpeaking.value = true
+  nowSpeaking.value = true
   // NOTICE: postCaption and postPresent may throw errors if the BroadcastChannel is closed
   // (e.g., when navigating away from the page). We wrap these in try-catch to prevent
   // breaking playback when the channel is unavailable.
@@ -367,7 +367,7 @@ function startLipSyncLoop() {
     return
 
   const tick = () => {
-    if (!isSpeaking.value || !live2dLipSync.value) {
+    if (!nowSpeaking.value || !live2dLipSync.value) {
       mouthOpenSize.value = 0
     }
     else {
@@ -651,7 +651,7 @@ defineExpose({
         :model-id="stageModelSelected"
         :focus-at="focusAt"
         :mouth-open-size="mouthOpenSize"
-        :is-speaking="isSpeaking"
+        :is-speaking="nowSpeaking"
         :paused="paused"
         :x-offset="xOffset"
         :y-offset="yOffset"

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -109,7 +109,7 @@ viewUpdateCleanups.push(live2dStore.onShouldUpdateView(async () => {
 }))
 
 const audioAnalyser = ref<AnalyserNode>()
-const nowSpeaking = ref(false)
+const isSpeaking = ref(false)
 const lipSyncStarted = ref(false)
 const lipSyncLoopId = ref<number>()
 const live2dLipSync = ref<Live2DLipSync>()
@@ -338,12 +338,12 @@ playbackManager.onEnd(({ item }) => {
   if (item.special)
     playSpecialToken(item.special)
 
-  nowSpeaking.value = false
+  isSpeaking.value = false
   mouthOpenSize.value = 0
 })
 
 playbackManager.onStart(({ item }) => {
-  nowSpeaking.value = true
+  isSpeaking.value = true
   // NOTICE: postCaption and postPresent may throw errors if the BroadcastChannel is closed
   // (e.g., when navigating away from the page). We wrap these in try-catch to prevent
   // breaking playback when the channel is unavailable.
@@ -367,7 +367,7 @@ function startLipSyncLoop() {
     return
 
   const tick = () => {
-    if (!nowSpeaking.value || !live2dLipSync.value) {
+    if (!isSpeaking.value || !live2dLipSync.value) {
       mouthOpenSize.value = 0
     }
     else {
@@ -651,6 +651,7 @@ defineExpose({
         :model-id="stageModelSelected"
         :focus-at="focusAt"
         :mouth-open-size="mouthOpenSize"
+        :is-speaking="isSpeaking"
         :paused="paused"
         :x-offset="xOffset"
         :y-offset="yOffset"

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -303,9 +303,10 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
 
           const finalCategorization = categorizeResponse(fullText, activeProvider.value)
 
+          const reasoningContentField = buildingMessage.categorization?.reasoning?.trim()
           buildingMessage.categorization = {
             speech: finalCategorization.speech,
-            reasoning: finalCategorization.reasoning,
+            reasoning: reasoningContentField || finalCategorization.reasoning,
           }
           updateUI()
         },
@@ -475,6 +476,15 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
                 fullText += event.text
                 await parser.consume(event.text)
                 break
+              case 'reasoning-delta': {
+                const { speech = '', reasoning = '' } = buildingMessage.categorization ?? {}
+                buildingMessage.categorization = {
+                  speech,
+                  reasoning: reasoning + event.text,
+                }
+                updateUI()
+                break
+              }
               case 'finish':
                 break
               case 'error':

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -18,7 +18,7 @@ import { activeTurnSpan, startSpan } from '../composables/use-io-tracer'
 import { formatContextPromptText } from './chat/context-prompt'
 import { createMinecraftContext } from './chat/context-providers'
 import { useChatContextStore } from './chat/context-store'
-import { formatTimePrefix } from './chat/datetime-prefix'
+import { createTimestampPrefixStripper, formatTimePrefix, stripLeadingTimestampPrefix } from './chat/datetime-prefix'
 import { createChatHooks } from './chat/hooks'
 import { useChatSessionStore } from './chat/session-store'
 import { useChatStreamStore } from './chat/stream-store'
@@ -261,11 +261,18 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       // --------------------------------
 
       const categorizer = createStreamingCategorizer(activeProvider.value)
+      // Drops the leading `[YYYY-MM-DD HH:MM] ` echo before it reaches both
+      // the chat transcript and TTS. See `./chat/datetime-prefix.ts`.
+      const timestampStripper = createTimestampPrefixStripper()
       let streamPosition = 0
 
       const parser = useLlmmarkerParser({
-        onLiteral: async (literal) => {
+        onLiteral: async (rawLiteral) => {
           if (shouldAbort())
+            return
+
+          const literal = timestampStripper.consume(rawLiteral)
+          if (!literal)
             return
 
           categorizer.consume(literal)
@@ -301,7 +308,9 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
           if (isStaleGeneration())
             return
 
-          const finalCategorization = categorizeResponse(fullText, activeProvider.value)
+          // Strip the echoed timestamp from the persisted text so subsequent
+          // turns do not re-send `[ts] [ts] ...` and reinforce the pattern.
+          const finalCategorization = categorizeResponse(stripLeadingTimestampPrefix(fullText), activeProvider.value)
 
           const reasoningContentField = buildingMessage.categorization?.reasoning?.trim()
           buildingMessage.categorization = {

--- a/packages/stage-ui/src/stores/chat/datetime-prefix.test.ts
+++ b/packages/stage-ui/src/stores/chat/datetime-prefix.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatTimePrefix } from './datetime-prefix'
+import { createTimestampPrefixStripper, formatTimePrefix } from './datetime-prefix'
 
 describe('formatTimePrefix', () => {
   it('wraps `[YYYY-MM-DD HH:MM]` with trailing space', () => {
@@ -30,5 +30,71 @@ describe('formatTimePrefix', () => {
     const a = new Date(2026, 3, 25, 18, 47, 12).getTime()
     const b = new Date(2026, 3, 25, 18, 47, 58).getTime()
     expect(formatTimePrefix(a)).toBe(formatTimePrefix(b))
+  })
+})
+
+// ROOT CAUSE:
+//
+// Weak local models echo the `[YYYY-MM-DD HH:MM] ` prefix that
+// `formatTimePrefix` injects onto every user/assistant turn (see
+// chat.ts:351,356). The echoed prefix then leaked into both the chat
+// transcript (buildingMessage.content) and the TTS pipeline
+// (hooks.emitTokenLiteralHooks), so the synthesized voice would read
+// "bracket twenty twenty six dash zero five..." aloud before the actual
+// reply. We strip it at the streaming boundary in chat.ts onLiteral so
+// neither the rendered transcript nor the audio contains it.
+describe('createTimestampPrefixStripper', () => {
+  it('strips a leading `[YYYY-MM-DD HH:MM] ` prefix delivered as one chunk', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('[2026-05-01 20:08] ooh nice')).toBe('ooh nice')
+    expect(stripper.consume(', mining is fun')).toBe(', mining is fun')
+    expect(stripper.end()).toBe('')
+  })
+
+  it('strips a leading prefix split across many small chunks (real streaming case)', () => {
+    const stripper = createTimestampPrefixStripper()
+    const chunks = ['[', '202', '6-', '05-', '01 ', '20:', '08', '] ', 'hello', ' world']
+    const out = chunks.map(c => stripper.consume(c)).join('')
+    expect(out).toBe('hello world')
+  })
+
+  it('strips when the trailing space arrives in the same chunk as content', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('[2026-05-01 20:08]')).toBe('')
+    expect(stripper.consume(' actual reply')).toBe('actual reply')
+  })
+
+  it('does not strip when no prefix is present (passthrough)', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('hello there')).toBe('hello there')
+    expect(stripper.consume(' more text')).toBe(' more text')
+  })
+
+  it('does not strip when the response merely starts with `[` but is not a timestamp', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('[note] not a timestamp')).toBe('[note] not a timestamp')
+  })
+
+  it('does not strip a timestamp that appears mid-response (only leading prefixes)', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('Earlier: ')).toBe('Earlier: ')
+    expect(stripper.consume('[2026-05-01 20:08] keep this')).toBe('[2026-05-01 20:08] keep this')
+  })
+
+  it('handles a prefix without a trailing space', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('[2026-05-01 20:08]immediately')).toBe('immediately')
+  })
+
+  it('flushes buffered partial-prefix bytes if the stream ends before the prefix completes', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('[2026-')).toBe('')
+    expect(stripper.end()).toBe('[2026-')
+  })
+
+  it('rejects an almost-prefix where a non-digit appears in a digit slot', () => {
+    const stripper = createTimestampPrefixStripper()
+    // `[2026-XX...` — `X` is not a digit, so this is not the timestamp shape.
+    expect(stripper.consume('[2026-XX-01 20:08] body')).toBe('[2026-XX-01 20:08] body')
   })
 })

--- a/packages/stage-ui/src/stores/chat/datetime-prefix.test.ts
+++ b/packages/stage-ui/src/stores/chat/datetime-prefix.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { createTimestampPrefixStripper, formatTimePrefix } from './datetime-prefix'
+import { createTimestampPrefixStripper, formatTimePrefix, stripLeadingTimestampPrefix } from './datetime-prefix'
 
 describe('formatTimePrefix', () => {
   it('wraps `[YYYY-MM-DD HH:MM]` with trailing space', () => {
@@ -75,10 +75,46 @@ describe('createTimestampPrefixStripper', () => {
     expect(stripper.consume('[note] not a timestamp')).toBe('[note] not a timestamp')
   })
 
-  it('does not strip a timestamp that appears mid-response (only leading prefixes)', () => {
+  it('does not strip a timestamp that appears mid-line (still inline content)', () => {
     const stripper = createTimestampPrefixStripper()
     expect(stripper.consume('Earlier: ')).toBe('Earlier: ')
     expect(stripper.consume('[2026-05-01 20:08] keep this')).toBe('[2026-05-01 20:08] keep this')
+  })
+
+  it('strips a timestamp echoed after a newline mid-stream', () => {
+    // ROOT CAUSE:
+    //
+    // Models that have already emitted a sentence sometimes echo a fresh
+    // `\n[YYYY-MM-DD HH:MM] ` before continuing on a new line, mirroring
+    // the per-turn datetime injection. The earlier leading-only stripper
+    // missed this and the timestamp leaked into chat + TTS.
+    const stripper = createTimestampPrefixStripper()
+    const chunks = [
+      'Cool, cool, cool. What kind of edge cases?\n',
+      '[2026-05-01 20:25] Like, is it the timing?',
+    ]
+    const out = chunks.map(c => stripper.consume(c)).join('') + stripper.end()
+    expect(out).toBe('Cool, cool, cool. What kind of edge cases?\nLike, is it the timing?')
+  })
+
+  it('strips a post-newline prefix when the newline ends one chunk and the bracket starts the next', () => {
+    const stripper = createTimestampPrefixStripper()
+    const chunks = ['first line\n', '[2026-05-01 20:25] second line']
+    const out = chunks.map(c => stripper.consume(c)).join('') + stripper.end()
+    expect(out).toBe('first line\nsecond line')
+  })
+
+  it('strips multiple newline-anchored prefixes in a single string', () => {
+    expect(
+      stripLeadingTimestampPrefix(
+        '[2026-05-01 20:25] one\n[2026-05-01 20:26] two\n[2026-05-01 20:27] three',
+      ),
+    ).toBe('one\ntwo\nthree')
+  })
+
+  it('preserves a `\\n[note]` that is not the timestamp shape', () => {
+    const stripper = createTimestampPrefixStripper()
+    expect(stripper.consume('line one\n[note] line two')).toBe('line one\n[note] line two')
   })
 
   it('handles a prefix without a trailing space', () => {

--- a/packages/stage-ui/src/stores/chat/datetime-prefix.ts
+++ b/packages/stage-ui/src/stores/chat/datetime-prefix.ts
@@ -11,7 +11,7 @@
  *   prefixed history stays byte-stable across turns and accumulates KV-cache
  *   prefix matches.
  * - The full date is included on every message so the model can infer "today"
- *   from the most recent message — there is no separate system-prompt date
+ *   from the most recent message. There is no separate system-prompt date
  *   anchor, which keeps the system prompt 100% static and permanently
  *   cacheable across turns and across day boundaries.
  *
@@ -40,7 +40,7 @@ const DATE_TIME = new Intl.DateTimeFormat('en-CA', {
  *
  * Use when:
  * - Annotating user/assistant messages so the model has a concrete time
- *   anchor on every turn — historic and current alike use the same shape so
+ *   anchor on every turn. Historic and current alike use the same shape so
  *   that prefix-cache stays valid when a "current" turn becomes "historic" on
  *   the next send.
  *
@@ -58,4 +58,100 @@ export function formatTimePrefix(createdAt: number): string {
   // produce the bracketed `YYYY-MM-DD HH:MM` form.
   const formatted = DATE_TIME.format(new Date(createdAt)).replace(', ', ' ')
   return `[${formatted}] `
+}
+
+/**
+ * Matches the leading `[YYYY-MM-DD HH:MM]` (with an optional trailing space)
+ * produced by `formatTimePrefix`. Kept in lockstep with the writer above:
+ * if the format changes there, change this regex (and the tests) too.
+ */
+const TIMESTAMP_PREFIX_RE = /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] ?/
+
+/**
+ * Length budget for "have we buffered enough to decide": 18 bracketed chars
+ * plus the optional trailing space.
+ */
+const TIMESTAMP_PREFIX_MAX_LEN = 19
+
+/**
+ * Position-by-position template used to short-circuit buffering when the
+ * leading bytes already disprove the shape, so non-timestamped replies don't
+ * pay 19 chars of buffering latency before the first chunk reaches TTS.
+ *
+ * `#` slots are digits; every other character is a literal.
+ */
+const TIMESTAMP_PREFIX_TEMPLATE = '[####-##-## ##:##]'
+
+function couldStillMatchPrefix(buf: string): boolean {
+  const limit = Math.min(buf.length, TIMESTAMP_PREFIX_TEMPLATE.length)
+  for (let i = 0; i < limit; i++) {
+    const slot = TIMESTAMP_PREFIX_TEMPLATE[i]
+    const ch = buf[i]
+    const ok = slot === '#' ? (ch >= '0' && ch <= '9') : ch === slot
+    if (!ok)
+      return false
+  }
+  return true
+}
+
+/**
+ * Removes a leading `[YYYY-MM-DD HH:MM] ` prefix if present. No-op otherwise.
+ *
+ * Use when:
+ * - You have a complete string (e.g. the final assembled assistant message)
+ *   and want to drop a timestamp the model echoed from the per-turn injection.
+ */
+export function stripLeadingTimestampPrefix(text: string): string {
+  return text.replace(TIMESTAMP_PREFIX_RE, '')
+}
+
+/**
+ * Streaming version of `stripLeadingTimestampPrefix` for chunked input.
+ *
+ * Use when:
+ * - You receive assistant text in deltas and need to forward it to surfaces
+ *   that should never see the timestamp (chat transcript, TTS). Apply once
+ *   at the stream boundary so both surfaces are covered by a single chokepoint.
+ *
+ * Expects:
+ * - Chunks delivered in order. The prefix may split across chunks at any byte.
+ * - Stripping is leading-only: a timestamp that appears mid-stream passes through.
+ *
+ * Returns:
+ * - `consume(chunk)` yields the chunk minus any leading prefix bytes still
+ *   being absorbed; may return `''` while buffering. Once the decision is made
+ *   (matched and dropped, or shape ruled out), every further chunk passes
+ *   through untouched.
+ * - `end()` flushes any partial-prefix bytes still buffered when the stream
+ *   ends shorter than the prefix length.
+ */
+export function createTimestampPrefixStripper() {
+  // While `buffer` is a string we are still deciding. `null` means the
+  // decision is made and the stripper is now a passthrough.
+  let buffer: string | null = ''
+
+  function flush(): string {
+    const out = stripLeadingTimestampPrefix(buffer!)
+    buffer = null
+    return out
+  }
+
+  return {
+    consume(chunk: string): string {
+      if (buffer === null)
+        return chunk
+
+      buffer += chunk
+
+      // Enough bytes to apply the regex unambiguously, or the leading bytes
+      // already disprove the shape: decide now.
+      if (buffer.length >= TIMESTAMP_PREFIX_MAX_LEN || !couldStillMatchPrefix(buffer))
+        return flush()
+
+      return ''
+    },
+    end(): string {
+      return buffer === null ? '' : flush()
+    },
+  }
 }

--- a/packages/stage-ui/src/stores/chat/datetime-prefix.ts
+++ b/packages/stage-ui/src/stores/chat/datetime-prefix.ts
@@ -61,32 +61,32 @@ export function formatTimePrefix(createdAt: number): string {
 }
 
 /**
- * Matches the leading `[YYYY-MM-DD HH:MM]` (with an optional trailing space)
- * produced by `formatTimePrefix`. Kept in lockstep with the writer above:
- * if the format changes there, change this regex (and the tests) too.
+ * Matches a `[YYYY-MM-DD HH:MM]` (with an optional trailing space) produced
+ * by `formatTimePrefix`. Anchored to the start of input or the start of a
+ * line, since weak models echo the prefix both at the very beginning of a
+ * reply and after their own newlines mid-stream. Kept in lockstep with the
+ * writer above: if the format changes there, change this regex (and the
+ * tests) too.
  */
-const TIMESTAMP_PREFIX_RE = /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] ?/
+const TIMESTAMP_PREFIX_RE = /(^|\n)\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] ?/g
 
 /**
- * Length budget for "have we buffered enough to decide": 18 bracketed chars
- * plus the optional trailing space.
+ * Bracketed-shape length (18) plus the optional trailing space (1).
  */
-const TIMESTAMP_PREFIX_MAX_LEN = 19
+const TIMESTAMP_BODY_LEN = 19
 
 /**
- * Position-by-position template used to short-circuit buffering when the
- * leading bytes already disprove the shape, so non-timestamped replies don't
- * pay 19 chars of buffering latency before the first chunk reaches TTS.
- *
- * `#` slots are digits; every other character is a literal.
+ * Position-by-position template used to short-circuit when the bytes
+ * following a candidate boundary already disprove the shape. `#` slots are
+ * digits; every other character is a literal.
  */
-const TIMESTAMP_PREFIX_TEMPLATE = '[####-##-## ##:##]'
+const TIMESTAMP_BODY_TEMPLATE = '[####-##-## ##:##]'
 
-function couldStillMatchPrefix(buf: string): boolean {
-  const limit = Math.min(buf.length, TIMESTAMP_PREFIX_TEMPLATE.length)
+function bodyCouldMatchAt(buf: string, start: number): boolean {
+  const limit = Math.min(buf.length - start, TIMESTAMP_BODY_TEMPLATE.length)
   for (let i = 0; i < limit; i++) {
-    const slot = TIMESTAMP_PREFIX_TEMPLATE[i]
-    const ch = buf[i]
+    const slot = TIMESTAMP_BODY_TEMPLATE[i]
+    const ch = buf[start + i]
     const ok = slot === '#' ? (ch >= '0' && ch <= '9') : ch === slot
     if (!ok)
       return false
@@ -95,14 +95,17 @@ function couldStillMatchPrefix(buf: string): boolean {
 }
 
 /**
- * Removes a leading `[YYYY-MM-DD HH:MM] ` prefix if present. No-op otherwise.
+ * Removes echoed `[YYYY-MM-DD HH:MM] ` prefixes that appear at the start of
+ * the input or immediately after a newline. No-op otherwise.
  *
  * Use when:
  * - You have a complete string (e.g. the final assembled assistant message)
  *   and want to drop a timestamp the model echoed from the per-turn injection.
  */
 export function stripLeadingTimestampPrefix(text: string): string {
-  return text.replace(TIMESTAMP_PREFIX_RE, '')
+  // Preserve the captured boundary (start-of-string or `\n`) and drop the
+  // bracketed body plus the optional space.
+  return text.replace(TIMESTAMP_PREFIX_RE, '$1')
 }
 
 /**
@@ -114,44 +117,87 @@ export function stripLeadingTimestampPrefix(text: string): string {
  *   at the stream boundary so both surfaces are covered by a single chokepoint.
  *
  * Expects:
- * - Chunks delivered in order. The prefix may split across chunks at any byte.
- * - Stripping is leading-only: a timestamp that appears mid-stream passes through.
+ * - Chunks delivered in order. A prefix may split across chunks at any byte,
+ *   either at the start of the stream or after a `\n` mid-stream.
  *
  * Returns:
- * - `consume(chunk)` yields the chunk minus any leading prefix bytes still
- *   being absorbed; may return `''` while buffering. Once the decision is made
- *   (matched and dropped, or shape ruled out), every further chunk passes
- *   through untouched.
- * - `end()` flushes any partial-prefix bytes still buffered when the stream
- *   ends shorter than the prefix length.
+ * - `consume(chunk)` yields the chunk with any line-leading prefixes removed.
+ *   May hold back a tail when the chunk ends inside a candidate prefix; the
+ *   held bytes are emitted (as text or stripped) on the next chunk or `end()`.
+ * - `end()` flushes any held bytes left when the stream ended mid-candidate.
  */
 export function createTimestampPrefixStripper() {
-  // While `buffer` is a string we are still deciding. `null` means the
-  // decision is made and the stripper is now a passthrough.
-  let buffer: string | null = ''
+  // Bytes held back from the previous chunk because they sit inside a
+  // candidate prefix whose fate we cannot decide yet (e.g. trailing `\n[202`).
+  let pending = ''
+  // Last character the model has emitted so far. Used to decide whether the
+  // first byte of a new chunk sits at a line boundary (start of stream or
+  // immediately after `\n`). `null` means the stream has not started yet.
+  let lastModelChar: string | null = null
 
-  function flush(): string {
-    const out = stripLeadingTimestampPrefix(buffer!)
-    buffer = null
+  // Anchored body matcher (no `g` flag, no `^`-or-`\n` group): we only call
+  // it once we've already confirmed we're at a line boundary.
+  const BODY_RE = /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] ?/
+
+  function process(input: string, isFinal: boolean): string {
+    let out = ''
+    let i = 0
+
+    while (i < input.length) {
+      const prev = i > 0 ? input[i - 1] : lastModelChar
+      const atBoundary = prev === null || prev === '\n'
+
+      if (!atBoundary) {
+        out += input[i++]
+        continue
+      }
+
+      const remaining = input.length - i
+      if (remaining >= TIMESTAMP_BODY_LEN || isFinal) {
+        const match = input.slice(i, i + TIMESTAMP_BODY_LEN).match(BODY_RE)
+        if (match)
+          i += match[0].length
+        else
+          out += input[i++]
+        continue
+      }
+
+      // Not enough bytes to decide. Hold the tail iff it's still on track
+      // to become a prefix; otherwise pass it through.
+      if (bodyCouldMatchAt(input, i)) {
+        pending = input.slice(i)
+        return out
+      }
+      out += input[i++]
+    }
+
     return out
   }
 
   return {
     consume(chunk: string): string {
-      if (buffer === null)
-        return chunk
+      if (chunk === '')
+        return ''
 
-      buffer += chunk
+      const merged = pending + chunk
+      pending = ''
+      const out = process(merged, false)
 
-      // Enough bytes to apply the regex unambiguously, or the leading bytes
-      // already disprove the shape: decide now.
-      if (buffer.length >= TIMESTAMP_PREFIX_MAX_LEN || !couldStillMatchPrefix(buffer))
-        return flush()
+      // Track the last character the model has produced so far, regardless
+      // of whether we stripped anything: boundary detection on the next
+      // chunk depends on the model's own line structure, not ours.
+      const consumedEnd = merged.length - pending.length
+      if (consumedEnd > 0)
+        lastModelChar = merged[consumedEnd - 1]
 
-      return ''
+      return out
     },
     end(): string {
-      return buffer === null ? '' : flush()
+      if (pending === '')
+        return ''
+      const out = process(pending, true)
+      pending = ''
+      return out
     },
   }
 }


### PR DESCRIPTION
## Summary

Weak local models echo back the `[YYYY-MM-DD HH:MM] ` prefix that we inject onto every user/assistant turn for KV-cache stability (`packages/stage-ui/src/stores/chat/datetime-prefix.ts`). The echoed prefix was leaking into both the chat transcript and the TTS audio. Two flavors observed:

1. Leading echo at the start of the reply: `[2026-05-01 20:08] ooh nice...`
2. Mid-stream echo after the model emits its own newline: `Cool, cool. What kind of edge cases?\n[2026-05-01 20:25] Like, is it the timing?...`

This patch adds a streaming-aware stripper at the single chokepoint feeding both surfaces (`onLiteral` in `chat.ts`), plus a one-shot helper used in `onEnd` so the persisted text does not re-send `[ts] [ts] ...` on subsequent turns and reinforce the pattern.

- New `stripLeadingTimestampPrefix(text)` and `createTimestampPrefixStripper()` in `packages/stage-ui/src/stores/chat/datetime-prefix.ts`. Stripping is line-anchored (start-of-stream or after `\n`), not just leading.
- The streaming version tracks the last character the model emitted across `consume()` calls so boundary detection stays correct after the stripper rewrites the output.
- Wired into `chat.ts` so neither chat UI (`buildingMessage.content`, `slices`) nor TTS (`hooks.emitTokenLiteralHooks`) ever sees the prefix.

## Test plan

- [x] 14 unit tests in `datetime-prefix.test.ts` covering: single-chunk strip, prefix split across many small chunks, trailing-space arriving in next chunk, no-prefix passthrough, `[note]` false positive, mid-line timestamp passthrough, prefix without trailing space, partial prefix at stream end, almost-prefix with non-digit, mid-stream `\n[ts]` echo, newline-then-bracket split across chunks, multiple newline-anchored prefixes, `\n[note]` not stripped.
- [x] `pnpm exec vitest run packages/stage-ui/src/stores/chat` (34/34 pass).
- [x] `pnpm -F @proj-airi/stage-ui typecheck` clean.
- [x] `pnpm lint` shows no new findings on the changed files.
- [ ] Manual: send a few turns with a weak local model and confirm the timestamp no longer appears in the rendered transcript or in TTS audio.