### PR TITLE
feat(stage-ui,core-agent): show reasoning-delta events for thinking models

### DIFF
--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -3,6 +3,7 @@ import type { CommonContentPart, CompletionToolCall, CompletionToolResult, Messa
 
 export type StreamEvent
   = | { type: 'text-delta', text: string }
+    | { type: 'reasoning-delta', text: string }
     | ({ type: 'finish' } & any)
     | ({ type: 'tool-call' } & CompletionToolCall)
     | (CompletionToolResult & { type: 'tool-error' })

--- a/packages/i18n/src/locales/es/server/auth.yaml
+++ b/packages/i18n/src/locales/es/server/auth.yaml
@@ -66,7 +66,7 @@ signIn:
   footer:
     prefix: Al continuar, aceptas nuestros
     terms: Términos
-    and: "y"
+    and: 'y'
     privacy: Política de Privacidad
 verifyEmail:
   title:

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -827,7 +827,7 @@ pages:
         description: >-
           Провайдеры транскрипции (speech-to-text): Whisper.cpp, OpenAI, Azure Speech
       artistry:
-        title: Artistry 
+        title: Artistry
         description: Поставщики моделей генерации и создания изображений, например ComfyUI, Replicate.
         items:
           comfyui:

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -482,6 +482,9 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
                 await parser.consume(event.text)
                 break
               case 'reasoning-delta': {
+                if (shouldAbort())
+                  return
+
                 const { reasoning = '' } = buildingMessage.categorization ?? {}
                 const nextReasoning = reasoning + event.text
                 buildingMessage.categorization = {

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -28,6 +28,11 @@ import { useAiriCardStore } from './modules/airi-card'
 import { useAutonomousArtistryStore } from './modules/artistry-autonomous'
 import { useConsciousnessStore } from './modules/consciousness'
 
+// updateUI structuredClones the whole message, which can stall the main thread
+// when streams emit token-per-event. Shared by the parser's literal threshold and
+// the reasoning-delta throttle so both refresh at the same cadence.
+const STREAMING_UI_FLUSH_CHUNK_SIZE = 24
+
 // Prepends a literal text fragment to a message's content. Handles both the
 // shorthand string form and the array-of-parts form. When the first part is
 // already text, it merges into that part to keep the part count stable for
@@ -310,7 +315,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
           }
           updateUI()
         },
-        minLiteralEmitLength: 24,
+        minLiteralEmitLength: STREAMING_UI_FLUSH_CHUNK_SIZE,
       })
 
       const toolCallQueue = createQueue<ChatSlices>({
@@ -477,12 +482,19 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
                 await parser.consume(event.text)
                 break
               case 'reasoning-delta': {
-                const { speech = '', reasoning = '' } = buildingMessage.categorization ?? {}
+                const { reasoning = '' } = buildingMessage.categorization ?? {}
+                const nextReasoning = reasoning + event.text
                 buildingMessage.categorization = {
-                  speech,
-                  reasoning: reasoning + event.text,
+                  // Mirror in-flight text content so categorization stays shape-consistent with onEnd.
+                  speech: typeof buildingMessage.content === 'string' ? buildingMessage.content : '',
+                  reasoning: nextReasoning,
                 }
-                updateUI()
+                // Match text-delta's batching cadence; first chunk fires so the panel appears immediately.
+                const crossesBoundary
+                  = Math.floor(nextReasoning.length / STREAMING_UI_FLUSH_CHUNK_SIZE)
+                    > Math.floor(reasoning.length / STREAMING_UI_FLUSH_CHUNK_SIZE)
+                if (!reasoning || crossesBoundary)
+                  updateUI()
                 break
               }
               case 'finish':

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -303,9 +303,10 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
 
           const finalCategorization = categorizeResponse(fullText, activeProvider.value)
 
+          const reasoningContentField = buildingMessage.categorization?.reasoning?.trim()
           buildingMessage.categorization = {
             speech: finalCategorization.speech,
-            reasoning: finalCategorization.reasoning,
+            reasoning: reasoningContentField || finalCategorization.reasoning,
           }
           updateUI()
         },
@@ -475,6 +476,15 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
                 fullText += event.text
                 await parser.consume(event.text)
                 break
+              case 'reasoning-delta': {
+                const { speech = '', reasoning = '' } = buildingMessage.categorization ?? {}
+                buildingMessage.categorization = {
+                  speech,
+                  reasoning: reasoning + event.text,
+                }
+                updateUI()
+                break
+              }
               case 'finish':
                 break
               case 'error':


### PR DESCRIPTION
## Description

Thinking models that emit reasoning via the `reasoning_content` field (instead of the inline `<think>...</think>` format) currently show nothing in the chat. The events come through xsai but our `StreamEvent` union doesn't include the variant, so the orchestrator silently drops them.

## Changes

- `packages/core-agent/src/types/llm.ts`: add `reasoning-delta` to the `StreamEvent` union
- `packages/stage-ui/src/stores/chat.ts`: handle the event in the streaming switch and accumulate chunks into `categorization.reasoning` so it shows up live as the model thinks

Inline `<think>...</think>` reasoning still works through the existing rehype fallback.

## Tested

Locally against llama-server running:
- `Qwen3.6-27B-Q4_K_M`
- `gemma-4-26B-A4B-it-Q4_K_M`