### PR TITLE
fix(stage-ui-live2d): prevent motions from overriding lip sync mouth values

### DIFF
--- a/packages/i18n/src/locales/es/server/auth.yaml
+++ b/packages/i18n/src/locales/es/server/auth.yaml
@@ -66,7 +66,7 @@ signIn:
   footer:
     prefix: Al continuar, aceptas nuestros
     terms: Términos
-    and: "y"
+    and: 'y'
     privacy: Política de Privacidad
 verifyEmail:
   title:

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -685,7 +685,7 @@ pages:
         empty: Здесь пока ничего нет. Добавьте одно ниже!
       add:
         title: Новый
-        description: "Заполните новый сервер, затем нажмите кнопку «Сохранить и перезапустить» — он будет перемещен в «Конфигурация» выше."
+        description: 'Заполните новый сервер, затем нажмите кнопку «Сохранить и перезапустить» — он будет перемещен в «Конфигурация» выше.'
         pending-badge: Не сохранено
       status:
         unknown: Не загружен
@@ -902,7 +902,7 @@ pages:
         description: >-
           Провайдеры транскрипции (speech-to-text): Whisper.cpp, OpenAI, Azure Speech
       artistry:
-        title: Artistry 
+        title: Artistry
         description: Поставщики моделей генерации и создания изображений, например ComfyUI, Replicate.
         items:
           comfyui:

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -685,7 +685,7 @@ pages:
         empty: 这里什么都还没有哦，在下面添加一个！
       add:
         title: 新建
-        description: "填写新的服务器配置，然后点击「保存并重启」，完成后将会更新至上方的「已配置」"
+        description: '填写新的服务器配置，然后点击「保存并重启」，完成后将会更新至上方的「已配置」'
         pending-badge: 未保存
       status:
         unknown: 未加载

--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -15,6 +15,7 @@ withDefaults(defineProps<{
 
   paused?: boolean
   mouthOpenSize?: number
+  nowSpeaking?: boolean
   focusAt?: { x: number, y: number }
   disableFocusAt?: boolean
   themeColorsHue?: number
@@ -30,6 +31,7 @@ withDefaults(defineProps<{
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
   mouthOpenSize: 0,
+  nowSpeaking: false,
   themeColorsHue: 220.44,
   themeColorsHueDynamic: false,
   live2dIdleAnimationEnabled: true,
@@ -84,6 +86,7 @@ defineExpose({
         :model-id="modelId"
         :app="app"
         :mouth-open-size="mouthOpenSize"
+        :now-speaking="nowSpeaking"
         :width="width"
         :height="height"
         :paused="paused"

--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
@@ -24,6 +24,7 @@ import {
   useMotionUpdatePluginExpression,
   useMotionUpdatePluginIdleDisable,
   useMotionUpdatePluginIdleFocus,
+  useMotionUpdatePluginLipSync,
 } from '../../../composables/live2d'
 import { Emotion, EmotionNeutralMotionName } from '../../../constants/emotions'
 import { useL2dViewControl, useLive2d } from '../../../stores/live2d'
@@ -34,6 +35,7 @@ const props = withDefaults(defineProps<{
 
   app?: Application
   mouthOpenSize?: number
+  nowSpeaking?: boolean
   width: number
   height: number
   paused?: boolean
@@ -48,6 +50,7 @@ const props = withDefaults(defineProps<{
   live2dShadowEnabled?: boolean
 }>(), {
   mouthOpenSize: 0,
+  nowSpeaking: false,
   paused: false,
   focusAt: () => ({ x: 0, y: 0 }),
   disableFocusAt: false,
@@ -96,6 +99,7 @@ const model = ref<Live2DModel<PixiLive2DInternalModel>>()
 const initialModelWidth = ref<number>(0)
 const initialModelHeight = ref<number>(0)
 const mouthOpenSize = computed(() => Math.max(0, Math.min(100, props.mouthOpenSize)))
+const nowSpeaking = toRef(() => props.nowSpeaking)
 const lastUpdateTime = ref(0)
 
 const { isDark: dark } = useTheme()
@@ -107,10 +111,6 @@ const dropShadowFilter = shallowRef(new DropShadowFilter({
   distance: 20,
   rotation: 45,
 }))
-
-function getCoreModel() {
-  return model.value!.internalModel.coreModel as any
-}
 
 let resizeAnimation: ReturnType<typeof animate> | undefined
 
@@ -369,6 +369,7 @@ async function loadModel() {
     // This ensures blink respects expression state (0 × blinkFactor = 0).
     motionManagerUpdate.register(useMotionUpdatePluginExpression(expressionController), 'final')
     motionManagerUpdate.register(useMotionUpdatePluginAutoEyeBlink(live2dExpressionEnabled), 'final')
+    motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize, nowSpeaking), 'final')
 
     const hookedUpdate = motionManager.update as (model: PixiLive2DInternalModel['coreModel'], now: number) => boolean
     motionManager.update = function (model: PixiLive2DInternalModel['coreModel'], now: number) {
@@ -563,7 +564,6 @@ watch([themeColorsHueDynamic, live2dShadowEnabled], ([dynamic, shadowEnabled]) =
   }
 }, { immediate: true })
 
-watch(mouthOpenSize, value => getCoreModel().setParameterValueById('ParamMouthOpenY', value))
 watch(currentMotion, value => setMotion(value.group, value.index))
 watch(paused, value => value ? pixiApp.value?.stop() : pixiApp.value?.start())
 

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -129,6 +129,14 @@ export function useLive2DMotionManagerUpdate(options: UseLive2DMotionManagerUpda
 
 // -- Plugins ---------------------------------------------------------------
 
+// pixi-live2d-display passes timeDelta in ms during normal frames but can pass
+// seconds at frame boundaries; threshold of 5 separates the two ranges safely
+// (5 ms == ~200 fps lower bound, 5 s == 5000 ms upper bound).
+function normalizeTimeDeltaMs(timeDelta: number | undefined): number {
+  const raw = Math.max(timeDelta ?? 0, 0)
+  return raw < 5 ? raw * 1000 : raw
+}
+
 export function useMotionUpdatePluginBeatSync(beatSync: BeatSyncController): MotionManagerPlugin {
   return (ctx) => {
     beatSync.updateTargets(ctx.now)
@@ -330,9 +338,7 @@ export function useMotionUpdatePluginAutoEyeBlink(
 
       // Force ON or eyeBlink null: timer blink + markHandled.
       if (ctx.live2dForceAutoBlinkEnabled.value || !ctx.internalModel.eyeBlink) {
-        const rawDelta = Math.max(ctx.timeDelta ?? 0, 0)
-        const dt = rawDelta < 5 ? rawDelta * 1000 : rawDelta
-        const safeDt = dt || 16
+        const safeDt = normalizeTimeDeltaMs(ctx.timeDelta) || 16
         const { eyeLOpen, eyeROpen } = updateForcedBlink(safeDt, baseLeft, baseRight)
         ctx.model.setParameterValueById('ParamEyeLOpen', eyeLOpen)
         ctx.model.setParameterValueById('ParamEyeROpen', eyeROpen)
@@ -399,9 +405,7 @@ export function useMotionUpdatePluginAutoEyeBlink(
 
     // Advance blink timer.
     const wasActive = blinkState.phase !== 'idle'
-    const rawDelta = Math.max(ctx.timeDelta ?? 0, 0)
-    const dt = rawDelta < 5 ? rawDelta * 1000 : rawDelta
-    const safeDt = dt || 16
+    const safeDt = normalizeTimeDeltaMs(ctx.timeDelta) || 16
     const { eyeLOpen: blinkFactorL, eyeROpen: blinkFactorR } = updateForcedBlink(safeDt, 1.0, 1.0)
 
     // Blink cycle complete: restore exact pre-blink values.
@@ -455,6 +459,7 @@ export function useMotionUpdatePluginLipSync(
   let releaseRemainingMs = 0
   let lastForcedValue = 0
 
+  // Smoothstep: 3t^2 - 2t^3, eases in/out with zero slope at endpoints.
   const smoothstep = (t: number) => t * t * (3 - 2 * t)
 
   return (ctx) => {
@@ -468,11 +473,7 @@ export function useMotionUpdatePluginLipSync(
     if (releaseRemainingMs <= 0)
       return
 
-    // timeDelta is usually ms but can arrive in seconds; mirror useMotionUpdatePluginAutoEyeBlink.
-    const rawDelta = Math.max(ctx.timeDelta ?? 0, 0)
-    const dtMs = rawDelta < 5 ? rawDelta * 1000 : rawDelta
-
-    releaseRemainingMs = Math.max(0, releaseRemainingMs - dtMs)
+    releaseRemainingMs = Math.max(0, releaseRemainingMs - normalizeTimeDeltaMs(ctx.timeDelta))
     const blend = smoothstep(1 - releaseRemainingMs / RELEASE_DURATION_MS)
 
     // ParamMouthOpenY was already written by motion + expression plugins this frame.

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -129,9 +129,10 @@ export function useLive2DMotionManagerUpdate(options: UseLive2DMotionManagerUpda
 
 // -- Plugins ---------------------------------------------------------------
 
-// pixi-live2d-display passes timeDelta in ms during normal frames but can pass
-// seconds at frame boundaries; threshold of 5 separates the two ranges safely
-// (5 ms == ~200 fps lower bound, 5 s == 5000 ms upper bound).
+// pixi-live2d-display passes timeDelta in seconds (e.g. 0.016 at 60 fps) on most
+// paths, but some callers in this codebase pass it already in ms. The < 5 threshold
+// distinguishes them: a 5 ms frame would imply ~200 fps which never happens, so
+// any value below 5 must be seconds and gets multiplied to ms.
 function normalizeTimeDeltaMs(timeDelta: number | undefined): number {
   const raw = Math.max(timeDelta ?? 0, 0)
   return raw < 5 ? raw * 1000 : raw

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -437,3 +437,48 @@ export function useMotionUpdatePluginExpression(
     controller.applyExpressions(ctx.model)
   }
 }
+
+/**
+ * Final-phase plugin that owns ParamMouthOpenY while speech is active and
+ * smoothly cross-fades back to the motion-driven value when speech ends.
+ *
+ * `nowSpeaking` (not `mouthOpenSize > 0`) is the speech boundary, so silent
+ * gaps between phonemes write 0 directly instead of triggering the release.
+ */
+export function useMotionUpdatePluginLipSync(
+  mouthOpenSize: Ref<number>,
+  nowSpeaking: Ref<boolean>,
+): MotionManagerPlugin {
+  // 200 ms covers a typical phoneme tail without lagging behind the next utterance.
+  const RELEASE_DURATION_MS = 200
+
+  let releaseRemainingMs = 0
+  let lastForcedValue = 0
+
+  const smoothstep = (t: number) => t * t * (3 - 2 * t)
+
+  return (ctx) => {
+    if (nowSpeaking.value) {
+      lastForcedValue = mouthOpenSize.value
+      releaseRemainingMs = RELEASE_DURATION_MS
+      ctx.model.setParameterValueById('ParamMouthOpenY', mouthOpenSize.value)
+      return
+    }
+
+    if (releaseRemainingMs <= 0)
+      return
+
+    // timeDelta is usually ms but can arrive in seconds; mirror useMotionUpdatePluginAutoEyeBlink.
+    const rawDelta = Math.max(ctx.timeDelta ?? 0, 0)
+    const dtMs = rawDelta < 5 ? rawDelta * 1000 : rawDelta
+
+    releaseRemainingMs = Math.max(0, releaseRemainingMs - dtMs)
+    const blend = smoothstep(1 - releaseRemainingMs / RELEASE_DURATION_MS)
+
+    // ParamMouthOpenY was already written by motion + expression plugins this frame.
+    const motionValue = ctx.model.getParameterValueById('ParamMouthOpenY') as number
+    const blended = lastForcedValue * (1 - blend) + motionValue * blend
+
+    ctx.model.setParameterValueById('ParamMouthOpenY', blended)
+  }
+}

--- a/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/motion-manager.ts
@@ -16,7 +16,9 @@ export type PixiLive2DInternalModel = InternalModel & {
 
 export interface MotionManagerUpdateContext {
   model: CubismModel
+  // in seconds
   now: number
+  // in seconds
   timeDelta: number
   hookedUpdate?: (model: CubismModel, now: number) => boolean
 }
@@ -128,15 +130,6 @@ export function useLive2DMotionManagerUpdate(options: UseLive2DMotionManagerUpda
 }
 
 // -- Plugins ---------------------------------------------------------------
-
-// pixi-live2d-display passes timeDelta in seconds (e.g. 0.016 at 60 fps) on most
-// paths, but some callers in this codebase pass it already in ms. The < 5 threshold
-// distinguishes them: a 5 ms frame would imply ~200 fps which never happens, so
-// any value below 5 must be seconds and gets multiplied to ms.
-function normalizeTimeDeltaMs(timeDelta: number | undefined): number {
-  const raw = Math.max(timeDelta ?? 0, 0)
-  return raw < 5 ? raw * 1000 : raw
-}
 
 export function useMotionUpdatePluginBeatSync(beatSync: BeatSyncController): MotionManagerPlugin {
   return (ctx) => {
@@ -339,7 +332,7 @@ export function useMotionUpdatePluginAutoEyeBlink(
 
       // Force ON or eyeBlink null: timer blink + markHandled.
       if (ctx.live2dForceAutoBlinkEnabled.value || !ctx.internalModel.eyeBlink) {
-        const safeDt = normalizeTimeDeltaMs(ctx.timeDelta) || 16
+        const safeDt = ctx.timeDelta * 1000 || 16
         const { eyeLOpen, eyeROpen } = updateForcedBlink(safeDt, baseLeft, baseRight)
         ctx.model.setParameterValueById('ParamEyeLOpen', eyeLOpen)
         ctx.model.setParameterValueById('ParamEyeROpen', eyeROpen)
@@ -406,7 +399,7 @@ export function useMotionUpdatePluginAutoEyeBlink(
 
     // Advance blink timer.
     const wasActive = blinkState.phase !== 'idle'
-    const safeDt = normalizeTimeDeltaMs(ctx.timeDelta) || 16
+    const safeDt = ctx.timeDelta * 1000 || 16
     const { eyeLOpen: blinkFactorL, eyeROpen: blinkFactorR } = updateForcedBlink(safeDt, 1.0, 1.0)
 
     // Blink cycle complete: restore exact pre-blink values.
@@ -474,7 +467,7 @@ export function useMotionUpdatePluginLipSync(
     if (releaseRemainingMs <= 0)
       return
 
-    releaseRemainingMs = Math.max(0, releaseRemainingMs - normalizeTimeDeltaMs(ctx.timeDelta))
+    releaseRemainingMs = Math.max(0, releaseRemainingMs - ctx.timeDelta * 1000)
     const blend = smoothstep(1 - releaseRemainingMs / RELEASE_DURATION_MS)
 
     // ParamMouthOpenY was already written by motion + expression plugins this frame.

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -69,7 +69,7 @@ const {
   live2dMaxFps,
   live2dRenderScale,
 } = storeToRefs(settingsStore)
-const { mouthOpenSize } = storeToRefs(useSpeakingStore())
+const { mouthOpenSize, nowSpeaking } = storeToRefs(useSpeakingStore())
 const { audioContext } = useAudioContext()
 const currentAudioSource = ref<AudioBufferSourceNode>()
 
@@ -106,7 +106,6 @@ viewUpdateCleanups.push(live2dStore.onShouldUpdateView(async () => {
 }))
 
 const audioAnalyser = ref<AnalyserNode>()
-const nowSpeaking = ref(false)
 const lipSyncStarted = ref(false)
 const lipSyncLoopId = ref<number>()
 const live2dLipSync = ref<Live2DLipSync>()
@@ -648,6 +647,7 @@ defineExpose({
         :model-id="stageModelSelected"
         :focus-at="focusAt"
         :mouth-open-size="mouthOpenSize"
+        :now-speaking="nowSpeaking"
         :paused="paused"
         :disable-focus-at="live2dDisableFocus"
         :theme-colors-hue="themeColorsHue"


### PR DESCRIPTION
## Context

Speech audio drives `mouthOpenSize` via the wlipsync analyser, but the previous wiring used a Vue `watch` inside `packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue` to push the value into `ParamMouthOpenY` from outside the Pixi render loop. The motion update hook ran in the Pixi tick and overwrote the watch most frames, so the mouth barely opened or stayed completely open during speech.

## Changes

Lip sync now runs as a motion-update plugin in the `final` stage instead of a Vue `watch` outside the Pixi render loop, with a 200 ms smoothstep release fade so the mouth eases back to motion's value when speech ends. Also stops shadowing `useSpeakingStore.nowSpeaking` with a local ref in `Stage.vue` (side effect: `nowSpeakingAvatarBorderOpacity` now toggles during TTS). Small `normalizeTimeDeltaMs` helper extracted along the way.

## Tested

- `pnpm -F @proj-airi/stage-ui typecheck` clean
- `pnpm -F @proj-airi/stage-ui-live2d typecheck` clean
- `pnpm exec eslint` on the four changed files clean
- Local TTS playback, ElevenLabs tts playback.

## Note

This adds a smoothing at the end so that the mouth can go back to its current idle animation coordinate without skipping to it right away.\
I did not implement a smoothing transition at the beginning of the animation because I was worried that it would add an un-natural delay, but it does mean that the transition from "idle animation mouth" to "speaking mouth" can show a slight jitter. \
I'm open to opinions on the subject.