### PR TITLE
:bug: fix(ui): add openOnClick prop to Combobox for reliable dropdown…

### DIFF
--- a/packages/ui/src/components/form/combobox/combobox.vue
+++ b/packages/ui/src/components/form/combobox/combobox.vue
@@ -35,10 +35,12 @@ const props = withDefaults(defineProps<{
   options: ComboboxOptionItem<T>[] | ComboboxOptionGroupItem<T>[]
   placeholder?: string
   disabled?: boolean
+  openOnClick?: boolean
   contentMinWidth?: string | number
   contentWidth?: string | number
 }>(), {
   disabled: false,
+  openOnClick: true,
 })
 
 const modelValue = defineModel<T>({ required: false })
@@ -83,6 +85,7 @@ function toCssSize(value?: string | number): string | undefined {
   <ComboboxRoot
     v-model="modelValue"
     :disabled="props.disabled"
+    :open-on-click="props.openOnClick"
     :class="['relative', 'w-full', 'h-fit']"
   >
     <ComboboxAnchor


### PR DESCRIPTION
… opening

reka-ui's ComboboxRoot defaults openOnClick to false, which prevents the dropdown from opening when the input area is clicked. Set it to true by default so the dropdown opens reliably on click.

## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
