### PR TITLE
fix(stage): keep controls island open after expand

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -40,7 +40,10 @@ const closeWindow = useElectronEventaInvoke(electronAppQuit)
 const setAlwaysOnTop = useElectronEventaInvoke(electronWindowSetAlwaysOnTop)
 
 const expanded = ref(false)
+const expandedAt = ref(0)
 const islandRef = ref<HTMLElement>()
+
+const EXPAND_AUTO_COLLAPSE_GRACE_MS = 1500
 
 // Tracks open overlays/dialogs that should prevent auto-collapse (e.g. 'hearing', 'profile-picker')
 const blockingOverlays = reactive(new Set<string>())
@@ -48,6 +51,10 @@ const isBlocked = computed(() => blockingOverlays.size > 0)
 
 function setOverlay(key: string, active: boolean) {
   active ? blockingOverlays.add(key) : blockingOverlays.delete(key)
+}
+
+function isWithinExpandGracePeriod() {
+  return expandedAt.value > 0 && Date.now() - expandedAt.value < EXPAND_AUTO_COLLAPSE_GRACE_MS
 }
 
 // Expose for parent (e.g. to disable click-through when a dialog is open)
@@ -60,19 +67,23 @@ const { isOutside } = useElectronMouseInElement(islandRef)
 const isOutsideAfter2seconds = refDebounced(isOutside, 1500)
 
 watch(isOutsideAfter2seconds, (outside) => {
-  if (outside && expanded.value && !isBlocked.value) {
+  if (outside && expanded.value && !isBlocked.value && !isWithinExpandGracePeriod()) {
     expanded.value = false
   }
 })
 
 watch(expanded, (isExpanded) => {
-  if (!isExpanded) {
+  if (isExpanded) {
+    expandedAt.value = Date.now()
+  }
+  else {
+    expandedAt.value = 0
     blockingOverlays.clear()
   }
 })
 
 useIntervalFn(() => {
-  if (expanded.value && isOutside.value && !isBlocked.value) {
+  if (expanded.value && isOutside.value && !isBlocked.value && !isWithinExpandGracePeriod()) {
     expanded.value = false
   }
 }, 1500)

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -57,6 +57,10 @@ function isWithinExpandGracePeriod() {
   return expandedAt.value > 0 && Date.now() - expandedAt.value < EXPAND_AUTO_COLLAPSE_GRACE_MS
 }
 
+function canAutoCollapse() {
+  return expanded.value && !isBlocked.value && !isWithinExpandGracePeriod()
+}
+
 // Expose for parent (e.g. to disable click-through when a dialog is open)
 defineExpose({
   get hearingDialogOpen() { return blockingOverlays.has('hearing') },
@@ -67,7 +71,7 @@ const { isOutside } = useElectronMouseInElement(islandRef)
 const isOutsideAfter2seconds = refDebounced(isOutside, 1500)
 
 watch(isOutsideAfter2seconds, (outside) => {
-  if (outside && expanded.value && !isBlocked.value && !isWithinExpandGracePeriod()) {
+  if (outside && canAutoCollapse()) {
     expanded.value = false
   }
 })
@@ -83,7 +87,7 @@ watch(expanded, (isExpanded) => {
 })
 
 useIntervalFn(() => {
-  if (expanded.value && isOutside.value && !isBlocked.value && !isWithinExpandGracePeriod()) {
+  if (isOutside.value && canAutoCollapse()) {
     expanded.value = false
   }
 }, 1500)


### PR DESCRIPTION
## Summary

- add a short auto-collapse grace window after the controls island is expanded
- prevent stale outside-mouse state from immediately collapsing the toolbar right after clicking Expand
- keep explicit click-to-collapse behavior and the existing outside/interval auto-collapse path after the grace window

Fixes #1667.

## Tests

- `git diff --check origin/main...HEAD`
- `bash /Users/ming/.openclaw/skills/code-change-delivery-contract/scripts/scan_delivery_blockers.sh /Users/ming/code/moeru-ai/airi-pr1667`

Not run: `pnpm exec moeru-lint apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue` because Corepack failed while downloading pnpm 10.33.0 through the configured proxy (`UND_ERR_SOCKET: other side closed`).
