### PR TITLE
fix(computer-use-mcp): terminate one-shot PTY commands

### DIFF
--- a/services/computer-use-mcp/src/workflows/engine.test.ts
+++ b/services/computer-use-mcp/src/workflows/engine.test.ts
@@ -819,6 +819,47 @@ describe('workflow engine', () => {
     expect(displayInfo?.displays).toHaveLength(2)
   })
 
+  it('terminates one-shot PTY commands before sending input', async () => {
+    const wf: WorkflowDefinition = {
+      id: 'test_pty_command_terminator',
+      name: 'PTY Command Terminator Test',
+      description: 'One-shot PTY commands should be submitted to the shell.',
+      maxRetries: 3,
+      steps: [
+        {
+          label: 'Run PTY command',
+          kind: 'run_command',
+          description: 'Run via PTY',
+          params: { command: 'echo hello' },
+          terminal: { mode: 'pty', interaction: 'one_shot' },
+        },
+      ],
+    }
+
+    const executeAction: ExecuteAction = vi.fn().mockResolvedValue(makeSuccessResult())
+    const executePrepTool = vi.fn().mockImplementation(async (toolName: string) => {
+      if (toolName.startsWith('pty_read_screen:')) {
+        return makePrepSuccessResult({ screenContent: 'hello' })
+      }
+      return makePrepSuccessResult({ status: 'ok' })
+    })
+    const acquirePty = vi.fn().mockResolvedValue({ acquired: true, ptySessionId: 'pty-1' })
+    const sm = new RunStateManager()
+
+    const result = await executeWorkflow({
+      workflow: wf,
+      executeAction,
+      executePrepTool,
+      acquirePty,
+      stateManager: sm,
+    })
+
+    expect(result.success).toBe(true)
+    expect(executeAction).not.toHaveBeenCalled()
+    expect(executePrepTool).toHaveBeenCalledWith('pty_send_input:pty-1:echo hello\r')
+    expect(executePrepTool).toHaveBeenCalledWith('pty_read_screen:pty-1')
+  })
+
   it('fails the workflow when a preparatory tool fails', async () => {
     const wf: WorkflowDefinition = {
       id: 'test_failed_prep',

--- a/services/computer-use-mcp/src/workflows/engine.ts
+++ b/services/computer-use-mcp/src/workflows/engine.ts
@@ -1086,6 +1086,10 @@ async function executePtyStepFamily(params: {
   }
 }
 
+function ensurePtyCommandTerminator(command: string): string {
+  return /[\r\n]$/.test(command) ? command : `${command}\r`
+}
+
 /**
  * Execute a one-shot command on a PTY session by sending the command,
  * waiting briefly, and reading the screen.
@@ -1109,8 +1113,10 @@ async function executePtyCommand(params: {
   }
 
   try {
-    // Send the command with a trailing carriage return
-    const sendResult = await executePrepTool(`pty_send_input:${ptySessionId}:${command}`)
+    // Send the command with a trailing carriage return so one-shot PTY
+    // commands are submitted instead of remaining buffered at the prompt.
+    const commandToSend = ensurePtyCommandTerminator(command)
+    const sendResult = await executePrepTool(`pty_send_input:${ptySessionId}:${commandToSend}`)
     if (sendResult.isError === true) {
       return {
         succeeded: false,


### PR DESCRIPTION
## Summary

- ensure one-shot PTY workflow commands end with a CR/LF before sending them through `pty_send_input`
- keep caller-provided command terminators unchanged
- add a workflow-engine regression test for the PTY `run_command` path

## Why

`executePtyCommand` drives `pty_send_input` directly for one-shot PTY steps. Without an explicit command terminator, the command can stay buffered at the shell prompt instead of being submitted.

## Tests

- `git diff --check`
- `bash /Users/ming/.openclaw/skills/code-change-delivery-contract/scripts/scan_delivery_blockers.sh /Users/ming/code/moeru-ai/airi-pty-terminator-duyua9/services/computer-use-mcp/src/workflows`

Not run locally: `pnpm -F @proj-airi/computer-use-mcp exec vitest run src/workflows/engine.test.ts` because this clean worktree had no installed `vitest`, and a scoped `pnpm install --frozen-lockfile --ignore-scripts --filter @proj-airi/computer-use-mcp...` was interrupted by repeated registry `ECONNRESET` errors through the configured proxy.
