### PR TITLE
feat(desktop): background scheduler for observe/click

### DIFF
--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -30,6 +30,7 @@
     "merge-latest-mac": "tsx scripts/merge-latest-mac.ts",
     "regenerate-windows-latest": "tsx scripts/regenerate-windows-latest.ts",
     "artifacts-metadata": "tsx scripts/artifacts-metadata.ts",
+    "smoke:desktop-overlay-live-window": "NODE_OPTIONS='--experimental-websocket' tsx scripts/desktop-overlay-live-window-smoke.ts",
     "update-test:generate": "tsx scripts/update-test/generate-manifest.ts",
     "update-test:server": "tsx scripts/update-test/start-server.ts",
     "update-test:matrix": "bash scripts/update-test/run-matrix.sh"

--- a/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.test.ts
+++ b/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.test.ts
@@ -24,7 +24,7 @@ function createMockSocket() {
   return socket
 }
 
-describe('CdpClient', () => {
+describe('cdpClient', () => {
   it('rejects pending requests when the socket closes', async () => {
     const socket = createMockSocket()
     const client = new CdpClient(socket as never)

--- a/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.test.ts
+++ b/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.test.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'node:events'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CdpClient } from './desktop-overlay-live-window-smoke'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function createMockSocket() {
+  const socket = new EventEmitter() as EventEmitter & {
+    send: ReturnType<typeof vi.fn>
+    close: ReturnType<typeof vi.fn>
+    addEventListener: (event: string, listener: (...args: any[]) => void) => void
+  }
+  socket.send = vi.fn()
+  socket.close = vi.fn(() => {
+    socket.emit('close')
+  })
+  socket.addEventListener = (event, listener) => {
+    socket.on(event, listener)
+  }
+  return socket
+}
+
+describe('CdpClient', () => {
+  it('rejects pending requests when the socket closes', async () => {
+    const socket = createMockSocket()
+    const client = new CdpClient(socket as never)
+
+    const pending = client.send('Runtime.evaluate', { expression: '1 + 1' })
+    expect(socket.send).toHaveBeenCalledTimes(1)
+
+    client.close()
+
+    await expect(pending).rejects.toThrow('CDP socket closed before completing request 1')
+    expect(socket.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
@@ -1,0 +1,538 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+import { spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+import { access, mkdir, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { dirname, resolve } from 'node:path'
+import { env, exit, kill as killProcess } from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { desktopOverlayPollHeartbeatMarker } from '../src/shared/desktop-overlay-heartbeat'
+import { selectDesktopOverlaySmokeCandidateId } from '../src/shared/desktop-overlay-live-window-smoke'
+
+interface DebugTarget {
+  id: string
+  title: string
+  type: string
+  url: string
+  webSocketDebuggerUrl?: string
+}
+
+interface McpResult {
+  content?: unknown[]
+  structuredContent?: Record<string, unknown>
+  isError?: boolean
+}
+
+interface McpApplyResult {
+  started: Array<{ name: string }>
+  failed: Array<{ name: string, error: string }>
+  skipped: Array<{ name: string, reason: string }>
+}
+
+interface McpToolDescriptor {
+  name: string
+  serverName: string
+  toolName: string
+}
+
+interface McpRuntimeStatus {
+  servers: Array<{
+    name: string
+    state: 'running' | 'stopped' | 'error'
+    lastError?: string
+  }>
+}
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const repoDir = resolve(packageDir, '../..')
+const runId = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-')
+const reportDir = resolve(repoDir, '.temp', `desktop-overlay-live-window-smoke-${runId}`)
+const userDataDir = resolve(reportDir, 'stage-user-data')
+const mcpSessionRoot = resolve(reportDir, 'computer-use-session')
+const stageLogPath = resolve(reportDir, 'stage-tamagotchi.log')
+const mcpConfigPath = resolve(userDataDir, 'mcp.json')
+const requiredWorkspaceBuildOutputs = [
+  'packages/electron-screen-capture/dist/main.mjs',
+  'packages/electron-vueuse/dist/main/index.mjs',
+  'packages/server-runtime/dist/server.mjs',
+]
+
+const smokeHtml = `<!doctype html>
+<html>
+  <head>
+    <title>AIRI Desktop Overlay Live Window Smoke</title>
+    <style>
+      body { font-family: sans-serif; padding: 48px; }
+      button { font-size: 18px; padding: 12px 18px; }
+    </style>
+  </head>
+  <body>
+    <h1>AIRI Desktop Overlay Live Window Smoke</h1>
+    <button id="airi-desktop-overlay-smoke-button">AIRI Desktop Overlay Smoke Button</button>
+  </body>
+</html>`
+
+const smokeUrl = `data:text/html;charset=utf-8,${encodeURIComponent(smokeHtml)}`
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition)
+    throw new Error(message)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function findAvailablePort(): Promise<number> {
+  return await new Promise((resolvePort, reject) => {
+    const server = createServer()
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      server.close(() => {
+        if (typeof address === 'object' && address?.port) {
+          resolvePort(address.port)
+        }
+        else {
+          reject(new Error('failed to allocate debug port'))
+        }
+      })
+    })
+    server.on('error', reject)
+  })
+}
+
+async function waitFor<T>(
+  label: string,
+  probe: () => Promise<T | undefined> | T | undefined,
+  timeoutMs: number,
+  intervalMs: number,
+): Promise<T> {
+  const start = Date.now()
+  let lastError: unknown
+
+  while ((Date.now() - start) < timeoutMs) {
+    try {
+      const value = await probe()
+      if (value !== undefined)
+        return value
+    }
+    catch (error) {
+      lastError = error
+    }
+    await sleep(intervalMs)
+  }
+
+  const suffix = lastError instanceof Error ? `: ${lastError.message}` : ''
+  throw new Error(`${label} timed out after ${timeoutMs}ms${suffix}`)
+}
+
+class CdpClient {
+  private socket: WebSocket
+  private nextId = 1
+  private pending = new Map<number, {
+    resolve: (value: Record<string, unknown>) => void
+    reject: (error: Error) => void
+  }>()
+
+  private constructor(socket: WebSocket) {
+    this.socket = socket
+    this.socket.addEventListener('message', (event) => {
+      const payload = JSON.parse(String(event.data)) as Record<string, unknown>
+      const id = typeof payload.id === 'number' ? payload.id : undefined
+      if (id === undefined)
+        return
+
+      const pending = this.pending.get(id)
+      if (!pending)
+        return
+
+      this.pending.delete(id)
+      if (payload.error) {
+        pending.reject(new Error(JSON.stringify(payload.error)))
+      }
+      else {
+        pending.resolve(payload)
+      }
+    })
+  }
+
+  static async connect(url: string): Promise<CdpClient> {
+    const socket = new WebSocket(url)
+    await new Promise<void>((resolveOpen, reject) => {
+      socket.addEventListener('open', () => resolveOpen(), { once: true })
+      socket.addEventListener('error', () => reject(new Error(`failed to connect CDP target: ${url}`)), { once: true })
+    })
+    return new CdpClient(socket)
+  }
+
+  async send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const id = this.nextId++
+    const promise = new Promise<Record<string, unknown>>((resolveMessage, reject) => {
+      this.pending.set(id, { resolve: resolveMessage, reject })
+    })
+
+    this.socket.send(JSON.stringify({ id, method, params: params ?? {} }))
+    return await promise
+  }
+
+  async evaluate<T>(expression: string): Promise<T> {
+    const response = await this.send('Runtime.evaluate', {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    })
+    const result = response.result
+    if (!isRecord(result))
+      throw new Error('Runtime.evaluate missing result')
+
+    const exceptionDetails = result.exceptionDetails
+    if (exceptionDetails) {
+      throw new Error(JSON.stringify(exceptionDetails))
+    }
+
+    const remoteObject = result.result
+    if (!isRecord(remoteObject))
+      throw new Error('Runtime.evaluate missing remote object')
+
+    return remoteObject.value as T
+  }
+
+  close() {
+    this.socket.close()
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok)
+    throw new Error(`${url} returned ${response.status}`)
+  return await response.json() as T
+}
+
+async function prepareMcpConfig() {
+  await mkdir(userDataDir, { recursive: true })
+  await mkdir(mcpSessionRoot, { recursive: true })
+
+  const mcpEnv: Record<string, string> = {
+    PATH: env.PATH || '',
+    HOME: env.HOME || '',
+    SHELL: env.SHELL || '',
+    LANG: env.LANG || 'en_US.UTF-8',
+    TMPDIR: env.TMPDIR || '',
+    COMPUTER_USE_EXECUTOR: env.COMPUTER_USE_SMOKE_EXECUTOR || env.COMPUTER_USE_EXECUTOR || 'macos-local',
+    COMPUTER_USE_APPROVAL_MODE: env.COMPUTER_USE_SMOKE_APPROVAL_MODE || env.COMPUTER_USE_APPROVAL_MODE || 'never',
+    COMPUTER_USE_OPENABLE_APPS: env.COMPUTER_USE_OPENABLE_APPS || 'Terminal,Cursor,Google Chrome',
+    COMPUTER_USE_SESSION_TAG: `desktop-overlay-live-window-smoke-${runId}`,
+    COMPUTER_USE_SESSION_ROOT: mcpSessionRoot,
+  }
+
+  for (const optionalEnvName of ['PNPM_HOME', 'COREPACK_HOME']) {
+    const value = env[optionalEnvName]?.trim()
+    if (value) {
+      mcpEnv[optionalEnvName] = value
+    }
+  }
+
+  const config = {
+    mcpServers: {
+      computer_use: {
+        command: 'pnpm',
+        args: ['-F', '@proj-airi/computer-use-mcp', 'start'],
+        cwd: repoDir,
+        enabled: true,
+        env: mcpEnv,
+      },
+    },
+  }
+
+  await writeFile(mcpConfigPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8')
+}
+
+async function ensureSmokePrerequisites() {
+  if (typeof WebSocket !== 'function') {
+    throw new Error('APP_START_FAILED: WebSocket is unavailable in this Node runtime. Run through the package script or set NODE_OPTIONS=--experimental-websocket.')
+  }
+
+  const missingOutputs: string[] = []
+  for (const relativePath of requiredWorkspaceBuildOutputs) {
+    try {
+      await access(resolve(repoDir, relativePath))
+    }
+    catch {
+      missingOutputs.push(relativePath)
+    }
+  }
+
+  if (missingOutputs.length === 0)
+    return
+
+  throw new Error([
+    'APP_START_FAILED: required workspace build outputs are missing.',
+    `Missing: ${missingOutputs.join(', ')}`,
+    'Build stage-tamagotchi dependencies manually before this smoke. The smoke command does not auto-build them to avoid saturating the local machine.',
+    'Suggested command: pnpm -F \'@proj-airi/stage-tamagotchi^...\' --if-present build',
+  ].join(' '))
+}
+
+async function waitForRemoteDebug(debugPort: number): Promise<string> {
+  const version = await waitFor('Electron remote debug endpoint', async () => {
+    const data = await fetchJson<{ webSocketDebuggerUrl?: string }>(`http://127.0.0.1:${debugPort}/json/version`)
+    return data.webSocketDebuggerUrl
+  }, 120_000, 500)
+
+  return version
+}
+
+async function findOverlayTarget(debugPort: number): Promise<DebugTarget> {
+  return await waitFor('desktop overlay debug target', async () => {
+    const targets = await fetchJson<DebugTarget[]>(`http://127.0.0.1:${debugPort}/json/list`)
+    return targets.find(target => target.type === 'page' && target.url.includes('#/desktop-overlay'))
+  }, 120_000, 500)
+}
+
+async function connectOverlayClient(debugPort: number): Promise<CdpClient> {
+  const overlayTarget = await findOverlayTarget(debugPort)
+  if (!overlayTarget.webSocketDebuggerUrl)
+    throw new Error('APP_START_FAILED: overlay target missing webSocketDebuggerUrl')
+
+  const client = await CdpClient.connect(overlayTarget.webSocketDebuggerUrl)
+
+  await waitFor('overlay smoke bridge', async () => {
+    return await client.evaluate<boolean>('Boolean(window.__AIRI_DESKTOP_OVERLAY_SMOKE__?.callMcpTool)')
+      ? true
+      : undefined
+  }, 60_000, 500)
+
+  return client
+}
+
+async function callOverlayMcpTool(client: CdpClient, name: string, args: Record<string, unknown> = {}): Promise<McpResult> {
+  const result = await client.evaluate<McpResult>(`window.__AIRI_DESKTOP_OVERLAY_SMOKE__.callMcpTool(${JSON.stringify({ name, arguments: args })})`)
+  if (result.isError) {
+    throw new Error(`${name} returned isError=true`)
+  }
+  return result
+}
+
+async function ensureOverlayMcpServerReady(client: CdpClient): Promise<void> {
+  const applyResult = await client.evaluate<McpApplyResult>('window.__AIRI_DESKTOP_OVERLAY_SMOKE__.applyAndRestartMcp()')
+  const failedComputerUse = applyResult.failed.find(item => item.name === 'computer_use')
+  if (failedComputerUse) {
+    throw new Error(`computer_use failed to start: ${failedComputerUse.error}`)
+  }
+
+  await waitFor('computer_use MCP runtime', async () => {
+    const status = await client.evaluate<McpRuntimeStatus>('window.__AIRI_DESKTOP_OVERLAY_SMOKE__.getMcpRuntimeStatus()')
+    const computerUse = status.servers.find(server => server.name === 'computer_use')
+    if (computerUse?.state === 'error') {
+      throw new Error(`computer_use runtime error: ${computerUse.lastError ?? 'unknown error'}`)
+    }
+    return computerUse?.state === 'running' ? true : undefined
+  }, 30_000, 500)
+
+  await waitFor('computer_use desktop tools', async () => {
+    const tools = await client.evaluate<McpToolDescriptor[]>('window.__AIRI_DESKTOP_OVERLAY_SMOKE__.listMcpTools()')
+    const names = new Set(tools.map(tool => tool.name))
+    return names.has('computer_use::desktop_get_state')
+      && names.has('computer_use::desktop_observe')
+      && names.has('computer_use::desktop_click_target')
+      ? true
+      : undefined
+  }, 30_000, 500)
+}
+
+function requireStructuredContent(result: McpResult, label: string): Record<string, unknown> {
+  if (!isRecord(result.structuredContent))
+    throw new Error(`${label} missing structuredContent`)
+
+  if (result.structuredContent.status && result.structuredContent.status !== 'ok')
+    throw new Error(`${label} expected status=ok, got ${String(result.structuredContent.status)}`)
+
+  return result.structuredContent
+}
+
+function requireRunState(result: McpResult, label: string): Record<string, unknown> {
+  const structuredContent = requireStructuredContent(result, label)
+  if (!isRecord(structuredContent.runState))
+    throw new Error(`${label} missing runState`)
+  return structuredContent.runState
+}
+
+function startStage(debugPort: number, heartbeatLines: string[]): ChildProcessWithoutNullStreams {
+  const stageProcess = spawn('pnpm', ['-F', '@proj-airi/stage-tamagotchi', 'dev'], {
+    cwd: repoDir,
+    detached: true,
+    env: {
+      ...env,
+      APP_REMOTE_DEBUG: 'true',
+      APP_REMOTE_DEBUG_PORT: String(debugPort),
+      APP_REMOTE_DEBUG_NO_OPEN: 'true',
+      APP_USER_DATA_PATH: userDataDir,
+      AIRI_DESKTOP_OVERLAY: '1',
+      AIRI_DESKTOP_OVERLAY_POLL_HEARTBEAT: '1',
+    },
+    stdio: 'pipe',
+  })
+
+  const stageLogStream = createWriteStream(stageLogPath, { flags: 'a' })
+  const capture = (chunk: Buffer) => {
+    const text = chunk.toString('utf-8')
+    stageLogStream.write(text)
+    for (const line of text.split(/\r?\n/u)) {
+      if (line.includes(desktopOverlayPollHeartbeatMarker)) {
+        heartbeatLines.push(line)
+      }
+    }
+  }
+  stageProcess.stdout.on('data', capture)
+  stageProcess.stderr.on('data', capture)
+  stageProcess.on('close', () => stageLogStream.end())
+
+  return stageProcess
+}
+
+async function stopStage(stageProcess: ChildProcessWithoutNullStreams | undefined) {
+  if (!stageProcess || stageProcess.exitCode !== null)
+    return
+
+  const signalStageProcessGroup = (signal: NodeJS.Signals) => {
+    try {
+      if (stageProcess.pid) {
+        killProcess(-stageProcess.pid, signal)
+        return
+      }
+    }
+    catch {
+      // Fall back to the pnpm wrapper process if process-group signalling is
+      // unavailable. The smoke starts a detached group to make this reliable on
+      // macOS, but the fallback keeps the helper safe on other local setups.
+    }
+
+    stageProcess.kill(signal)
+  }
+
+  signalStageProcessGroup('SIGTERM')
+  await Promise.race([
+    new Promise(resolve => stageProcess.once('exit', resolve)),
+    sleep(5_000).then(() => signalStageProcessGroup('SIGKILL')),
+  ])
+}
+
+function rejectWhenStageExits(stageProcess: ChildProcessWithoutNullStreams): Promise<never> {
+  return new Promise((_, reject) => {
+    stageProcess.once('exit', (code, signal) => {
+      reject(new Error(`stage-tamagotchi exited with code=${String(code)} signal=${String(signal)}`))
+    })
+  })
+}
+
+async function main() {
+  let stageProcess: ChildProcessWithoutNullStreams | undefined
+  let overlayClient: CdpClient | undefined
+  let stoppingStage = false
+  const heartbeatLines: string[] = []
+
+  try {
+    await ensureSmokePrerequisites()
+    await mkdir(reportDir, { recursive: true })
+    await prepareMcpConfig()
+
+    const debugPort = await findAvailablePort()
+    stageProcess = startStage(debugPort, heartbeatLines)
+    const stageExited = rejectWhenStageExits(stageProcess)
+    stageProcess.once('exit', (code, signal) => {
+      if (!stoppingStage && code !== null && code !== 0)
+        console.error(`APP_START_FAILED: stage-tamagotchi exited with code=${code} signal=${String(signal)}`)
+    })
+
+    await Promise.race([
+      waitForRemoteDebug(debugPort),
+      stageExited,
+    ]).catch((error) => {
+      throw new Error(`APP_START_FAILED: ${error instanceof Error ? error.message : String(error)}`)
+    })
+
+    overlayClient = await Promise.race([
+      connectOverlayClient(debugPort),
+      stageExited,
+    ]).catch((error) => {
+      throw new Error(`APP_START_FAILED: ${error instanceof Error ? error.message : String(error)}`)
+    })
+
+    // NOTICE:
+    // Vite's dev optimizer can trigger one renderer reload shortly after the
+    // Electron window first exposes the smoke bridge. Reconnect once after a
+    // short settle window so the following MCP calls do not race a closing CDP
+    // target. This is local smoke harness discipline, not product runtime.
+    await sleep(5_000)
+    overlayClient.close()
+    overlayClient = await Promise.race([
+      connectOverlayClient(debugPort),
+      stageExited,
+    ]).catch((error) => {
+      throw new Error(`APP_START_FAILED: ${error instanceof Error ? error.message : String(error)}`)
+    })
+
+    const readiness = await overlayClient.evaluate<{ state: 'booting' | 'ready' | 'degraded', error?: string }>('window.__AIRI_DESKTOP_OVERLAY_SMOKE__.getReadiness()')
+    if (readiness.state !== 'ready') {
+      throw new Error(`OVERLAY_READINESS_DEGRADED: state=${readiness.state}${readiness.error ? ` error=${readiness.error}` : ''}`)
+    }
+
+    try {
+      await ensureOverlayMcpServerReady(overlayClient)
+      await callOverlayMcpTool(overlayClient, 'computer_use::desktop_ensure_chrome', { url: smokeUrl })
+      await sleep(750)
+      await callOverlayMcpTool(overlayClient, 'computer_use::desktop_observe', { includeChrome: true })
+      const preClickRunState = requireRunState(
+        await callOverlayMcpTool(overlayClient, 'computer_use::desktop_get_state'),
+        'computer_use::desktop_get_state before click',
+      )
+      const candidateId = selectDesktopOverlaySmokeCandidateId(preClickRunState)
+      await callOverlayMcpTool(overlayClient, 'computer_use::desktop_click_target', {
+        candidateId,
+        button: 'left',
+        clickCount: 1,
+      })
+      const postClickRunState = requireRunState(
+        await callOverlayMcpTool(overlayClient, 'computer_use::desktop_get_state'),
+        'computer_use::desktop_get_state after click',
+      )
+      const pointerIntent = postClickRunState.lastPointerIntent
+      assert(isRecord(pointerIntent), 'computer_use::desktop_get_state missing lastPointerIntent after click')
+      assert(pointerIntent.candidateId === candidateId, `lastPointerIntent candidate mismatch: expected ${candidateId}, got ${String(pointerIntent.candidateId)}`)
+    }
+    catch (error) {
+      throw new Error(`MCP_CALL_FAILED: ${error instanceof Error ? error.message : String(error)}`)
+    }
+
+    const heartbeat = await waitFor('overlay poll heartbeat', () => {
+      return heartbeatLines.find(line => line.includes('snapshotId=') && line.includes('pointerIntent=yes'))
+    }, 30_000, 250).catch((error) => {
+      throw new Error(`HEARTBEAT_TIMEOUT: ${error instanceof Error ? error.message : String(error)}`)
+    })
+
+    console.info(JSON.stringify({
+      ok: true,
+      reportDir,
+      stageLogPath,
+      heartbeat,
+    }, null, 2))
+  }
+  finally {
+    overlayClient?.close()
+    stoppingStage = true
+    await stopStage(stageProcess)
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  console.error(`stage log: ${stageLogPath}`)
+  exit(1)
+})

--- a/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
@@ -132,15 +132,15 @@ async function waitFor<T>(
   throw new Error(`${label} timed out after ${timeoutMs}ms${suffix}`)
 }
 
-class CdpClient {
-  private socket: WebSocket
+export class CdpClient {
+  private socket?: WebSocket
   private nextId = 1
   private pending = new Map<number, {
     resolve: (value: Record<string, unknown>) => void
     reject: (error: Error) => void
   }>()
 
-  private constructor(socket: WebSocket) {
+  constructor(socket: WebSocket) {
     this.socket = socket
     this.socket.addEventListener('message', (event) => {
       const payload = JSON.parse(String(event.data)) as Record<string, unknown>
@@ -160,6 +160,12 @@ class CdpClient {
         pending.resolve(payload)
       }
     })
+    this.socket.addEventListener('close', () => {
+      this.failPending('CDP socket closed')
+    })
+    this.socket.addEventListener('error', () => {
+      this.failPending('CDP socket errored')
+    })
   }
 
   static async connect(url: string): Promise<CdpClient> {
@@ -172,6 +178,10 @@ class CdpClient {
   }
 
   async send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (!this.socket) {
+      throw new Error('CDP socket is closed')
+    }
+
     const id = this.nextId++
     const promise = new Promise<Record<string, unknown>>((resolveMessage, reject) => {
       this.pending.set(id, { resolve: resolveMessage, reject })
@@ -204,7 +214,20 @@ class CdpClient {
   }
 
   close() {
-    this.socket.close()
+    this.failPending('CDP socket closed')
+    this.socket?.close()
+    this.socket = undefined
+  }
+
+  private failPending(reason: string) {
+    if (this.pending.size === 0) {
+      return
+    }
+
+    for (const [id, pending] of this.pending.entries()) {
+      this.pending.delete(id)
+      pending.reject(new Error(`${reason} before completing request ${id}`))
+    }
   }
 }
 
@@ -531,8 +554,10 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error))
-  console.error(`stage log: ${stageLogPath}`)
-  exit(1)
-})
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    console.error(`stage log: ${stageLogPath}`)
+    exit(1)
+  })
+}

--- a/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
@@ -279,7 +279,7 @@ async function prepareMcpConfig() {
 
 async function ensureSmokePrerequisites() {
   if (typeof WebSocket !== 'function') {
-    throw new Error('APP_START_FAILED: WebSocket is unavailable in this Node runtime. Run through the package script or set NODE_OPTIONS=--experimental-websocket.')
+    throw new TypeError('APP_START_FAILED: WebSocket is unavailable in this Node runtime. Run through the package script or set NODE_OPTIONS=--experimental-websocket.')
   }
 
   const missingOutputs: string[] = []

--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -58,6 +58,11 @@ setupDebugger()
 
 const log = useLogg('main').useGlobalConfig()
 
+const appUserDataPath = env.APP_USER_DATA_PATH?.trim()
+if (appUserDataPath) {
+  app.setPath('userData', appUserDataPath)
+}
+
 // Thanks to [@blurymind](https://github.com/blurymind),
 //
 // When running Electron on Linux, navigator.gpu.requestAdapter() fails.

--- a/apps/stage-tamagotchi/src/main/windows/desktop-overlay/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/desktop-overlay/index.ts
@@ -27,6 +27,7 @@ import { join, resolve } from 'node:path'
 
 import { BrowserWindow, screen } from 'electron'
 
+import { desktopOverlayPollHeartbeatMarker, desktopOverlayPollHeartbeatQueryParam } from '../../../shared/desktop-overlay-heartbeat'
 import { baseUrl, getElectronMainDirname, load, withHashRoute } from '../../libs/electron/location'
 import { setupDesktopOverlayElectronInvokes } from './rpc/index.electron'
 import {
@@ -34,7 +35,6 @@ import {
   createDesktopOverlayWindowOptions,
   showDesktopOverlayWithoutFocus,
 } from './window-contract'
-import { desktopOverlayPollHeartbeatMarker, desktopOverlayPollHeartbeatQueryParam } from '../../../shared/desktop-overlay-heartbeat'
 
 /** Whether the desktop overlay feature is enabled */
 export function isDesktopOverlayEnabled(): boolean {

--- a/apps/stage-tamagotchi/src/main/windows/desktop-overlay/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/desktop-overlay/index.ts
@@ -34,10 +34,20 @@ import {
   createDesktopOverlayWindowOptions,
   showDesktopOverlayWithoutFocus,
 } from './window-contract'
+import { desktopOverlayPollHeartbeatMarker, desktopOverlayPollHeartbeatQueryParam } from '../../../shared/desktop-overlay-heartbeat'
 
 /** Whether the desktop overlay feature is enabled */
 export function isDesktopOverlayEnabled(): boolean {
   return process.env.AIRI_DESKTOP_OVERLAY === '1'
+}
+
+/**
+ * Smoke-only overlay heartbeat mode.
+ * The recut desktop smoke uses this to surface renderer console lines and
+ * mount the in-page smoke bridge.
+ */
+export function isDesktopOverlayPollHeartbeatEnabled(): boolean {
+  return process.env.AIRI_DESKTOP_OVERLAY_POLL_HEARTBEAT === '1'
 }
 
 let overlayWindow: BrowserWindow | null = null
@@ -81,6 +91,14 @@ export async function setupDesktopOverlayWindow(params: {
     overlayWindow = null
   })
 
+  if (isDesktopOverlayPollHeartbeatEnabled()) {
+    overlayWindow.webContents.on('console-message', (_event, _level, message) => {
+      if (message.includes(desktopOverlayPollHeartbeatMarker)) {
+        console.info(message)
+      }
+    })
+  }
+
   // NOTICE: Wire eventa RPC BEFORE loading the renderer page.
   // The overlay's onMounted fires during load() and immediately starts
   // polling via callTool. If the handlers aren't registered yet, the
@@ -99,7 +117,9 @@ export async function setupDesktopOverlayWindow(params: {
     overlayWindow,
     withHashRoute(
       baseUrl(resolve(getElectronMainDirname(), '..', 'renderer')),
-      '/desktop-overlay',
+      isDesktopOverlayPollHeartbeatEnabled()
+        ? `/desktop-overlay?${desktopOverlayPollHeartbeatQueryParam}=1`
+        : '/desktop-overlay',
     ),
   )
 

--- a/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.test.ts
+++ b/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.test.ts
@@ -6,6 +6,8 @@ import type { McpStdioManager } from '../../../services/airi/mcp-servers'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setupDesktopOverlayElectronInvokes } from './index.electron'
+
 const defineInvokeHandlerMock = vi.hoisted(() => vi.fn())
 const createContextMock = vi.hoisted(() => vi.fn(() => ({ context: { id: 'desktop-overlay-test' } })))
 const setupBaseWindowElectronInvokesMock = vi.hoisted(() => vi.fn())
@@ -39,8 +41,6 @@ vi.mock('../../shared/window', () => ({
 vi.mock('../../../services/airi/mcp-servers', () => ({
   createMcpServersService: createMcpServersServiceMock,
 }))
-
-import { setupDesktopOverlayElectronInvokes } from './index.electron'
 
 describe('setupDesktopOverlayElectronInvokes', () => {
   const window = {} as BrowserWindow

--- a/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.test.ts
+++ b/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.test.ts
@@ -1,0 +1,98 @@
+import type { BrowserWindow } from 'electron'
+
+import type { I18n } from '../../../libs/i18n'
+import type { ServerChannel } from '../../../services/airi/channel-server'
+import type { McpStdioManager } from '../../../services/airi/mcp-servers'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const defineInvokeHandlerMock = vi.hoisted(() => vi.fn())
+const createContextMock = vi.hoisted(() => vi.fn(() => ({ context: { id: 'desktop-overlay-test' } })))
+const setupBaseWindowElectronInvokesMock = vi.hoisted(() => vi.fn())
+const createMcpServersServiceMock = vi.hoisted(() => vi.fn())
+const ipcMainMock = vi.hoisted(() => ({ setMaxListeners: vi.fn() }))
+
+vi.mock('@moeru/eventa', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@moeru/eventa')>()
+  return {
+    ...actual,
+    defineInvokeHandler: defineInvokeHandlerMock,
+  }
+})
+
+vi.mock('@moeru/eventa/adapters/electron/main', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@moeru/eventa/adapters/electron/main')>()
+  return {
+    ...actual,
+    createContext: createContextMock,
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: ipcMainMock,
+}))
+
+vi.mock('../../shared/window', () => ({
+  setupBaseWindowElectronInvokes: setupBaseWindowElectronInvokesMock,
+}))
+
+vi.mock('../../../services/airi/mcp-servers', () => ({
+  createMcpServersService: createMcpServersServiceMock,
+}))
+
+import { setupDesktopOverlayElectronInvokes } from './index.electron'
+
+describe('setupDesktopOverlayElectronInvokes', () => {
+  const window = {} as BrowserWindow
+  const mcpStdioManager = {} as McpStdioManager
+  const serverChannel = {} as ServerChannel
+  const i18n = {} as I18n
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('publishes ready after the base window invokes and MCP services are wired', async () => {
+    let readinessHandler: (() => Promise<{ state: 'booting' | 'ready' | 'degraded', error?: string }>) | undefined
+
+    defineInvokeHandlerMock.mockImplementation((_context, _contract, handler) => {
+      readinessHandler = handler
+    })
+    setupBaseWindowElectronInvokesMock.mockResolvedValue(undefined)
+    createMcpServersServiceMock.mockReturnValue(undefined)
+
+    await setupDesktopOverlayElectronInvokes({
+      window,
+      mcpStdioManager,
+      serverChannel,
+      i18n,
+    })
+
+    expect(ipcMainMock.setMaxListeners).toHaveBeenCalledWith(0)
+    expect(createContextMock).toHaveBeenCalledTimes(1)
+    expect(setupBaseWindowElectronInvokesMock).toHaveBeenCalledTimes(1)
+    expect(createMcpServersServiceMock).toHaveBeenCalledTimes(1)
+    expect(readinessHandler).toBeDefined()
+    await expect(readinessHandler!()).resolves.toEqual({ state: 'ready' })
+  })
+
+  it('publishes degraded when the base window invokes fail', async () => {
+    let readinessHandler: (() => Promise<{ state: 'booting' | 'ready' | 'degraded', error?: string }>) | undefined
+
+    defineInvokeHandlerMock.mockImplementation((_context, _contract, handler) => {
+      readinessHandler = handler
+    })
+    setupBaseWindowElectronInvokesMock.mockRejectedValueOnce(new Error('boom'))
+
+    await setupDesktopOverlayElectronInvokes({
+      window,
+      mcpStdioManager,
+      serverChannel,
+      i18n,
+    })
+
+    expect(createMcpServersServiceMock).not.toHaveBeenCalled()
+    expect(readinessHandler).toBeDefined()
+    await expect(readinessHandler!()).resolves.toEqual({ state: 'degraded', error: 'boom' })
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.test.ts
@@ -269,14 +269,17 @@ describe('createOverlayPollController', () => {
     // First poll: fails (but empty ready state was emitted)
     await vi.advanceTimersByTimeAsync(0)
     expect(callTool).toHaveBeenCalledTimes(1)
-    expect(received).toHaveLength(1)
+    expect(received).toHaveLength(2)
     expect(received[0].bootstrapState).toBe('ready')
+    expect(received[1].bootstrapState).toBe('booting')
+    expect(getReadiness).toHaveBeenCalledTimes(1)
 
     // Wait for fallback interval
     await vi.advanceTimersByTimeAsync(200)
+    expect(getReadiness).toHaveBeenCalledTimes(2)
     expect(callTool).toHaveBeenCalledTimes(2)
-    expect(received).toHaveLength(2)
-    expect(received[1].snapshotId).toBe('dg_recover')
+    expect(received[2].bootstrapState).toBe('ready')
+    expect(received[3].snapshotId).toBe('dg_recover')
 
     controller.stop()
   })
@@ -345,13 +348,74 @@ describe('createOverlayPollController', () => {
 
     // Advance past the 500ms timeout → catch triggers, schedules fallback
     await vi.advanceTimersByTimeAsync(500)
-    expect(received).toHaveLength(1)
+    expect(received).toHaveLength(2)
+    expect(received[1].bootstrapState).toBe('booting')
 
     // Advance past the 200ms fallback interval → second poll fires and succeeds
     await vi.advanceTimersByTimeAsync(200)
+    expect(getReadiness).toHaveBeenCalledTimes(2)
     expect(callTool).toHaveBeenCalledTimes(2)
-    expect(received).toHaveLength(2)
-    expect(received[1].snapshotId).toBe('dg_after_timeout')
+    expect(received[2].bootstrapState).toBe('ready')
+    expect(received[3].snapshotId).toBe('dg_after_timeout')
+
+    controller.stop()
+  })
+
+  it('re-enters readiness polling after a successful poll later loses the MCP bridge', async () => {
+    vi.useFakeTimers()
+
+    const callTool = vi.fn<(name: string) => Promise<McpCallToolResult>>()
+      .mockResolvedValueOnce({
+        structuredContent: {
+          runState: {
+            lastGroundingSnapshot: {
+              snapshotId: 'dg_initial',
+              targetCandidates: [],
+              staleFlags: { screenshot: false, ax: false, chromeSemantic: false },
+            },
+          },
+        },
+      })
+      .mockRejectedValueOnce(new Error('bridge disconnected'))
+      .mockResolvedValueOnce({
+        structuredContent: {
+          runState: {
+            lastGroundingSnapshot: {
+              snapshotId: 'dg_recovered',
+              targetCandidates: [],
+              staleFlags: { screenshot: false, ax: false, chromeSemantic: false },
+            },
+          },
+        },
+      })
+
+    const getReadiness = vi.fn()
+      .mockResolvedValueOnce({ state: 'ready' })
+      .mockResolvedValueOnce({ state: 'ready' })
+
+    const received: OverlayState[] = []
+
+    const controller = createOverlayPollController({
+      callTool,
+      getReadiness,
+      onState: state => received.push(state),
+      intervalMs: 100,
+      fallbackIntervalMs: 200,
+    })
+
+    controller.start()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callTool).toHaveBeenCalledTimes(1)
+    expect(received.at(-1)?.snapshotId).toBe('dg_initial')
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(callTool).toHaveBeenCalledTimes(2)
+    expect(received.at(-1)?.bootstrapState).toBe('booting')
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(getReadiness).toHaveBeenCalledTimes(2)
+    expect(callTool).toHaveBeenCalledTimes(3)
+    expect(received.at(-1)?.snapshotId).toBe('dg_recovered')
 
     controller.stop()
   })
@@ -468,21 +532,30 @@ describe('createOverlayPollController', () => {
     await vi.advanceTimersByTimeAsync(500)
     await vi.advanceTimersByTimeAsync(1000)
     expect(callTool).toHaveBeenCalledTimes(2)
-    expect(received).toHaveLength(1)
+    expect(received.some(state => state.bootstrapState === 'booting')).toBe(true)
 
     resolveFirst({ structuredContent: {} })
     await vi.advanceTimersByTimeAsync(0)
     await vi.advanceTimersByTimeAsync(200)
     expect(callTool).toHaveBeenCalledTimes(3)
-    expect(received).toHaveLength(2)
-    expect(received[1].snapshotId).toBe('dg_after_lease')
+    expect(received.at(-1)?.snapshotId).toBe('dg_after_lease')
 
     controller.stop()
   })
 
   it('waits for readiness before entering main poll loop', async () => {
     vi.useFakeTimers()
-    const callTool = vi.fn()
+    const callTool = vi.fn().mockResolvedValue({
+      structuredContent: {
+        runState: {
+          lastGroundingSnapshot: {
+            snapshotId: 'dg_ready',
+            targetCandidates: [],
+            staleFlags: { screenshot: false, ax: false, chromeSemantic: false },
+          },
+        },
+      },
+    })
     const getReadiness = vi.fn()
       .mockResolvedValueOnce({ state: 'booting' })
       .mockResolvedValueOnce({ state: 'booting' })
@@ -510,6 +583,7 @@ describe('createOverlayPollController', () => {
     await vi.advanceTimersByTimeAsync(200)
     expect(callTool).toHaveBeenCalledTimes(1)
     expect(received.at(-1)?.bootstrapState).toBe('ready')
+    expect(received.at(-1)?.snapshotId).toBe('dg_ready')
 
     controller.stop()
   })

--- a/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.ts
+++ b/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.ts
@@ -7,6 +7,8 @@
 
 import type { McpCallToolResult } from '@proj-airi/stage-ui/stores/mcp-tool-bridge'
 
+import { desktopOverlayPollHeartbeatMarker, desktopOverlayPollHeartbeatQueryParam } from '../../shared/desktop-overlay-heartbeat'
+
 // ---------------------------------------------------------------------------
 // Types — minimal shapes matching RunState fields the overlay consumes
 // ---------------------------------------------------------------------------
@@ -44,6 +46,12 @@ export interface OverlayState {
   pointerIntent: OverlayPointerIntent | null
   bootstrapState: 'booting' | 'ready' | 'degraded'
   lastBootstrapError?: string
+}
+
+export interface OverlayPollHeartbeat {
+  snapshotId: string
+  candidateCount: number
+  hasPointerIntent: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +119,37 @@ export function extractRunStateFromResult(result: McpCallToolResult): Record<str
   return sc as Record<string, unknown>
 }
 
+export function createOverlayPollHeartbeat(state: OverlayState): OverlayPollHeartbeat | undefined {
+  if (!state.hasSnapshot || !state.snapshotId)
+    return undefined
+
+  return {
+    snapshotId: state.snapshotId,
+    candidateCount: state.candidates.length,
+    hasPointerIntent: state.pointerIntent !== null,
+  }
+}
+
+export function formatOverlayPollHeartbeat(heartbeat: OverlayPollHeartbeat): string {
+  return [
+    desktopOverlayPollHeartbeatMarker,
+    `snapshotId=${heartbeat.snapshotId}`,
+    `candidates=${heartbeat.candidateCount}`,
+    `pointerIntent=${heartbeat.hasPointerIntent ? 'yes' : 'no'}`,
+  ].join(' ')
+}
+
+export function isOverlayPollHeartbeatEnabled(locationLike: Pick<Location, 'hash' | 'search'> = window.location): boolean {
+  const hashQuery = locationLike.hash.includes('?')
+    ? locationLike.hash.slice(locationLike.hash.indexOf('?') + 1)
+    : ''
+  const hashParams = new URLSearchParams(hashQuery)
+  const searchParams = new URLSearchParams(locationLike.search)
+
+  return hashParams.get(desktopOverlayPollHeartbeatQueryParam) === '1'
+    || searchParams.get(desktopOverlayPollHeartbeatQueryParam) === '1'
+}
+
 // ---------------------------------------------------------------------------
 // Polling controller (framework-agnostic)
 // ---------------------------------------------------------------------------
@@ -129,6 +168,8 @@ export interface OverlayPollConfig {
   callTool: (name: string) => Promise<McpCallToolResult>
   /** Callback with extracted state on each successful poll. */
   onState: (state: OverlayState) => void
+  /** Optional debug-only callback with a small heartbeat marker. */
+  onHeartbeat?: (heartbeat: OverlayPollHeartbeat) => void
   /** Function to ping main process readiness contract via Eventa. */
   getReadiness: () => Promise<{ state: 'booting' | 'ready' | 'degraded', error?: string }>
   /** Normal poll interval in ms. Default: 250. */
@@ -299,6 +340,10 @@ export function createOverlayPollController(config: OverlayPollConfig): OverlayP
         state.bootstrapState = currentBootstrapState
         state.lastBootstrapError = currentBootstrapError
         config.onState(state)
+        const heartbeat = createOverlayPollHeartbeat(state)
+        if (heartbeat && config.onHeartbeat) {
+          config.onHeartbeat(heartbeat)
+        }
       }
       else {
         nextInterval = fallbackInterval

--- a/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.ts
+++ b/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.ts
@@ -214,7 +214,25 @@ export function createOverlayPollController(config: OverlayPollConfig): OverlayP
 
   function scheduleNext(nextInterval: number) {
     if (running) {
-      timer = setTimeout(poll, nextInterval)
+      if (timer !== null) {
+        clearTimeout(timer)
+      }
+      timer = setTimeout(() => {
+        timer = null
+        void poll()
+      }, nextInterval)
+    }
+  }
+
+  function scheduleBootstrap(nextInterval: number) {
+    if (running) {
+      if (bootstrapTimer !== null) {
+        clearTimeout(bootstrapTimer)
+      }
+      bootstrapTimer = setTimeout(() => {
+        bootstrapTimer = null
+        void bootstrapPoll()
+      }, nextInterval)
     }
   }
 
@@ -230,6 +248,13 @@ export function createOverlayPollController(config: OverlayPollConfig): OverlayP
     if (backgroundHungCalls.length < MAX_BACKGROUND_HUNG_CALLS) {
       lastHungRecoveryProbeAt = null
     }
+  }
+
+  function restartBootstrap(error?: unknown) {
+    currentBootstrapState = 'booting'
+    currentBootstrapError = error instanceof Error ? error.message : typeof error === 'string' ? error : undefined
+    emitEmptyState()
+    scheduleBootstrap(fallbackInterval)
   }
 
   function canStartPoll(now: number) {
@@ -273,11 +298,11 @@ export function createOverlayPollController(config: OverlayPollConfig): OverlayP
 
     if (currentBootstrapState === 'ready') {
       emitEmptyState()
-      poll()
+      void poll()
     }
     else {
       emitEmptyState()
-      bootstrapTimer = setTimeout(bootstrapPoll, fallbackInterval)
+      scheduleBootstrap(fallbackInterval)
     }
   }
 
@@ -287,7 +312,6 @@ export function createOverlayPollController(config: OverlayPollConfig): OverlayP
       return
     }
 
-    let nextInterval = normalInterval
     let timeoutId: ReturnType<typeof setTimeout> | undefined
 
     try {
@@ -344,22 +368,22 @@ export function createOverlayPollController(config: OverlayPollConfig): OverlayP
         if (heartbeat && config.onHeartbeat) {
           config.onHeartbeat(heartbeat)
         }
+        scheduleNext(normalInterval)
       }
       else {
-        nextInterval = fallbackInterval
+        restartBootstrap('desktop_get_state returned no runState')
       }
     }
-    catch {
-      // MCP server not running, bridge disconnected, or timeout — graceful degradation
-      nextInterval = fallbackInterval
+    catch (error) {
+      // MCP server not running, bridge disconnected, or timeout — re-handshake
+      // readiness before resuming the main poll loop.
+      restartBootstrap(error)
     }
     finally {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId)
       }
     }
-
-    scheduleNext(nextInterval)
   }
 
   return {

--- a/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay.vue
@@ -18,12 +18,24 @@ import type { OverlayState } from './desktop-overlay-polling'
 
 import { electron } from '@proj-airi/electron-eventa'
 import { useElectronEventaInvoke } from '@proj-airi/electron-vueuse'
-import { getMcpToolBridge } from '@proj-airi/stage-ui/stores/mcp-tool-bridge'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
-import { getDesktopOverlayReadinessContract } from '../../shared/eventa'
+import { electronMcpApplyAndRestart, electronMcpCallTool, electronMcpGetRuntimeStatus, electronMcpListTools, getDesktopOverlayReadinessContract } from '../../shared/eventa'
 import { pointInOverlay, rectIntersectsOverlay, screenRectToLocal, screenToLocal } from './desktop-overlay-coordinates'
-import { createEmptyOverlayState, createOverlayPollController } from './desktop-overlay-polling'
+import { createEmptyOverlayState, createOverlayPollController, formatOverlayPollHeartbeat, isOverlayPollHeartbeatEnabled } from './desktop-overlay-polling'
+
+declare global {
+  interface Window {
+    __AIRI_DESKTOP_OVERLAY_SMOKE__?: {
+      applyAndRestartMcp: () => Promise<unknown>
+      callMcpTool: (payload: { name: string, arguments?: Record<string, unknown> }) => Promise<unknown>
+      getMcpRuntimeStatus: () => Promise<unknown>
+      getOverlayState: () => OverlayState
+      getReadiness: () => Promise<{ state: 'booting' | 'ready' | 'degraded', error?: string }>
+      listMcpTools: () => Promise<unknown>
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Overlay window bounds — read once on mount from main process
@@ -31,7 +43,12 @@ import { createEmptyOverlayState, createOverlayPollController } from './desktop-
 
 const getWindowBounds = useElectronEventaInvoke(electron.window.getBounds)
 const getReadiness = useElectronEventaInvoke(getDesktopOverlayReadinessContract)
+const applyAndRestartMcp = useElectronEventaInvoke(electronMcpApplyAndRestart)
+const callMcpTool = useElectronEventaInvoke(electronMcpCallTool)
+const getMcpRuntimeStatus = useElectronEventaInvoke(electronMcpGetRuntimeStatus)
+const listMcpTools = useElectronEventaInvoke(electronMcpListTools)
 const overlayBounds = ref<Rect | null>(null)
+const pollHeartbeatEnabled = isOverlayPollHeartbeatEnabled()
 
 // ---------------------------------------------------------------------------
 // Reactive state — single ref driven by poll controller
@@ -71,21 +88,15 @@ const matchedCandidate = computed(() => {
 // Polling controller
 // ---------------------------------------------------------------------------
 
-let bridgeAvailable = false
-
 const controller = createOverlayPollController({
-  callTool: async (name) => {
-    // Probe bridge availability lazily
-    if (!bridgeAvailable) {
-      getMcpToolBridge() // Throws if not set
-      bridgeAvailable = true
-    }
-    return getMcpToolBridge().callTool({ name })
-  },
+  callTool: name => callMcpTool({ name }),
   getReadiness: async () => getReadiness(),
   onState: (newState) => {
     state.value = newState
   },
+  onHeartbeat: pollHeartbeatEnabled
+    ? heartbeat => console.info(formatOverlayPollHeartbeat(heartbeat))
+    : undefined,
 })
 
 // ---------------------------------------------------------------------------
@@ -199,11 +210,23 @@ onMounted(async () => {
     }
   }
 
+  if (pollHeartbeatEnabled) {
+    window.__AIRI_DESKTOP_OVERLAY_SMOKE__ = {
+      applyAndRestartMcp,
+      callMcpTool,
+      getMcpRuntimeStatus,
+      getOverlayState: () => state.value,
+      getReadiness,
+      listMcpTools,
+    }
+  }
+
   controller.start()
 })
 
 onUnmounted(() => {
   controller.stop()
+  delete window.__AIRI_DESKTOP_OVERLAY_SMOKE__
 })
 </script>
 

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-heartbeat.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-heartbeat.ts
@@ -1,0 +1,5 @@
+/** Debug-only marker used by the local overlay live-window smoke. */
+export const desktopOverlayPollHeartbeatMarker = '[AIRI_DESKTOP_OVERLAY_POLL_HEARTBEAT]'
+
+/** Query parameter used to enable overlay polling heartbeat logs. */
+export const desktopOverlayPollHeartbeatQueryParam = 'pollHeartbeat'

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.test.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.test.ts
@@ -16,30 +16,17 @@ describe('selectDesktopOverlaySmokeCandidateId', () => {
     expect(candidateId).toBe('smoke')
   })
 
-  it('falls back to a button role', () => {
-    const candidateId = selectDesktopOverlaySmokeCandidateId({
-      lastGroundingSnapshot: {
-        targetCandidates: [
-          { id: 'plain', label: 'Something else', role: 'text' },
-          { id: 'buttonish', label: 'Not the smoke label', role: 'Button' },
-        ],
-      },
-    })
-
-    expect(candidateId).toBe('buttonish')
-  })
-
-  it('falls back to the first candidate when no better match exists', () => {
-    const candidateId = selectDesktopOverlaySmokeCandidateId({
-      lastGroundingSnapshot: {
-        targetCandidates: [
-          { id: 'first', label: 'Alpha', role: 'link' },
-          { id: 'second', label: 'Beta', role: 'text' },
-        ],
-      },
-    })
-
-    expect(candidateId).toBe('first')
+  it('fails when the smoke label is missing', () => {
+    expect(() => {
+      selectDesktopOverlaySmokeCandidateId({
+        lastGroundingSnapshot: {
+          targetCandidates: [
+            { id: 'first', label: 'Alpha', role: 'link' },
+            { id: 'second', label: 'Beta', role: 'button' },
+          ],
+        },
+      })
+    }).toThrow('desktop_observe did not return the AIRI Desktop Overlay Smoke Button chrome_dom candidate')
   })
 
   it('throws when no candidate ids exist', () => {
@@ -49,6 +36,6 @@ describe('selectDesktopOverlaySmokeCandidateId', () => {
           targetCandidates: [{ label: 'Missing id', role: 'button' }],
         },
       })
-    }).toThrow('desktop_observe produced no clickable target candidate id')
+    }).toThrow('desktop_observe did not return the AIRI Desktop Overlay Smoke Button chrome_dom candidate')
   })
 })

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.test.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectDesktopOverlaySmokeCandidateId } from './desktop-overlay-live-window-smoke'
+
+describe('selectDesktopOverlaySmokeCandidateId', () => {
+  it('prefers the smoke button label', () => {
+    const candidateId = selectDesktopOverlaySmokeCandidateId({
+      lastGroundingSnapshot: {
+        targetCandidates: [
+          { id: 'first', label: 'Something else', role: 'link' },
+          { id: 'smoke', label: 'AIRI Desktop Overlay Smoke Button', role: 'button' },
+        ],
+      },
+    })
+
+    expect(candidateId).toBe('smoke')
+  })
+
+  it('falls back to a button role', () => {
+    const candidateId = selectDesktopOverlaySmokeCandidateId({
+      lastGroundingSnapshot: {
+        targetCandidates: [
+          { id: 'plain', label: 'Something else', role: 'text' },
+          { id: 'buttonish', label: 'Not the smoke label', role: 'Button' },
+        ],
+      },
+    })
+
+    expect(candidateId).toBe('buttonish')
+  })
+
+  it('falls back to the first candidate when no better match exists', () => {
+    const candidateId = selectDesktopOverlaySmokeCandidateId({
+      lastGroundingSnapshot: {
+        targetCandidates: [
+          { id: 'first', label: 'Alpha', role: 'link' },
+          { id: 'second', label: 'Beta', role: 'text' },
+        ],
+      },
+    })
+
+    expect(candidateId).toBe('first')
+  })
+
+  it('throws when no candidate ids exist', () => {
+    expect(() => {
+      selectDesktopOverlaySmokeCandidateId({
+        lastGroundingSnapshot: {
+          targetCandidates: [{ label: 'Missing id', role: 'button' }],
+        },
+      })
+    }).toThrow('desktop_observe produced no clickable target candidate id')
+  })
+})

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.test.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.test.ts
@@ -7,13 +7,25 @@ describe('selectDesktopOverlaySmokeCandidateId', () => {
     const candidateId = selectDesktopOverlaySmokeCandidateId({
       lastGroundingSnapshot: {
         targetCandidates: [
-          { id: 'first', label: 'Something else', role: 'link' },
-          { id: 'smoke', label: 'AIRI Desktop Overlay Smoke Button', role: 'button' },
+          { id: 'first', label: 'Something else', role: 'link', source: 'chrome_dom' },
+          { id: 'smoke', label: 'AIRI Desktop Overlay Smoke Button', role: 'button', source: 'chrome_dom' },
         ],
       },
     })
 
     expect(candidateId).toBe('smoke')
+  })
+
+  it('requires the smoke button to come from chrome_dom', () => {
+    expect(() => {
+      selectDesktopOverlaySmokeCandidateId({
+        lastGroundingSnapshot: {
+          targetCandidates: [
+            { id: 'ax-smoke', label: 'AIRI Desktop Overlay Smoke Button', role: 'button', source: 'ax' },
+          ],
+        },
+      })
+    }).toThrow('desktop_observe did not return the AIRI Desktop Overlay Smoke Button chrome_dom candidate')
   })
 
   it('fails when the smoke label is missing', () => {

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.ts
@@ -1,0 +1,24 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function selectDesktopOverlaySmokeCandidateId(runState: Record<string, unknown>): string {
+  const snapshot = runState.lastGroundingSnapshot
+  if (!isRecord(snapshot))
+    throw new Error('desktop_get_state missing lastGroundingSnapshot after desktop_observe')
+
+  const candidates = Array.isArray(snapshot.targetCandidates)
+    ? snapshot.targetCandidates.filter(isRecord)
+    : []
+
+  const selected = candidates.find((candidate) => {
+    return String(candidate.label || '').includes('AIRI Desktop Overlay Smoke Button')
+      || String(candidate.role || '').toLowerCase().includes('button')
+  }) ?? candidates[0]
+
+  const id = typeof selected?.id === 'string' ? selected.id : ''
+  if (!id)
+    throw new Error('desktop_observe produced no clickable target candidate id')
+
+  return id
+}

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.ts
@@ -12,7 +12,8 @@ export function selectDesktopOverlaySmokeCandidateId(runState: Record<string, un
     : []
 
   const selected = candidates.find((candidate) => {
-    return String(candidate.label || '').includes('AIRI Desktop Overlay Smoke Button')
+    return candidate.source === 'chrome_dom'
+      && String(candidate.label || '').includes('AIRI Desktop Overlay Smoke Button')
   })
 
   const id = typeof selected?.id === 'string' ? selected.id : ''

--- a/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/src/shared/desktop-overlay-live-window-smoke.ts
@@ -13,12 +13,11 @@ export function selectDesktopOverlaySmokeCandidateId(runState: Record<string, un
 
   const selected = candidates.find((candidate) => {
     return String(candidate.label || '').includes('AIRI Desktop Overlay Smoke Button')
-      || String(candidate.role || '').toLowerCase().includes('button')
-  }) ?? candidates[0]
+  })
 
   const id = typeof selected?.id === 'string' ? selected.id : ''
   if (!id)
-    throw new Error('desktop_observe produced no clickable target candidate id')
+    throw new Error('desktop_observe did not return the AIRI Desktop Overlay Smoke Button chrome_dom candidate')
 
   return id
 }

--- a/docs/desktop-lane-status.md
+++ b/docs/desktop-lane-status.md
@@ -1,6 +1,6 @@
 # Desktop Lane Status
 
-Updated: 2026-04-14
+Updated: 2026-05-06
 
 This note is a factual status memo for the current desktop lane work around PR #1649. It is intentionally narrow: only current state, actual blockers, and what should happen now vs later.
 
@@ -18,6 +18,8 @@ This note is a factual status memo for the current desktop lane work around PR #
     - `makeWindowPassThrough()` uses ignore-mouse-events + non-focusable overlay behavior
   - `/Users/liuziheng/airi/services/computer-use-mcp/src/browser-dom/cdp-bridge.ts`
     - 5-second heartbeat with teardown after 3 consecutive failures
+  - `/Users/liuziheng/airi/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts`
+    - desktop v3 smoke that proves the ensure / observe / click / state chain
 - The Chrome extension bridge and iframe offset work are no longer hypothetical:
   - PR #1649 already contains a real extension-side WebSocket client bridge
   - PR #1649 already contains frame offset propagation for iframe DOM candidates
@@ -26,7 +28,14 @@ This note is a factual status memo for the current desktop lane work around PR #
 
 These are the remaining real issues, ordered by severity.
 
-### 1. Extension unknown actions still return `ok: true`
+### 1. Live desktop v3 smoke exists, but it is baseline coverage, not product support.
+
+- Current smoke proves:
+  `desktop_ensure_chrome -> desktop_observe -> desktop_click_target -> desktop_get_state`
+- It does not prove Chrome semantic DOM routing, live overlay-window rendering,
+  or user-input isolation.
+
+### 2. Extension unknown actions still return `ok: true`
 
 - File:
   - `/Users/liuziheng/airi-pr1649/services/computer-use-mcp/chrome-extension/background.js`
@@ -38,7 +47,7 @@ These are the remaining real issues, ordered by severity.
   - that can suppress OS-input fallback even though nothing actually happened
 - This is still a real unresolved review blocker.
 
-### 2. Browser-dom click routing still ignores non-default click semantics
+### 3. Browser-dom click routing still ignores non-default click semantics
 
 - File:
   - `/Users/liuziheng/airi-pr1649/services/computer-use-mcp/src/browser-action-router.ts`
@@ -50,7 +59,7 @@ These are the remaining real issues, ordered by severity.
   - right-click or double-click can still be routed to a DOM path that only performs a standard primary click
 - This is not as severe as the first issue, but it is still a real correctness gap.
 
-### 3. Overlay lifecycle / RPC readiness is not fully closed yet
+### 4. Overlay lifecycle / RPC readiness is not fully closed yet
 
 - Files currently being worked on:
   - `/Users/liuziheng/airi-pr1649/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/contracts.ts`

--- a/docs/desktop-lane-status.md
+++ b/docs/desktop-lane-status.md
@@ -1,8 +1,8 @@
 # Desktop Lane Status
 
-Updated: 2026-05-06
+Updated: 2026-05-08
 
-This note is a factual status memo for the current desktop lane work around PR #1649. It is intentionally narrow: only current state, actual blockers, and what should happen now vs later.
+This note is a factual status memo for the current desktop lane work in this recut branch. It is intentionally narrow: only current state, actual blockers, and what should happen now vs later.
 
 ## What is already true
 
@@ -21,8 +21,11 @@ This note is a factual status memo for the current desktop lane work around PR #
   - `/Users/liuziheng/airi/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts`
     - desktop v3 smoke that proves the ensure / observe / click / state chain
 - The Chrome extension bridge and iframe offset work are no longer hypothetical:
-  - PR #1649 already contains a real extension-side WebSocket client bridge
-  - PR #1649 already contains frame offset propagation for iframe DOM candidates
+  - the recut branch already contains a real extension-side WebSocket client bridge
+  - the recut branch already contains frame offset propagation for iframe DOM candidates
+- The browser-dom route contract is now fail-closed:
+  - non-left clicks and multi-clicks stay on OS input
+  - `BrowserDomExtensionBridge` rejects `ok: false` responses instead of treating them as success
 
 ## What is actually still blocking
 
@@ -35,47 +38,20 @@ These are the remaining real issues, ordered by severity.
 - It does not prove Chrome semantic DOM routing, live overlay-window rendering,
   or user-input isolation.
 
-### 2. Extension unknown actions still return `ok: true`
-
-- File:
-  - `/Users/liuziheng/airi-pr1649/services/computer-use-mcp/chrome-extension/background.js`
-- Current behavior:
-  - unsupported actions fall into `result = { error: ... }`
-  - but the response still returns `{ ok: true, result }`
-- Why this matters:
-  - upper layers can interpret unsupported DOM actions as successful bridge execution
-  - that can suppress OS-input fallback even though nothing actually happened
-- This is still a real unresolved review blocker.
-
-### 3. Browser-dom click routing still ignores non-default click semantics
-
-- File:
-  - `/Users/liuziheng/airi-pr1649/services/computer-use-mcp/src/browser-action-router.ts`
-  - called from `/Users/liuziheng/airi-pr1649/services/computer-use-mcp/src/server/register-desktop-grounding.ts`
-- Current behavior:
-  - `chrome_dom` candidates route to browser-dom if selector + bridge are available
-  - routing does not currently incorporate `button` / `clickCount`
-- Why this matters:
-  - right-click or double-click can still be routed to a DOM path that only performs a standard primary click
-- This is not as severe as the first issue, but it is still a real correctness gap.
-
-### 4. Overlay lifecycle / RPC readiness is not fully closed yet
+### 2. Overlay lifecycle / RPC readiness still needs a live-window pass on this recut branch.
 
 - Files currently being worked on:
-  - `/Users/liuziheng/airi-pr1649/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/contracts.ts`
-  - `/Users/liuziheng/airi-pr1649/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.ts`
-  - `/Users/liuziheng/airi-pr1649/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.ts`
-  - `/Users/liuziheng/airi-pr1649/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.test.ts`
+  - `/Users/liuziheng/airi-desktop-recut/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/contracts.ts`
+  - `/Users/liuziheng/airi-desktop-recut/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.ts`
+  - `/Users/liuziheng/airi-desktop-recut/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.ts`
+  - `/Users/liuziheng/airi-desktop-recut/apps/stage-tamagotchi/src/renderer/pages/desktop-overlay-polling.test.ts`
 - Current state:
-  - there is already a preload-order mitigation in `desktop-overlay/index.ts`
-  - there is already a per-call timeout in `desktop-overlay-polling.ts`
-  - there is now work-in-progress code for an explicit readiness contract
-- Why this is not yet "done":
-  - the readiness flow is still uncommitted work
-  - the live window context still needs one narrow verification pass
-- This is not proven broken today, but it is the most likely remaining runtime risk on the overlay path.
+  - the readiness contract is already wired in `desktop-overlay/rpc/index.electron.ts`
+  - the renderer poll controller already waits on readiness and handles degraded state
+  - the live window still needs one fresh pass on this recut branch to confirm the runtime proof is current
+- This is the remaining runtime risk on the overlay path.
 
-### 5. Local overlay live-window smoke exists in the recut branch, but it still needs a live run on this branch.
+### 3. Local overlay live-window smoke exists in the recut branch, but it still needs a live run on this branch.
 
 - The smoke is now wired in `apps/stage-tamagotchi/package.json` as
   `smoke:desktop-overlay-live-window`.
@@ -109,12 +85,9 @@ In short: m13v gave good runtime advice. That does not mean every suggestion is 
 
 ## What should happen now
 
-1. Fix the extension unknown-action response contract so unsupported actions return `ok: false`.
-2. Restrict browser-dom click routing to left single-click only; force OS-input for right-click or multi-click.
-3. Finish or explicitly shelve the overlay readiness contract work:
-   - if kept, validate it in a live overlay window context before merging
-   - if not finished now, do not half-merge it
-4. Rerun the local overlay live-window smoke on this recut branch before calling it current proof.
+1. No action needed for the extension unknown-action contract; it is already fail-closed.
+2. Keep browser-dom routing fail-closed for non-left clicks and bridge errors; this stays covered, not product-supported.
+3. Rerun the local overlay live-window smoke on this recut branch before calling it current proof.
 
 ## What should happen later
 

--- a/docs/desktop-lane-status.md
+++ b/docs/desktop-lane-status.md
@@ -75,6 +75,15 @@ These are the remaining real issues, ordered by severity.
   - the live window context still needs one narrow verification pass
 - This is not proven broken today, but it is the most likely remaining runtime risk on the overlay path.
 
+### 5. Local overlay live-window smoke exists in the recut branch, but it still needs a live run on this branch.
+
+- The smoke is now wired in `apps/stage-tamagotchi/package.json` as
+  `smoke:desktop-overlay-live-window`.
+- The shared candidate-selection helper is unit-tested.
+- What is still missing here is a fresh pass on this recut branch with the real
+  Electron overlay window, to confirm the heartbeat marker and MCP polling still
+  behave the same as the older line.
+
 ## What is not a current blocker
 
 These items are real ideas or cleanup work, but they are not the thing that should block the line right now.
@@ -105,6 +114,7 @@ In short: m13v gave good runtime advice. That does not mean every suggestion is 
 3. Finish or explicitly shelve the overlay readiness contract work:
    - if kept, validate it in a live overlay window context before merging
    - if not finished now, do not half-merge it
+4. Rerun the local overlay live-window smoke on this recut branch before calling it current proof.
 
 ## What should happen later
 

--- a/services/computer-use-mcp/chrome-extension/background.js
+++ b/services/computer-use-mcp/chrome-extension/background.js
@@ -8,13 +8,12 @@
  * It receives commands directly from the existing BrowserDomExtensionBridge
  * WebSocket connection in the AIRI computer-use-mcp service.
  *
- * Only read-only observation commands are supported.
- * All DOM-mutating actions (click, type, hover, scroll) have been removed
- * because the desktop lane uses real macOS OS-level input events.
+ * Read-only observation commands are supported, plus clickAt for DOM-level
+ * browser click routing.
  *
  * Adapted from /Users/liuziheng/computer_use/chrome-extension/background.js.
- * Stripped: offscreen management, Python bridge, all DOM-action commands
- * (clickAt, typeAt, hoverAt, scrollAt, simulateDragDrop, readStorage,
+ * Stripped: offscreen management, Python bridge, most DOM-action commands
+ * (typeAt, hoverAt, scrollAt, simulateDragDrop, readStorage,
  * setStorage, readCanvasData, injectCSS, executeScript, etc.)
  */
 
@@ -394,7 +393,7 @@ async function readAllFramesDOMWithOffsets(tabId, frameIds, opts) {
 /**
  * Handle a command from the AIRI BrowserDomExtensionBridge.
  *
- * Only read-only observation commands are supported:
+ * Supported commands:
  * - getActiveTab: get the active tab info
  * - getAllFrames: list all frames in the active tab
  * - readAllFramesDOM: collect interactive elements from all frames
@@ -405,6 +404,7 @@ async function readAllFramesDOMWithOffsets(tabId, frameIds, opts) {
  * - readInputValue: read the current value of an input/textarea/select
  * - getComputedStyles: read computed CSS styles of an element
  * - waitForElement: poll until a CSS selector matches in any frame
+ * - clickAt: dispatch a click event at viewport coordinates
  */
 async function handleCommand(cmd) {
   const { action, id } = cmd
@@ -530,6 +530,13 @@ async function handleCommand(cmd) {
         })
         break
       }
+
+      case 'clickAt':
+        result = await runCUAction(tabId, cmd.frameIds || null, 'clickAt', [
+          cmd.x ?? 0,
+          cmd.y ?? 0,
+        ])
+        break
 
       default:
         return { id, ok: false, error: `unknown action: ${action}` }

--- a/services/computer-use-mcp/chrome-extension/content.js
+++ b/services/computer-use-mcp/chrome-extension/content.js
@@ -4,15 +4,14 @@
  * Injected into every frame (including cross-origin iframes) in the MAIN world.
  * Namespace: window.__AIRI_DG__
  *
- * IMPORTANT: This script is READ-ONLY. It does NOT perform any DOM mutations,
- * clicks, typing, or navigation. All execution is done via real macOS OS-level
- * input events through the desktop grounding executor.
+ * IMPORTANT: This script is observation-first. It keeps the DOM inspection
+ * helpers plus the minimal click dispatcher used by browser_dom click routing.
  *
  * Adapted from the repository's Chrome extension source.
- * Stripped: clickAt, typeAt, hoverAt, scrollAt, simulateDragDrop, readStorage,
+ * Stripped: typeAt, hoverAt, scrollAt, simulateDragDrop, readStorage,
  * setStorage, readCanvasData, injectCSS, and all other DOM-mutating methods.
  * Kept: collectFrameDOM, _describeElement, _collectInteractiveElements,
- * findElement, findElements, getClickTarget.
+ * findElement, findElements, getClickTarget, waitForElement, clickAt.
  */
 (function () {
   'use strict'
@@ -335,12 +334,59 @@
         return { success: false, error: e.message }
       }
     },
+
+    /**
+     * Wait for an element matching the selector to appear in the DOM.
+     */
+    waitForElement(selector, timeoutMs) {
+      timeoutMs = timeoutMs || 5000
+      const existing = document.querySelector(selector)
+      if (existing)
+        return { success: true, found: true }
+
+      return new Promise((resolve) => {
+        let timer
+        const observer = new MutationObserver(() => {
+          if (document.querySelector(selector)) {
+            observer.disconnect()
+            clearTimeout(timer)
+            resolve({ success: true, found: true })
+          }
+        })
+        observer.observe(document.documentElement, { childList: true, subtree: true })
+        timer = setTimeout(() => {
+          observer.disconnect()
+          resolve({ success: false, error: 'timeout' })
+        }, timeoutMs)
+      })
+    },
+
+    /**
+     * Dispatch a click event at viewport coordinates (x, y).
+     */
+    clickAt(x, y) {
+      try {
+        const el = document.elementFromPoint(x, y)
+        if (!el)
+          return { success: false, error: 'no element at point' }
+        el.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+        }))
+        return { success: true, tagName: el.tagName.toLowerCase() }
+      }
+      catch (e) {
+        return { success: false, error: e.message }
+      }
+    },
   }
 
   window.__AIRI_DG__ = __AIRI_DG__
 
   // ---- Message handler: ISOLATED world bridge → MAIN world ----
-  window.addEventListener('message', (evt) => {
+  window.addEventListener('message', async (evt) => {
     if (evt.source !== window)
       return
     const data = evt.data
@@ -353,7 +399,10 @@
 
     if (typeof fn === 'function') {
       try {
-        result = { success: true, data: fn.apply(__AIRI_DG__, args || []) }
+        const value = fn.apply(__AIRI_DG__, args || [])
+        result = value instanceof Promise
+          ? { success: true, data: await value }
+          : { success: true, data: value }
       }
       catch (e) {
         result = { success: false, error: e.message || String(e) }

--- a/services/computer-use-mcp/package.json
+++ b/services/computer-use-mcp/package.json
@@ -42,6 +42,7 @@
     "smoke:remote": "tsx ./src/bin/smoke-remote.ts",
     "smoke:stdio": "tsx ./src/bin/smoke-stdio.ts",
     "smoke:macos": "tsx ./src/bin/smoke-macos.ts",
+    "smoke:desktop-v3": "tsx ./src/bin/smoke-chrome-grounding.ts",
     "smoke:workflow": "tsx ./src/bin/smoke-workflow.ts",
     "mcp:inspector": "pnpx @modelcontextprotocol/inspector pnpm -F @proj-airi/computer-use-mcp start",
     "build": "tsdown",

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
   extractOverlaySmokeState,
+  requireChromeDomSmokeCandidate,
   parseCommandArgs,
   requirePostClickOverlayState,
   requireRunState,
   requireStructuredContent,
   requireTextContent,
+  selectPendingActionForTool,
   selectDesktopV3SmokeCandidate,
 } from './smoke-chrome-grounding'
 
@@ -54,7 +56,7 @@ describe('smoke-chrome-grounding helpers', () => {
     }, 'desktop_get_state')).toThrow('desktop_get_state expected status=ok')
   })
 
-  it('selects explicit candidate first and otherwise prefers the smoke target button', () => {
+  it('selects explicit candidate first and otherwise prefers a chrome_dom smoke target', () => {
     const runState = {
       lastGroundingSnapshot: {
         snapshotId: 'dg_1',
@@ -75,7 +77,7 @@ describe('smoke-chrome-grounding helpers', () => {
           },
           {
             id: 't_2',
-            source: 'ax',
+            source: 'chrome_dom',
             role: 'AXButton',
             label: 'AIRI Desktop V3 Smoke Button',
             interactable: true,
@@ -89,7 +91,7 @@ describe('smoke-chrome-grounding helpers', () => {
     expect(() => selectDesktopV3SmokeCandidate(runState, 'missing')).toThrow('did not return requested candidate')
   })
 
-  it('falls back to button-like candidates before generic interactable candidates', () => {
+  it('does not select generic non-chrome candidates by default', () => {
     const runState = {
       lastGroundingSnapshot: {
         snapshotId: 'dg_1',
@@ -102,6 +104,14 @@ describe('smoke-chrome-grounding helpers', () => {
           },
           {
             id: 't_1',
+            source: 'ax',
+            role: 'AXButton',
+            label: 'Submit',
+            interactable: true,
+          },
+          {
+            id: 't_2',
+            source: 'chrome_dom',
             role: 'AXButton',
             label: 'Submit',
             interactable: true,
@@ -110,7 +120,7 @@ describe('smoke-chrome-grounding helpers', () => {
       },
     }
 
-    expect(selectDesktopV3SmokeCandidate(runState).id).toBe('t_1')
+    expect(selectDesktopV3SmokeCandidate(runState).id).toBe('t_2')
   })
 
   it('locks pre-click and post-click overlay state shape', () => {
@@ -165,5 +175,23 @@ describe('smoke-chrome-grounding helpers', () => {
     const structured = requireStructuredContent(clickResult, 'desktop_click_target')
     expect(typeof structured.backendResult).toBe('object')
     expect((structured.backendResult as Record<string, unknown>).executionRoute).toContain('browser_dom')
+  })
+
+  it('selects pending actions by tool name and fails with a useful message when missing', () => {
+    const pendingActions = [
+      { toolName: 'desktop_open_app', id: 'p_0' },
+      { toolName: 'desktop_click_target', id: 'p_1' },
+    ]
+
+    expect(selectPendingActionForTool(pendingActions, 'desktop_click_target').id).toBe('p_1')
+    expect(() => selectPendingActionForTool(pendingActions, 'desktop_ensure_chrome')).toThrow('no pending action for desktop_ensure_chrome (found: desktop_open_app, desktop_click_target)')
+  })
+
+  it('requires the smoke target to come from chrome_dom', () => {
+    expect(() => requireChromeDomSmokeCandidate({
+      id: 't_0',
+      source: 'ax',
+      label: 'Smoke',
+    })).toThrow('smoke target button was not captured as a chrome_dom candidate')
   })
 })

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractOverlaySmokeState,
+  parseCommandArgs,
+  requirePostClickOverlayState,
+  requireRunState,
+  requireStructuredContent,
+  requireTextContent,
+  selectDesktopV3SmokeCandidate,
+} from './smoke-chrome-grounding'
+
+describe('smoke-chrome-grounding helpers', () => {
+  it('parses server command args with fallback', () => {
+    expect(parseCommandArgs(undefined, ['start'])).toEqual(['start'])
+    expect(parseCommandArgs(' start -- --flag ', ['fallback'])).toEqual(['start', '--', '--flag'])
+  })
+
+  it('requires structured content and text content', () => {
+    expect(requireStructuredContent({
+      structuredContent: {
+        status: 'ok',
+      },
+    }, 'tool')).toEqual({ status: 'ok' })
+
+    expect(requireTextContent({
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'image', data: 'ignored' },
+        { type: 'text', text: 'world' },
+      ],
+    }, 'tool')).toBe('hello\nworld')
+
+    expect(() => requireStructuredContent({}, 'tool')).toThrow('tool missing structuredContent')
+    expect(() => requireTextContent({ content: [] }, 'tool')).toThrow('tool missing text content')
+  })
+
+  it('extracts runState from desktop_get_state structured content', () => {
+    expect(requireRunState({
+      structuredContent: {
+        status: 'ok',
+        runState: {
+          lastClickedCandidateId: 't_0',
+        },
+      },
+    }, 'desktop_get_state')).toEqual({
+      lastClickedCandidateId: 't_0',
+    })
+
+    expect(() => requireRunState({
+      structuredContent: {
+        status: 'error',
+      },
+    }, 'desktop_get_state')).toThrow('desktop_get_state expected status=ok')
+  })
+
+  it('selects explicit candidate first and otherwise prefers the smoke target button', () => {
+    const runState = {
+      lastGroundingSnapshot: {
+        snapshotId: 'dg_1',
+        targetCandidates: [
+          {
+            id: 't_0',
+            source: 'ax',
+            role: 'button',
+            label: 'Disabled',
+            interactable: false,
+          },
+          {
+            id: 't_1',
+            source: 'chrome_dom',
+            role: 'AXToolbar',
+            label: 'Toolbar',
+            interactable: true,
+          },
+          {
+            id: 't_2',
+            source: 'ax',
+            role: 'AXButton',
+            label: 'AIRI Desktop V3 Smoke Button',
+            interactable: true,
+          },
+        ],
+      },
+    }
+
+    expect(selectDesktopV3SmokeCandidate(runState).id).toBe('t_2')
+    expect(selectDesktopV3SmokeCandidate(runState, 't_0').id).toBe('t_0')
+    expect(() => selectDesktopV3SmokeCandidate(runState, 'missing')).toThrow('did not return requested candidate')
+  })
+
+  it('falls back to button-like candidates before generic interactable candidates', () => {
+    const runState = {
+      lastGroundingSnapshot: {
+        snapshotId: 'dg_1',
+        targetCandidates: [
+          {
+            id: 't_0',
+            role: 'AXToolbar',
+            label: 'Toolbar',
+            interactable: true,
+          },
+          {
+            id: 't_1',
+            role: 'AXButton',
+            label: 'Submit',
+            interactable: true,
+          },
+        ],
+      },
+    }
+
+    expect(selectDesktopV3SmokeCandidate(runState).id).toBe('t_1')
+  })
+
+  it('locks pre-click and post-click overlay state shape', () => {
+    const runState = {
+      lastGroundingSnapshot: {
+        snapshotId: 'dg_1',
+        targetCandidates: [
+          { id: 't_0' },
+        ],
+        staleFlags: {
+          screenshot: false,
+          ax: false,
+          chromeSemantic: false,
+        },
+      },
+    }
+
+    expect(extractOverlaySmokeState(runState)).toMatchObject({
+      hasSnapshot: true,
+      snapshotId: 'dg_1',
+      candidateCount: 1,
+    })
+
+    expect(requirePostClickOverlayState({
+      ...runState,
+      lastPointerIntent: {
+        candidateId: 't_0',
+        phase: 'completed',
+      },
+      lastClickedCandidateId: 't_0',
+    }, 't_0')).toMatchObject({
+      pointerIntent: {
+        candidateId: 't_0',
+      },
+      lastClickedCandidateId: 't_0',
+    })
+
+    expect(() => requirePostClickOverlayState(runState, 't_0')).toThrow('missing lastPointerIntent')
+  })
+
+  it('reads chrome_dom routing evidence from desktop_click_target structured content', () => {
+    const clickResult = {
+      structuredContent: {
+        status: 'executed',
+        backendResult: {
+          executionRoute: 'browser_dom (chrome_dom candidate with selector "#login-btn" routed to browser-dom bridge)',
+          routeReason: 'chrome_dom candidate with selector "#login-btn" routed to browser-dom bridge',
+        },
+      },
+    }
+
+    const structured = requireStructuredContent(clickResult, 'desktop_click_target')
+    expect(typeof structured.backendResult).toBe('object')
+    expect((structured.backendResult as Record<string, unknown>).executionRoute).toContain('browser_dom')
+  })
+})

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
@@ -68,7 +68,7 @@ describe('smoke-chrome-grounding helpers', () => {
     }, 'desktop_get_state')).toThrow('desktop_get_state expected status=ok')
   })
 
-  it('selects explicit candidate first and otherwise prefers a chrome_dom smoke target', () => {
+  it('selects explicit candidate first and otherwise requires the chrome_dom smoke target label', () => {
     const runState = {
       lastGroundingSnapshot: {
         snapshotId: 'dg_1',
@@ -103,7 +103,7 @@ describe('smoke-chrome-grounding helpers', () => {
     expect(() => selectDesktopV3SmokeCandidate(runState, 'missing')).toThrow('did not return requested candidate')
   })
 
-  it('does not select generic non-chrome candidates by default', () => {
+  it('does not fall back to a generic chrome_dom candidate when the smoke label is missing', () => {
     const runState = {
       lastGroundingSnapshot: {
         snapshotId: 'dg_1',
@@ -132,7 +132,7 @@ describe('smoke-chrome-grounding helpers', () => {
       },
     }
 
-    expect(selectDesktopV3SmokeCandidate(runState).id).toBe('t_2')
+    expect(() => selectDesktopV3SmokeCandidate(runState)).toThrow('desktop_observe did not return the AIRI Desktop V3 Smoke Button chrome_dom candidate')
   })
 
   it('locks pre-click and post-click overlay state shape', () => {

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
@@ -4,6 +4,8 @@ import {
   extractOverlaySmokeState,
   requireChromeDomSmokeCandidate,
   parseCommandArgs,
+  parseNumber,
+  parseOptionalString,
   requirePostClickOverlayState,
   requireRunState,
   requireStructuredContent,
@@ -16,6 +18,16 @@ describe('smoke-chrome-grounding helpers', () => {
   it('parses server command args with fallback', () => {
     expect(parseCommandArgs(undefined, ['start'])).toEqual(['start'])
     expect(parseCommandArgs(' start -- --flag ', ['fallback'])).toEqual(['start', '--', '--flag'])
+  })
+
+  it('parses numbers and optional string sentinels', () => {
+    expect(parseNumber(undefined, 12)).toBe(12)
+    expect(parseNumber('9.8', 12)).toBe(9)
+    expect(parseNumber('foo', 12)).toBe(12)
+    expect(parseOptionalString(undefined)).toBeUndefined()
+    expect(parseOptionalString(' undefined ')).toBeUndefined()
+    expect(parseOptionalString(' null ')).toBeUndefined()
+    expect(parseOptionalString(' t_1 ')).toBe('t_1')
   })
 
   it('requires structured content and text content', () => {

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   extractOverlaySmokeState,
+  findDesktopV3SmokeCandidate,
   requireChromeDomSmokeCandidate,
   parseCommandArgs,
   parseNumber,
@@ -10,6 +11,7 @@ import {
   requireRunState,
   requireStructuredContent,
   requireTextContent,
+  shouldExpectBrowserDomRoute,
   selectPendingActionForTool,
   selectDesktopV3SmokeCandidate,
 } from './smoke-chrome-grounding'
@@ -99,6 +101,7 @@ describe('smoke-chrome-grounding helpers', () => {
     }
 
     expect(selectDesktopV3SmokeCandidate(runState).id).toBe('t_2')
+    expect(findDesktopV3SmokeCandidate(runState)?.id).toBe('t_2')
     expect(selectDesktopV3SmokeCandidate(runState, 't_0').id).toBe('t_0')
     expect(() => selectDesktopV3SmokeCandidate(runState, 'missing')).toThrow('did not return requested candidate')
   })
@@ -132,6 +135,7 @@ describe('smoke-chrome-grounding helpers', () => {
       },
     }
 
+    expect(findDesktopV3SmokeCandidate(runState)).toBeUndefined()
     expect(() => selectDesktopV3SmokeCandidate(runState)).toThrow('desktop_observe did not return the AIRI Desktop V3 Smoke Button chrome_dom candidate')
   })
 
@@ -187,6 +191,37 @@ describe('smoke-chrome-grounding helpers', () => {
     const structured = requireStructuredContent(clickResult, 'desktop_click_target')
     expect(typeof structured.backendResult).toBe('object')
     expect((structured.backendResult as Record<string, unknown>).executionRoute).toContain('browser_dom')
+  })
+
+  it('expects desktop_ensure_chrome structured content to expose ensureOutcome', () => {
+    const structured = requireStructuredContent({
+      structuredContent: {
+        status: 'ok',
+        ensureOutcome: 'reused',
+      },
+    }, 'desktop_ensure_chrome')
+
+    expect(structured.ensureOutcome).toBe('reused')
+  })
+
+  it('expects browser-dom routing only when browser_dom surface is available', () => {
+    expect(shouldExpectBrowserDomRoute({
+      browserSurfaceAvailability: {
+        availableSurfaces: ['browser_dom'],
+        preferredSurface: 'browser_dom',
+        selectedToolName: 'browser_dom_read_page',
+      },
+    })).toBe(true)
+
+    expect(shouldExpectBrowserDomRoute({
+      browserSurfaceAvailability: {
+        availableSurfaces: ['browser_cdp'],
+        preferredSurface: 'browser_cdp',
+        selectedToolName: 'browser_cdp_collect_elements',
+      },
+    })).toBe(false)
+
+    expect(shouldExpectBrowserDomRoute({})).toBe(false)
   })
 
   it('selects pending actions by tool name and fails with a useful message when missing', () => {

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.test.ts
@@ -3,17 +3,17 @@ import { describe, expect, it } from 'vitest'
 import {
   extractOverlaySmokeState,
   findDesktopV3SmokeCandidate,
-  requireChromeDomSmokeCandidate,
   parseCommandArgs,
   parseNumber,
   parseOptionalString,
+  requireChromeDomSmokeCandidate,
   requirePostClickOverlayState,
   requireRunState,
   requireStructuredContent,
   requireTextContent,
-  shouldExpectBrowserDomRoute,
-  selectPendingActionForTool,
   selectDesktopV3SmokeCandidate,
+  selectPendingActionForTool,
+  shouldExpectBrowserDomRoute,
 } from './smoke-chrome-grounding'
 
 describe('smoke-chrome-grounding helpers', () => {

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
@@ -1,0 +1,470 @@
+/**
+ * End-to-end smoke test for the desktop v3 Chrome grounding pipeline.
+ *
+ * Verifies that:
+ * 1. `desktop_ensure_chrome` starts or joins an agent Chrome window.
+ * 2. `desktop_observe` captures a valid grounding snapshot.
+ * 3. `desktop_get_state` exposes overlay-consumable grounding state.
+ * 4. `desktop_click_target` updates pointer intent and clicked-candidate state.
+ *
+ * Usage:
+ *   pnpm -F @proj-airi/computer-use-mcp smoke:desktop-v3
+ */
+
+import { dirname, resolve } from 'node:path'
+import { argv, env, exit } from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const WHITESPACE_SPLIT_RE = /\s+/u
+const SMOKE_TARGET_LABEL = 'AIRI Desktop V3 Smoke Button'
+
+const DEFAULT_SMOKE_URL = `data:text/html;charset=utf-8,${encodeURIComponent(`<!doctype html>
+<html>
+  <head>
+    <title>AIRI Desktop V3 Smoke</title>
+    <style>
+      body { font-family: sans-serif; padding: 48px; }
+      button { font-size: 18px; padding: 12px 18px; }
+    </style>
+  </head>
+  <body>
+    <h1>AIRI Desktop V3 Smoke</h1>
+    <button id="airi-desktop-v3-smoke-button">AIRI Desktop V3 Smoke Button</button>
+  </body>
+</html>`)}`;
+
+export interface DesktopV3SmokeCandidate {
+  id: string
+  source?: string
+  role?: string
+  label?: string
+  interactable?: boolean
+}
+
+interface CandidateRecord extends Record<string, unknown> {
+  id: string
+}
+
+export interface OverlaySmokeState {
+  hasSnapshot: boolean
+  snapshotId: string
+  candidateCount: number
+  staleFlags: unknown
+  pointerIntent?: Record<string, unknown>
+  lastClickedCandidateId?: string
+}
+
+export interface ApprovalEvent {
+  toolName: string
+  pendingActionId: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function parseCommandArgs(raw: string | undefined, fallback: string[]): string[] {
+  if (!raw?.trim())
+    return fallback
+
+  return raw
+    .split(WHITESPACE_SPLIT_RE)
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+export function requireStructuredContent(result: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(result))
+    throw new Error(`${label} did not return an object result`)
+
+  const structuredContent = result.structuredContent
+  if (!isRecord(structuredContent))
+    throw new Error(`${label} missing structuredContent`)
+
+  return structuredContent
+}
+
+export function requireTextContent(result: unknown, label: string): string {
+  if (!isRecord(result) || !Array.isArray(result.content))
+    throw new Error(`${label} missing content`)
+
+  const text = result.content
+    .filter(isRecord)
+    .map(item => typeof item.text === 'string' ? item.text : '')
+    .filter(Boolean)
+    .join('\n')
+
+  if (!text.trim())
+    throw new Error(`${label} missing text content`)
+
+  return text
+}
+
+export function requireRunState(result: unknown, label: string): Record<string, unknown> {
+  const structuredContent = requireStructuredContent(result, label)
+  if (structuredContent.status !== 'ok')
+    throw new Error(`${label} expected status=ok, got ${String(structuredContent.status)}`)
+
+  if (!isRecord(structuredContent.runState))
+    throw new Error(`${label} missing runState`)
+
+  return structuredContent.runState
+}
+
+export function selectDesktopV3SmokeCandidate(
+  runState: Record<string, unknown>,
+  requestedCandidateId?: string,
+): DesktopV3SmokeCandidate {
+  const snapshot = runState.lastGroundingSnapshot
+  if (!isRecord(snapshot))
+    throw new Error('desktop_get_state missing lastGroundingSnapshot after desktop_observe')
+
+  const candidates = Array.isArray(snapshot.targetCandidates)
+    ? snapshot.targetCandidates.filter(isRecord)
+    : []
+
+  if (candidates.length === 0)
+    throw new Error('desktop_observe produced no target candidates')
+
+  const requested = requestedCandidateId?.trim()
+  const candidatesWithIds = candidates.filter((candidate): candidate is CandidateRecord => {
+    return typeof candidate.id === 'string' && candidate.id.length > 0
+  })
+  const selected = requested
+    ? candidatesWithIds.find(candidate => candidate.id === requested)
+    : selectDefaultCandidate(candidatesWithIds)
+
+  if (!selected) {
+    throw new Error(`desktop_observe did not return requested candidate "${requested}"`)
+  }
+
+  return {
+    id: selected.id,
+    source: typeof selected.source === 'string' ? selected.source : undefined,
+    role: typeof selected.role === 'string' ? selected.role : undefined,
+    label: typeof selected.label === 'string' ? selected.label : undefined,
+    interactable: typeof selected.interactable === 'boolean' ? selected.interactable : undefined,
+  }
+}
+
+function candidateText(candidate: Record<string, unknown>): string {
+  return [
+    candidate.id,
+    candidate.label,
+    candidate.role,
+    candidate.source,
+  ]
+    .filter(item => typeof item === 'string')
+    .join(' ')
+    .toLowerCase()
+}
+
+function selectDefaultCandidate(candidates: CandidateRecord[]): CandidateRecord | undefined {
+  const interactableCandidates = candidates.filter(candidate => candidate.interactable !== false)
+  const pool = interactableCandidates.length > 0 ? interactableCandidates : candidates
+
+  return pool.find(candidate => candidateText(candidate).includes(SMOKE_TARGET_LABEL.toLowerCase()))
+    ?? pool.find((candidate) => {
+      const text = candidateText(candidate)
+      return text.includes('button')
+        || text.includes('link')
+        || text.includes('checkbox')
+        || text.includes('menuitem')
+        || text.includes('textbox')
+    })
+    ?? pool[0]
+}
+
+export function extractOverlaySmokeState(runState: Record<string, unknown>): OverlaySmokeState {
+  const snapshot = runState.lastGroundingSnapshot
+  if (!isRecord(snapshot))
+    throw new Error('desktop_get_state missing lastGroundingSnapshot')
+
+  const snapshotId = typeof snapshot.snapshotId === 'string' ? snapshot.snapshotId : ''
+  if (!snapshotId)
+    throw new Error('lastGroundingSnapshot missing snapshotId')
+
+  const candidates = Array.isArray(snapshot.targetCandidates) ? snapshot.targetCandidates : []
+  const pointerIntent = isRecord(runState.lastPointerIntent)
+    ? runState.lastPointerIntent
+    : undefined
+  const lastClickedCandidateId = typeof runState.lastClickedCandidateId === 'string'
+    ? runState.lastClickedCandidateId
+    : undefined
+
+  return {
+    hasSnapshot: true,
+    snapshotId,
+    candidateCount: candidates.length,
+    staleFlags: snapshot.staleFlags,
+    pointerIntent,
+    lastClickedCandidateId,
+  }
+}
+
+export function requirePostClickOverlayState(
+  runState: Record<string, unknown>,
+  selectedCandidateId: string,
+): OverlaySmokeState {
+  const overlayState = extractOverlaySmokeState(runState)
+
+  if (!overlayState.pointerIntent)
+    throw new Error('desktop_get_state missing lastPointerIntent after desktop_click_target')
+
+  if (overlayState.pointerIntent.candidateId !== selectedCandidateId) {
+    throw new Error(`lastPointerIntent candidate mismatch: expected ${selectedCandidateId}, got ${String(overlayState.pointerIntent.candidateId)}`)
+  }
+
+  if (overlayState.lastClickedCandidateId !== selectedCandidateId) {
+    throw new Error(`lastClickedCandidateId mismatch: expected ${selectedCandidateId}, got ${String(overlayState.lastClickedCandidateId)}`)
+  }
+
+  return overlayState
+}
+
+async function approveFirstPending(
+  client: Client,
+  expectedToolName: string,
+): Promise<{ result: unknown, approvalEvent: ApprovalEvent }> {
+  const pending = await client.callTool({
+    name: 'desktop_list_pending_actions',
+    arguments: {},
+  })
+  const pendingData = requireStructuredContent(pending, 'desktop_list_pending_actions')
+  const pendingActions = Array.isArray(pendingData.pendingActions)
+    ? pendingData.pendingActions.filter(isRecord)
+    : []
+  const matchingPending = pendingActions.find(action => action.toolName === expectedToolName) ?? pendingActions[0]
+
+  if (!matchingPending)
+    throw new Error(`no pending action after ${expectedToolName}`)
+
+  const pendingActionId = typeof matchingPending.id === 'string' ? matchingPending.id : ''
+  if (!pendingActionId)
+    throw new Error(`pending action missing id after ${expectedToolName}`)
+
+  const result = await client.callTool({
+    name: 'desktop_approve_pending_action',
+    arguments: { id: pendingActionId },
+  })
+
+  return {
+    result,
+    approvalEvent: {
+      toolName: expectedToolName,
+      pendingActionId,
+    },
+  }
+}
+
+async function resolveApprovalIfNeeded(
+  client: Client,
+  toolName: string,
+  result: unknown,
+  approvalEvents: ApprovalEvent[],
+): Promise<unknown> {
+  const structuredContent = isRecord(result)
+    ? result.structuredContent
+    : undefined
+
+  if (!isRecord(structuredContent) || structuredContent.status !== 'approval_required')
+    return result
+
+  const approved = await approveFirstPending(client, toolName)
+  approvalEvents.push(approved.approvalEvent)
+  return approved.result
+}
+
+function assertToolRegistered(toolNames: Set<string>, toolName: string) {
+  if (!toolNames.has(toolName))
+    throw new Error(`required desktop v3 tool is not registered: ${toolName}`)
+}
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (!value?.trim())
+    return fallback
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : fallback
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
+  const command = env.COMPUTER_USE_SMOKE_SERVER_COMMAND?.trim() || 'pnpm'
+  const args = parseCommandArgs(env.COMPUTER_USE_SMOKE_SERVER_ARGS, ['start'])
+  const cwd = env.COMPUTER_USE_SMOKE_SERVER_CWD?.trim() || packageDir
+  const smokeUrl = env.COMPUTER_USE_DESKTOP_V3_SMOKE_URL?.trim() || DEFAULT_SMOKE_URL
+  const requestedCandidateId = env.COMPUTER_USE_DESKTOP_V3_SMOKE_CANDIDATE_ID
+  const settleMs = parseNumber(env.COMPUTER_USE_DESKTOP_V3_SMOKE_SETTLE_MS, 750)
+
+  const transport = new StdioClientTransport({
+    command,
+    args,
+    cwd,
+    env: {
+      ...env,
+      COMPUTER_USE_EXECUTOR: env.COMPUTER_USE_SMOKE_EXECUTOR || env.COMPUTER_USE_EXECUTOR || 'macos-local',
+      COMPUTER_USE_APPROVAL_MODE: env.COMPUTER_USE_SMOKE_APPROVAL_MODE || env.COMPUTER_USE_APPROVAL_MODE || 'actions',
+      COMPUTER_USE_OPENABLE_APPS: env.COMPUTER_USE_OPENABLE_APPS || 'Terminal,Cursor,Google Chrome',
+    },
+    stderr: 'pipe',
+  })
+  const client = new Client({
+    name: '@proj-airi/computer-use-mcp-smoke-desktop-v3',
+    version: '0.1.0',
+  })
+
+  transport.stderr?.on('data', (chunk) => {
+    const text = chunk.toString('utf-8').trim()
+    if (text)
+      console.error(`[computer-use-mcp stderr] ${text}`)
+  })
+
+  const approvalEvents: ApprovalEvent[] = []
+
+  try {
+    await client.connect(transport)
+
+    const tools = await client.listTools()
+    const toolNames = new Set(tools.tools.map(tool => tool.name))
+    const requiredTools = [
+      'desktop_ensure_chrome',
+      'desktop_observe',
+      'desktop_click_target',
+      'desktop_get_state',
+      'desktop_list_pending_actions',
+      'desktop_approve_pending_action',
+    ]
+
+    for (const toolName of requiredTools) {
+      assertToolRegistered(toolNames, toolName)
+    }
+
+    console.info('=== Phase 1: desktop_ensure_chrome ===')
+    const ensureChrome = await resolveApprovalIfNeeded(
+      client,
+      'desktop_ensure_chrome',
+      await client.callTool({
+        name: 'desktop_ensure_chrome',
+        arguments: { url: smokeUrl },
+      }),
+      approvalEvents,
+    )
+    const ensureChromeData = requireStructuredContent(ensureChrome, 'desktop_ensure_chrome')
+
+    if (settleMs > 0)
+      await delay(settleMs)
+
+    console.info('=== Phase 2: desktop_observe ===')
+    const observation = await client.callTool({
+      name: 'desktop_observe',
+      arguments: { includeChrome: true },
+    })
+    const observeText = requireTextContent(observation, 'desktop_observe')
+
+    console.info('=== Phase 3: desktop_get_state before click ===')
+    const preClickState = requireRunState(await client.callTool({
+      name: 'desktop_get_state',
+      arguments: {},
+    }), 'desktop_get_state')
+    const preClickOverlayState = extractOverlaySmokeState(preClickState)
+    const selectedCandidate = selectDesktopV3SmokeCandidate(preClickState, requestedCandidateId)
+
+    console.info('=== Phase 4: desktop_click_target ===')
+    const clickTarget = await resolveApprovalIfNeeded(
+      client,
+      'desktop_click_target',
+      await client.callTool({
+        name: 'desktop_click_target',
+        arguments: {
+          candidateId: selectedCandidate.id,
+          button: 'left',
+          clickCount: 1,
+        },
+      }),
+      approvalEvents,
+    )
+    requireTextContent(clickTarget, 'desktop_click_target')
+
+    console.info('=== Phase 5: desktop_get_state after click ===')
+    const postClickState = requireRunState(await client.callTool({
+      name: 'desktop_get_state',
+      arguments: {},
+    }), 'desktop_get_state')
+    const postClickOverlayState = requirePostClickOverlayState(postClickState, selectedCandidate.id)
+    const clickStructured = requireStructuredContent(clickTarget, 'desktop_click_target')
+    const clickBackendResult = isRecord(clickStructured.backendResult)
+      ? clickStructured.backendResult as Record<string, unknown>
+      : undefined
+    const clickExecutionRoute = typeof clickBackendResult?.executionRoute === 'string'
+      ? clickBackendResult.executionRoute
+      : undefined
+    const clickRouteReason = typeof clickBackendResult?.routeReason === 'string'
+      ? clickBackendResult.routeReason
+      : undefined
+
+    if (!clickExecutionRoute) {
+      throw new Error('desktop_click_target missing backendResult.executionRoute')
+    }
+
+    if (selectedCandidate.source === 'chrome_dom' && !clickExecutionRoute.startsWith('browser_dom')) {
+      throw new Error(`expected chrome_dom candidate to route through browser_dom, got ${clickExecutionRoute}`)
+    }
+
+    return {
+      ok: true,
+      toolChain: [
+        'desktop_ensure_chrome',
+        'desktop_observe',
+        'desktop_get_state',
+        'desktop_click_target',
+        'desktop_get_state',
+      ],
+      ensureChrome: ensureChromeData,
+      observeSummary: observeText.split('\n').slice(0, 8),
+      selectedCandidate,
+      preClickOverlayState,
+      postClickOverlayState,
+      clickExecutionRoute,
+      clickRouteReason,
+      approvalEvents,
+    }
+  }
+  finally {
+    await client.close().catch(() => {})
+  }
+}
+
+const invokedPath = argv[1] ? pathToFileURL(argv[1]).href : undefined
+
+if (invokedPath === import.meta.url) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.info(`Usage:
+  pnpm -F @proj-airi/computer-use-mcp smoke:desktop-v3
+
+Environment:
+  COMPUTER_USE_DESKTOP_V3_SMOKE_URL            Target URL. Defaults to an inline data: smoke page.
+  COMPUTER_USE_DESKTOP_V3_SMOKE_CANDIDATE_ID   Optional candidate id override from desktop_observe.
+  COMPUTER_USE_DESKTOP_V3_SMOKE_SETTLE_MS      Delay after desktop_ensure_chrome. Default: 750.
+  COMPUTER_USE_SMOKE_EXECUTOR                  Executor override. Default: macos-local.
+  COMPUTER_USE_SMOKE_APPROVAL_MODE             Approval mode override. Default: actions.
+`)
+    exit(0)
+  }
+
+  runDesktopV3Smoke()
+    .then((result) => {
+      console.info(JSON.stringify(result, null, 2))
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.stack || error.message : String(error))
+      exit(1)
+    })
+}

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
@@ -63,6 +63,11 @@ export interface ApprovalEvent {
   pendingActionId: string
 }
 
+export interface PendingActionRecord extends Record<string, unknown> {
+  toolName?: string
+  id?: string
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
@@ -136,7 +141,7 @@ export function selectDesktopV3SmokeCandidate(
   })
   const selected = requested
     ? candidatesWithIds.find(candidate => candidate.id === requested)
-    : selectDefaultCandidate(candidatesWithIds)
+    : selectDefaultChromeDomCandidate(candidatesWithIds)
 
   if (!selected) {
     throw new Error(`desktop_observe did not return requested candidate "${requested}"`)
@@ -163,20 +168,9 @@ function candidateText(candidate: Record<string, unknown>): string {
     .toLowerCase()
 }
 
-function selectDefaultCandidate(candidates: CandidateRecord[]): CandidateRecord | undefined {
-  const interactableCandidates = candidates.filter(candidate => candidate.interactable !== false)
-  const pool = interactableCandidates.length > 0 ? interactableCandidates : candidates
-
-  return pool.find(candidate => candidateText(candidate).includes(SMOKE_TARGET_LABEL.toLowerCase()))
-    ?? pool.find((candidate) => {
-      const text = candidateText(candidate)
-      return text.includes('button')
-        || text.includes('link')
-        || text.includes('checkbox')
-        || text.includes('menuitem')
-        || text.includes('textbox')
-    })
-    ?? pool[0]
+function selectDefaultChromeDomCandidate(candidates: CandidateRecord[]): CandidateRecord | undefined {
+  return candidates.find(candidate => candidate.source === 'chrome_dom' && candidateText(candidate).includes(SMOKE_TARGET_LABEL.toLowerCase()))
+    ?? candidates.find(candidate => candidate.source === 'chrome_dom')
 }
 
 export function extractOverlaySmokeState(runState: Record<string, unknown>): OverlaySmokeState {
@@ -226,6 +220,29 @@ export function requirePostClickOverlayState(
   return overlayState
 }
 
+export function requireChromeDomSmokeCandidate(candidate: DesktopV3SmokeCandidate): void {
+  if (candidate.source !== 'chrome_dom') {
+    throw new Error(`smoke target button was not captured as a chrome_dom candidate (got: ${candidate.source ?? 'unknown'}). Verify extension is connected.`)
+  }
+}
+
+export function selectPendingActionForTool(
+  pendingActions: PendingActionRecord[],
+  expectedToolName: string,
+): PendingActionRecord {
+  const matchingPending = pendingActions.find(action => action.toolName === expectedToolName)
+
+  if (!matchingPending) {
+    const found = pendingActions
+      .map(action => action.toolName)
+      .filter((toolName): toolName is string => typeof toolName === 'string' && toolName.length > 0)
+      .join(', ') || 'none'
+    throw new Error(`no pending action for ${expectedToolName} (found: ${found})`)
+  }
+
+  return matchingPending
+}
+
 async function approveFirstPending(
   client: Client,
   expectedToolName: string,
@@ -236,12 +253,9 @@ async function approveFirstPending(
   })
   const pendingData = requireStructuredContent(pending, 'desktop_list_pending_actions')
   const pendingActions = Array.isArray(pendingData.pendingActions)
-    ? pendingData.pendingActions.filter(isRecord)
+    ? pendingData.pendingActions.filter(isRecord) as PendingActionRecord[]
     : []
-  const matchingPending = pendingActions.find(action => action.toolName === expectedToolName) ?? pendingActions[0]
-
-  if (!matchingPending)
-    throw new Error(`no pending action after ${expectedToolName}`)
+  const matchingPending = selectPendingActionForTool(pendingActions, expectedToolName)
 
   const pendingActionId = typeof matchingPending.id === 'string' ? matchingPending.id : ''
   if (!pendingActionId)
@@ -376,6 +390,7 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
     }), 'desktop_get_state')
     const preClickOverlayState = extractOverlaySmokeState(preClickState)
     const selectedCandidate = selectDesktopV3SmokeCandidate(preClickState, requestedCandidateId)
+    requireChromeDomSmokeCandidate(selectedCandidate)
 
     console.info('=== Phase 4: desktop_click_target ===')
     const clickTarget = await resolveApprovalIfNeeded(

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
@@ -35,7 +35,7 @@ const DEFAULT_SMOKE_URL = `data:text/html;charset=utf-8,${encodeURIComponent(`<!
     <h1>AIRI Desktop V3 Smoke</h1>
     <button id="airi-desktop-v3-smoke-button">AIRI Desktop V3 Smoke Button</button>
   </body>
-</html>`)}`;
+</html>`)}`
 
 export interface DesktopV3SmokeCandidate {
   id: string

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
@@ -124,6 +124,22 @@ export function selectDesktopV3SmokeCandidate(
   runState: Record<string, unknown>,
   requestedCandidateId?: string,
 ): DesktopV3SmokeCandidate {
+  const selected = findDesktopV3SmokeCandidate(runState, requestedCandidateId)
+  if (selected) {
+    return selected
+  }
+
+  const requested = requestedCandidateId?.trim()
+  if (!requested) {
+    throw new Error('desktop_observe did not return the AIRI Desktop V3 Smoke Button chrome_dom candidate')
+  }
+  throw new Error(`desktop_observe did not return requested candidate "${requested}"`)
+}
+
+export function findDesktopV3SmokeCandidate(
+  runState: Record<string, unknown>,
+  requestedCandidateId?: string,
+): DesktopV3SmokeCandidate | undefined {
   const snapshot = runState.lastGroundingSnapshot
   if (!isRecord(snapshot))
     throw new Error('desktop_get_state missing lastGroundingSnapshot after desktop_observe')
@@ -145,10 +161,7 @@ export function selectDesktopV3SmokeCandidate(
     : selectDefaultChromeDomCandidate(chromeDomCandidates)
 
   if (!selected) {
-    if (!requested) {
-      throw new Error('desktop_observe did not return the AIRI Desktop V3 Smoke Button chrome_dom candidate')
-    }
-    throw new Error(`desktop_observe did not return requested candidate "${requested}"`)
+    return undefined
   }
 
   return {
@@ -229,6 +242,28 @@ export function requireChromeDomSmokeCandidate(candidate: DesktopV3SmokeCandidat
   if (candidate.source !== 'chrome_dom') {
     throw new Error(`smoke target button was not captured as a chrome_dom candidate (got: ${candidate.source ?? 'unknown'}). Verify extension is connected.`)
   }
+}
+
+export function shouldExpectBrowserDomRoute(runState: Record<string, unknown>): boolean {
+  const browserSurfaceAvailability = isRecord(runState.browserSurfaceAvailability)
+    ? runState.browserSurfaceAvailability
+    : undefined
+
+  const preferredSurface = typeof browserSurfaceAvailability?.preferredSurface === 'string'
+    ? browserSurfaceAvailability.preferredSurface
+    : undefined
+
+  const selectedToolName = typeof browserSurfaceAvailability?.selectedToolName === 'string'
+    ? browserSurfaceAvailability.selectedToolName
+    : undefined
+
+  const availableSurfaces = Array.isArray(browserSurfaceAvailability?.availableSurfaces)
+    ? browserSurfaceAvailability.availableSurfaces.filter((surface): surface is string => typeof surface === 'string')
+    : []
+
+  return preferredSurface === 'browser_dom'
+    || selectedToolName === 'browser_dom_read_page'
+    || availableSurfaces.includes('browser_dom')
 }
 
 export function selectPendingActionForTool(
@@ -323,6 +358,83 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+async function waitForChromeDomSmokeCandidate(
+  client: Client,
+  requestedCandidateId: string | undefined,
+  timeoutMs: number,
+  retryIntervalMs: number,
+): Promise<{
+  observationText: string
+  runState: Record<string, unknown>
+  overlayState: OverlaySmokeState
+  candidate: DesktopV3SmokeCandidate
+}> {
+  const deadline = Date.now() + timeoutMs
+  let lastRunState: Record<string, unknown> | undefined
+  let lastObservationText = ''
+  let lastCandidateSummary = ''
+
+  while (Date.now() <= deadline) {
+    const observation = await client.callTool({
+      name: 'desktop_observe',
+      arguments: { includeChrome: true },
+    })
+    lastObservationText = requireTextContent(observation, 'desktop_observe')
+
+    const runState = requireRunState(await client.callTool({
+      name: 'desktop_get_state',
+      arguments: {},
+    }), 'desktop_get_state')
+    lastRunState = runState
+    const snapshot = isRecord(runState.lastGroundingSnapshot)
+      ? runState.lastGroundingSnapshot
+      : undefined
+    const candidates = Array.isArray(snapshot?.targetCandidates)
+      ? snapshot.targetCandidates.filter(isRecord)
+      : []
+    lastCandidateSummary = JSON.stringify(candidates.map(candidate => ({
+      id: candidate.id,
+      source: candidate.source,
+      role: candidate.role,
+      label: candidate.label,
+    })).slice(0, 12))
+
+    const candidate = findDesktopV3SmokeCandidate(runState, requestedCandidateId)
+    if (candidate) {
+      return {
+        observationText: lastObservationText,
+        runState,
+        overlayState: extractOverlaySmokeState(runState),
+        candidate,
+      }
+    }
+
+    await delay(retryIntervalMs)
+  }
+
+  if (lastRunState) {
+    const browserSurfaceAvailability = isRecord(lastRunState.browserSurfaceAvailability)
+      ? JSON.stringify(lastRunState.browserSurfaceAvailability)
+      : 'missing'
+    const chromeSession = isRecord(lastRunState.chromeSession)
+      ? JSON.stringify({
+          ensureOutcome: lastRunState.chromeSession.ensureOutcome,
+          pid: lastRunState.chromeSession.pid,
+          cdpUrl: lastRunState.chromeSession.cdpUrl,
+        })
+      : 'missing'
+    throw new Error(
+      `desktop_observe did not return the AIRI Desktop V3 Smoke Button chrome_dom candidate; `
+      + `browserSurfaceAvailability=${browserSurfaceAvailability}; `
+      + `chromeSession=${chromeSession}; `
+      + `observeSummary=${JSON.stringify(lastObservationText.split('\n').slice(0, 12))}; `
+      + `candidates=${lastCandidateSummary}`,
+    )
+  }
+
+  throw new Error(`desktop_v3 chrome_dom candidate did not become ready within ${timeoutMs}ms`)
+}
+
 export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
   const command = env.COMPUTER_USE_SMOKE_SERVER_COMMAND?.trim() || 'pnpm'
   const args = parseCommandArgs(env.COMPUTER_USE_SMOKE_SERVER_ARGS, ['start'])
@@ -330,6 +442,8 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
   const smokeUrl = env.COMPUTER_USE_DESKTOP_V3_SMOKE_URL?.trim() || DEFAULT_SMOKE_URL
   const requestedCandidateId = parseOptionalString(env.COMPUTER_USE_DESKTOP_V3_SMOKE_CANDIDATE_ID)
   const settleMs = parseNumber(env.COMPUTER_USE_DESKTOP_V3_SMOKE_SETTLE_MS, 750)
+  const chromeDomTimeoutMs = parseNumber(env.COMPUTER_USE_DESKTOP_V3_CHROME_DOM_TIMEOUT_MS, 15_000)
+  const chromeDomRetryIntervalMs = parseNumber(env.COMPUTER_USE_DESKTOP_V3_CHROME_DOM_RETRY_INTERVAL_MS, 500)
 
   const transport = new StdioClientTransport({
     command,
@@ -385,27 +499,50 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
       approvalEvents,
     )
     const ensureChromeData = requireStructuredContent(ensureChrome, 'desktop_ensure_chrome')
+    const initialEnsureOutcome = typeof ensureChromeData.ensureOutcome === 'string'
+      ? ensureChromeData.ensureOutcome
+      : undefined
+    if (!initialEnsureOutcome) {
+      throw new Error('desktop_ensure_chrome missing structuredContent.ensureOutcome')
+    }
+
+    console.info('=== Phase 1b: desktop_ensure_chrome reuse check ===')
+    const ensureChromeReuse = await resolveApprovalIfNeeded(
+      client,
+      'desktop_ensure_chrome',
+      await client.callTool({
+        name: 'desktop_ensure_chrome',
+        arguments: { url: smokeUrl },
+      }),
+      approvalEvents,
+    )
+    const ensureChromeReuseData = requireStructuredContent(ensureChromeReuse, 'desktop_ensure_chrome reuse')
+    const reuseEnsureOutcome = typeof ensureChromeReuseData.ensureOutcome === 'string'
+      ? ensureChromeReuseData.ensureOutcome
+      : undefined
+    if (reuseEnsureOutcome !== 'reused') {
+      throw new Error(`desktop_ensure_chrome reuse check expected ensureOutcome=reused, got ${reuseEnsureOutcome ?? 'missing'}`)
+    }
 
     if (settleMs > 0)
       await delay(settleMs)
 
-    console.info('=== Phase 2: desktop_observe ===')
-    const observation = await client.callTool({
-      name: 'desktop_observe',
-      arguments: { includeChrome: true },
-    })
-    const observeText = requireTextContent(observation, 'desktop_observe')
-
-    console.info('=== Phase 3: desktop_get_state before click ===')
-    const preClickState = requireRunState(await client.callTool({
-      name: 'desktop_get_state',
-      arguments: {},
-    }), 'desktop_get_state')
-    const preClickOverlayState = extractOverlaySmokeState(preClickState)
-    const selectedCandidate = selectDesktopV3SmokeCandidate(preClickState, requestedCandidateId)
+    console.info('=== Phase 2: desktop_observe until chrome_dom is ready ===')
+    const {
+      observationText: observeText,
+      runState: preClickState,
+      overlayState: preClickOverlayState,
+      candidate: selectedCandidate,
+    } = await waitForChromeDomSmokeCandidate(
+      client,
+      requestedCandidateId,
+      chromeDomTimeoutMs,
+      chromeDomRetryIntervalMs,
+    )
     requireChromeDomSmokeCandidate(selectedCandidate)
+    const browserDomRouteExpected = shouldExpectBrowserDomRoute(preClickState)
 
-    console.info('=== Phase 4: desktop_click_target ===')
+    console.info('=== Phase 3: desktop_click_target ===')
     const clickTarget = await resolveApprovalIfNeeded(
       client,
       'desktop_click_target',
@@ -421,7 +558,7 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
     )
     requireTextContent(clickTarget, 'desktop_click_target')
 
-    console.info('=== Phase 5: desktop_get_state after click ===')
+    console.info('=== Phase 4: desktop_get_state after click ===')
     const postClickState = requireRunState(await client.callTool({
       name: 'desktop_get_state',
       arguments: {},
@@ -442,7 +579,7 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
       throw new Error('desktop_click_target missing backendResult.executionRoute')
     }
 
-    if (selectedCandidate.source === 'chrome_dom' && !clickExecutionRoute.startsWith('browser_dom')) {
+    if (browserDomRouteExpected && selectedCandidate.source === 'chrome_dom' && !clickExecutionRoute.startsWith('browser_dom')) {
       throw new Error(`expected chrome_dom candidate to route through browser_dom, got ${clickExecutionRoute}`)
     }
 
@@ -456,9 +593,13 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
         'desktop_get_state',
       ],
       ensureChrome: ensureChromeData,
+      ensureChromeReuse: ensureChromeReuseData,
+      initialEnsureOutcome,
+      reuseEnsureOutcome,
       observeSummary: observeText.split('\n').slice(0, 8),
       selectedCandidate,
       preClickOverlayState,
+      browserDomRouteExpected,
       postClickOverlayState,
       clickExecutionRoute,
       clickRouteReason,
@@ -481,6 +622,8 @@ Environment:
   COMPUTER_USE_DESKTOP_V3_SMOKE_URL            Target URL. Defaults to an inline data: smoke page.
   COMPUTER_USE_DESKTOP_V3_SMOKE_CANDIDATE_ID   Optional candidate id override from desktop_observe.
   COMPUTER_USE_DESKTOP_V3_SMOKE_SETTLE_MS      Delay after desktop_ensure_chrome. Default: 750.
+  COMPUTER_USE_DESKTOP_V3_CHROME_DOM_TIMEOUT_MS Wait for chrome_dom candidate readiness. Default: 15000.
+  COMPUTER_USE_DESKTOP_V3_CHROME_DOM_RETRY_INTERVAL_MS Retry interval for observe/get_state while waiting for chrome_dom. Default: 500.
   COMPUTER_USE_SMOKE_EXECUTOR                  Executor override. Default: macos-local.
   COMPUTER_USE_SMOKE_APPROVAL_MODE             Approval mode override. Default: actions.
 `)

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
@@ -139,11 +139,15 @@ export function selectDesktopV3SmokeCandidate(
   const candidatesWithIds = candidates.filter((candidate): candidate is CandidateRecord => {
     return typeof candidate.id === 'string' && candidate.id.length > 0
   })
+  const chromeDomCandidates = candidatesWithIds.filter(candidate => candidate.source === 'chrome_dom')
   const selected = requested
     ? candidatesWithIds.find(candidate => candidate.id === requested)
-    : selectDefaultChromeDomCandidate(candidatesWithIds)
+    : selectDefaultChromeDomCandidate(chromeDomCandidates)
 
   if (!selected) {
+    if (!requested) {
+      throw new Error('desktop_observe did not return the AIRI Desktop V3 Smoke Button chrome_dom candidate')
+    }
     throw new Error(`desktop_observe did not return requested candidate "${requested}"`)
   }
 
@@ -169,8 +173,9 @@ function candidateText(candidate: Record<string, unknown>): string {
 }
 
 function selectDefaultChromeDomCandidate(candidates: CandidateRecord[]): CandidateRecord | undefined {
-  return candidates.find(candidate => candidate.source === 'chrome_dom' && candidateText(candidate).includes(SMOKE_TARGET_LABEL.toLowerCase()))
-    ?? candidates.find(candidate => candidate.source === 'chrome_dom')
+  return candidates.find(candidate =>
+    candidateText(candidate).includes(SMOKE_TARGET_LABEL.toLowerCase()),
+  )
 }
 
 export function extractOverlaySmokeState(runState: Record<string, unknown>): OverlaySmokeState {

--- a/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
+++ b/services/computer-use-mcp/src/bin/smoke-chrome-grounding.ts
@@ -298,12 +298,20 @@ function assertToolRegistered(toolNames: Set<string>, toolName: string) {
     throw new Error(`required desktop v3 tool is not registered: ${toolName}`)
 }
 
-function parseNumber(value: string | undefined, fallback: number): number {
+export function parseNumber(value: string | undefined, fallback: number): number {
   if (!value?.trim())
     return fallback
 
   const parsed = Number(value)
   return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : fallback
+}
+
+export function parseOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed || trimmed === 'undefined' || trimmed === 'null')
+    return undefined
+
+  return trimmed
 }
 
 function delay(ms: number): Promise<void> {
@@ -315,7 +323,7 @@ export async function runDesktopV3Smoke(): Promise<Record<string, unknown>> {
   const args = parseCommandArgs(env.COMPUTER_USE_SMOKE_SERVER_ARGS, ['start'])
   const cwd = env.COMPUTER_USE_SMOKE_SERVER_CWD?.trim() || packageDir
   const smokeUrl = env.COMPUTER_USE_DESKTOP_V3_SMOKE_URL?.trim() || DEFAULT_SMOKE_URL
-  const requestedCandidateId = env.COMPUTER_USE_DESKTOP_V3_SMOKE_CANDIDATE_ID
+  const requestedCandidateId = parseOptionalString(env.COMPUTER_USE_DESKTOP_V3_SMOKE_CANDIDATE_ID)
   const settleMs = parseNumber(env.COMPUTER_USE_DESKTOP_V3_SMOKE_SETTLE_MS, 750)
 
   const transport = new StdioClientTransport({

--- a/services/computer-use-mcp/src/browser-action-router.test.ts
+++ b/services/computer-use-mcp/src/browser-action-router.test.ts
@@ -57,6 +57,18 @@ describe('decideBrowserAction', () => {
     expect(decision.reason).toContain('not connected')
   })
 
+  it('falls back to os_input for right clicks even when chrome_dom is available', () => {
+    const decision = decideBrowserAction(makeCandidate(), true, 'right')
+    expect(decision.route).toBe('os_input')
+    expect(decision.reason).toContain('left single-click')
+  })
+
+  it('falls back to os_input for multi-click chrome_dom actions', () => {
+    const decision = decideBrowserAction(makeCandidate(), true, 'left', 2)
+    expect(decision.route).toBe('os_input')
+    expect(decision.reason).toContain('count 2')
+  })
+
   it('preserves non-zero frameId for sub-frame candidates', () => {
     const decision = decideBrowserAction(makeCandidate({ frameId: 3 }), true)
     expect(decision.route).toBe('browser_dom')

--- a/services/computer-use-mcp/src/browser-dom/extension-bridge.test.ts
+++ b/services/computer-use-mcp/src/browser-dom/extension-bridge.test.ts
@@ -287,6 +287,29 @@ describe('browserDomExtensionBridge', () => {
     expect(bridge.getStatus().pendingRequests).toBe(0)
   })
 
+  it('rejects bridge calls when the extension responds with ok:false', async () => {
+    const result = await createConnectedBridge()
+    bridge = result.bridge
+    client = result.client
+
+    client.on('message', (raw) => {
+      const data = JSON.parse(String(raw)) as Record<string, unknown>
+      if (typeof data.id !== 'string')
+        return
+      if (data.action !== 'getActiveTab')
+        return
+
+      client.send(JSON.stringify({
+        id: data.id,
+        ok: false,
+        error: 'unknown action: getActiveTab',
+      }))
+    })
+
+    await expect(bridge.getActiveTab()).rejects.toThrow('unknown action: getActiveTab')
+    expect(bridge.getStatus().pendingRequests).toBe(0)
+  })
+
   it('can retry startup after an initial bind failure', async () => {
     blocker = new WebSocketServer({
       host: '127.0.0.1',

--- a/services/computer-use-mcp/src/browser-dom/extension-bridge.test.ts
+++ b/services/computer-use-mcp/src/browser-dom/extension-bridge.test.ts
@@ -124,12 +124,14 @@ describe('browserDomExtensionBridge', () => {
     expect(bridge.supportsAction('findElements')).toBe(true)
     expect(bridge.supportsAction('getElementAttributes')).toBe(true)
 
-    // Mutating actions should NOT be supported
+    // Write-capable action used by browser_dom click routing should be supported.
+    expect(bridge.supportsAction('clickAt')).toBe(true)
+
+    // Other mutating actions should NOT be supported
     expect(bridge.supportsAction('setInputValue')).toBe(false)
     expect(bridge.supportsAction('checkCheckbox')).toBe(false)
     expect(bridge.supportsAction('selectOption')).toBe(false)
     expect(bridge.supportsAction('triggerEvent')).toBe(false)
-    expect(bridge.supportsAction('clickAt')).toBe(false)
   })
 
   it('readInputValue round-trips through the bridge', async () => {

--- a/services/computer-use-mcp/src/browser-dom/extension-bridge.ts
+++ b/services/computer-use-mcp/src/browser-dom/extension-bridge.ts
@@ -18,6 +18,7 @@ const SUPPORTED_ACTIONS = new Set([
   'findElement',
   'findElements',
   'getClickTarget',
+  'clickAt',
   'getElementAttributes',
   'readInputValue',
   'getComputedStyles',

--- a/services/computer-use-mcp/src/chrome-semantic-adapter.ts
+++ b/services/computer-use-mcp/src/chrome-semantic-adapter.ts
@@ -3,7 +3,7 @@
  * and maps it to DesktopTargetCandidate format.
  *
  * Uses the extension bridge as primary source and CDP bridge as fallback.
- * Only active when Chrome is the foreground app.
+ * Best effort when browser surfaces are available.
  *
  * The adapter handles coordinate transformation from page-relative
  * (CSS viewport) coordinates to screen-absolute coordinates using

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -16,6 +16,7 @@ import { runProcess } from './utils/process'
 vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   mkdtemp: vi.fn().mockResolvedValue('/tmp/test/chrome-profile-abc123'),
+  rm: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('./utils/process', () => ({
   runProcess: vi.fn(),
@@ -24,11 +25,12 @@ vi.mock('./utils/sleep', () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }))
 
-import { mkdir, mkdtemp } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 
 const mockedRunProcess = vi.mocked(runProcess)
 const mockedMkdir = vi.mocked(mkdir)
 const mockedMkdtemp = vi.mocked(mkdtemp)
+const mockedRm = vi.mocked(rm)
 
 function makeConfig(): ComputerUseConfig {
   return {
@@ -67,6 +69,7 @@ function mockLaunchFlow(pid: number, userApp = 'Terminal', cdpPort = 9222) {
 function mockReuseFlow(pid: number) {
   mockedRunProcess
     .mockResolvedValueOnce(ok(`${pid}\n`)) // isProcessAlive
+    .mockResolvedValueOnce(ok('1\n')) // hasChromeWindow
 }
 
 describe('chromeSessionManager', () => {
@@ -130,6 +133,25 @@ describe('chromeSessionManager', () => {
       expect(second).not.toBeNull()
     })
 
+    it('recreates the session if the Chrome process is alive but the agent window is gone', async () => {
+      mockLaunchFlow(11111)
+      await manager.ensureAgentWindow()
+
+      vi.clearAllMocks()
+      mockedRunProcess
+        .mockResolvedValueOnce(ok('11111\n')) // isProcessAlive
+        .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
+      mockLaunchFlow(22222)
+
+      const second = await manager.ensureAgentWindow()
+
+      expect(second.pid).toBe(22222)
+      expect(mockedRunProcess).toHaveBeenNthCalledWith(2, '/usr/bin/osascript', [
+        '-e',
+        'tell application "System Events" to get count of windows of (first application process whose unix id is 11111)',
+      ], expect.any(Object))
+    })
+
     it('passes a custom CDP port and URL through', async () => {
       mockLaunchFlow(33333, 'Terminal', 9333)
 
@@ -143,6 +165,20 @@ describe('chromeSessionManager', () => {
       expect(mockedRunProcess.mock.calls[2]?.[1]).toContain('--user-data-dir=/tmp/test/chrome-profile-abc123')
       expect(mockedRunProcess.mock.calls[2]?.[1]).toContain('https://example.com')
     })
+
+    it('cleans up the active chrome profile directory on endSession', async () => {
+      mockLaunchFlow(11111)
+      await manager.ensureAgentWindow()
+
+      vi.clearAllMocks()
+      manager.endSession()
+
+      expect(mockedRm).toHaveBeenCalledWith('/tmp/test/chrome-profile-abc123', {
+        recursive: true,
+        force: true,
+      })
+      expect(manager.getSessionInfo()).toBeNull()
+    })
   })
 
   describe('bringToFront', () => {
@@ -152,12 +188,13 @@ describe('chromeSessionManager', () => {
 
       vi.clearAllMocks()
       mockedRunProcess.mockResolvedValueOnce(ok('11111\n'))
+      mockedRunProcess.mockResolvedValueOnce(ok('1\n'))
       mockedRunProcess.mockResolvedValueOnce(ok())
 
       const result = await manager.bringToFront()
 
       expect(result).toBe(true)
-      expect(mockedRunProcess).toHaveBeenCalledTimes(2)
+      expect(mockedRunProcess).toHaveBeenCalledTimes(3)
     })
 
     it('returns false when session is gone', async () => {
@@ -166,6 +203,21 @@ describe('chromeSessionManager', () => {
 
       vi.clearAllMocks()
       mockedRunProcess.mockRejectedValueOnce(new Error('no match'))
+
+      const result = await manager.bringToFront()
+
+      expect(result).toBe(false)
+      expect(manager.getSessionInfo()).toBeNull()
+    })
+
+    it('returns false when the agent window is gone even if the process still exists', async () => {
+      mockLaunchFlow(11111)
+      await manager.ensureAgentWindow()
+
+      vi.clearAllMocks()
+      mockedRunProcess
+        .mockResolvedValueOnce(ok('11111\n')) // isProcessAlive
+        .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
 
       const result = await manager.bringToFront()
 

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -13,7 +13,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createChromeSessionManager } from './chrome-session-manager'
 import { runProcess } from './utils/process'
 
-// Mock runProcess and sleep before importing the module under test
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  mkdtemp: vi.fn().mockResolvedValue('/tmp/test/chrome-profile-abc123'),
+}))
 vi.mock('./utils/process', () => ({
   runProcess: vi.fn(),
 }))
@@ -21,7 +24,11 @@ vi.mock('./utils/sleep', () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }))
 
+import { mkdir, mkdtemp } from 'node:fs/promises'
+
 const mockedRunProcess = vi.mocked(runProcess)
+const mockedMkdir = vi.mocked(mkdir)
+const mockedMkdtemp = vi.mocked(mkdtemp)
 
 function makeConfig(): ComputerUseConfig {
   return {
@@ -46,42 +53,20 @@ function ok(stdout = ''): any {
   return { stdout, stderr: '' }
 }
 
-/**
- * Mock for "chrome not running → launch" flow (first call, no existing session).
- *
- * Call sequence when `session` is null:
- * 1. osascript (getCurrentForegroundApp)
- * 2. pgrep (isChromeRunning for wasAlreadyRunning) → reject (not running)
- * 3. open (launchChromeWithCdp)
- * 4. osascript (activateChrome)
- * 5. pgrep (getChromeMainPid) → ok with pid
- */
-function mockLaunchFlow(pid: number, userApp = '') {
+function mockLaunchFlow(pid: number, userApp = 'Terminal', cdpPort = 9222) {
   mockedRunProcess
-    .mockResolvedValueOnce(ok(userApp)) // 1. getCurrentForegroundApp
-    .mockRejectedValueOnce(new Error('no match')) // 2. isChromeRunning → false
-    .mockResolvedValueOnce(ok()) // 3. open command
-    .mockResolvedValueOnce(ok()) // 4. activateChrome
-    .mockResolvedValueOnce(ok(`${pid}\n`)) // 5. getChromeMainPid
+    .mockResolvedValueOnce(ok(userApp)) // foreground app
+    .mockRejectedValueOnce(new Error('no match')) // wasAlreadyRunning → false
+    .mockResolvedValueOnce(ok()) // open
+    .mockResolvedValueOnce(ok()) // activateChrome
+    .mockResolvedValueOnce(ok(
+      `${pid} /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=${cdpPort}\n`,
+    )) // getChromePidForProfile
 }
 
-/**
- * Mock for "chrome already running → new window" flow (first call, no existing session).
- *
- * Call sequence when `session` is null:
- * 1. osascript (getCurrentForegroundApp)
- * 2. pgrep (isChromeRunning for wasAlreadyRunning) → ok (running)
- * 3. osascript (createNewWindow)
- * 4. osascript (activateChrome)
- * 5. pgrep (getChromeMainPid)
- */
-function mockJoinFlow(pid: number, userApp = 'Terminal') {
+function mockReuseFlow(pid: number) {
   mockedRunProcess
-    .mockResolvedValueOnce(ok(userApp)) // 1. getCurrentForegroundApp
-    .mockResolvedValueOnce(ok(`${pid}\n`)) // 2. isChromeRunning → true
-    .mockResolvedValueOnce(ok()) // 3. createNewWindow
-    .mockResolvedValueOnce(ok()) // 4. activateChrome
-    .mockResolvedValueOnce(ok(`${pid}\n`)) // 5. getChromeMainPid
+    .mockResolvedValueOnce(ok(`${pid}\n`)) // isProcessAlive
 }
 
 describe('chromeSessionManager', () => {
@@ -92,12 +77,8 @@ describe('chromeSessionManager', () => {
     manager = createChromeSessionManager(makeConfig())
   })
 
-  // -----------------------------------------------------------------------
-  // ensureAgentWindow
-  // -----------------------------------------------------------------------
-
   describe('ensureAgentWindow', () => {
-    it('should launch Chrome when not running', async () => {
+    it('launches a dedicated Chrome profile with CDP', async () => {
       mockLaunchFlow(12345)
 
       const info = await manager.ensureAgentWindow()
@@ -107,233 +88,89 @@ describe('chromeSessionManager', () => {
       expect(info.pid).toBe(12345)
       expect(info.cdpUrl).toBe('http://127.0.0.1:9222')
       expect(info.windowId).toBe('12345:0:Google Chrome')
-      expect(info.createdAt).toBeTruthy()
+      expect(mockedMkdir).toHaveBeenCalledWith('/tmp/test', { recursive: true })
+      expect(mockedMkdtemp).toHaveBeenCalledWith('/tmp/test/chrome-profile-')
+      expect(mockedRunProcess.mock.calls[2]).toEqual([
+        '/usr/bin/open',
+        [
+          '-na',
+          'Google Chrome',
+          '--args',
+          '--new-window',
+          '--remote-debugging-port=9222',
+          '--user-data-dir=/tmp/test/chrome-profile-abc123',
+        ],
+        expect.any(Object),
+      ])
     })
 
-    it('should create new window when Chrome is already running', async () => {
-      mockJoinFlow(99999, 'Terminal')
-
-      const info = await manager.ensureAgentWindow()
-
-      expect(info.wasAlreadyRunning).toBe(true)
-      expect(info.agentOwned).toBe(false)
-      expect(info.pid).toBe(99999)
-      // No CDP URL when joining existing Chrome
-      expect(info.cdpUrl).toBeUndefined()
-    })
-
-    it('should reuse an existing session when the agent launched a dedicated Chrome instance', async () => {
+    it('reuses an alive agent session', async () => {
       mockLaunchFlow(11111)
       const first = await manager.ensureAgentWindow()
 
-      // Second call: session exists → isChromeRunning check (1 call)
-      mockedRunProcess.mockResolvedValueOnce(ok('11111\n')) // isChromeRunning → still alive
+      vi.clearAllMocks()
+      mockReuseFlow(11111)
+
       const second = await manager.ensureAgentWindow()
 
       expect(second).toBe(first)
     })
 
-    it('should create a fresh agent window on repeated calls when joining an existing Chrome instance', async () => {
-      mockJoinFlow(99999, 'Terminal')
-      const first = await manager.ensureAgentWindow()
+    it('recreates the session if the tracked process is gone', async () => {
+      mockLaunchFlow(11111)
+      await manager.ensureAgentWindow()
 
       vi.clearAllMocks()
-
-      mockedRunProcess
-        .mockResolvedValueOnce(ok('99999\n')) // session reuse check → Chrome still running
-      mockJoinFlow(99999, 'Terminal')
-
-      const second = await manager.ensureAgentWindow()
-
-      expect(second).not.toBe(first)
-      expect(second.wasAlreadyRunning).toBe(true)
-      expect(second.pid).toBe(99999)
-      expect(mockedRunProcess.mock.calls[3]?.[0]).toBe('/usr/bin/osascript')
-      expect(mockedRunProcess.mock.calls[3]?.[1]).toEqual(['-e', 'tell application "Google Chrome" to make new window'])
-    })
-
-    it('should recreate session if Chrome crashed between calls', async () => {
-      mockLaunchFlow(11111)
-      const first = await manager.ensureAgentWindow()
-      expect(first.pid).toBe(11111)
-
-      // Second call: session exists → isChromeRunning fails (Chrome crashed)
       mockedRunProcess.mockRejectedValueOnce(new Error('no match'))
-      // session=null now, goes through full launch flow (5 calls)
       mockLaunchFlow(22222)
 
       const second = await manager.ensureAgentWindow()
+
       expect(second.pid).toBe(22222)
-      expect(second).not.toBe(first)
+      expect(second).not.toBeNull()
     })
 
-    it('should pass custom URL to Chrome', async () => {
-      mockLaunchFlow(33333)
+    it('passes a custom CDP port and URL through', async () => {
+      mockLaunchFlow(33333, 'Terminal', 9333)
 
-      const info = await manager.ensureAgentWindow({ url: 'https://example.com' })
-      expect(info.initialUrl).toBe('https://example.com')
-    })
+      const info = await manager.ensureAgentWindow({
+        cdpPort: 9333,
+        url: 'https://example.com',
+      })
 
-    it('should pass URL to osascript as argv instead of interpolating it into script source', async () => {
-      const maliciousUrl = 'https://example.com/" & do shell script "touch /tmp/pwned" & "'
-      mockJoinFlow(33333, 'Terminal')
-
-      await manager.ensureAgentWindow({ url: maliciousUrl })
-
-      const createWindowCall = mockedRunProcess.mock.calls[2]
-      expect(createWindowCall?.[0]).toBe('/usr/bin/osascript')
-      expect(createWindowCall?.[1]).toEqual([
-        '-e',
-        expect.stringContaining('item 1 of argv'),
-        '--',
-        maliciousUrl,
-      ])
-      expect(createWindowCall?.[1]?.[1]).not.toContain(maliciousUrl)
-    })
-
-    it('should use custom CDP port', async () => {
-      mockLaunchFlow(44444)
-
-      const info = await manager.ensureAgentWindow({ cdpPort: 9333 })
       expect(info.cdpUrl).toBe('http://127.0.0.1:9333')
-    })
-
-    it('should throw if Chrome PID cannot be obtained after launch', async () => {
-      mockedRunProcess
-        .mockResolvedValueOnce(ok()) // 1. foreground
-        .mockRejectedValueOnce(new Error('no match')) // 2. wasAlreadyRunning → false
-        .mockResolvedValueOnce(ok()) // 3. launch
-        .mockResolvedValueOnce(ok()) // 4. activate
-        .mockRejectedValueOnce(new Error('no match')) // 5. getChromeMainPid → fails
-
-      await expect(manager.ensureAgentWindow()).rejects.toThrow('Failed to get Chrome PID')
-    })
-
-    it('should record the user\'s previous foreground app', async () => {
-      mockLaunchFlow(55555, 'Finder')
-
-      await manager.ensureAgentWindow()
-
-      // First call should have been getCurrentForegroundApp
-      const firstCall = mockedRunProcess.mock.calls[0]
-      expect(firstCall[1]).toContainEqual(expect.stringContaining('first application process'))
+      expect(info.initialUrl).toBe('https://example.com')
+      expect(mockedRunProcess.mock.calls[2]?.[1]).toContain('--user-data-dir=/tmp/test/chrome-profile-abc123')
+      expect(mockedRunProcess.mock.calls[2]?.[1]).toContain('https://example.com')
     })
   })
 
-  // -----------------------------------------------------------------------
-  // bringToFront
-  // -----------------------------------------------------------------------
-
   describe('bringToFront', () => {
-    it('should activate Chrome when session exists', async () => {
+    it('activates Chrome when session exists', async () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
-      vi.clearAllMocks()
 
-      mockedRunProcess
-        .mockResolvedValueOnce(ok('11111\n')) // isChromeRunning
-        .mockResolvedValueOnce(ok()) // activateChrome
+      vi.clearAllMocks()
+      mockedRunProcess.mockResolvedValueOnce(ok('11111\n'))
+      mockedRunProcess.mockResolvedValueOnce(ok())
 
       const result = await manager.bringToFront()
 
       expect(result).toBe(true)
       expect(mockedRunProcess).toHaveBeenCalledTimes(2)
-      const activateCall = mockedRunProcess.mock.calls[1]
-      expect(activateCall[1]).toEqual(['-e', 'tell application "Google Chrome" to activate'])
     })
 
-    it('should be no-op when no session exists', async () => {
-      const result = await manager.bringToFront()
-      expect(result).toBe(false)
-      expect(mockedRunProcess).not.toHaveBeenCalled()
-    })
-
-    it('should clear session if Chrome crashed', async () => {
+    it('returns false when session is gone', async () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
-      vi.clearAllMocks()
 
-      // Chrome crashed
+      vi.clearAllMocks()
       mockedRunProcess.mockRejectedValueOnce(new Error('no match'))
 
       const result = await manager.bringToFront()
+
       expect(result).toBe(false)
       expect(manager.getSessionInfo()).toBeNull()
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // restorePreviousForeground
-  // -----------------------------------------------------------------------
-
-  describe('restorePreviousForeground', () => {
-    it('should activate the user\'s previous app', async () => {
-      mockLaunchFlow(11111, 'Terminal')
-      await manager.ensureAgentWindow()
-      vi.clearAllMocks()
-
-      mockedRunProcess.mockResolvedValueOnce(ok())
-
-      await manager.restorePreviousForeground()
-
-      expect(mockedRunProcess).toHaveBeenCalledWith(
-        '/usr/bin/osascript',
-        ['-e', 'tell application "Terminal" to activate'],
-        expect.any(Object),
-      )
-    })
-
-    it('should be no-op if user was already in Chrome', async () => {
-      mockLaunchFlow(11111, 'Google Chrome')
-      await manager.ensureAgentWindow()
-      vi.clearAllMocks()
-
-      await manager.restorePreviousForeground()
-      expect(mockedRunProcess).not.toHaveBeenCalled()
-    })
-
-    it('should be no-op if no session was created', async () => {
-      await manager.restorePreviousForeground()
-      expect(mockedRunProcess).not.toHaveBeenCalled()
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // session lifecycle
-  // -----------------------------------------------------------------------
-
-  describe('session lifecycle', () => {
-    it('should return null before any session', () => {
-      expect(manager.getSessionInfo()).toBeNull()
-    })
-
-    it('should return session info after ensureAgentWindow', async () => {
-      mockLaunchFlow(55555)
-
-      await manager.ensureAgentWindow()
-      const info = manager.getSessionInfo()
-      expect(info).not.toBeNull()
-      expect(info!.pid).toBe(55555)
-      expect(info!.agentOwned).toBe(true)
-    })
-
-    it('should clear session on endSession', async () => {
-      mockLaunchFlow(55555)
-      await manager.ensureAgentWindow()
-      expect(manager.getSessionInfo()).not.toBeNull()
-
-      manager.endSession()
-      expect(manager.getSessionInfo()).toBeNull()
-    })
-
-    it('should restore fully after endSession and re-ensureAgentWindow', async () => {
-      mockLaunchFlow(11111)
-      await manager.ensureAgentWindow()
-      manager.endSession()
-
-      mockLaunchFlow(22222)
-      const info = await manager.ensureAgentWindow()
-      expect(info.pid).toBe(22222)
     })
   })
 })

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -8,6 +8,9 @@
 import type { ChromeSessionManager } from './chrome-session-manager'
 import type { ComputerUseConfig } from './types'
 
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createChromeSessionManager } from './chrome-session-manager'
@@ -28,9 +31,6 @@ vi.mock('./utils/sleep', () => ({
 vi.mock('node:net', () => ({
   createServer: vi.fn(),
 }))
-
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { createServer } from 'node:net'
 
 const mockedRunProcess = vi.mocked(runProcess)
 const mockedMkdir = vi.mocked(mkdir)

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -206,6 +206,26 @@ describe('chromeSessionManager', () => {
         force: true,
       })
     })
+
+    it('terminates a launched Chrome process and cleans up the profile if launch fails before PID lookup completes', async () => {
+      mockedRunProcess
+        .mockResolvedValueOnce(ok('Terminal')) // foreground app
+        .mockRejectedValueOnce(new Error('no match')) // wasAlreadyRunning → false
+        .mockResolvedValueOnce(ok()) // open
+        .mockRejectedValueOnce(new Error('activate failed')) // activateChrome
+        .mockResolvedValueOnce(ok(
+          '11111 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=9222\n',
+        )) // findAndTerminateChromeByProfile
+        .mockResolvedValueOnce(ok()) // findAndTerminateChromeByProfile: kill -TERM
+        .mockResolvedValueOnce(ok()) // findAndTerminateChromeByProfile: post-TERM liveness check
+
+      await expect(manager.ensureAgentWindow()).rejects.toThrow('activate failed')
+      expect(mockedRunProcess).toHaveBeenCalledWith('kill', ['-TERM', '11111'], expect.any(Object))
+      expect(mockedRm).toHaveBeenCalledWith('/tmp/test/chrome-profile-abc123', {
+        recursive: true,
+        force: true,
+      })
+    })
   })
 
   describe('bringToFront', () => {

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -72,6 +72,12 @@ function mockReuseFlow(pid: number) {
     .mockResolvedValueOnce(ok('1\n')) // hasChromeWindow
 }
 
+function mockWindowMissingFlow(pid: number) {
+  mockedRunProcess
+    .mockResolvedValueOnce(ok(`${pid}\n`)) // isProcessAlive
+    .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
+}
+
 describe('chromeSessionManager', () => {
   let manager: ChromeSessionManager
 
@@ -138,9 +144,7 @@ describe('chromeSessionManager', () => {
       await manager.ensureAgentWindow()
 
       vi.clearAllMocks()
-      mockedRunProcess
-        .mockResolvedValueOnce(ok('11111\n')) // isProcessAlive
-        .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
+      mockWindowMissingFlow(11111)
       mockLaunchFlow(22222)
 
       const second = await manager.ensureAgentWindow()
@@ -179,6 +183,23 @@ describe('chromeSessionManager', () => {
       })
       expect(manager.getSessionInfo()).toBeNull()
     })
+
+    it('cleans up the active chrome profile when relaunching after a missing window', async () => {
+      mockLaunchFlow(11111)
+      await manager.ensureAgentWindow()
+
+      vi.clearAllMocks()
+      mockWindowMissingFlow(11111)
+      mockLaunchFlow(22222)
+
+      const second = await manager.ensureAgentWindow()
+
+      expect(second.pid).toBe(22222)
+      expect(mockedRm).toHaveBeenCalledWith('/tmp/test/chrome-profile-abc123', {
+        recursive: true,
+        force: true,
+      })
+    })
   })
 
   describe('bringToFront', () => {
@@ -215,9 +236,7 @@ describe('chromeSessionManager', () => {
       await manager.ensureAgentWindow()
 
       vi.clearAllMocks()
-      mockedRunProcess
-        .mockResolvedValueOnce(ok('11111\n')) // isProcessAlive
-        .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
+      mockWindowMissingFlow(11111)
 
       const result = await manager.bringToFront()
 

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -17,6 +17,7 @@ vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   mkdtemp: vi.fn().mockResolvedValue('/tmp/test/chrome-profile-abc123'),
   rm: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('./utils/process', () => ({
   runProcess: vi.fn(),
@@ -24,13 +25,19 @@ vi.mock('./utils/process', () => ({
 vi.mock('./utils/sleep', () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }))
+vi.mock('node:net', () => ({
+  createServer: vi.fn(),
+}))
 
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
 
 const mockedRunProcess = vi.mocked(runProcess)
 const mockedMkdir = vi.mocked(mkdir)
 const mockedMkdtemp = vi.mocked(mkdtemp)
 const mockedRm = vi.mocked(rm)
+const mockedWriteFile = vi.mocked(writeFile)
+const mockedCreateServer = vi.mocked(createServer)
 
 function makeConfig(): ComputerUseConfig {
   return {
@@ -55,19 +62,63 @@ function ok(stdout = ''): any {
   return { stdout, stderr: '' }
 }
 
-function mockLaunchFlow(pid: number, userApp = 'Terminal', cdpPort = 9222) {
+function mockPortAvailability(...results: boolean[]) {
+  for (const result of results) {
+    mockedCreateServer.mockImplementationOnce(() => {
+      const handlers = new Map<string, (...args: any[]) => void>()
+      return {
+        once(event: string, handler: (...args: any[]) => void) {
+          handlers.set(event, handler)
+          return this
+        },
+        listen(_port: number, _host: string, callback: () => void) {
+          if (result) {
+            callback()
+          }
+          else {
+            handlers.get('error')?.(new Error('EADDRINUSE'))
+          }
+          return this
+        },
+        close(callback: () => void) {
+          callback()
+          return this
+        },
+      } as any
+    })
+  }
+}
+
+function mockLaunchFlow(pid: number, userApp = 'Terminal', cdpPort = 9222, pidLookupAttempts = 4) {
+  const chromeProcessListing = ok(
+    `${pid} /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=${cdpPort}\n`,
+  )
+
   mockedRunProcess
     .mockResolvedValueOnce(ok(userApp)) // foreground app
     .mockRejectedValueOnce(new Error('no match')) // wasAlreadyRunning → false
     .mockResolvedValueOnce(ok()) // open
     .mockResolvedValueOnce(ok()) // activateChrome
-    .mockResolvedValueOnce(ok(
-      `${pid} /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=${cdpPort}\n`,
-    )) // getChromePidForProfile
+
+  for (let index = 0; index < pidLookupAttempts; index += 1) {
+    mockedRunProcess.mockResolvedValueOnce(chromeProcessListing) // getChromePidForProfile
+  }
+}
+
+function primeDefaultPortAvailability() {
+  if (mockedCreateServer.mock.calls.length === 0 && mockedCreateServer.mock.results.length === 0) {
+    mockPortAvailability(true)
+  }
+}
+
+function resetLaunchMocks() {
+  mockedRunProcess.mockReset()
+  mockedCreateServer.mockReset()
 }
 
 function mockReuseFlow(pid: number) {
   mockedRunProcess
+    .mockResolvedValueOnce(ok(`${pid} /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=9222\n`)) // getTrackedChromePid
     .mockResolvedValueOnce(ok(`${pid}\n`)) // isProcessAlive
     .mockResolvedValueOnce(ok('1\n')) // hasChromeWindow
 }
@@ -78,11 +129,26 @@ function mockWindowMissingFlow(pid: number) {
     .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
 }
 
+function mockEnsureWindowMissingFlow(pid: number) {
+  mockedRunProcess
+    .mockResolvedValueOnce(ok(`${pid} /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=9222\n`)) // getTrackedChromePid
+    .mockResolvedValueOnce(ok(`${pid}\n`)) // isProcessAlive
+    .mockResolvedValueOnce(ok('0\n')) // hasChromeWindow
+}
+
+function mockStalePidFlow(pid: number) {
+  mockedRunProcess
+    .mockResolvedValueOnce(ok(`${pid} /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/tmp/test/chrome-profile-abc123 --remote-debugging-port=9222\n`)) // getTrackedChromePid
+}
+
 describe('chromeSessionManager', () => {
   let manager: ChromeSessionManager
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockedRunProcess.mockReset()
+    mockedCreateServer.mockReset()
+    mockPortAvailability(true)
     manager = createChromeSessionManager(makeConfig())
   })
 
@@ -92,6 +158,7 @@ describe('chromeSessionManager', () => {
 
       const info = await manager.ensureAgentWindow()
 
+      expect(info.ensureOutcome).toBe('launched')
       expect(info.wasAlreadyRunning).toBe(false)
       expect(info.agentOwned).toBe(true)
       expect(info.pid).toBe(12345)
@@ -99,6 +166,7 @@ describe('chromeSessionManager', () => {
       expect(info.windowId).toBe('12345:0:Google Chrome')
       expect(mockedMkdir).toHaveBeenCalledWith('/tmp/test', { recursive: true })
       expect(mockedMkdtemp).toHaveBeenCalledWith('/tmp/test/chrome-profile-')
+      expect(mockedWriteFile).toHaveBeenCalledWith('/tmp/test/chrome-profile-abc123/First Run', '')
       expect(mockedRunProcess.mock.calls[2]).toEqual([
         '/usr/bin/open',
         [
@@ -106,6 +174,10 @@ describe('chromeSessionManager', () => {
           'Google Chrome',
           '--args',
           '--new-window',
+          '--no-first-run',
+          '--no-default-browser-check',
+          '--disable-default-apps',
+          '--disable-features=ChromeWhatsNewUI',
           '--remote-debugging-port=9222',
           '--user-data-dir=/tmp/test/chrome-profile-abc123',
         ],
@@ -117,11 +189,12 @@ describe('chromeSessionManager', () => {
       mockLaunchFlow(11111)
       const first = await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
       mockReuseFlow(11111)
 
       const second = await manager.ensureAgentWindow()
 
+      expect(second.ensureOutcome).toBe('reused')
       expect(second).toBe(first)
     })
 
@@ -129,28 +202,49 @@ describe('chromeSessionManager', () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
+      primeDefaultPortAvailability()
       mockedRunProcess.mockRejectedValueOnce(new Error('no match'))
       mockLaunchFlow(22222)
 
       const second = await manager.ensureAgentWindow()
 
+      expect(second.ensureOutcome).toBe('recreated_after_process_exit')
       expect(second.pid).toBe(22222)
       expect(second).not.toBeNull()
+    })
+
+    it('does not terminate a reused pid after verifying it no longer belongs to the tracked Chrome profile', async () => {
+      mockLaunchFlow(11111)
+      await manager.ensureAgentWindow()
+
+      resetLaunchMocks()
+      primeDefaultPortAvailability()
+      mockStalePidFlow(33333)
+      mockLaunchFlow(22222)
+
+      const second = await manager.ensureAgentWindow()
+
+      expect(second.ensureOutcome).toBe('recreated_after_process_exit')
+      expect(second.pid).toBe(22222)
+      expect(mockedRunProcess).not.toHaveBeenCalledWith('kill', ['-TERM', '11111'], expect.any(Object))
+      expect(mockedRunProcess).not.toHaveBeenCalledWith('kill', ['-KILL', '11111'], expect.any(Object))
     })
 
     it('recreates the session if the Chrome process is alive but the agent window is gone', async () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
-      mockWindowMissingFlow(11111)
+      resetLaunchMocks()
+      primeDefaultPortAvailability()
+      mockEnsureWindowMissingFlow(11111)
       mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: kill -TERM
       mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: post-TERM liveness check
       mockLaunchFlow(22222)
 
       const second = await manager.ensureAgentWindow()
 
+      expect(second.ensureOutcome).toBe('recreated_after_missing_window')
       expect(second.pid).toBe(22222)
       expect(mockedRunProcess).toHaveBeenCalledWith('kill', ['-TERM', '11111'], expect.any(Object))
       expect(mockedRunProcess).not.toHaveBeenCalledWith('kill', ['-KILL', '11111'], expect.any(Object))
@@ -174,11 +268,22 @@ describe('chromeSessionManager', () => {
       expect(mockedRunProcess.mock.calls[2]?.[1]).toContain('https://example.com')
     })
 
+    it('falls forward to the next available default CDP port when 9222 is occupied', async () => {
+      resetLaunchMocks()
+      mockPortAvailability(false, true)
+      mockLaunchFlow(12345, 'Terminal', 9223)
+
+      const info = await manager.ensureAgentWindow()
+
+      expect(info.cdpUrl).toBe('http://127.0.0.1:9223')
+      expect(mockedRunProcess.mock.calls[2]?.[1]).toContain('--remote-debugging-port=9223')
+    })
+
     it('cleans up the active chrome profile directory on endSession', async () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
       manager.endSession()
 
       expect(mockedRm).toHaveBeenCalledWith('/tmp/test/chrome-profile-abc123', {
@@ -192,7 +297,8 @@ describe('chromeSessionManager', () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
+      primeDefaultPortAvailability()
       mockWindowMissingFlow(11111)
       mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: kill -TERM
       mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: post-TERM liveness check
@@ -233,7 +339,7 @@ describe('chromeSessionManager', () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
       mockedRunProcess.mockResolvedValueOnce(ok('11111\n'))
       mockedRunProcess.mockResolvedValueOnce(ok('1\n'))
       mockedRunProcess.mockResolvedValueOnce(ok())
@@ -248,7 +354,7 @@ describe('chromeSessionManager', () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
       mockedRunProcess.mockRejectedValueOnce(new Error('no match'))
 
       const result = await manager.bringToFront()
@@ -261,7 +367,7 @@ describe('chromeSessionManager', () => {
       mockLaunchFlow(11111)
       await manager.ensureAgentWindow()
 
-      vi.clearAllMocks()
+      resetLaunchMocks()
       mockWindowMissingFlow(11111)
 
       const result = await manager.bringToFront()

--- a/services/computer-use-mcp/src/chrome-session-manager.test.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.test.ts
@@ -145,12 +145,16 @@ describe('chromeSessionManager', () => {
 
       vi.clearAllMocks()
       mockWindowMissingFlow(11111)
+      mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: kill -TERM
+      mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: post-TERM liveness check
       mockLaunchFlow(22222)
 
       const second = await manager.ensureAgentWindow()
 
       expect(second.pid).toBe(22222)
-      expect(mockedRunProcess).toHaveBeenNthCalledWith(2, '/usr/bin/osascript', [
+      expect(mockedRunProcess).toHaveBeenCalledWith('kill', ['-TERM', '11111'], expect.any(Object))
+      expect(mockedRunProcess).not.toHaveBeenCalledWith('kill', ['-KILL', '11111'], expect.any(Object))
+      expect(mockedRunProcess).toHaveBeenCalledWith('/usr/bin/osascript', [
         '-e',
         'tell application "System Events" to get count of windows of (first application process whose unix id is 11111)',
       ], expect.any(Object))
@@ -190,6 +194,8 @@ describe('chromeSessionManager', () => {
 
       vi.clearAllMocks()
       mockWindowMissingFlow(11111)
+      mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: kill -TERM
+      mockedRunProcess.mockResolvedValueOnce(ok()) // terminateChromeProcess: post-TERM liveness check
       mockLaunchFlow(22222)
 
       const second = await manager.ensureAgentWindow()

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -11,8 +11,9 @@
 
 import type { ChromeSessionInfo, ComputerUseConfig } from './types'
 
+import { createServer } from 'node:net'
 import { join } from 'node:path'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 
 import { runProcess } from './utils/process'
 import { sleep } from './utils/sleep'
@@ -23,6 +24,7 @@ import { sleep } from './utils/sleep'
 
 const CHROME_APP_NAME = 'Google Chrome'
 const DEFAULT_CDP_PORT = 9222
+const DEFAULT_CDP_PORT_SCAN_ATTEMPTS = 20
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -181,6 +183,24 @@ export function createChromeSessionManager(
     }
   }
 
+  async function getTrackedChromePid(trackedSession: ChromeSessionInfo): Promise<number | undefined> {
+    if (!activeProfileDir || !trackedSession.cdpUrl) {
+      return undefined
+    }
+
+    try {
+      const cdpPort = Number.parseInt(new URL(trackedSession.cdpUrl).port, 10)
+      if (!Number.isFinite(cdpPort)) {
+        return undefined
+      }
+
+      return await getChromePidForProfile(activeProfileDir, cdpPort)
+    }
+    catch {
+      return undefined
+    }
+  }
+
   async function getCurrentForegroundApp(): Promise<string | undefined> {
     try {
       const { stdout } = await runProcess(config.binaries.osascript, [
@@ -194,12 +214,47 @@ export function createChromeSessionManager(
     }
   }
 
+  async function canListenOnPort(port: number): Promise<boolean> {
+    return await new Promise<boolean>((resolvePromise) => {
+      const server = createServer()
+      server.once('error', () => {
+        resolvePromise(false)
+      })
+      server.listen(port, '127.0.0.1', () => {
+        server.close(() => resolvePromise(true))
+      })
+    })
+  }
+
+  async function resolveLaunchCdpPort(requestedPort: number, explicit: boolean): Promise<number> {
+    if (explicit) {
+      return requestedPort
+    }
+
+    for (let index = 0; index < DEFAULT_CDP_PORT_SCAN_ATTEMPTS; index += 1) {
+      const candidate = requestedPort + index
+      if (await canListenOnPort(candidate)) {
+        return candidate
+      }
+    }
+
+    throw new Error(`Could not find an available Chrome CDP port starting from ${requestedPort}`)
+  }
+
   async function launchChromeWithCdp(cdpPort: number, profileDir: string, url?: string): Promise<void> {
+    // Chrome uses the user-data-dir root "First Run" sentinel to decide
+    // whether the branded first-run dialog should appear.
+    await writeFile(join(profileDir, 'First Run'), '').catch(() => {})
+
     const args = [
       '-na',
       CHROME_APP_NAME,
       '--args',
       '--new-window',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-default-apps',
+      '--disable-features=ChromeWhatsNewUI',
       `--remote-debugging-port=${cdpPort}`,
       `--user-data-dir=${profileDir}`,
     ]
@@ -238,21 +293,39 @@ export function createChromeSessionManager(
 
   return {
     async ensureAgentWindow(options) {
+      let ensureOutcome: ChromeSessionInfo['ensureOutcome'] = 'launched'
+
       if (session) {
         const trackedSession = session
-        const stillRunning = await isProcessAlive(trackedSession.pid)
-        const stillHasWindow = stillRunning && await hasChromeWindow(trackedSession.pid)
-        if (stillHasWindow) {
-          return trackedSession
-        }
+        const trackedChromePid = await getTrackedChromePid(trackedSession)
 
-        try {
-          if (stillRunning) {
-            await terminateChromeProcess(trackedSession.pid)
+        if (trackedChromePid === trackedSession.pid) {
+          const stillRunning = await isProcessAlive(trackedSession.pid)
+          const stillHasWindow = stillRunning && await hasChromeWindow(trackedSession.pid)
+          if (stillHasWindow) {
+            trackedSession.ensureOutcome = 'reused'
+            return trackedSession
+          }
+
+          try {
+            if (stillRunning) {
+              ensureOutcome = 'recreated_after_missing_window'
+              await terminateChromeProcess(trackedSession.pid)
+            }
+            else {
+              ensureOutcome = 'recreated_after_process_exit'
+            }
+          }
+          finally {
+            // Chrome died or the tracked window disappeared — clear stale session.
+            await clearSessionState()
+            onSessionLost?.()
           }
         }
-        finally {
-          // Chrome died or the tracked window disappeared — clear stale session.
+        else {
+          // The tracked PID no longer resolves to the expected Chrome profile.
+          // Treat it as stale and relaunch without touching that PID.
+          ensureOutcome = 'recreated_after_process_exit'
           await clearSessionState()
           onSessionLost?.()
         }
@@ -261,7 +334,10 @@ export function createChromeSessionManager(
       // Record the user's current foreground app before we steal focus.
       previousForegroundApp = await getCurrentForegroundApp()
 
-      const cdpPort = options?.cdpPort ?? DEFAULT_CDP_PORT
+      const cdpPort = await resolveLaunchCdpPort(
+        options?.cdpPort ?? DEFAULT_CDP_PORT,
+        options?.cdpPort !== undefined,
+      )
       const wasAlreadyRunning = await isChromeRunning()
       await mkdir(config.sessionRoot, { recursive: true })
       activeProfileDir = await mkdtemp(join(config.sessionRoot, 'chrome-profile-'))
@@ -289,6 +365,7 @@ export function createChromeSessionManager(
         }
 
         session = {
+          ensureOutcome,
           wasAlreadyRunning,
           windowId: `${pid}:0:${CHROME_APP_NAME}`,
           cdpUrl: `http://127.0.0.1:${cdpPort}`,

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -33,7 +33,7 @@ export interface ChromeSessionManager {
    * Ensure the agent has a usable Chrome window.
    *
    * - No active agent session → launch a dedicated Chrome profile with CDP
-   * - Existing agent session still alive → reuse it
+   * - Existing agent session still has a live Chrome window → reuse it
    *
    * Human-owned Chrome instances are not reused. The agent always launches its
    * own profile so browser-dom/CDP capture has a stable endpoint.
@@ -42,7 +42,8 @@ export interface ChromeSessionManager {
 
   /**
    * Bring the agent's Chrome window to the foreground.
-   * Returns false if the tracked session is missing or Chrome is no longer running.
+   * Returns false if the tracked session is missing, Chrome is no longer
+   * running, or the tracked window is gone.
    */
   bringToFront: () => Promise<boolean>
 
@@ -113,6 +114,18 @@ export function createChromeSessionManager(
     catch {
       return false
     }
+  }
+
+  async function clearSessionState(): Promise<void> {
+    session = null
+    previousForegroundApp = undefined
+    if (activeProfileDir) {
+      const profileDir = activeProfileDir
+      activeProfileDir = undefined
+      await rm(profileDir, { recursive: true, force: true }).catch(() => {})
+      return
+    }
+    activeProfileDir = undefined
   }
 
   async function getChromePidForProfile(profileDir: string, cdpPort: number): Promise<number | undefined> {
@@ -206,15 +219,12 @@ export function createChromeSessionManager(
         if (stillHasWindow) {
           return session
         }
-        if (!stillRunning || !stillHasWindow) {
-          // Chrome died — clear stale session.
-          onSessionLost?.()
-        }
-        session = null
-        activeProfileDir = undefined
+        // Chrome died or the tracked window disappeared — clear stale session.
+        await clearSessionState()
+        onSessionLost?.()
       }
 
-      // Record the user's current foreground app before we steal focus
+      // Record the user's current foreground app before we steal focus.
       previousForegroundApp = await getCurrentForegroundApp()
 
       const cdpPort = options?.cdpPort ?? DEFAULT_CDP_PORT
@@ -225,9 +235,9 @@ export function createChromeSessionManager(
       // Always launch a dedicated profile so CDP is stable even when Chrome is already running.
       await launchChromeWithCdp(cdpPort, activeProfileDir, options?.url)
 
-      // Bring Chrome to front
+      // Bring Chrome to front.
       await activateChrome()
-      // Brief wait for activation
+      // Brief wait for activation.
       await sleep(300)
 
       const deadline = Date.now() + config.timeoutMs
@@ -240,6 +250,7 @@ export function createChromeSessionManager(
         await sleep(250)
       }
       if (!pid) {
+        await clearSessionState()
         throw new Error('Failed to get Chrome PID after launch')
       }
 
@@ -262,8 +273,7 @@ export function createChromeSessionManager(
       const stillRunning = await isProcessAlive(session.pid)
       const stillHasWindow = stillRunning && await hasChromeWindow(session.pid)
       if (!stillHasWindow) {
-        session = null
-        activeProfileDir = undefined
+        await clearSessionState()
         onSessionLost?.()
         return false
       }
@@ -283,13 +293,7 @@ export function createChromeSessionManager(
 
     endSession() {
       const hadSession = session !== null
-      const profileDir = activeProfileDir
-      session = null
-      activeProfileDir = undefined
-      previousForegroundApp = undefined
-      if (profileDir) {
-        void rm(profileDir, { recursive: true, force: true })
-      }
+      void clearSessionState()
       if (hadSession) {
         onSessionLost?.()
       }

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -2,16 +2,17 @@
  * Chrome Session Manager — agent-owned Chrome window lifecycle.
  *
  * Responsibilities:
- * - Detect whether Chrome is already running
- * - Launch Chrome with CDP if not running
- * - Create a new window in existing Chrome
- * - Track window identity via PID
+ * - Launch a dedicated Chrome profile with CDP
+ * - Track the launched browser PID
  * - Bring agent window to front / restore user's previous foreground
  *
  * macOS only. Uses AppleScript and `open` CLI for Chrome lifecycle control.
  */
 
 import type { ChromeSessionInfo, ComputerUseConfig } from './types'
+
+import { join } from 'node:path'
+import { mkdir, mkdtemp } from 'node:fs/promises'
 
 import { runProcess } from './utils/process'
 import { sleep } from './utils/sleep'
@@ -31,13 +32,11 @@ export interface ChromeSessionManager {
   /**
    * Ensure the agent has a usable Chrome window.
    *
-   * - Chrome not running → launch with CDP flag + new window
-   * - Chrome running → create new window in existing instance
+   * - No active agent session → launch a dedicated Chrome profile with CDP
+   * - Existing agent session still alive → reuse it
    *
-   * Reuses the cached session only when the agent launched a dedicated Chrome
-   * instance itself. When joining an existing user-owned Chrome process, a
-   * fresh window must be created on every ensure because this module does not
-   * track a verifiable OS window handle for the agent tab/window.
+   * Human-owned Chrome instances are not reused. The agent always launches its
+   * own profile so browser-dom/CDP capture has a stable endpoint.
    */
   ensureAgentWindow: (options?: { url?: string, cdpPort?: number }) => Promise<ChromeSessionInfo>
 
@@ -74,6 +73,7 @@ export function createChromeSessionManager(
   let session: ChromeSessionInfo | null = null
   let previousForegroundApp: string | undefined
   const onSessionLost = options?.onSessionLost
+  let activeProfileDir: string | undefined
 
   // -- Helpers ------------------------------------------------------------
 
@@ -90,14 +90,40 @@ export function createChromeSessionManager(
     }
   }
 
-  async function getChromeMainPid(): Promise<number | undefined> {
+  async function isProcessAlive(pid: number): Promise<boolean> {
     try {
-      const { stdout } = await runProcess('pgrep', ['-x', 'Google Chrome'], {
+      const { stdout } = await runProcess('ps', ['-p', String(pid), '-o', 'pid='], {
         timeoutMs: config.timeoutMs,
       })
-      const pids = stdout.trim().split('\n').map(Number).filter(n => !Number.isNaN(n))
-      // The lowest PID is typically the main Chrome process
-      return pids.length > 0 ? Math.min(...pids) : undefined
+      return stdout.trim().length > 0
+    }
+    catch {
+      return false
+    }
+  }
+
+  async function getChromePidForProfile(profileDir: string, cdpPort: number): Promise<number | undefined> {
+    try {
+      const { stdout } = await runProcess('ps', ['-axww', '-o', 'pid=,command='], {
+        timeoutMs: config.timeoutMs,
+      })
+      const matchingLine = stdout
+        .split('\n')
+        .map(line => line.trim())
+        .find(line =>
+          line.includes('/Contents/MacOS/Google Chrome')
+          && !line.includes('Helper')
+          && line.includes(`--user-data-dir=${profileDir}`)
+          && line.includes(`--remote-debugging-port=${cdpPort}`),
+        )
+
+      if (!matchingLine) {
+        return undefined
+      }
+
+      const pidText = matchingLine.split(/\s+/u)[0]
+      const pid = Number(pidText)
+      return Number.isFinite(pid) ? pid : undefined
     }
     catch {
       return undefined
@@ -117,13 +143,14 @@ export function createChromeSessionManager(
     }
   }
 
-  async function launchChromeWithCdp(cdpPort: number, url?: string): Promise<void> {
+  async function launchChromeWithCdp(cdpPort: number, profileDir: string, url?: string): Promise<void> {
     const args = [
       '-na',
       CHROME_APP_NAME,
       '--args',
       '--new-window',
       `--remote-debugging-port=${cdpPort}`,
+      `--user-data-dir=${profileDir}`,
     ]
     if (url) {
       args.push(url)
@@ -135,31 +162,6 @@ export function createChromeSessionManager(
 
     // Wait for Chrome to finish launching
     await sleep(2000)
-  }
-
-  async function createNewWindow(url?: string): Promise<void> {
-    // NOTICE: Pass the URL as an `osascript` argv value instead of interpolating
-    // it into the AppleScript source. `desktop_ensure_chrome` accepts arbitrary
-    // strings, so direct interpolation creates an AppleScript injection path when
-    // the URL contains quotes. The review report on PR #1649 correctly called this
-    // out as a P1 command-injection issue.
-    const script = url
-      ? `on run argv
-tell application "${CHROME_APP_NAME}" to make new window with properties {mode:"normal"}
-tell application "${CHROME_APP_NAME}" to set URL of active tab of front window to item 1 of argv
-end run`
-      : `tell application "${CHROME_APP_NAME}" to make new window`
-
-    const args = url
-      ? ['-e', script, '--', url]
-      : ['-e', script]
-
-    await runProcess(config.binaries.osascript, args, {
-      timeoutMs: config.timeoutMs,
-    })
-
-    // Brief delay for the window to appear
-    await sleep(500)
   }
 
   async function activateChrome(): Promise<void> {
@@ -185,14 +187,9 @@ end run`
 
   return {
     async ensureAgentWindow(options) {
-      // If we already have a session, only reuse it when the agent launched a
-      // dedicated Chrome instance. Joined sessions only cache process metadata,
-      // not a verifiable OS window handle, so blindly reusing them after the
-      // user closes that window would redirect later focus/click flows onto a
-      // different Chrome window.
       if (session) {
-        const stillRunning = await isChromeRunning()
-        if (stillRunning && !session.wasAlreadyRunning) {
+        const stillRunning = await isProcessAlive(session.pid)
+        if (stillRunning) {
           return session
         }
         if (!stillRunning) {
@@ -200,6 +197,7 @@ end run`
           onSessionLost?.()
         }
         session = null
+        activeProfileDir = undefined
       }
 
       // Record the user's current foreground app before we steal focus
@@ -207,23 +205,26 @@ end run`
 
       const cdpPort = options?.cdpPort ?? DEFAULT_CDP_PORT
       const wasAlreadyRunning = await isChromeRunning()
+      await mkdir(config.sessionRoot, { recursive: true })
+      activeProfileDir = await mkdtemp(join(config.sessionRoot, 'chrome-profile-'))
 
-      if (wasAlreadyRunning) {
-        // Chrome is running — create a new window in the existing instance
-        await createNewWindow(options?.url)
-      }
-      else {
-        // Chrome not running — launch with CDP
-        await launchChromeWithCdp(cdpPort, options?.url)
-      }
+      // Always launch a dedicated profile so CDP is stable even when Chrome is already running.
+      await launchChromeWithCdp(cdpPort, activeProfileDir, options?.url)
 
       // Bring Chrome to front
       await activateChrome()
       // Brief wait for activation
       await sleep(300)
 
-      // Get the Chrome PID
-      const pid = await getChromeMainPid()
+      const deadline = Date.now() + config.timeoutMs
+      let pid: number | undefined
+      while (Date.now() < deadline) {
+        pid = await getChromePidForProfile(activeProfileDir, cdpPort)
+        if (pid) {
+          break
+        }
+        await sleep(250)
+      }
       if (!pid) {
         throw new Error('Failed to get Chrome PID after launch')
       }
@@ -231,9 +232,9 @@ end run`
       session = {
         wasAlreadyRunning,
         windowId: `${pid}:0:${CHROME_APP_NAME}`,
-        cdpUrl: wasAlreadyRunning ? undefined : `http://127.0.0.1:${cdpPort}`,
+        cdpUrl: `http://127.0.0.1:${cdpPort}`,
         pid,
-        agentOwned: !wasAlreadyRunning,
+        agentOwned: true,
         initialUrl: options?.url,
         createdAt: new Date().toISOString(),
       }
@@ -244,9 +245,10 @@ end run`
     async bringToFront() {
       if (!session)
         return false
-      const stillRunning = await isChromeRunning()
+      const stillRunning = await isProcessAlive(session.pid)
       if (!stillRunning) {
         session = null
+        activeProfileDir = undefined
         onSessionLost?.()
         return false
       }
@@ -267,6 +269,7 @@ end run`
     endSession() {
       const hadSession = session !== null
       session = null
+      activeProfileDir = undefined
       previousForegroundApp = undefined
       if (hadSession) {
         onSessionLost?.()

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -132,6 +132,15 @@ export function createChromeSessionManager(
     }
   }
 
+  async function findAndTerminateChromeByProfile(profileDir: string, cdpPort: number): Promise<void> {
+    const pid = await getChromePidForProfile(profileDir, cdpPort)
+    if (!pid) {
+      return
+    }
+
+    await terminateChromeProcess(pid)
+  }
+
   async function clearSessionState(): Promise<void> {
     session = null
     previousForegroundApp = undefined
@@ -292,6 +301,7 @@ export function createChromeSessionManager(
         return session
       }
       catch (error) {
+        await findAndTerminateChromeByProfile(activeProfileDir, cdpPort)
         await clearSessionState()
         throw error
       }

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -116,6 +116,22 @@ export function createChromeSessionManager(
     }
   }
 
+  async function terminateChromeProcess(pid: number): Promise<void> {
+    await runProcess('kill', ['-TERM', String(pid)], { timeoutMs: config.timeoutMs }).catch(() => {})
+    await sleep(250)
+
+    if (!await isProcessAlive(pid)) {
+      return
+    }
+
+    await runProcess('kill', ['-KILL', String(pid)], { timeoutMs: config.timeoutMs }).catch(() => {})
+    await sleep(250)
+
+    if (await isProcessAlive(pid)) {
+      throw new Error(`Failed to terminate stale Chrome process ${pid}`)
+    }
+  }
+
   async function clearSessionState(): Promise<void> {
     session = null
     previousForegroundApp = undefined
@@ -214,14 +230,23 @@ export function createChromeSessionManager(
   return {
     async ensureAgentWindow(options) {
       if (session) {
-        const stillRunning = await isProcessAlive(session.pid)
-        const stillHasWindow = stillRunning && await hasChromeWindow(session.pid)
+        const trackedSession = session
+        const stillRunning = await isProcessAlive(trackedSession.pid)
+        const stillHasWindow = stillRunning && await hasChromeWindow(trackedSession.pid)
         if (stillHasWindow) {
-          return session
+          return trackedSession
         }
-        // Chrome died or the tracked window disappeared — clear stale session.
-        await clearSessionState()
-        onSessionLost?.()
+
+        try {
+          if (stillRunning) {
+            await terminateChromeProcess(trackedSession.pid)
+          }
+        }
+        finally {
+          // Chrome died or the tracked window disappeared — clear stale session.
+          await clearSessionState()
+          onSessionLost?.()
+        }
       }
 
       // Record the user's current foreground app before we steal focus.
@@ -232,39 +257,44 @@ export function createChromeSessionManager(
       await mkdir(config.sessionRoot, { recursive: true })
       activeProfileDir = await mkdtemp(join(config.sessionRoot, 'chrome-profile-'))
 
-      // Always launch a dedicated profile so CDP is stable even when Chrome is already running.
-      await launchChromeWithCdp(cdpPort, activeProfileDir, options?.url)
+      try {
+        // Always launch a dedicated profile so CDP is stable even when Chrome is already running.
+        await launchChromeWithCdp(cdpPort, activeProfileDir, options?.url)
 
-      // Bring Chrome to front.
-      await activateChrome()
-      // Brief wait for activation.
-      await sleep(300)
+        // Bring Chrome to front.
+        await activateChrome()
+        // Brief wait for activation.
+        await sleep(300)
 
-      const deadline = Date.now() + config.timeoutMs
-      let pid: number | undefined
-      while (Date.now() < deadline) {
-        pid = await getChromePidForProfile(activeProfileDir, cdpPort)
-        if (pid) {
-          break
+        const deadline = Date.now() + config.timeoutMs
+        let pid: number | undefined
+        while (Date.now() < deadline) {
+          pid = await getChromePidForProfile(activeProfileDir, cdpPort)
+          if (pid) {
+            break
+          }
+          await sleep(250)
         }
-        await sleep(250)
+        if (!pid) {
+          throw new Error('Failed to get Chrome PID after launch')
+        }
+
+        session = {
+          wasAlreadyRunning,
+          windowId: `${pid}:0:${CHROME_APP_NAME}`,
+          cdpUrl: `http://127.0.0.1:${cdpPort}`,
+          pid,
+          agentOwned: true,
+          initialUrl: options?.url,
+          createdAt: new Date().toISOString(),
+        }
+
+        return session
       }
-      if (!pid) {
+      catch (error) {
         await clearSessionState()
-        throw new Error('Failed to get Chrome PID after launch')
+        throw error
       }
-
-      session = {
-        wasAlreadyRunning,
-        windowId: `${pid}:0:${CHROME_APP_NAME}`,
-        cdpUrl: `http://127.0.0.1:${cdpPort}`,
-        pid,
-        agentOwned: true,
-        initialUrl: options?.url,
-        createdAt: new Date().toISOString(),
-      }
-
-      return session
     },
 
     async bringToFront() {

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -12,7 +12,7 @@
 import type { ChromeSessionInfo, ComputerUseConfig } from './types'
 
 import { join } from 'node:path'
-import { mkdir, mkdtemp } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 
 import { runProcess } from './utils/process'
 import { sleep } from './utils/sleep'
@@ -96,6 +96,19 @@ export function createChromeSessionManager(
         timeoutMs: config.timeoutMs,
       })
       return stdout.trim().length > 0
+    }
+    catch {
+      return false
+    }
+  }
+
+  async function hasChromeWindow(pid: number): Promise<boolean> {
+    try {
+      const { stdout } = await runProcess(config.binaries.osascript, [
+        '-e',
+        `tell application "System Events" to get count of windows of (first application process whose unix id is ${pid})`,
+      ], { timeoutMs: config.timeoutMs })
+      return Number.parseInt(stdout.trim(), 10) > 0
     }
     catch {
       return false
@@ -189,10 +202,11 @@ export function createChromeSessionManager(
     async ensureAgentWindow(options) {
       if (session) {
         const stillRunning = await isProcessAlive(session.pid)
-        if (stillRunning) {
+        const stillHasWindow = stillRunning && await hasChromeWindow(session.pid)
+        if (stillHasWindow) {
           return session
         }
-        if (!stillRunning) {
+        if (!stillRunning || !stillHasWindow) {
           // Chrome died — clear stale session.
           onSessionLost?.()
         }
@@ -246,7 +260,8 @@ export function createChromeSessionManager(
       if (!session)
         return false
       const stillRunning = await isProcessAlive(session.pid)
-      if (!stillRunning) {
+      const stillHasWindow = stillRunning && await hasChromeWindow(session.pid)
+      if (!stillHasWindow) {
         session = null
         activeProfileDir = undefined
         onSessionLost?.()
@@ -268,9 +283,13 @@ export function createChromeSessionManager(
 
     endSession() {
       const hadSession = session !== null
+      const profileDir = activeProfileDir
       session = null
       activeProfileDir = undefined
       previousForegroundApp = undefined
+      if (profileDir) {
+        void rm(profileDir, { recursive: true, force: true })
+      }
       if (hadSession) {
         onSessionLost?.()
       }

--- a/services/computer-use-mcp/src/chrome-session-manager.ts
+++ b/services/computer-use-mcp/src/chrome-session-manager.ts
@@ -11,9 +11,9 @@
 
 import type { ChromeSessionInfo, ComputerUseConfig } from './types'
 
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:net'
 import { join } from 'node:path'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 
 import { runProcess } from './utils/process'
 import { sleep } from './utils/sleep'

--- a/services/computer-use-mcp/src/desktop-grounding-types.ts
+++ b/services/computer-use-mcp/src/desktop-grounding-types.ts
@@ -147,7 +147,7 @@ export interface DesktopGroundingSnapshot {
   screenshot: ScreenshotArtifact
   /** macOS AX tree snapshot (if captured successfully) */
   axSnapshot?: AXSnapshot
-  /** Chrome semantic snapshot (only when Chrome is foreground) */
+  /** Chrome semantic snapshot (best effort when browser surfaces are available) */
   chromeSemanticSnapshot?: ChromeSemanticSnapshot
   /** Merged, deduplicated, ranked target candidates */
   targetCandidates: DesktopTargetCandidate[]

--- a/services/computer-use-mcp/src/desktop-grounding.test.ts
+++ b/services/computer-use-mcp/src/desktop-grounding.test.ts
@@ -1,9 +1,9 @@
 import type { AXNode, AXSnapshot } from './accessibility/types'
 import type { ChromeSemanticSnapshot, DesktopGroundingSnapshot } from './desktop-grounding-types'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { buildTargetCandidates, formatGroundingForAgent } from './desktop-grounding'
+import { buildTargetCandidates, captureDesktopGrounding, formatGroundingForAgent } from './desktop-grounding'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -167,6 +167,91 @@ describe('buildTargetCandidates', () => {
     ])
     const candidates = buildTargetCandidates({ axSnapshot: ax, foregroundApp: 'Finder' })
     expect(candidates[0].interactable).toBe(false)
+  })
+})
+
+describe('captureDesktopGrounding', () => {
+  it('retries window observation with app filter when Chrome is foreground and the generic list misses it', async () => {
+    const chromeWindow = { x: 0, y: 0, width: 1920, height: 1080 }
+    const chromeElements = [
+      { tag: 'button', text: 'Submit', rect: { x: 10, y: 10, w: 80, h: 30 } },
+    ]
+
+    const executor = {
+      takeScreenshot: vi.fn().mockResolvedValue({
+        dataBase64: '',
+        mimeType: 'image/png',
+        path: '/tmp/screenshot.png',
+        capturedAt: new Date().toISOString(),
+      }),
+      observeWindows: vi.fn()
+        .mockResolvedValueOnce({
+          frontmostAppName: 'Google Chrome',
+          frontmostWindowTitle: 'Chrome',
+          windows: [
+            {
+              appName: 'Control Center',
+              title: 'Clock',
+              bounds: { x: 0, y: 0, width: 100, height: 30 },
+            },
+          ],
+          observedAt: new Date().toISOString(),
+        })
+        .mockResolvedValueOnce({
+          frontmostAppName: 'Google Chrome',
+          frontmostWindowTitle: 'Chrome',
+          windows: [
+            {
+              appName: 'Google Chrome',
+              title: 'Chrome',
+              bounds: chromeWindow,
+              ownerPid: 1234,
+              id: '1234:0:Chrome',
+              layer: 0,
+              isOnScreen: true,
+            },
+          ],
+          observedAt: new Date().toISOString(),
+        }),
+      focusApp: vi.fn(),
+      openApp: vi.fn(),
+      click: vi.fn(),
+      typeText: vi.fn(),
+      pressKeys: vi.fn(),
+      scroll: vi.fn(),
+      getForegroundContext: vi.fn().mockResolvedValue({
+        available: true,
+        appName: 'Google Chrome',
+        platform: 'darwin',
+      }),
+      getDisplayInfo: vi.fn(),
+      getExecutionTarget: vi.fn(),
+      describe: vi.fn(),
+    } as any
+
+    const cdpBridge = {
+      getStatus: vi.fn().mockReturnValue({
+        connected: true,
+        pageUrl: 'https://example.com',
+        pageTitle: 'Example Page',
+      }),
+      collectInteractiveElements: vi.fn().mockResolvedValue(chromeElements),
+    } as any
+
+    const config = {
+      timeoutMs: 5000,
+    } as any
+
+    const snapshot = await captureDesktopGrounding({
+      config,
+      executor,
+      input: { includeChrome: true },
+      cdpBridge,
+    })
+
+    expect(executor.observeWindows).toHaveBeenNthCalledWith(1, { limit: 12 })
+    expect(executor.observeWindows).toHaveBeenNthCalledWith(2, { app: 'Google Chrome', limit: 12 })
+    expect(snapshot.targetCandidates.some(candidate => candidate.source === 'chrome_dom')).toBe(true)
   })
 })
 

--- a/services/computer-use-mcp/src/desktop-grounding.test.ts
+++ b/services/computer-use-mcp/src/desktop-grounding.test.ts
@@ -253,6 +253,95 @@ describe('captureDesktopGrounding', () => {
     expect(executor.observeWindows).toHaveBeenNthCalledWith(2, { app: 'Google Chrome', limit: 12 })
     expect(snapshot.targetCandidates.some(candidate => candidate.source === 'chrome_dom')).toBe(true)
   })
+
+  it('uses the Chrome page title to recover window bounds when the filtered window list has no Chrome app name', async () => {
+    const chromeWindow = { x: 320, y: 140, width: 1440, height: 900 }
+    const chromeElements = [
+      { tag: 'button', text: 'Submit', rect: { x: 10, y: 10, w: 80, h: 30 } },
+    ]
+
+    const executor = {
+      takeScreenshot: vi.fn().mockResolvedValue({
+        dataBase64: '',
+        mimeType: 'image/png',
+        path: '/tmp/screenshot.png',
+        capturedAt: new Date().toISOString(),
+      }),
+      observeWindows: vi.fn()
+        .mockResolvedValueOnce({
+          frontmostAppName: 'Google Chrome',
+          frontmostWindowTitle: 'AIRI Desktop V3 Smoke',
+          windows: [
+            {
+              appName: 'Control Center',
+              title: 'Clock',
+              bounds: { x: 0, y: 0, width: 100, height: 30 },
+            },
+          ],
+          observedAt: new Date().toISOString(),
+        })
+        .mockResolvedValueOnce({
+          frontmostAppName: 'Google Chrome',
+          frontmostWindowTitle: 'AIRI Desktop V3 Smoke',
+          windows: [
+            {
+              appName: 'Utility Panel',
+              title: 'AIRI Desktop V3 Smoke',
+              bounds: chromeWindow,
+              ownerPid: 1234,
+              id: '1234:0:Utility Panel',
+              layer: 0,
+              isOnScreen: true,
+            },
+          ],
+          observedAt: new Date().toISOString(),
+        }),
+      focusApp: vi.fn(),
+      openApp: vi.fn(),
+      click: vi.fn(),
+      typeText: vi.fn(),
+      pressKeys: vi.fn(),
+      scroll: vi.fn(),
+      getForegroundContext: vi.fn().mockResolvedValue({
+        available: true,
+        appName: 'Google Chrome',
+        platform: 'darwin',
+      }),
+      getDisplayInfo: vi.fn(),
+      getExecutionTarget: vi.fn(),
+      describe: vi.fn(),
+    } as any
+
+    const cdpBridge = {
+      getStatus: vi.fn().mockReturnValue({
+        connected: true,
+        pageUrl: 'https://example.com',
+        pageTitle: 'AIRI Desktop V3 Smoke',
+      }),
+      collectInteractiveElements: vi.fn().mockResolvedValue(chromeElements),
+    } as any
+
+    const config = {
+      timeoutMs: 5000,
+    } as any
+
+    const snapshot = await captureDesktopGrounding({
+      config,
+      executor,
+      input: { includeChrome: true },
+      cdpBridge,
+    })
+
+    expect(executor.observeWindows).toHaveBeenNthCalledWith(1, { limit: 12 })
+    expect(executor.observeWindows).toHaveBeenNthCalledWith(2, { app: 'Google Chrome', limit: 12 })
+    expect(snapshot.targetCandidates.some(candidate => candidate.source === 'chrome_dom')).toBe(true)
+    expect(snapshot.targetCandidates[0].bounds).toEqual({
+      x: chromeWindow.x + 10,
+      y: chromeWindow.y + 88 + 10,
+      width: 80,
+      height: 30,
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/services/computer-use-mcp/src/desktop-grounding.ts
+++ b/services/computer-use-mcp/src/desktop-grounding.ts
@@ -81,6 +81,25 @@ export async function captureDesktopGrounding(params: {
   const foregroundApp = windowObs.frontmostAppName || axSnapshot?.appName || 'unknown'
   const isChromeInFront = isChromeApp(foregroundApp)
 
+  // If Chrome is foreground, ask the executor for a Chrome-filtered window list.
+  // The generic top-N window snapshot is often dominated by system UI and can
+  // miss Chrome entirely, which would prevent chrome_dom candidates from being
+  // mapped to screen coordinates.
+  let chromeWindowBounds = findChromeWindowBounds(windowObs, foregroundApp)
+  if (isChromeInFront && !chromeWindowBounds) {
+    try {
+      const chromeWindows = await executor.observeWindows({
+        app: foregroundApp,
+        limit: 12,
+      })
+      chromeWindowBounds = findChromeWindowBounds(chromeWindows, foregroundApp)
+    }
+    catch {
+      // Best-effort only. Fall back to AX-only candidates if filtered window
+      // enumeration fails.
+    }
+  }
+
   // Phase 2: Chrome semantic data (only if Chrome is foreground and allowed)
   let chromeSemanticSnapshot: ChromeSemanticSnapshot | null = null
   if (isChromeInFront && input?.includeChrome !== false) {
@@ -88,7 +107,6 @@ export async function captureDesktopGrounding(params: {
   }
 
   // Phase 3: Build target candidates
-  const chromeWindowBounds = findChromeWindowBounds(windowObs, foregroundApp)
   const candidates = buildTargetCandidates({
     axSnapshot,
     chromeSnapshot: chromeSemanticSnapshot ?? undefined,

--- a/services/computer-use-mcp/src/desktop-grounding.ts
+++ b/services/computer-use-mcp/src/desktop-grounding.ts
@@ -86,13 +86,14 @@ export async function captureDesktopGrounding(params: {
   // miss Chrome entirely, which would prevent chrome_dom candidates from being
   // mapped to screen coordinates.
   let chromeWindowBounds = findChromeWindowBounds(windowObs, foregroundApp)
+  let chromeWindowObservation: WindowObservation | undefined
   if (isChromeInFront && !chromeWindowBounds) {
     try {
-      const chromeWindows = await executor.observeWindows({
+      chromeWindowObservation = await executor.observeWindows({
         app: foregroundApp,
         limit: 12,
       })
-      chromeWindowBounds = findChromeWindowBounds(chromeWindows, foregroundApp)
+      chromeWindowBounds = findChromeWindowBounds(chromeWindowObservation, foregroundApp)
     }
     catch {
       // Best-effort only. Fall back to AX-only candidates if filtered window
@@ -104,6 +105,13 @@ export async function captureDesktopGrounding(params: {
   let chromeSemanticSnapshot: ChromeSemanticSnapshot | null = null
   if (isChromeInFront && input?.includeChrome !== false) {
     chromeSemanticSnapshot = await captureChromeSemantics(extensionBridge, cdpBridge)
+    if (!chromeWindowBounds && chromeSemanticSnapshot?.pageTitle) {
+      chromeWindowBounds = findChromeWindowBounds(
+        chromeWindowObservation ?? windowObs,
+        foregroundApp,
+        chromeSemanticSnapshot.pageTitle,
+      )
+    }
   }
 
   // Phase 3: Build target candidates
@@ -339,7 +347,30 @@ function isChromeApp(appName: string): boolean {
 function findChromeWindowBounds(
   observation: WindowObservation,
   _foregroundApp: string,
+  titleHint?: string,
 ): Bounds | undefined {
+  const normalizedTitleHint = titleHint?.trim().toLowerCase()
+  if (normalizedTitleHint) {
+    const titleMatchedWindow = observation.windows.find((window) => {
+      if (!window.bounds) {
+        return false
+      }
+
+      const normalizedWindowTitle = window.title?.trim().toLowerCase()
+      if (!normalizedWindowTitle) {
+        return false
+      }
+
+      return normalizedWindowTitle === normalizedTitleHint
+        || normalizedWindowTitle.includes(normalizedTitleHint)
+        || normalizedTitleHint.includes(normalizedWindowTitle)
+    })
+
+    if (titleMatchedWindow?.bounds) {
+      return titleMatchedWindow.bounds
+    }
+  }
+
   const chromeWindow = observation.windows.find(w =>
     w.appName.toLowerCase().includes('chrome') && w.bounds,
   )

--- a/services/computer-use-mcp/src/desktop-grounding.ts
+++ b/services/computer-use-mcp/src/desktop-grounding.ts
@@ -3,8 +3,8 @@
  *
  * This is the main entry point for the `desktop_observe` tool.
  * It captures screenshot, window observation, AX tree, and Chrome semantics
- * in parallel, then merges everything into a single `DesktopGroundingSnapshot`
- * with deduplicated, ranked target candidates.
+ * in parallel when available, then merges everything into a single
+ * `DesktopGroundingSnapshot` with deduplicated, ranked target candidates.
  */
 
 import type { AXNode, AXSnapshot } from './accessibility/types'
@@ -36,21 +36,13 @@ import { boundsIoU } from './snap-resolver'
  */
 const STALENESS_THRESHOLD_MS = 2000
 
-/** Known Chrome-like browser app names (lowercase, no .app suffix) */
-const CHROME_APPS = new Set([
-  'google chrome',
-  'chrome',
-  'google chrome canary',
-  'chromium',
-])
-
 let nextSnapshotId = 1
 
 /**
  * Capture a unified desktop grounding snapshot.
  *
  * Runs screenshot, window observation, and AX tree capture in parallel.
- * If the foreground app is Chrome (and `includeChrome` is not false),
+ * If Chrome browser surfaces are available (and `includeChrome` is not false),
  * also captures Chrome semantic data.
  *
  * @param params - Capture parameters (config, executor, input, bridges)
@@ -79,21 +71,21 @@ export async function captureDesktopGrounding(params: {
 
   // Determine foreground app
   const foregroundApp = windowObs.frontmostAppName || axSnapshot?.appName || 'unknown'
-  const isChromeInFront = isChromeApp(foregroundApp)
+  const shouldCaptureChrome = input?.includeChrome !== false
 
-  // If Chrome is foreground, ask the executor for a Chrome-filtered window list.
-  // The generic top-N window snapshot is often dominated by system UI and can
-  // miss Chrome entirely, which would prevent chrome_dom candidates from being
-  // mapped to screen coordinates.
-  let chromeWindowBounds = findChromeWindowBounds(windowObs, foregroundApp)
+  // Ask the executor for a Chrome-filtered window list when Chrome semantics
+  // are requested. The generic top-N window snapshot is often dominated by
+  // system UI and can miss Chrome entirely, which would prevent chrome_dom
+  // candidates from being mapped to screen coordinates.
+  let chromeWindowBounds = findChromeWindowBounds(windowObs)
   let chromeWindowObservation: WindowObservation | undefined
-  if (isChromeInFront && !chromeWindowBounds) {
+  if (shouldCaptureChrome && !chromeWindowBounds) {
     try {
       chromeWindowObservation = await executor.observeWindows({
-        app: foregroundApp,
+        app: 'Google Chrome',
         limit: 12,
       })
-      chromeWindowBounds = findChromeWindowBounds(chromeWindowObservation, foregroundApp)
+      chromeWindowBounds = findChromeWindowBounds(chromeWindowObservation)
     }
     catch {
       // Best-effort only. Fall back to AX-only candidates if filtered window
@@ -103,12 +95,11 @@ export async function captureDesktopGrounding(params: {
 
   // Phase 2: Chrome semantic data (only if Chrome is foreground and allowed)
   let chromeSemanticSnapshot: ChromeSemanticSnapshot | null = null
-  if (isChromeInFront && input?.includeChrome !== false) {
+  if (shouldCaptureChrome) {
     chromeSemanticSnapshot = await captureChromeSemantics(extensionBridge, cdpBridge)
     if (!chromeWindowBounds && chromeSemanticSnapshot?.pageTitle) {
       chromeWindowBounds = findChromeWindowBounds(
         chromeWindowObservation ?? windowObs,
-        foregroundApp,
         chromeSemanticSnapshot.pageTitle,
       )
     }
@@ -128,7 +119,7 @@ export async function captureDesktopGrounding(params: {
     screenshot,
     axSnapshot,
     chromeSemanticSnapshot: chromeSemanticSnapshot ?? undefined,
-    isChromeInFront,
+    chromeSemanticEnabled: shouldCaptureChrome,
     assemblyTimestamp: now,
   })
 
@@ -337,16 +328,8 @@ function axNodesToTargetCandidates(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Compiled regex for stripping .app suffix from macOS app names */
-const APP_SUFFIX_RE = /\.app$/u
-
-function isChromeApp(appName: string): boolean {
-  return CHROME_APPS.has(appName.trim().toLowerCase().replace(APP_SUFFIX_RE, ''))
-}
-
 function findChromeWindowBounds(
   observation: WindowObservation,
-  _foregroundApp: string,
   titleHint?: string,
 ): Bounds | undefined {
   const normalizedTitleHint = titleHint?.trim().toLowerCase()
@@ -381,10 +364,10 @@ function computeStaleness(params: {
   screenshot: ScreenshotArtifact
   axSnapshot?: AXSnapshot
   chromeSemanticSnapshot?: ChromeSemanticSnapshot
-  isChromeInFront: boolean
+  chromeSemanticEnabled: boolean
   assemblyTimestamp: number
 }): GroundingStalenessFlags {
-  const { screenshot, axSnapshot, chromeSemanticSnapshot, isChromeInFront, assemblyTimestamp } = params
+  const { screenshot, axSnapshot, chromeSemanticSnapshot, chromeSemanticEnabled, assemblyTimestamp } = params
 
   const screenshotStale = !screenshot.capturedAt
     || (assemblyTimestamp - new Date(screenshot.capturedAt).getTime()) > STALENESS_THRESHOLD_MS
@@ -394,7 +377,7 @@ function computeStaleness(params: {
     || !axSnapshot.capturedAt
     || (assemblyTimestamp - new Date(axSnapshot.capturedAt).getTime()) > STALENESS_THRESHOLD_MS
 
-  const chromeStale = !isChromeInFront
+  const chromeStale = !chromeSemanticEnabled
     || !chromeSemanticSnapshot
     || !chromeSemanticSnapshot.capturedAt
     || (assemblyTimestamp - new Date(chromeSemanticSnapshot.capturedAt).getTime()) > STALENESS_THRESHOLD_MS

--- a/services/computer-use-mcp/src/server/action-executor.test.ts
+++ b/services/computer-use-mcp/src/server/action-executor.test.ts
@@ -71,6 +71,9 @@ function createRuntimeForActionTest(configOverrides: Partial<ComputerUseConfig> 
       connected: true,
       pendingRequests: 0,
     }),
+    supportsAction: vi.fn().mockReturnValue(true),
+    clickSelector: vi.fn().mockResolvedValue(undefined),
+    checkCheckbox: vi.fn().mockResolvedValue(undefined),
   }
   const cdpBridgeManager = {
     probeAvailability: vi.fn().mockResolvedValue({
@@ -321,6 +324,113 @@ describe('createExecuteAction', () => {
         actualForegroundContext: expect.objectContaining({ appName: 'AIRI' }),
       }),
     }))
+  })
+
+  it('does not refocus when desktop_click_target stays on browser_dom', async () => {
+    const { runtime, executor, stateManager, desktopSessionController } = createRuntimeForActionTest()
+    stateManager.updateGroundingSnapshot({
+      snapshotId: 'dg_1',
+      capturedAt: new Date().toISOString(),
+      foregroundApp: 'Google Chrome',
+      windows: [],
+      screenshot: {
+        dataBase64: '',
+        mimeType: 'image/png',
+        path: '',
+        capturedAt: new Date().toISOString(),
+      },
+      targetCandidates: [
+        {
+          id: 't_0',
+          source: 'chrome_dom',
+          appName: 'Google Chrome',
+          role: 'button',
+          label: 'Submit',
+          bounds: { x: 100, y: 200, width: 80, height: 30 },
+          confidence: 0.95,
+          interactable: true,
+          selector: '#submit',
+          frameId: 0,
+          isPageContent: true,
+        },
+      ],
+      staleFlags: { screenshot: false, ax: false, chromeSemantic: false },
+    } as any)
+    desktopSessionController.getSession.mockReturnValue({
+      id: 'ds_1',
+      controlledApp: 'Google Chrome',
+      ownedWindows: [],
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    })
+    executor.getForegroundContext.mockResolvedValue({
+      available: true,
+      appName: 'AIRI',
+      platform: 'darwin',
+    })
+
+    const executeAction = createExecuteAction(runtime)
+    const result = await executeAction({ kind: 'desktop_click_target', input: { candidateId: 't_0' } }, 'desktop_click_target')
+
+    expect(result.isError).not.toBe(true)
+    expect(desktopSessionController.ensureControlledAppInForeground).not.toHaveBeenCalled()
+    expect(executor.focusApp).not.toHaveBeenCalled()
+    expect(executor.click).not.toHaveBeenCalled()
+    expect(result.structuredContent).toMatchObject({
+      status: 'executed',
+      backendResult: expect.objectContaining({
+        executionMode: 'browser_surface',
+      }),
+    })
+  })
+
+  it('refocuses when desktop_click_target falls back to OS input', async () => {
+    const { runtime, executor, stateManager, desktopSessionController } = createRuntimeForActionTest()
+    stateManager.updateGroundingSnapshot({
+      snapshotId: 'dg_1',
+      capturedAt: new Date().toISOString(),
+      foregroundApp: 'Google Chrome',
+      windows: [],
+      screenshot: {
+        dataBase64: '',
+        mimeType: 'image/png',
+        path: '',
+        capturedAt: new Date().toISOString(),
+      },
+      targetCandidates: [
+        {
+          id: 't_0',
+          source: 'ax',
+          appName: 'Google Chrome',
+          role: 'AXButton',
+          label: 'Submit',
+          bounds: { x: 100, y: 200, width: 80, height: 30 },
+          confidence: 0.95,
+          interactable: true,
+        },
+      ],
+      staleFlags: { screenshot: false, ax: false, chromeSemantic: false },
+    } as any)
+    desktopSessionController.getSession.mockReturnValue({
+      id: 'ds_1',
+      controlledApp: 'Google Chrome',
+      ownedWindows: [],
+      createdAt: new Date().toISOString(),
+      lastActiveAt: new Date().toISOString(),
+    })
+    desktopSessionController.ensureControlledAppInForeground.mockResolvedValue(true)
+    executor.getForegroundContext.mockResolvedValue({
+      available: true,
+      appName: 'AIRI',
+      platform: 'darwin',
+    })
+
+    const executeAction = createExecuteAction(runtime)
+    const result = await executeAction({ kind: 'desktop_click_target', input: { candidateId: 't_0' } }, 'desktop_click_target')
+
+    expect(result.isError).not.toBe(true)
+    expect(desktopSessionController.ensureControlledAppInForeground).toHaveBeenCalled()
+    expect(executor.click).toHaveBeenCalledOnce()
   })
 
   it('returns a structured failure when controlled-app refocus fails during desktop_click_target execution', async () => {

--- a/services/computer-use-mcp/src/server/desktop-grounding-actions.ts
+++ b/services/computer-use-mcp/src/server/desktop-grounding-actions.ts
@@ -6,8 +6,8 @@ import { errorMessageFrom } from '@moeru/std'
 import { decideBrowserAction } from '../browser-action-router'
 import { getUnsupportedBrowserDomActions, isBrowserDomActionSupported } from '../browser-dom/capabilities'
 import { resolveSnapByCandidate } from '../snap-resolver'
-import { decideDesktopExecutionMode } from './desktop-scheduler'
 import { sleep } from '../utils/sleep'
+import { decideDesktopExecutionMode } from './desktop-scheduler'
 
 const DESKTOP_CLICK_SNAPSHOT_MAX_AGE_MS = 5000
 

--- a/services/computer-use-mcp/src/server/desktop-grounding-actions.ts
+++ b/services/computer-use-mcp/src/server/desktop-grounding-actions.ts
@@ -6,6 +6,7 @@ import { errorMessageFrom } from '@moeru/std'
 import { decideBrowserAction } from '../browser-action-router'
 import { getUnsupportedBrowserDomActions, isBrowserDomActionSupported } from '../browser-dom/capabilities'
 import { resolveSnapByCandidate } from '../snap-resolver'
+import { decideDesktopExecutionMode } from './desktop-scheduler'
 import { sleep } from '../utils/sleep'
 
 const DESKTOP_CLICK_SNAPSHOT_MAX_AGE_MS = 5000
@@ -46,23 +47,6 @@ export async function executeDesktopClickTarget(
     throw new Error(`Candidate "${candidateId}" not found in snapshot "${snapshot.snapshotId}". Available candidates: ${snapshot.targetCandidates.map(c => c.id).join(', ')}`)
   }
 
-  const sessionCtrl = runtime.desktopSessionController
-  const activeSession = sessionCtrl.getSession()
-  if (activeSession?.controlledApp) {
-    const currentForeground = await runtime.executor.getForegroundContext()
-    const wasAlreadyInFront = await sessionCtrl.ensureControlledAppInForeground({
-      currentForeground,
-      chromeSessionManager: runtime.chromeSessionManager,
-      activateApp: async (appName) => {
-        await runtime.executor.focusApp({ app: appName })
-      },
-    })
-    if (!wasAlreadyInFront) {
-      await sleep(200)
-    }
-    sessionCtrl.touch()
-  }
-
   const candidate = snapshot.targetCandidates.find(c => c.id === candidateId)
   const intent = {
     mode: 'execute' as const,
@@ -83,6 +67,8 @@ export async function executeDesktopClickTarget(
   let routeNote = ''
   let routeReason = 'candidate not found'
   let osInputResult: ExecutorActionResult | undefined
+  let executionMode: 'background' | 'browser_surface' | 'foreground' = 'foreground'
+  let executionModeReason = 'desktop_click_target uses native input and needs foreground access'
 
   const executeOsClick = async () => {
     const result = await runtime.executor.click({
@@ -96,11 +82,42 @@ export async function executeDesktopClickTarget(
     return result
   }
 
+  const ensureForegroundForOsInput = async () => {
+    const sessionCtrl = runtime.desktopSessionController
+    const activeSession = sessionCtrl.getSession()
+    if (!activeSession?.controlledApp) {
+      return
+    }
+
+    const currentForeground = await runtime.executor.getForegroundContext()
+    const wasAlreadyInFront = await sessionCtrl.ensureControlledAppInForeground({
+      currentForeground,
+      chromeSessionManager: runtime.chromeSessionManager,
+      activateApp: async (appName) => {
+        await runtime.executor.focusApp({ app: appName })
+      },
+    })
+    if (!wasAlreadyInFront) {
+      await sleep(200)
+    }
+    sessionCtrl.touch()
+  }
+
   try {
     const bridgeConnected = runtime.browserDomBridge?.getStatus().connected ?? false
     const routeDecision = candidate
       ? decideBrowserAction(candidate, bridgeConnected, button, clickCount)
       : { route: 'os_input' as const, reason: 'candidate not found' }
+
+    const schedulingDecision = decideDesktopExecutionMode({
+      action: { kind: 'desktop_click_target', input },
+      browserSurface: runtime.stateManager.getState().browserSurfaceAvailability,
+      browserDomRoute: routeDecision.route === 'browser_dom',
+    })
+    if (routeDecision.route === 'browser_dom') {
+      executionMode = schedulingDecision.executionMode
+      executionModeReason = schedulingDecision.executionReason
+    }
 
     executionRoute = routeDecision.route
     routeReason = routeDecision.reason
@@ -114,6 +131,9 @@ export async function executeDesktopClickTarget(
         executionRoute = 'os_input'
         routeReason = `browser-dom extension transport does not support ${requiredActions.join(' + ')}`
         routeNote = `browser-dom ${routeDecision.bridgeMethod ?? 'click'} is unavailable on the connected extension transport (${getUnsupportedBrowserDomActions(runtime.browserDomBridge, ...requiredActions).join(', ')} unsupported), fell back to OS input`
+        executionMode = 'foreground'
+        executionModeReason = 'browser_dom is unavailable, so native input fallback needs foreground access'
+        await ensureForegroundForOsInput()
         osInputResult = await executeOsClick()
       }
       else {
@@ -135,11 +155,17 @@ export async function executeDesktopClickTarget(
         catch (browserError) {
           executionRoute = 'os_input'
           routeNote = `browser-dom ${routeDecision.bridgeMethod ?? 'click'} failed (${errorMessageFrom(browserError) ?? 'unknown error'}), fell back to OS input`
+          executionMode = 'foreground'
+          executionModeReason = 'browser_dom failed, so native input fallback needs foreground access'
+          await ensureForegroundForOsInput()
           osInputResult = await executeOsClick()
         }
       }
     }
     else {
+      executionMode = schedulingDecision.executionMode
+      executionModeReason = schedulingDecision.executionReason
+      await ensureForegroundForOsInput()
       osInputResult = await executeOsClick()
     }
 
@@ -157,6 +183,7 @@ export async function executeDesktopClickTarget(
       `  Snap: ${snap.reason}`,
       `  Point: (${snap.snappedPoint.x}, ${snap.snappedPoint.y})`,
       `  Route: ${executionRoute} (${routeReason})`,
+      `  Execution mode: ${executionMode} (${executionModeReason})`,
       `  Button: ${button || 'left'}, clicks: ${clickCount ?? 1}`,
     ]
 
@@ -177,6 +204,8 @@ export async function executeDesktopClickTarget(
         candidate,
         executionRoute,
         routeReason,
+        executionMode,
+        executionModeReason,
         routeNote: routeNote || undefined,
         osInputResult,
       },

--- a/services/computer-use-mcp/src/server/desktop-scheduler.test.ts
+++ b/services/computer-use-mcp/src/server/desktop-scheduler.test.ts
@@ -1,7 +1,8 @@
+import type { BrowserSurfaceAvailability } from '../types'
+
 import { describe, expect, it } from 'vitest'
 
 import { decideDesktopExecutionMode } from './desktop-scheduler'
-import type { BrowserSurfaceAvailability } from '../types'
 
 function makeBrowserSurfaceAvailability(): BrowserSurfaceAvailability {
   return {

--- a/services/computer-use-mcp/src/server/desktop-scheduler.test.ts
+++ b/services/computer-use-mcp/src/server/desktop-scheduler.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { decideDesktopExecutionMode } from './desktop-scheduler'
+import type { BrowserSurfaceAvailability } from '../types'
+
+function makeBrowserSurfaceAvailability(): BrowserSurfaceAvailability {
+  return {
+    executionMode: 'local-windowed' as const,
+    suitable: true,
+    availableSurfaces: ['browser_dom', 'browser_cdp'],
+    preferredSurface: 'browser_dom' as const,
+    selectedToolName: 'browser_dom_read_page' as const,
+    reason: 'connected',
+    extension: {
+      enabled: true,
+      connected: true,
+    },
+    cdp: {
+      endpoint: 'http://localhost:9222',
+      connected: true,
+      connectable: true,
+    },
+  }
+}
+
+describe('decideDesktopExecutionMode', () => {
+  it('keeps desktop_observe background when Chrome capture is disabled', () => {
+    const decision = decideDesktopExecutionMode({
+      action: { kind: 'desktop_observe', input: { includeChrome: false } },
+    })
+
+    expect(decision).toMatchObject({
+      executionMode: 'background',
+      foregroundRequired: false,
+    })
+  })
+
+  it('treats desktop_observe as browser_surface when browser surfaces are available', () => {
+    const decision = decideDesktopExecutionMode({
+      action: { kind: 'desktop_observe', input: { includeChrome: true } },
+      browserSurface: makeBrowserSurfaceAvailability(),
+    })
+
+    expect(decision).toMatchObject({
+      executionMode: 'browser_surface',
+      browserSurfacePreferred: true,
+      foregroundRequired: false,
+    })
+  })
+
+  it('keeps desktop_click_target background-safe when browser_dom is available', () => {
+    const decision = decideDesktopExecutionMode({
+      action: { kind: 'desktop_click_target', input: { candidateId: 't_0' } },
+      browserSurface: makeBrowserSurfaceAvailability(),
+      browserDomRoute: true,
+    })
+
+    expect(decision).toMatchObject({
+      executionMode: 'browser_surface',
+      browserSurfacePreferred: true,
+      foregroundRequired: false,
+    })
+  })
+})

--- a/services/computer-use-mcp/src/server/desktop-scheduler.ts
+++ b/services/computer-use-mcp/src/server/desktop-scheduler.ts
@@ -1,0 +1,119 @@
+import type { ActionInvocation, BrowserSurfaceAvailability } from '../types'
+
+export type DesktopExecutionMode = 'background' | 'browser_surface' | 'foreground'
+
+export interface DesktopSchedulingDecision {
+  executionMode: DesktopExecutionMode
+  executionReason: string
+  browserSurfacePreferred: boolean
+  foregroundRequired: boolean
+}
+
+function hasBrowserDomSurface(browserSurface?: BrowserSurfaceAvailability): boolean {
+  return Boolean(browserSurface?.availableSurfaces?.some(surface => surface === 'browser_dom' || surface === 'browser_cdp'))
+}
+
+function isBackgroundReadAction(action: ActionInvocation): boolean {
+  return action.kind === 'desktop_observe'
+    || action.kind === 'observe_windows'
+    || action.kind === 'screenshot'
+}
+
+function isBrowserDomCapableAction(action: ActionInvocation): boolean {
+  return action.kind === 'desktop_click_target'
+}
+
+function isNativeForegroundAction(action: ActionInvocation): boolean {
+  return action.kind === 'click'
+    || action.kind === 'press_keys'
+    || action.kind === 'scroll'
+    || action.kind === 'wait'
+    || action.kind === 'open_app'
+    || action.kind === 'focus_app'
+    || action.kind === 'terminal_exec'
+    || action.kind === 'terminal_reset'
+    || action.kind === 'clipboard_write_text'
+    || action.kind === 'clipboard_read_text'
+    || action.kind === 'secret_read_env_value'
+}
+
+export function decideDesktopExecutionMode(params: {
+  action: ActionInvocation
+  browserSurface?: BrowserSurfaceAvailability
+  browserDomRoute?: boolean
+}): DesktopSchedulingDecision {
+  const { action, browserSurface, browserDomRoute } = params
+  const browserSurfaceAvailable = hasBrowserDomSurface(browserSurface)
+
+  if (action.kind === 'desktop_observe') {
+    if (action.input?.includeChrome === false) {
+      return {
+        executionMode: 'background',
+        executionReason: 'desktop_observe is background-only when Chrome capture is disabled',
+        browserSurfacePreferred: false,
+        foregroundRequired: false,
+      }
+    }
+
+    if (browserSurfaceAvailable) {
+      return {
+        executionMode: 'browser_surface',
+        executionReason: 'browser surface is available, so desktop_observe can collect Chrome semantics without a foreground switch',
+        browserSurfacePreferred: true,
+        foregroundRequired: false,
+      }
+    }
+
+    return {
+      executionMode: 'background',
+      executionReason: 'desktop_observe stays background-only because no browser surface is available',
+      browserSurfacePreferred: false,
+      foregroundRequired: false,
+    }
+  }
+
+  if (isBackgroundReadAction(action)) {
+    return {
+      executionMode: 'background',
+      executionReason: `${action.kind} is read-only and does not need foreground switching`,
+      browserSurfacePreferred: false,
+      foregroundRequired: false,
+    }
+  }
+
+  if (isBrowserDomCapableAction(action)) {
+    if (browserDomRoute) {
+      return {
+        executionMode: 'browser_surface',
+        executionReason: 'browser_dom route is available, so click_target can stay background-safe',
+        browserSurfacePreferred: true,
+        foregroundRequired: false,
+      }
+    }
+
+    return {
+      executionMode: 'foreground',
+      executionReason: browserSurfaceAvailable
+        ? 'desktop_click_target needs foreground because browser_dom is unavailable for this candidate'
+        : 'desktop_click_target needs foreground because no browser surface is available',
+      browserSurfacePreferred: false,
+      foregroundRequired: true,
+    }
+  }
+
+  if (isNativeForegroundAction(action)) {
+    return {
+      executionMode: 'foreground',
+      executionReason: `${action.kind} uses native input and needs foreground access`,
+      browserSurfacePreferred: false,
+      foregroundRequired: true,
+    }
+  }
+
+  return {
+    executionMode: 'foreground',
+    executionReason: `defaulting ${action.kind} to foreground execution`,
+    browserSurfacePreferred: false,
+    foregroundRequired: true,
+  }
+}

--- a/services/computer-use-mcp/src/server/register-chrome-session.test.ts
+++ b/services/computer-use-mcp/src/server/register-chrome-session.test.ts
@@ -150,34 +150,6 @@ describe('registerChromeSessionTools', () => {
     expect(runtime.stateManager.getState().pendingApprovalCount).toBe(1)
   })
 
-  it('audits joined Chrome sessions as open_app because ensure can create a new window', async () => {
-    runtime.config = createTestConfig({
-      executor: 'macos-local',
-      approvalMode: 'all',
-    })
-    vi.mocked(runtime.chromeSessionManager.getSessionInfo).mockReturnValue({
-      wasAlreadyRunning: true,
-      windowId: 'chrome-window-existing',
-      pid: 9999,
-      agentOwned: false,
-      createdAt: new Date().toISOString(),
-    })
-
-    const { server, invoke } = createMockServer()
-    registerChromeSessionTools({ server, runtime })
-
-    const result = await invoke('desktop_ensure_chrome')
-
-    const structured = result.structuredContent as Record<string, any>
-    expect(structured.status).toBe('approval_required')
-    expect(structured.action).toEqual({
-      kind: 'desktop_ensure_chrome',
-      input: {},
-    })
-    expect(structured.transparency.intent).toBe('Open an agent Chrome window with CDP support')
-    expect(runtime.chromeSessionManager.ensureAgentWindow).not.toHaveBeenCalled()
-  })
-
   it('consumes operation budget and persists chrome session when approvals are disabled', async () => {
     vi.mocked(runtime.chromeSessionManager.ensureAgentWindow).mockResolvedValue({
       wasAlreadyRunning: false,
@@ -206,5 +178,39 @@ describe('registerChromeSessionTools', () => {
     expect(runtime.session.record).toHaveBeenCalledTimes(2)
     expect((runtime.session.record as any).mock.calls[0][0].event).toBe('requested')
     expect((runtime.session.record as any).mock.calls[1][0].event).toBe('executed')
+  })
+
+  it('uses focus_app when a chrome session already exists', async () => {
+    runtime.config = createTestConfig({
+      executor: 'macos-local',
+      approvalMode: 'all',
+    })
+    vi.mocked(runtime.chromeSessionManager.getSessionInfo).mockReturnValue({
+      wasAlreadyRunning: false,
+      windowId: 'chrome-window-existing',
+      pid: 9999,
+      agentOwned: true,
+      createdAt: new Date().toISOString(),
+    })
+
+    const { server, invoke } = createMockServer()
+    registerChromeSessionTools({ server, runtime })
+
+    const result = await invoke('desktop_ensure_chrome')
+
+    const structured = result.structuredContent as Record<string, any>
+    expect(structured.status).toBe('approval_required')
+    expect(structured.action).toEqual({
+      kind: 'desktop_ensure_chrome',
+      input: {},
+    })
+    expect(structured.transparency.intent).toBe('Bring the agent Chrome window to the foreground')
+    expect(runtime.chromeSessionManager.ensureAgentWindow).not.toHaveBeenCalled()
+    expect((runtime.session.record as any).mock.calls[0][0].result.approvalAction).toEqual({
+      kind: 'focus_app',
+      input: {
+        app: 'Google Chrome',
+      },
+    })
   })
 })

--- a/services/computer-use-mcp/src/server/register-chrome-session.test.ts
+++ b/services/computer-use-mcp/src/server/register-chrome-session.test.ts
@@ -152,6 +152,7 @@ describe('registerChromeSessionTools', () => {
 
   it('consumes operation budget and persists chrome session when approvals are disabled', async () => {
     vi.mocked(runtime.chromeSessionManager.ensureAgentWindow).mockResolvedValue({
+      ensureOutcome: 'launched',
       wasAlreadyRunning: false,
       windowId: 'chrome-window-1',
       pid: 4242,
@@ -169,6 +170,8 @@ describe('registerChromeSessionTools', () => {
 
     expect(result.isError).not.toBe(true)
     expect((result.content?.[0] as Record<string, unknown>)?.text).toContain('Chrome session launched')
+    expect((result.content?.[0] as Record<string, unknown>)?.text).toContain('Ensure outcome: launched')
+    expect((result.structuredContent as Record<string, unknown>).ensureOutcome).toBe('launched')
     expect(runtime.session.consumeOperation).toHaveBeenCalledWith(2)
     expect(runtime.stateManager.getState().chromeSession).toMatchObject({
       windowId: 'chrome-window-1',
@@ -186,6 +189,7 @@ describe('registerChromeSessionTools', () => {
       approvalMode: 'all',
     })
     vi.mocked(runtime.chromeSessionManager.getSessionInfo).mockReturnValue({
+      ensureOutcome: 'reused',
       wasAlreadyRunning: false,
       windowId: 'chrome-window-existing',
       pid: 9999,

--- a/services/computer-use-mcp/src/server/register-chrome-session.ts
+++ b/services/computer-use-mcp/src/server/register-chrome-session.ts
@@ -30,7 +30,7 @@ const CHROME_APP_NAME = 'Google Chrome'
 function getChromeSessionAction(runtime: ComputerUseServerRuntime): ActionInvocation {
   const sessionInfo = runtime.chromeSessionManager.getSessionInfo()
   return {
-    kind: sessionInfo && !sessionInfo.wasAlreadyRunning ? 'focus_app' : 'open_app',
+    kind: sessionInfo ? 'focus_app' : 'open_app',
     input: {
       app: CHROME_APP_NAME,
     },
@@ -63,7 +63,7 @@ export async function executeChromeEnsure(
       appName: 'Google Chrome',
       windowId: sessionInfo.windowId,
       pid: sessionInfo.pid,
-      agentLaunched: !sessionInfo.wasAlreadyRunning,
+      agentLaunched: sessionInfo.agentOwned,
     })
   }
 
@@ -76,7 +76,7 @@ export async function executeChromeEnsure(
     }
   }
 
-  // Auto-connect CDP bridge when the agent launched Chrome with CDP.
+  // Auto-connect CDP bridge when the agent owns Chrome and CDP is available.
   // Best-effort only: Chrome may need a moment before the DevTools server answers.
   let cdpStatus = 'not applicable'
   if (sessionInfo.cdpUrl) {
@@ -97,7 +97,7 @@ export async function executeChromeEnsure(
   }
 
   const lines = [
-    `Chrome session ${sessionInfo.wasAlreadyRunning ? 'joined' : 'launched'}:`,
+    'Chrome session launched:',
     `  PID: ${sessionInfo.pid}`,
     `  Window: ${sessionInfo.windowId}`,
     `  Agent-owned: ${sessionInfo.agentOwned}`,

--- a/services/computer-use-mcp/src/server/register-chrome-session.ts
+++ b/services/computer-use-mcp/src/server/register-chrome-session.ts
@@ -98,6 +98,7 @@ export async function executeChromeEnsure(
 
   const lines = [
     'Chrome session launched:',
+    `  Ensure outcome: ${sessionInfo.ensureOutcome}`,
     `  PID: ${sessionInfo.pid}`,
     `  Window: ${sessionInfo.windowId}`,
     `  Agent-owned: ${sessionInfo.agentOwned}`,
@@ -121,6 +122,7 @@ export async function executeChromeEnsure(
     content: [textContent(lines.join('\n'))],
     structuredContent: {
       status: 'ok',
+      ensureOutcome: sessionInfo.ensureOutcome,
       pid: sessionInfo.pid,
       windowId: sessionInfo.windowId,
       agentOwned: sessionInfo.agentOwned,

--- a/services/computer-use-mcp/src/server/register-desktop-grounding-tools.test.ts
+++ b/services/computer-use-mcp/src/server/register-desktop-grounding-tools.test.ts
@@ -165,4 +165,31 @@ describe('registerDesktopGroundingTools', () => {
       }),
     ])
   })
+
+  it('does not refocus before desktop_observe', async () => {
+    const { runtime, executeAction } = createRuntime()
+    const { server, invoke } = createMockServer()
+    registerDesktopGroundingTools({ server, runtime, executeAction })
+
+    captureDesktopGroundingMock.mockResolvedValueOnce({
+      snapshotId: 'dg_bg',
+      capturedAt: new Date().toISOString(),
+      foregroundApp: 'Google Chrome',
+      windows: [],
+      screenshot: {
+        dataBase64: '',
+        mimeType: 'image/png',
+        path: '/tmp/shot.png',
+        capturedAt: new Date().toISOString(),
+      },
+      targetCandidates: [],
+      staleFlags: { screenshot: false, ax: false, chromeSemantic: false },
+    } as any)
+
+    const result = await invoke('desktop_observe', { includeChrome: true })
+
+    expect(result.isError).not.toBe(true)
+    expect(runtime.desktopSessionController.ensureControlledAppInForeground).not.toHaveBeenCalled()
+    expect(captureDesktopGroundingMock).toHaveBeenCalledOnce()
+  })
 })

--- a/services/computer-use-mcp/src/server/register-desktop-grounding.test.ts
+++ b/services/computer-use-mcp/src/server/register-desktop-grounding.test.ts
@@ -4,11 +4,13 @@ import type {
   PointerIntent,
   TargetSource,
 } from '../desktop-grounding-types'
+import type { ComputerUseServerRuntime } from './runtime'
 
 import { describe, expect, it, vi } from 'vitest'
 
 import { getUnsupportedBrowserDomActions, isBrowserDomActionSupported } from '../browser-dom/capabilities'
 import { RunStateManager } from '../state'
+import { createTestConfig } from '../test-fixtures'
 
 // ---------------------------------------------------------------------------
 // Test grounding state management through RunStateManager

--- a/services/computer-use-mcp/src/server/register-desktop-grounding.test.ts
+++ b/services/computer-use-mcp/src/server/register-desktop-grounding.test.ts
@@ -433,7 +433,7 @@ describe('desktop_click_target handler integration', () => {
   }
 
   // -----------------------------------------------------------------------
-  // browser_dom routing: calls clickSelector
+  // browser_dom routing: calls clickSelector when clickAt is available
   // -----------------------------------------------------------------------
 
   it('routes chrome_dom candidate through clickSelector when bridge is connected', async () => {
@@ -468,7 +468,7 @@ describe('desktop_click_target handler integration', () => {
     expect(result.text).toContain('Route: browser_dom')
   })
 
-  it('falls back to OS click when the connected extension transport is read-only', async () => {
+  it('falls back to OS click when the connected extension transport lacks clickAt', async () => {
     const sm = new RunStateManager()
     const iframeAbsoluteBounds = { x: 456, y: 390, width: 90, height: 32 }
     const candidate = makeCandidate({

--- a/services/computer-use-mcp/src/server/register-desktop-grounding.test.ts
+++ b/services/computer-use-mcp/src/server/register-desktop-grounding.test.ts
@@ -4,13 +4,11 @@ import type {
   PointerIntent,
   TargetSource,
 } from '../desktop-grounding-types'
-import type { ComputerUseServerRuntime } from './runtime'
 
 import { describe, expect, it, vi } from 'vitest'
 
 import { getUnsupportedBrowserDomActions, isBrowserDomActionSupported } from '../browser-dom/capabilities'
 import { RunStateManager } from '../state'
-import { createTestConfig } from '../test-fixtures'
 
 // ---------------------------------------------------------------------------
 // Test grounding state management through RunStateManager

--- a/services/computer-use-mcp/src/server/register-desktop-grounding.ts
+++ b/services/computer-use-mcp/src/server/register-desktop-grounding.ts
@@ -23,7 +23,6 @@ import process from 'node:process'
 import { z } from 'zod'
 
 import { captureDesktopGrounding, formatGroundingForAgent } from '../desktop-grounding'
-import { sleep } from '../utils/sleep'
 import { textContent } from './content'
 import { registerToolWithDescriptor, requireDescriptor } from './tool-descriptors/register-helper'
 
@@ -50,47 +49,11 @@ export function registerDesktopGroundingTools(params: {
     descriptor: requireDescriptor('desktop_observe'),
 
     schema: {
-      includeChrome: z.boolean().optional().describe('Whether to include Chrome semantic data. Default: auto-detect based on foreground app.'),
+      includeChrome: z.boolean().optional().describe('Whether to include Chrome semantic data. Default: best-effort when browser surfaces are available.'),
     },
 
     handler: async ({ includeChrome }) => {
       try {
-        // If the agent has a desktop session with a controlled app,
-        // ensure that app is in the foreground before observing.
-        // Falls back to Chrome session check for backward compatibility.
-        const sessionCtrl = runtime.desktopSessionController
-        const activeSession = sessionCtrl.getSession()
-        if (activeSession?.controlledApp) {
-          const currentForeground = await runtime.executor.getForegroundContext()
-          const wasAlreadyInFront = await sessionCtrl.ensureControlledAppInForeground({
-            currentForeground,
-            chromeSessionManager: runtime.chromeSessionManager,
-            activateApp: async (appName) => {
-              await runtime.executor.focusApp({ app: appName })
-            },
-          })
-          if (!wasAlreadyInFront) {
-            await sleep(300)
-          }
-        }
-        else {
-          // Fallback: Chrome session without desktop session
-          const chromeSession = runtime.chromeSessionManager.getSessionInfo()
-          if (chromeSession) {
-            const currentForeground = await runtime.executor.getForegroundContext()
-            if (currentForeground.available && currentForeground.appName !== 'Google Chrome') {
-              if (currentForeground.appName) {
-                runtime.stateManager.savePreviousUserForeground(currentForeground.appName)
-              }
-              const activated = await runtime.chromeSessionManager.bringToFront()
-              if (!activated) {
-                throw new Error('Chrome session is unavailable; call desktop_ensure_chrome before observing Chrome.')
-              }
-              await sleep(300)
-            }
-          }
-        }
-
         // Try to get or reconnect a CDP bridge.
         // NOTICE: `desktop_ensure_chrome` can launch Chrome before its DevTools
         // endpoint is fully ready. When observe runs later, reconnect from the

--- a/services/computer-use-mcp/src/server/register-desktop-grounding.ts
+++ b/services/computer-use-mcp/src/server/register-desktop-grounding.ts
@@ -97,14 +97,14 @@ export function registerDesktopGroundingTools(params: {
         // recorded session URL instead of staying stuck in AX-only mode.
         let cdpBridge: import('../browser-dom/cdp-bridge').CdpBridge | undefined
         try {
-          const cdpStatus = runtime.cdpBridgeManager.getStatus()
-          if (cdpStatus.connected) {
-            cdpBridge = await runtime.cdpBridgeManager.ensureBridge()
+          const chromeSession = runtime.chromeSessionManager.getSessionInfo()
+          if (chromeSession?.cdpUrl) {
+            cdpBridge = await runtime.cdpBridgeManager.ensureBridge(chromeSession.cdpUrl)
           }
           else {
-            const chromeSession = runtime.chromeSessionManager.getSessionInfo()
-            if (chromeSession?.cdpUrl) {
-              cdpBridge = await runtime.cdpBridgeManager.ensureBridge(chromeSession.cdpUrl)
+            const cdpStatus = runtime.cdpBridgeManager.getStatus()
+            if (cdpStatus.connected) {
+              cdpBridge = await runtime.cdpBridgeManager.ensureBridge(cdpStatus.cdpUrl)
             }
           }
         }

--- a/services/computer-use-mcp/src/server/register-tools-pty-approval.test.ts
+++ b/services/computer-use-mcp/src/server/register-tools-pty-approval.test.ts
@@ -258,7 +258,7 @@ describe('registerComputerUseTools: PTY approval bridge', () => {
     expect((runtime.browserDomBridge.triggerEvent as any)).not.toHaveBeenCalled()
   })
 
-  it('rejects browser_dom_click when the connected extension transport is read-only', async () => {
+  it('rejects browser_dom_click when the connected extension transport lacks clickAt', async () => {
     ;(runtime.browserDomBridge.getStatus as any).mockReturnValue({
       enabled: true,
       connected: true,

--- a/services/computer-use-mcp/src/support-matrix.test.ts
+++ b/services/computer-use-mcp/src/support-matrix.test.ts
@@ -53,4 +53,12 @@ describe('support matrix', () => {
     const ps = getProductSupported()
     expect(ps.length).toBeGreaterThanOrEqual(4)
   })
+
+  it('includes desktop v3 smoke coverage as covered, not product-supported', () => {
+    const entry = supportMatrix.find(item => item.id === 'desktop_v3_chrome_grounding')
+    expect(entry).toBeDefined()
+    expect(entry?.lane).toBe('desktop-native')
+    expect(entry?.level).toBe('covered')
+    expect(entry?.smokeCommand).toBe('pnpm -F @proj-airi/computer-use-mcp smoke:desktop-v3')
+  })
 })

--- a/services/computer-use-mcp/src/support-matrix.test.ts
+++ b/services/computer-use-mcp/src/support-matrix.test.ts
@@ -61,4 +61,15 @@ describe('support matrix', () => {
     expect(entry?.level).toBe('covered')
     expect(entry?.smokeCommand).toBe('pnpm -F @proj-airi/computer-use-mcp smoke:desktop-v3')
   })
+
+  it('includes browser-dom route contract as covered, not product-supported', () => {
+    const entry = supportMatrix.find(item => item.id === 'desktop_browser_dom_route_contract')
+    expect(entry).toBeDefined()
+    expect(entry?.lane).toBe('desktop-native')
+    expect(entry?.level).toBe('covered')
+    expect(entry?.unitTests).toEqual([
+      'src/browser-action-router.test.ts',
+      'src/browser-dom/extension-bridge.test.ts',
+    ])
+  })
 })

--- a/services/computer-use-mcp/src/support-matrix.ts
+++ b/services/computer-use-mcp/src/support-matrix.ts
@@ -159,6 +159,20 @@ export const supportMatrix: SupportMatrixEntry[] = [
   },
   {
     lane: 'desktop-native',
+    id: 'desktop_v3_chrome_grounding',
+    label: 'Desktop v3 Chrome grounding smoke (ensure / observe / click / state)',
+    level: 'covered',
+    unitTests: [
+      'src/bin/smoke-chrome-grounding.test.ts',
+      'src/server/register-chrome-session.test.ts',
+      'src/server/register-desktop-grounding.test.ts',
+      'src/server/register-desktop-grounding-tools.test.ts',
+    ],
+    smokeCommand: 'pnpm -F @proj-airi/computer-use-mcp smoke:desktop-v3',
+    happyPath: 'desktop_ensure_chrome → desktop_observe → desktop_click_target → desktop_get_state updates grounding and pointer state',
+  },
+  {
+    lane: 'desktop-native',
     id: 'desktop_click_type_press',
     label: 'Native mouse click / keyboard type / key press',
     level: 'implemented',

--- a/services/computer-use-mcp/src/support-matrix.ts
+++ b/services/computer-use-mcp/src/support-matrix.ts
@@ -173,6 +173,16 @@ export const supportMatrix: SupportMatrixEntry[] = [
   },
   {
     lane: 'desktop-native',
+    id: 'desktop_browser_dom_route_contract',
+    label: 'Browser-dom route contract (left single-click, fail-closed bridge responses)',
+    level: 'covered',
+    unitTests: [
+      'src/browser-action-router.test.ts',
+      'src/browser-dom/extension-bridge.test.ts',
+    ],
+  },
+  {
+    lane: 'desktop-native',
     id: 'desktop_click_type_press',
     label: 'Native mouse click / keyboard type / key press',
     level: 'implemented',

--- a/services/computer-use-mcp/src/types.ts
+++ b/services/computer-use-mcp/src/types.ts
@@ -134,6 +134,8 @@ export interface ForegroundContext {
  * `RunState.chromeSession` for the lifetime of the agent session.
  */
 export interface ChromeSessionInfo {
+  /** Outcome of the most recent ensureAgentWindow() call for this session. */
+  ensureOutcome: 'launched' | 'reused' | 'recreated_after_process_exit' | 'recreated_after_missing_window'
   /** Whether Chrome was already running before the agent launched it. */
   wasAlreadyRunning: boolean
   /** Window identity string from observe-windows (ownerPid:layer:title). */


### PR DESCRIPTION
desktop_observe no longer forces a foreground switch just to capture Chrome semantics. desktop_click_target only switches foreground when the browser-dom route is unavailable and the action falls back to OS input.

Validation:
- pnpm -C services/computer-use-mcp exec vitest run src/desktop-grounding.test.ts src/server/register-desktop-grounding-tools.test.ts src/server/register-desktop-grounding.test.ts src/server/action-executor.test.ts src/server/desktop-scheduler.test.ts
- pnpm -C services/computer-use-mcp exec tsc --noEmit --pretty false
- git diff --check

This is intentionally separate from PR #1780.