### PR TITLE
fix(stage): refresh attachment preview URLs after failed send

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -14,18 +14,19 @@ import { BasicTextarea } from '@proj-airi/ui'
 import { useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuRoot, DropdownMenuTrigger } from 'reka-ui'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 import JournalToolCallBlock from './chat-tool-renderers/journal-tool-call-block.vue'
 
 import { useChatSyncStore } from '../stores/chat-sync'
+import { recreateAttachmentObjectUrls, revokeAttachmentObjectUrls, type ChatImageAttachment } from '../utils/chat-attachments'
 
 const router = useRouter()
 const messageInput = ref('')
 const lastEnterTime = ref(0)
-const attachments = ref<{ type: 'image', data: string, mimeType: string, url: string }[]>([])
+const attachments = ref<ChatImageAttachment[]>([])
 
 const chatOrchestrator = useChatOrchestratorStore()
 const chatSession = useChatSessionStore()
@@ -92,12 +93,14 @@ async function handleSend() {
       toolset: 'artistry',
     })
 
-    attachmentsToSend.forEach(att => URL.revokeObjectURL(att.url))
+    revokeAttachmentObjectUrls(attachmentsToSend)
   }
   catch (error) {
-    // restore on failure
+    // restore on failure with fresh preview URLs, then release the original optimistic-send URLs
+    const restoredAttachments = recreateAttachmentObjectUrls(attachmentsToSend)
+    revokeAttachmentObjectUrls(attachmentsToSend)
     messageInput.value = textToSend
-    attachments.value = attachmentsToSend
+    attachments.value = restoredAttachments
     chatSession.setSessionMessages(chatSession.activeSessionId, [
       ...messages.value,
       {
@@ -184,7 +187,7 @@ async function handleFilePaste(files: File[]) {
 function removeAttachment(index: number) {
   const attachment = attachments.value[index]
   if (attachment) {
-    URL.revokeObjectURL(attachment.url)
+    revokeAttachmentObjectUrls([attachment])
     attachments.value.splice(index, 1)
   }
 }
@@ -201,6 +204,10 @@ async function handleDeleteMessage(index: number) {
 
 onMounted(() => {
   backgroundStore.initializeStore()
+})
+
+onUnmounted(() => {
+  revokeAttachmentObjectUrls(attachments.value)
 })
 
 async function handleRetryMessage(index: number) {

--- a/apps/stage-tamagotchi/src/renderer/utils/chat-attachments.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/utils/chat-attachments.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { recreateAttachmentObjectUrls, revokeAttachmentObjectUrls, type ChatImageAttachment } from './chat-attachments'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('chat attachment object URLs', () => {
+  it('recreates preview object URLs from stored base64 data before restoring attachments', () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValueOnce('blob:fresh-preview')
+
+    const restored = recreateAttachmentObjectUrls([
+      {
+        type: 'image',
+        data: 'aGVsbG8=',
+        mimeType: 'image/png',
+        url: 'blob:original-preview',
+      },
+    ])
+
+    expect(restored).toEqual([
+      {
+        type: 'image',
+        data: 'aGVsbG8=',
+        mimeType: 'image/png',
+        url: 'blob:fresh-preview',
+      },
+    ])
+    expect(createObjectURL).toHaveBeenCalledOnce()
+    expect(createObjectURL.mock.calls[0]?.[0]).toBeInstanceOf(Blob)
+  })
+
+  it('revokes every attachment object URL', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const attachments: ChatImageAttachment[] = [
+      { type: 'image', data: 'Zmlyc3Q=', mimeType: 'image/png', url: 'blob:first' },
+      { type: 'image', data: 'c2Vjb25k', mimeType: 'image/jpeg', url: 'blob:second' },
+    ]
+
+    revokeAttachmentObjectUrls(attachments)
+
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURL).toHaveBeenNthCalledWith(1, 'blob:first')
+    expect(revokeObjectURL).toHaveBeenNthCalledWith(2, 'blob:second')
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/utils/chat-attachments.ts
+++ b/apps/stage-tamagotchi/src/renderer/utils/chat-attachments.ts
@@ -1,0 +1,32 @@
+import { createObjectUrlFromBytes } from './create-object-url-from-bytes'
+
+export interface ChatImageAttachment {
+  type: 'image'
+  data: string
+  mimeType: string
+  url: string
+}
+
+export function createObjectUrlFromBase64(data: string, mimeType: string): string {
+  const binary = atob(data)
+  const bytes = new Uint8Array(binary.length)
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+
+  return createObjectUrlFromBytes(bytes, mimeType)
+}
+
+export function recreateAttachmentObjectUrls(attachments: ChatImageAttachment[]): ChatImageAttachment[] {
+  return attachments.map(attachment => ({
+    ...attachment,
+    url: createObjectUrlFromBase64(attachment.data, attachment.mimeType),
+  }))
+}
+
+export function revokeAttachmentObjectUrls(attachments: ChatImageAttachment[]): void {
+  for (const attachment of attachments) {
+    URL.revokeObjectURL(attachment.url)
+  }
+}


### PR DESCRIPTION
## Summary
- recreate attachment preview object URLs after a failed send before restoring the attachment list
- revoke the optimistic-send object URLs on both success and failure
- revoke any remaining attachment preview URLs when the interactive area unmounts
- add focused tests for recreating and revoking attachment object URLs

## Tests
- `node ../../node_modules/vitest/dist/cli.js run src/renderer/utils/chat-attachments.test.ts --config vitest.config.ts` (from `apps/stage-tamagotchi`) — 2 passed

Note: I also attempted a full workspace `pnpm install --frozen-lockfile --ignore-scripts` to run the normal package commands, but the registry repeatedly returned `ECONNRESET` before the install completed.
