### PR TITLE
fix(stage-*): follow-up fix for #1696

### DIFF
--- a/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
+++ b/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import { controlConfig as threeCtrlConf, supportedControl as threeSupportedControl, useThreeViewControl } from '@proj-airi/stage-ui-three'
-import { controlConfig as l2dCtrlConf, supportedControl as l2dSupportedCtrl, useL2dViewControl } from '@proj-airi/stage-ui/stores/live2d'
+import { defaultControlConfig as threeCtrlConf, supportedControl as threeSupportedControl, useThreeViewControl } from '@proj-airi/stage-ui-three'
+import { defaultControlConfig as l2dCtrlConf, supportedControl as l2dSupportedCtrl, useL2dViewControl } from '@proj-airi/stage-ui/stores/live2d'
 import { useSettingsStageModel } from '@proj-airi/stage-ui/stores/settings/stage-model'
 import { Button } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'

--- a/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
+++ b/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
@@ -33,7 +33,7 @@ function handleViewControlsToggle(targetMode: string) {
     <Transition name="fade">
       <div v-if="controlEnabled?.enabled.value" w-full flex justify-between gap-2>
         <Button
-          v-for="control in controlEnabled.supported" variant="secondary-muted"
+          v-for="control in controlEnabled.supported" :key="control" variant="secondary-muted"
           :toggled="controlEnabled.mode.value === control" w-full @click="handleViewControlsToggle(control)"
         >
           {{ (controlEnabled.conf as any)[control].buttonText }}

--- a/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
+++ b/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
@@ -1,19 +1,19 @@
 <script lang="ts" setup>
-import { supportedControl as threeSupportedControl, useThreeViewControl } from '@proj-airi/stage-ui-three'
-import { supportedControl as l2dSupportedCtrl, useL2dViewControl } from '@proj-airi/stage-ui/stores/live2d'
+import { controlConfig as threeCtrlConf, supportedControl as threeSupportedControl, useThreeViewControl } from '@proj-airi/stage-ui-three'
+import { controlConfig as l2dCtrlConf, supportedControl as l2dSupportedCtrl, useL2dViewControl } from '@proj-airi/stage-ui/stores/live2d'
 import { useSettingsStageModel } from '@proj-airi/stage-ui/stores/settings/stage-model'
 import { Button } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 
 const { stageModelRenderer } = storeToRefs(useSettingsStageModel())
-const { viewControlsEnabled: l2dViewCtrlEnabled, viewControlMode: l2dCtrlMode, reset: l2dReset } = useL2dViewControl()
-const { viewControlsEnabled: threePlainCtrlEnabled, viewControlMode: threeCtrlMode, reset: threeReset } = useThreeViewControl()
+const { viewControlsEnabled: l2dViewCtrlEnabled, viewControlMode: l2dCtrlMode, set: l2dSet } = useL2dViewControl()
+const { viewControlsEnabled: threeSliderCtrlEnabled, viewControlMode: threeCtrlMode, set: threeSet } = useThreeViewControl()
 const controlEnabled = computed(() => {
   if (stageModelRenderer.value === 'live2d')
-    return { enabled: l2dViewCtrlEnabled, mode: l2dCtrlMode, supported: l2dSupportedCtrl, reset: l2dReset }
+    return { enabled: l2dViewCtrlEnabled, mode: l2dCtrlMode, supported: l2dSupportedCtrl, conf: l2dCtrlConf, reset: l2dSet }
   if (stageModelRenderer.value === 'vrm')
-    return { enabled: threePlainCtrlEnabled, mode: threeCtrlMode, supported: threeSupportedControl, reset: threeReset }
+    return { enabled: threeSliderCtrlEnabled, mode: threeCtrlMode, supported: threeSupportedControl, conf: threeCtrlConf, reset: threeSet }
   return null
 })
 
@@ -26,39 +26,23 @@ function handleViewControlsToggle(targetMode: string) {
   }
   controlEnabled.value.mode.value = targetMode as any
 }
-
-// watch()
 </script>
 
 <template>
   <div w-full flex flex-1 items-center self-end justify-end gap-2>
     <Transition name="fade">
       <div v-if="controlEnabled?.enabled.value" w-full flex justify-between gap-2>
-        <Button variant="secondary-muted" :toggled="controlEnabled.mode.value === 'x'" w-full @click="handleViewControlsToggle('x')">
-          X
-        </Button>
-        <Button variant="secondary-muted" :toggled="controlEnabled.mode.value === 'y'" w-full @click="handleViewControlsToggle('y')">
-          Y
-        </Button>
-        <Button v-if="controlEnabled.supported.includes('z' as any)" variant="secondary-muted" :toggled="controlEnabled.mode.value === 'z'" w-full @click="handleViewControlsToggle('z')">
-          Z
-        </Button>
-        <Button v-if="controlEnabled.supported.includes('cameraFOV' as any)" variant="secondary-muted" :toggled="controlEnabled.mode.value === 'cameraFOV'" w-full @click="handleViewControlsToggle('cameraFOV')">
-          FOV
-        </Button>
-        <Button v-if="controlEnabled.supported.includes('scale' as any)" variant="secondary-muted" :toggled="controlEnabled.mode.value === 'scale'" w-full @click="handleViewControlsToggle('scale')">
-          Scale
-        </Button>
-        <Button v-if="controlEnabled.supported.includes('cameraDistance' as any)" variant="secondary-muted" :toggled="controlEnabled.mode.value === 'cameraDistance'" w-full @click="handleViewControlsToggle('cameraDistance')">
-          Dis
+        <Button
+          v-for="control in controlEnabled.supported" variant="secondary-muted"
+          :toggled="controlEnabled.mode.value === control" w-full @click="handleViewControlsToggle(control)"
+        >
+          {{ (controlEnabled.conf as any)[control].buttonText }}
         </Button>
       </div>
     </Transition>
     <button
       w-fit flex items-center self-end justify-center justify-self-end rounded-xl p-2 backdrop-blur-md
-      border="2 solid neutral-100/60 dark:neutral-800/30"
-      bg="neutral-50/70 dark:neutral-800/70"
-      title="View"
+      border="2 solid neutral-100/60 dark:neutral-800/30" bg="neutral-50/70 dark:neutral-800/70" title="View"
       text="neutral-500 dark:neutral-400"
       @click="controlEnabled && (controlEnabled.enabled.value = !controlEnabled.enabled.value)"
     >

--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -31,7 +31,6 @@ import { useTranscriptions } from '../../composables/use-transcriptions'
 import { BackgroundDialogPicker } from '../Backgrounds'
 
 const { isDark, toggleDark } = useTheme()
-const hearingDialogOpen = ref(false)
 const chatOrchestrator = useChatOrchestratorStore()
 const chatSession = useChatSessionStore()
 const chatStream = useChatStreamStore()
@@ -123,7 +122,7 @@ function teardownAnalyzer() {
 
 async function setupAnalyzer() {
   teardownAnalyzer()
-  if (!hearingDialogOpen.value || !enabled.value || !stream.value)
+  if (!enabled.value || !stream.value)
     return
   if (audioContext.state === 'suspended')
     await audioContext.resume()
@@ -137,12 +136,6 @@ async function setupAnalyzer() {
 watch([enabled, stream], () => {
   setupAnalyzer()
 }, { immediate: true })
-
-watch(hearingDialogOpen, (value) => {
-  if (value) {
-    settingsAudioDevice.askPermission()
-  }
-})
 
 onAfterMessageComposed(async () => {
 })
@@ -197,7 +190,6 @@ onMounted(() => {
           </button>
           <ChatSessionsDrawer v-model="sessionsDrawerOpen" />
           <HearingConfigDialog
-            v-model:show="hearingDialogOpen"
             v-model:enabled="enabled"
             :transcription="isListening"
             :toggle-transcription="toggleTranscription"

--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -63,7 +63,7 @@ const { enabled, stream } = storeToRefs(settingsAudioDevice)
 const { ingest, onAfterMessageComposed } = chatOrchestrator
 const { t } = useI18n()
 const { audioContext } = useAudioContext()
-const { startAnalyzer, stopAnalyzer, volumeLevel } = useAudioAnalyzer()
+const { startAnalyzer, stopAnalyzer } = useAudioAnalyzer()
 let analyzerSource: MediaStreamAudioSourceNode | undefined
 
 function isMobileDevice() {
@@ -201,7 +201,6 @@ onMounted(() => {
             v-model:enabled="enabled"
             :transcription="isListening"
             :toggle-transcription="toggleTranscription"
-            :volume-level="volumeLevel"
             :granted="true"
           >
             <button

--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -59,7 +59,7 @@ const { themeColorsHueDynamic } = storeToRefs(useSettings())
 const { viewControlsEnabled: l2dViewCtrlEnabled } = useL2dViewControl()
 const { viewControlsEnabled: threeViewCtrlEnabled } = useThreeViewControl()
 const settingsAudioDevice = useSettingsAudioDevice()
-const { enabled, selectedAudioInput, stream, audioInputs } = storeToRefs(settingsAudioDevice)
+const { enabled, stream } = storeToRefs(settingsAudioDevice)
 const { ingest, onAfterMessageComposed } = chatOrchestrator
 const { t } = useI18n()
 const { audioContext } = useAudioContext()
@@ -70,13 +70,14 @@ function isMobileDevice() {
   return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 }
 
-const { isListening } = useTranscriptions(
+const { isListening, startStreamingTranscription, stopStreamingTranscription } = useTranscriptions(
   {
     messageInputRef: messageInput,
     sendMessage: handleSend,
     isStageTamagotchi,
   },
 )
+const toggleTranscription = () => isListening.value ? stopStreamingTranscription() : startStreamingTranscription()
 
 async function handleSubmit() {
   if (!isMobileDevice()) {
@@ -115,7 +116,7 @@ function teardownAnalyzer() {
   try {
     analyzerSource?.disconnect()
   }
-  catch {}
+  catch { }
   analyzerSource = undefined
   stopAnalyzer()
 }
@@ -198,8 +199,8 @@ onMounted(() => {
           <HearingConfigDialog
             v-model:show="hearingDialogOpen"
             v-model:enabled="enabled"
-            v-model:selected-audio-input="selectedAudioInput"
-            :audio-inputs="audioInputs"
+            :transcription="isListening"
+            :toggle-transcription="toggleTranscription"
             :volume-level="volumeLevel"
             :granted="true"
           >

--- a/packages/stage-layouts/src/components/Widgets/ChatArea.vue
+++ b/packages/stage-layouts/src/components/Widgets/ChatArea.vue
@@ -139,8 +139,7 @@ watch(hearingPopoverOpen, async (value) => {
 onAfterMessageComposed(async () => {
 })
 
-const { startAnalyzer, stopAnalyzer, volumeLevel } = useAudioAnalyzer()
-const normalizedVolume = computed(() => Math.min(1, Math.max(0, (volumeLevel.value ?? 0) / 100)))
+const { startAnalyzer, stopAnalyzer } = useAudioAnalyzer()
 let analyzerSource: MediaStreamAudioSourceNode | undefined
 
 function teardownAnalyzer() {
@@ -294,7 +293,6 @@ watch(sendMode, () => {
               v-model:auto-send="autoSendEnabled"
               :transcription="isListening"
               :granted="true"
-              :volume-level="normalizedVolume"
               @toggle-transcription="() => isListening ? stopStreamingTranscription() : startStreamingTranscription()"
             />
           </PopoverContent>

--- a/packages/stage-layouts/src/composables/use-transcriptions.ts
+++ b/packages/stage-layouts/src/composables/use-transcriptions.ts
@@ -17,13 +17,14 @@ export function useTranscriptions(options: TranscriptionOptions) {
   const { messageInputRef: messageInput, sendMessage, isStageTamagotchi } = options
 
   const hearingStore = useHearingStore()
+  const audioDeviceSettingsStore = useSettingsAudioDevice()
   const hearingPipeline = useHearingSpeechInputPipeline()
   const { transcribeForMediaStream, stopStreamingTranscription } = hearingPipeline
   const { supportsStreamInput } = storeToRefs(hearingPipeline)
   const { configured: hearingConfigured, autoSendEnabled, autoSendDelay } = storeToRefs(hearingStore)
-  const { enabled: hearingEnabled, stream } = storeToRefs(useSettingsAudioDevice())
+  const { enabled: hearingEnabled, stream } = storeToRefs(audioDeviceSettingsStore)
   const providersStore = useProvidersStore()
-  const { askPermission, startStream } = useSettingsAudioDevice()
+  const { askPermission, startStream } = audioDeviceSettingsStore
 
   const isListening = ref(false)
 

--- a/packages/stage-ui-live2d/package.json
+++ b/packages/stage-ui-live2d/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@types/culori": "^4.0.1",
     "@types/three": "^0.184.0",
+    "vitest": "catalog:",
     "vue-tsc": "^3.2.6"
   }
 }

--- a/packages/stage-ui-live2d/src/components/ViewControls/SliderControls.vue
+++ b/packages/stage-ui-live2d/src/components/ViewControls/SliderControls.vue
@@ -2,7 +2,7 @@
 import { RoundRange } from '@proj-airi/ui'
 import { computed, onUnmounted } from 'vue'
 
-import { controlConfig as conf, useL2dViewControl } from '../../stores'
+import { defaultControlConfig as conf, formatter, useL2dViewControl } from '../../stores'
 
 const { scale, position, viewControlsEnabled, viewControlMode, set: setValue } = useL2dViewControl()
 
@@ -23,7 +23,7 @@ const controlledValue = computed({
 })
 
 const formattedValue = computed(() => {
-  return conf[viewControlMode.value].format(controlledValue.value)
+  return formatter[viewControlMode.value](controlledValue.value)
 })
 
 onUnmounted(() => {

--- a/packages/stage-ui-live2d/src/components/ViewControls/SliderControls.vue
+++ b/packages/stage-ui-live2d/src/components/ViewControls/SliderControls.vue
@@ -1,10 +1,30 @@
 <script setup lang="ts">
 import { RoundRange } from '@proj-airi/ui'
-import { onUnmounted } from 'vue'
+import { computed, onUnmounted } from 'vue'
 
-import { controlConfig, useL2dViewControl } from '../../stores'
+import { controlConfig as conf, useL2dViewControl } from '../../stores'
 
-const { scale, position, viewControlsEnabled, viewControlMode } = useL2dViewControl()
+const { scale, position, viewControlsEnabled, viewControlMode, set: setValue } = useL2dViewControl()
+
+const controlledValue = computed({
+  get() {
+    switch (viewControlMode.value) {
+      case 'x':
+        return position.value.x
+      case 'y':
+        return position.value.y
+      case 'scale':
+        return scale.value
+    }
+  },
+  set(value) {
+    setValue(viewControlMode.value, value)
+  },
+})
+
+const formattedValue = computed(() => {
+  return conf[viewControlMode.value].format(controlledValue.value)
+})
 
 onUnmounted(() => {
   viewControlsEnabled.value = false
@@ -15,31 +35,13 @@ onUnmounted(() => {
   <Transition name="fade-side-pops-in">
     <div v-if="viewControlsEnabled">
       <Transition name="fade-side-pops-in" mode="out-in">
-        <div v-if="viewControlMode === 'x'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
+        <div :key="viewControlMode" relative class="[&_.round-range-tooltip]:hover:opacity-100">
           <RoundRange
-            v-model="position.x" :min="controlConfig.x.min" :max="controlConfig.x.max" :step="controlConfig.x.step" handle-wheel
+            v-model="controlledValue" :min="conf[viewControlMode].min" :max="conf[viewControlMode].max" :step="conf[viewControlMode].step" handle-wheel
             data-direction="vertical" h="50%" write-vertical-left
           />
           <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ controlConfig.x.format(position.x) }}
-          </div>
-        </div>
-        <div v-else-if="viewControlMode === 'y'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
-          <RoundRange
-            v-model="position.y" :min="controlConfig.y.min" :max="controlConfig.y.max" :step="controlConfig.y.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
-          />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ controlConfig.y.format(position.y) }}
-          </div>
-        </div>
-        <div v-else-if="viewControlMode === 'scale'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
-          <RoundRange
-            v-model="scale" :min="controlConfig.scale.min" :max="controlConfig.scale.max" :step="controlConfig.scale.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
-          />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ controlConfig.scale.format(scale) }}
+            {{ formattedValue }}
           </div>
         </div>
       </Transition>

--- a/packages/stage-ui-live2d/src/components/ViewControls/SliderControls.vue
+++ b/packages/stage-ui-live2d/src/components/ViewControls/SliderControls.vue
@@ -15,6 +15,7 @@ const controlledValue = computed({
         return position.value.y
       case 'scale':
         return scale.value
+      default: throw new Error(`Unexpected control key: ${viewControlMode.value}`)
     }
   },
   set(value) {

--- a/packages/stage-ui-live2d/src/stores/live2d.ts
+++ b/packages/stage-ui-live2d/src/stores/live2d.ts
@@ -62,13 +62,13 @@ export const useLive2d = defineStore('live2d', () => {
   const currentMotion = useLocalStorageManualReset<{ group: string, index?: number }>('settings/live2d/current-motion', () => ({ group: 'Idle', index: 0 }))
   const availableMotions = useLocalStorageManualReset<{ motionName: string, motionIndex: number, fileName: string }[]>('settings/live2d/available-motions', () => [])
   const motionMap = useLocalStorageManualReset<Record<string, string>>('settings/live2d/motion-map', {})
-  const { position, scale, reset: resetViewControl } = useL2dViewControl()
+  const { position, scale, set: setViewControl } = useL2dViewControl()
 
   // Live2D model parameters
   const modelParameters = useLocalStorageManualReset<Record<string, number>>('settings/live2d/parameters', defaultModelParameters)
 
   function resetState() {
-    supportedControl.forEach(c => resetViewControl(c))
+    supportedControl.forEach(c => setViewControl(c))
     currentMotion.reset()
     availableMotions.reset()
     motionMap.reset()

--- a/packages/stage-ui-live2d/src/stores/view-control.test.ts
+++ b/packages/stage-ui-live2d/src/stores/view-control.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { defaultControlConfig, formatter, supportedControl, useL2dViewControl } from './view-control'
+
+vi.mock('@vueuse/core', async () => {
+  const vue = await import('vue')
+  return {
+    useLocalStorage: vi.fn((_key, initialValue) => vue.ref(initialValue)),
+  }
+})
+
+describe('useL2dViewControl', () => {
+  let composable: ReturnType<typeof useL2dViewControl>
+
+  beforeEach(() => {
+    composable = useL2dViewControl()
+  })
+
+  it('should initialize with defaults', () => {
+    expect(composable.viewControlsEnabled.value).toBe(false)
+    expect(composable.viewControlMode.value).toBe('scale')
+    expect(composable.position.value).toEqual({ x: 0, y: 0 })
+    expect(composable.scale.value).toBe(1)
+  })
+
+  describe('set function', () => {
+    it('should set model position x', () => {
+      composable.set('x', 5)
+      expect(composable.position.value.x).toBe(5)
+    })
+
+    it('should set scale', () => {
+      composable.set('scale', 2)
+      expect(composable.scale.value).toBe(2)
+    })
+
+    it('should clamp values to max', () => {
+      supportedControl.forEach(key => composable.set(key, Number.MAX_VALUE))
+      expect(composable.position.value.x).toBe(defaultControlConfig.x.max)
+      expect(composable.position.value.y).toBe(defaultControlConfig.y.max)
+      expect(composable.scale.value).toBe(defaultControlConfig.scale.max)
+    })
+
+    it('should clamp values to min', () => {
+      supportedControl.forEach(key => composable.set(key, -Number.MAX_VALUE))
+      expect(composable.position.value.x).toBe(defaultControlConfig.x.min)
+      expect(composable.position.value.y).toBe(defaultControlConfig.y.min)
+      expect(composable.scale.value).toBe(defaultControlConfig.scale.min)
+    })
+
+    it('should reset to default when value is omitted', () => {
+      supportedControl.forEach(k => composable.set(k, defaultControlConfig[k].default + 1))
+      supportedControl.forEach(k => composable.set(k))
+      expect(composable.position.value.x).toBe(defaultControlConfig.x.default)
+      expect(composable.position.value.y).toBe(defaultControlConfig.y.default)
+      expect(composable.scale.value).toBe(defaultControlConfig.scale.default)
+    })
+  })
+
+  describe('formatter', () => {
+    it('should format percentages with 1 decimals', () => {
+      expect(formatter.x(123.44)).toBe('123.4%')
+      expect(formatter.x(123.56)).toBe('123.6%')
+      expect(formatter.y(11.22)).toBe('11.2%')
+    })
+
+    it('should format to percentage with 0 decimal', () => {
+      expect(formatter.scale(1.234)).toBe('123%')
+      expect(formatter.scale(1.236)).toBe('124%')
+      expect(formatter.scale(0.11)).toBe('11%')
+    })
+  })
+})

--- a/packages/stage-ui-live2d/src/stores/view-control.ts
+++ b/packages/stage-ui-live2d/src/stores/view-control.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 
 export const supportedControl = ['x', 'y', 'scale'] as const
 type SupportedControl = typeof supportedControl[number]
-interface ControlConfig { min: number, max: number, step: number, default: number, format: (val: number) => string }
+interface ControlConfig { min: number, max: number, step: number, default: number, buttonText: string, format: (val: number) => string }
 
 /** show or hide the control element(slider) on stage */
 const viewControlsEnabled = ref(false)
@@ -24,6 +24,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 500,
     step: 0.1,
     default: 0,
+    buttonText: 'X',
     format: formatPercentD1,
   },
   y: {
@@ -31,6 +32,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 500,
     step: 0.1,
     default: 0,
+    buttonText: 'Y',
     format: formatPercentD1,
   },
   scale: {
@@ -38,6 +40,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 3,
     step: 0.01,
     default: 1,
+    buttonText: 'Scale',
     format: formatToPercent,
   },
 }
@@ -46,17 +49,18 @@ export function useL2dViewControl() {
   /**
    * reset the given control to its default value.
    *  @param key the control to reset
+   *  @param value optional, will reset the value to its default if not provided
    */
-  function reset(key: SupportedControl) {
+  function set(key: SupportedControl, value?: number) {
     switch (key) {
       case 'x':
-        position.value.x = controlConfig.x.default
+        position.value.x = value ?? controlConfig.x.default
         break
       case 'y':
-        position.value.y = controlConfig.y.default
+        position.value.y = value ?? controlConfig.y.default
         break
       case 'scale':
-        scale.value = controlConfig.scale.default
+        scale.value = value ?? controlConfig.scale.default
         break
     }
   }
@@ -67,7 +71,7 @@ export function useL2dViewControl() {
     /** model scaling in percentages. `100` means no scaling. */
     scale,
     /** reset the given control to its default value. */
-    reset,
+    set,
     /** show or hide the control element(slider) on stage */
     viewControlsEnabled,
     /** what value to control for the control element */

--- a/packages/stage-ui-live2d/src/stores/view-control.ts
+++ b/packages/stage-ui-live2d/src/stores/view-control.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 
 export const supportedControl = ['x', 'y', 'scale'] as const
 type SupportedControl = typeof supportedControl[number]
-interface ControlConfig { min: number, max: number, step: number, default: number, buttonText: string, format: (val: number) => string }
+interface ControlConfig { min: number, max: number, step: number, default: number, buttonText: string }
 
 /** show or hide the control element(slider) on stage */
 const viewControlsEnabled = ref(false)
@@ -17,7 +17,7 @@ const scale = useLocalStorage('settings/live2d/scale', 1)
 const formatPercentD1 = (val: number) => `${val.toFixed(1)}%`
 const formatToPercent = (val: number) => `${(val * 100).toFixed(0)}%`
 
-export const controlConfig: Record<SupportedControl, ControlConfig> = {
+export const defaultControlConfig: Record<SupportedControl, ControlConfig> = {
   // TODO: calculate the min and max value dynamically according to window height/width, or allow user to set it
   x: {
     min: -500,
@@ -25,7 +25,6 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.1,
     default: 0,
     buttonText: 'X',
-    format: formatPercentD1,
   },
   y: {
     min: -500,
@@ -33,7 +32,6 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.1,
     default: 0,
     buttonText: 'Y',
-    format: formatPercentD1,
   },
   scale: {
     min: 0.01,
@@ -41,10 +39,15 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.01,
     default: 1,
     buttonText: 'Scale',
-    format: formatToPercent,
   },
 }
 
+export const formatter: Record<SupportedControl, (val: number) => string> = {
+  x: formatPercentD1,
+  y: formatPercentD1,
+  scale: formatToPercent,
+}
+const clampMinMax = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
 export function useL2dViewControl() {
   /**
    * reset the given control to its default value.
@@ -52,15 +55,16 @@ export function useL2dViewControl() {
    *  @param value optional, will reset the value to its default if not provided
    */
   function set(key: SupportedControl, value?: number) {
+    const clamped = value ? clampMinMax(value, defaultControlConfig[key].min, defaultControlConfig[key].max) : null
     switch (key) {
       case 'x':
-        position.value.x = value ?? controlConfig.x.default
+        position.value.x = clamped ?? defaultControlConfig.x.default
         break
       case 'y':
-        position.value.y = value ?? controlConfig.y.default
+        position.value.y = clamped ?? defaultControlConfig.y.default
         break
       case 'scale':
-        scale.value = value ?? controlConfig.scale.default
+        scale.value = clamped ?? defaultControlConfig.scale.default
         break
     }
   }

--- a/packages/stage-ui-live2d/src/stores/view-control.ts
+++ b/packages/stage-ui-live2d/src/stores/view-control.ts
@@ -9,16 +9,16 @@ interface ControlConfig { min: number, max: number, step: number, default: numbe
 const viewControlsEnabled = ref(false)
 /** what value to control for the control element */
 const viewControlMode = ref<SupportedControl>('scale')
-/** model position relative to the center of the screen, in pixels */
+/** model position relative to the center of the screen, in percentages */
 const position = useLocalStorage<{ x: number, y: number }>('settings/live2d/position', { x: 0, y: 0 })
-/** model scaling. `1` means no scaling. */
+/** model scaling factor. `1` means no scaling. */
 const scale = useLocalStorage('settings/live2d/scale', 1)
 
 const formatPercentD1 = (val: number) => `${val.toFixed(1)}%`
 const formatToPercent = (val: number) => `${(val * 100).toFixed(0)}%`
 
 export const defaultControlConfig: Record<SupportedControl, ControlConfig> = {
-  // TODO: calculate the min and max value dynamically according to window height/width, or allow user to set it
+  // TODO: allow user to set preferred default
   x: {
     min: -500,
     max: 500,

--- a/packages/stage-ui-live2d/src/stores/view-control.ts
+++ b/packages/stage-ui-live2d/src/stores/view-control.ts
@@ -55,7 +55,7 @@ export function useL2dViewControl() {
    *  @param value optional, will reset the value to its default if not provided
    */
   function set(key: SupportedControl, value?: number) {
-    const clamped = value ? clampMinMax(value, defaultControlConfig[key].min, defaultControlConfig[key].max) : null
+    const clamped = value !== undefined ? clampMinMax(value, defaultControlConfig[key].min, defaultControlConfig[key].max) : undefined
     switch (key) {
       case 'x':
         position.value.x = clamped ?? defaultControlConfig.x.default

--- a/packages/stage-ui-live2d/vitest.config.ts
+++ b/packages/stage-ui-live2d/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/stage-ui-three/package.json
+++ b/packages/stage-ui-three/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/culori": "^4.0.1",
     "@types/three": "^0.184.0",
+    "vitest": "catalog:",
     "vue-tsc": "^3.2.6"
   }
 }

--- a/packages/stage-ui-three/src/components/Controls/OrbitControls.vue
+++ b/packages/stage-ui-three/src/components/Controls/OrbitControls.vue
@@ -2,7 +2,6 @@
 /*
   * - Extend OrbitControls from three
   * - Define camera behavior
-  * - TODO: implement the control elements and replace the <slot/>
 */
 
 import type { Vec3 } from '../../stores/model-store'
@@ -19,6 +18,9 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 // From stage-ui-three package
 import { onMounted, onUnmounted, shallowRef, toRefs, watch } from 'vue'
 
+import { useThreeCamera } from '../../stores/camera'
+import { useThreeViewControl } from '../../stores/view-control'
+
 /*
   * Props:
   * - model size
@@ -30,10 +32,7 @@ import { onMounted, onUnmounted, shallowRef, toRefs, watch } from 'vue'
 const props = defineProps<{
   controlEnable: boolean
   modelSize: Vec3
-  cameraPosition: Vec3
   cameraTarget: Vec3
-  cameraFOV: number
-  cameraDistance: number
 }>()
 /*
   * Emits:
@@ -51,10 +50,7 @@ const emit = defineEmits<{
 const {
   controlEnable,
   modelSize,
-  cameraPosition,
   cameraTarget,
-  cameraFOV,
-  cameraDistance,
 } = toRefs(props)
 
 extend({ OrbitControls })
@@ -64,6 +60,8 @@ const controls = shallowRef<OrbitControls>()
 const camera = shallowRef<PerspectiveCamera | null>(null)
 let disposeControlsChange: (() => void) | undefined
 
+const { cameraPosition, cameraFOV, cameraDistance } = useThreeCamera()
+const { viewControlsEnabled } = useThreeViewControl()
 // Initialisation on onMounted
 function registerInfoFlow() {
   /*
@@ -121,11 +119,11 @@ function registerInfoFlow() {
     camera.value.updateProjectionMatrix()
     controls.value.update()
   })
-  watch(controlEnable, (newEnable) => {
+  watch([controlEnable, viewControlsEnabled], (newEnable) => {
     if (!camera.value || !controls.value)
       return
-    controls.value.enableRotate = newEnable
-    controls.value.enableZoom = newEnable
+    controls.value.enableRotate = newEnable.every(Boolean)
+    controls.value.enableZoom = newEnable.every(Boolean)
   }, { immediate: true })
 
   /*

--- a/packages/stage-ui-three/src/components/Controls/OrbitControls.vue
+++ b/packages/stage-ui-three/src/components/Controls/OrbitControls.vue
@@ -16,7 +16,7 @@ import {
 } from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 // From stage-ui-three package
-import { onMounted, onUnmounted, shallowRef, toRefs, watch } from 'vue'
+import { inject, onMounted, onUnmounted, shallowRef, toRefs, watch } from 'vue'
 
 import { useThreeCamera } from '../../stores/camera'
 import { useThreeViewControl } from '../../stores/view-control'
@@ -59,6 +59,8 @@ let disposeControlsChange: (() => void) | undefined
 
 const { cameraPosition, cameraFOV, cameraDistance } = useThreeCamera()
 const { viewControlsEnabled } = useThreeViewControl()
+const isPreviewStage = inject<boolean>('previewStage')
+
 // Initialisation on onMounted
 function registerInfoFlow() {
   /*
@@ -119,8 +121,8 @@ function registerInfoFlow() {
   watch([controlEnable, viewControlsEnabled], (newEnable) => {
     if (!camera.value || !controls.value)
       return
-    controls.value.enableRotate = newEnable.every(Boolean)
-    controls.value.enableZoom = newEnable.every(Boolean)
+    controls.value.enableRotate = isPreviewStage || newEnable.every(Boolean)
+    controls.value.enableZoom = isPreviewStage || newEnable.every(Boolean)
   }, { immediate: true })
 
   /*

--- a/packages/stage-ui-three/src/components/Controls/OrbitControls.vue
+++ b/packages/stage-ui-three/src/components/Controls/OrbitControls.vue
@@ -24,10 +24,7 @@ import { useThreeViewControl } from '../../stores/view-control'
 /*
   * Props:
   * - model size
-  * - camera position
   * - camera target: camera looking at target
-  * - camera fov angle
-  * - camera distance: camera position - camera target
 */
 const props = defineProps<{
   controlEnable: boolean

--- a/packages/stage-ui-three/src/components/Controls/SliderControls.vue
+++ b/packages/stage-ui-three/src/components/Controls/SliderControls.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia'
 import { computed, onUnmounted } from 'vue'
 
 import { useModelStore } from '../../stores/model-store'
-import { controlConfig as conf, useThreeViewControl } from '../../stores/view-control'
+import { defaultControlConfig as conf, formatter, useThreeViewControl } from '../../stores/view-control'
 
 const { cameraDistance, cameraFOV, modelOffset, viewControlsEnabled, viewControlMode, set: setValue } = useThreeViewControl()
 const { sceneMutationLocked } = storeToRefs(useModelStore())
@@ -32,7 +32,7 @@ const controlledValue = computed({
 })
 
 const formattedValue = computed(() => {
-  return conf[viewControlMode.value].format(controlledValue.value)
+  return formatter[viewControlMode.value](controlledValue.value)
 })
 
 onUnmounted(() => {

--- a/packages/stage-ui-three/src/components/Controls/SliderControls.vue
+++ b/packages/stage-ui-three/src/components/Controls/SliderControls.vue
@@ -1,10 +1,39 @@
 <script setup lang="ts">
 import { RoundRange } from '@proj-airi/ui'
-import { onUnmounted } from 'vue'
+import { storeToRefs } from 'pinia'
+import { computed, onUnmounted } from 'vue'
 
+import { useModelStore } from '../../stores/model-store'
 import { controlConfig as conf, useThreeViewControl } from '../../stores/view-control'
 
-const { cameraDistance, cameraFOV, modelOffset, viewControlsEnabled, viewControlMode } = useThreeViewControl()
+const { cameraDistance, cameraFOV, modelOffset, viewControlsEnabled, viewControlMode, set: setValue } = useThreeViewControl()
+const { sceneMutationLocked } = storeToRefs(useModelStore())
+
+const controlledValue = computed({
+  get() {
+    switch (viewControlMode.value) {
+      case 'x':
+        return modelOffset.value.x
+      case 'y':
+        return modelOffset.value.y
+      case 'z':
+        return modelOffset.value.z
+      case 'cameraDistance':
+        return cameraDistance.value
+      case 'cameraFOV':
+        return cameraFOV.value
+    }
+  },
+  set(value) {
+    if (sceneMutationLocked.value)
+      return
+    setValue(viewControlMode.value, value)
+  },
+})
+
+const formattedValue = computed(() => {
+  return conf[viewControlMode.value].format(controlledValue.value)
+})
 
 onUnmounted(() => {
   viewControlsEnabled.value = false
@@ -13,56 +42,23 @@ onUnmounted(() => {
 
 <template>
   <Transition name="fade-side-pops-in">
-    <div v-if="viewControlsEnabled">
+    <fieldset v-if="viewControlsEnabled">
       <Transition name="fade-side-pops-in" mode="out-in">
-        <!-- TODO: generate the controls programmatically, while preserving the transition -->
-        <div v-if="viewControlMode === 'x'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
+        <div :key="viewControlMode" relative class="[&_.round-range-tooltip]:hover:opacity-100">
           <RoundRange
-            v-model="modelOffset.x" :min="conf.x.min" :max="conf.x.max" :step="conf.x.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
+            v-model="controlledValue" :min="conf[viewControlMode].min" :max="conf[viewControlMode].max"
+            :disabled="sceneMutationLocked" :step="conf[viewControlMode].step" handle-wheel data-direction="vertical"
+            h="50%" write-vertical-left
           />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ conf.x.format(modelOffset.x) }}
-          </div>
-        </div>
-        <div v-else-if="viewControlMode === 'y'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
-          <RoundRange
-            v-model="modelOffset.y" :min="conf.y.min" :max="conf.y.max" :step="conf.y.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
-          />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ conf.y.format(modelOffset.y) }}
-          </div>
-        </div>
-        <div v-else-if="viewControlMode === 'z'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
-          <RoundRange
-            v-model="modelOffset.z" :min="conf.z.min" :max="conf.z.max" :step="conf.z.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
-          />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ conf.z.format(modelOffset.z) }}
-          </div>
-        </div>
-        <div v-else-if="viewControlMode === 'cameraDistance'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
-          <RoundRange
-            v-model="cameraDistance" :min="conf.cameraDistance.min" :max="conf.cameraDistance.max" :step="conf.cameraDistance.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
-          />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ conf.cameraDistance.format(cameraDistance) }}
-          </div>
-        </div>
-        <div v-else-if="viewControlMode === 'cameraFOV'" relative class="[&_.round-range-tooltip]:hover:opacity-100">
-          <RoundRange
-            v-model="cameraFOV" :min="conf.cameraFOV.min" :max="conf.cameraFOV.max" :step="conf.cameraFOV.step" handle-wheel
-            data-direction="vertical" h="50%" write-vertical-left
-          />
-          <div class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0 transition="all duration-200 ease-in-out">
-            {{ conf.cameraFOV.format(cameraFOV) }}
+          <div
+            class="round-range-tooltip" top="50%" translate-y="[-50%]" absolute left-10 font-mono op-0
+            transition="all duration-200 ease-in-out"
+          >
+            {{ formattedValue }}
           </div>
         </div>
       </Transition>
-    </div>
+    </fieldset>
   </Transition>
 </template>
 

--- a/packages/stage-ui-three/src/components/Controls/SliderControls.vue
+++ b/packages/stage-ui-three/src/components/Controls/SliderControls.vue
@@ -22,6 +22,7 @@ const controlledValue = computed({
         return cameraDistance.value
       case 'cameraFOV':
         return cameraFOV.value
+      default: throw new Error(`Unexpected control key: ${viewControlMode.value}`)
     }
   },
   set(value) {

--- a/packages/stage-ui-three/src/components/ThreeScene.vue
+++ b/packages/stage-ui-three/src/components/ThreeScene.vue
@@ -100,7 +100,6 @@ const {
   modelOffset,
   modelRotationY,
 
-  cameraFOV,
   cameraPosition,
   cameraDistance,
 
@@ -436,8 +435,7 @@ function onOrbitControlsReady() {
 const controlEnable = computed(() => {
   return controlsReady.value
     && modelPhase.value === 'ready'
-    && scenePhase.value === 'mounted'
-    && sceneTransactionDepth.value === 0
+    && !sceneMutationLocked.value
 })
 function onVRMModelLoadStart(reason: VrmLifecycleReason) {
   modelPhase.value = 'loading'
@@ -728,10 +726,7 @@ defineExpose({
         ref="controlsRef"
         :control-enable="controlEnable"
         :model-size="modelSize"
-        :camera-position="cameraPosition"
         :camera-target="modelOrigin"
-        :camera-f-o-v="cameraFOV"
-        :camera-distance="cameraDistance"
         @orbit-controls-camera-changed="onOrbitControlsCameraChanged"
         @orbit-controls-ready="onOrbitControlsReady"
       />

--- a/packages/stage-ui-three/src/stores/camera.ts
+++ b/packages/stage-ui-three/src/stores/camera.ts
@@ -14,7 +14,7 @@ const cameraDistance = useLocalStorage('settings/stage-ui-three/cameraDistance',
 /**
  * Internal state of the camera. Users should not be able to set this directly, use `cameraDistance` instead.
  */
-const cameraPosition = useLocalStorage('settings/stage-ui-three/camera-position', DEFAULT_CAMERA_POSITION)
+const cameraPosition = useLocalStorage('settings/stage-ui-three/camera-position', { ...DEFAULT_CAMERA_POSITION })
 
 export function useThreeCamera() {
   return {

--- a/packages/stage-ui-three/src/stores/camera.ts
+++ b/packages/stage-ui-three/src/stores/camera.ts
@@ -1,16 +1,20 @@
 import { useLocalStorage } from '@vueuse/core'
 
+export const DEFAULT_CAMERA_FOV = 40
+export const DEFAULT_CAMERA_DISTANCE = 1
+export const DEFAULT_CAMERA_POSITION = { x: 0, y: 0, z: -1 }
+
 /** camera field of view, in degrees. */
-const cameraFOV = useLocalStorage('settings/stage-ui-three/cameraFOV', 40)
+const cameraFOV = useLocalStorage('settings/stage-ui-three/cameraFOV', DEFAULT_CAMERA_FOV)
 /**
  * euclidean distance between the model center and the camera center, in meters.
  * setting this value will move the camera along the axis.
  */
-const cameraDistance = useLocalStorage('settings/stage-ui-three/cameraDistance', 1)
+const cameraDistance = useLocalStorage('settings/stage-ui-three/cameraDistance', DEFAULT_CAMERA_DISTANCE)
 /**
  * Internal state of the camera. Users should not be able to set this directly, use `cameraDistance` instead.
  */
-const cameraPosition = useLocalStorage('settings/stage-ui-three/camera-position', { x: 0, y: 0, z: -1 })
+const cameraPosition = useLocalStorage('settings/stage-ui-three/camera-position', DEFAULT_CAMERA_POSITION)
 
 export function useThreeCamera() {
   return {

--- a/packages/stage-ui-three/src/stores/camera.ts
+++ b/packages/stage-ui-three/src/stores/camera.ts
@@ -1,0 +1,21 @@
+import { useLocalStorage } from '@vueuse/core'
+
+/** camera field of view, in degrees. */
+const cameraFOV = useLocalStorage('settings/stage-ui-three/cameraFOV', 40)
+/**
+ * euclidean distance between the model center and the camera center, in meters.
+ * setting this value will move the camera along the axis.
+ */
+const cameraDistance = useLocalStorage('settings/stage-ui-three/cameraDistance', 1)
+/**
+ * Internal state of the camera. Users should not be able to set this directly, use `cameraDistance` instead.
+ */
+const cameraPosition = useLocalStorage('settings/stage-ui-three/camera-position', { x: 0, y: 0, z: -1 })
+
+export function useThreeCamera() {
+  return {
+    cameraFOV,
+    cameraDistance,
+    cameraPosition,
+  }
+}

--- a/packages/stage-ui-three/src/stores/model-store.ts
+++ b/packages/stage-ui-three/src/stores/model-store.ts
@@ -6,6 +6,7 @@ import { computed, ref, watch } from 'vue'
 
 import defaultSkyBoxSrc from '../components/Environment/assets/sky_linekotsi_23_HDRI.hdr?url'
 
+import { useThreeCamera } from './camera'
 import { supportedControl, useThreeViewControl } from './view-control'
 
 // TODO: this is for future type injection features
@@ -79,8 +80,8 @@ interface BroadcastChannelEventShouldUpdateView {
 
 const vrmViewUpdateRuntimeInstanceId = Math.random().toString(36).slice(2, 10)
 let vrmViewUpdateMessageSequence = 0
-const { cameraFOV, cameraDistance, modelOffset, reset: resetViewControl } = useThreeViewControl()
-
+const { modelOffset, set: setViewControl } = useThreeViewControl()
+const { cameraDistance, cameraFOV, cameraPosition } = useThreeCamera()
 export const useModelStore = defineStore('modelStore', () => {
   const { post, data } = useBroadcastChannel<BroadcastChannelEvents, BroadcastChannelEvents>({ name: 'airi-stores-stage-ui-three-vrm' })
   const shouldUpdateViewHooks = ref(new Set<() => void>())
@@ -149,10 +150,7 @@ export const useModelStore = defineStore('modelStore', () => {
   const trackingMode = useLocalStorage('settings/stage-ui-three/trackingMode', 'none' as 'camera' | 'mouse' | 'none')
 
   // === View state ===
-  // `cameraDistance` is the user-facing distance control. `cameraPosition` and
-  // `lookAtTarget` represent the current runtime pose and may be recalculated when
-  // a new model bootstrap is applied.
-  const cameraPosition = useLocalStorage('settings/stage-ui-three/camera-position', { x: 0, y: 0, z: -1 })
+  /** current runtime pose. may be recalculated when a new model bootstrap is applied. */
   const lookAtTarget = useLocalStorage('settings/stage-ui-three/lookAtTarget', { x: 0, y: 0, z: 0 })
 
   function resetModelStore() {
@@ -165,7 +163,7 @@ export const useModelStore = defineStore('modelStore', () => {
     modelRotationY.value = 0
 
     cameraPosition.value = { x: 0, y: 0, z: 0 }
-    supportedControl.forEach(c => resetViewControl(c))
+    supportedControl.forEach(c => setViewControl(c))
 
     lookAtTarget.value = { x: 0, y: 0, z: 0 }
     trackingMode.value = 'none'

--- a/packages/stage-ui-three/src/stores/model-store.ts
+++ b/packages/stage-ui-three/src/stores/model-store.ts
@@ -6,7 +6,7 @@ import { computed, ref, watch } from 'vue'
 
 import defaultSkyBoxSrc from '../components/Environment/assets/sky_linekotsi_23_HDRI.hdr?url'
 
-import { useThreeCamera } from './camera'
+import { DEFAULT_CAMERA_POSITION, useThreeCamera } from './camera'
 import { supportedControl, useThreeViewControl } from './view-control'
 
 // TODO: this is for future type injection features
@@ -162,7 +162,7 @@ export const useModelStore = defineStore('modelStore', () => {
     modelOrigin.value = { x: 0, y: 0, z: 0 }
     modelRotationY.value = 0
 
-    cameraPosition.value = { x: 0, y: 0, z: 0 }
+    cameraPosition.value = { ...DEFAULT_CAMERA_POSITION }
     supportedControl.forEach(c => setViewControl(c))
 
     lookAtTarget.value = { x: 0, y: 0, z: 0 }

--- a/packages/stage-ui-three/src/stores/view-control.test.ts
+++ b/packages/stage-ui-three/src/stores/view-control.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { defaultControlConfig, formatter, supportedControl, useThreeViewControl } from './view-control'
+
+vi.mock('./camera', async () => {
+  const vue = await import('vue')
+  return {
+    DEFAULT_CAMERA_DISTANCE: 20,
+    DEFAULT_CAMERA_FOV: 40,
+    useThreeCamera: vi.fn(() => ({
+      cameraDistance: vue.ref(20),
+      cameraFOV: vue.ref(40),
+    })),
+  }
+})
+
+vi.mock('@vueuse/core', async () => {
+  const vue = await import('vue')
+  return {
+    useLocalStorage: vi.fn((_key, initialValue) => vue.ref(initialValue)),
+  }
+})
+
+describe('useThreeViewControl', () => {
+  let composable: ReturnType<typeof useThreeViewControl>
+
+  beforeEach(() => {
+    composable = useThreeViewControl()
+  })
+
+  it('should initialize with defaults', () => {
+    expect(composable.viewControlsEnabled.value).toBe(false)
+    expect(composable.viewControlMode.value).toBe('cameraDistance')
+    expect(composable.modelOffset.value).toEqual({ x: 0, y: 0, z: 0 })
+    expect(composable.cameraDistance.value).toBe(20)
+    expect(composable.cameraFOV.value).toBe(40)
+  })
+
+  describe('set function', () => {
+    it('should set model offset x', () => {
+      composable.set('x', 5)
+      expect(composable.modelOffset.value.x).toBe(5)
+    })
+
+    it('should set camera distance', () => {
+      composable.set('cameraDistance', 8)
+      expect(composable.cameraDistance.value).toBe(8)
+    })
+
+    it('should set camera FOV', () => {
+      composable.set('cameraFOV', 60)
+      expect(composable.cameraFOV.value).toBe(60)
+    })
+
+    it('should clamp values to max', () => {
+      supportedControl.forEach(key => composable.set(key, Number.MAX_VALUE))
+      expect(composable.modelOffset.value.x).toBe(defaultControlConfig.x.max)
+      expect(composable.modelOffset.value.y).toBe(defaultControlConfig.y.max)
+      expect(composable.modelOffset.value.z).toBe(defaultControlConfig.z.max)
+      expect(composable.cameraDistance.value).toBe(defaultControlConfig.cameraDistance.max)
+      expect(composable.cameraFOV.value).toBe(defaultControlConfig.cameraFOV.max)
+    })
+
+    it('should clamp values to min', () => {
+      supportedControl.forEach(key => composable.set(key, -Number.MAX_VALUE))
+      expect(composable.modelOffset.value.x).toBe(defaultControlConfig.x.min)
+      expect(composable.modelOffset.value.y).toBe(defaultControlConfig.y.min)
+      expect(composable.modelOffset.value.z).toBe(defaultControlConfig.z.min)
+      expect(composable.cameraDistance.value).toBe(defaultControlConfig.cameraDistance.min)
+      expect(composable.cameraFOV.value).toBe(defaultControlConfig.cameraFOV.min)
+    })
+
+    it('should reset to default when value is omitted', () => {
+      supportedControl.forEach(k => composable.set(k, defaultControlConfig[k].default + 1))
+      supportedControl.forEach(k => composable.set(k))
+      expect(composable.modelOffset.value.x).toBe(defaultControlConfig.x.default)
+      expect(composable.modelOffset.value.y).toBe(defaultControlConfig.y.default)
+      expect(composable.modelOffset.value.z).toBe(defaultControlConfig.z.default)
+      expect(composable.cameraDistance.value).toBe(defaultControlConfig.cameraDistance.default)
+      expect(composable.cameraFOV.value).toBe(defaultControlConfig.cameraFOV.default)
+    })
+  })
+
+  describe('formatter', () => {
+    it('should format meters with 2 decimals', () => {
+      expect(formatter.x(1.234)).toBe('1.23m')
+      expect(formatter.x(1.236)).toBe('1.24m')
+      expect(formatter.y(10)).toBe('10.00m')
+    })
+
+    it('should format camera FOV with 0 decimal', () => {
+      expect(formatter.cameraFOV(45.4)).toBe('45°')
+      expect(formatter.cameraFOV(45.5)).toBe('46°')
+      expect(formatter.cameraFOV(90)).toBe('90°')
+    })
+  })
+})

--- a/packages/stage-ui-three/src/stores/view-control.ts
+++ b/packages/stage-ui-three/src/stores/view-control.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from '@vueuse/core'
 import { ref } from 'vue'
 
-import { useThreeCamera } from './camera'
+import { DEFAULT_CAMERA_DISTANCE, DEFAULT_CAMERA_FOV, useThreeCamera } from './camera'
 
 export const supportedControl = ['x', 'y', 'z', 'cameraDistance', 'cameraFOV'] as const
 export type SupportedControl = typeof supportedControl[number]
@@ -39,7 +39,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     min: 0,
     max: 10,
     step: 0.01,
-    default: 1,
+    default: DEFAULT_CAMERA_DISTANCE,
     buttonText: 'Dis',
     format: formatDecimal2Meters,
   },
@@ -47,7 +47,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     min: 10,
     max: 120,
     step: 1,
-    default: 40,
+    default: DEFAULT_CAMERA_FOV,
     buttonText: 'FOV',
     format: (val: number) => `${val.toFixed(0)}°`,
   },
@@ -55,7 +55,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
 
 const { cameraDistance, cameraFOV } = useThreeCamera()
 /** model position from the scene origin, in meters. */
-const modelOffset = useLocalStorage('settings/stage-ui-three/modelOffset', { x: 0, y: 0, z: 0 })
+const modelOffset = useLocalStorage('settings/stage-ui-three/modelOffset', { x: controlConfig.x.default, y: controlConfig.y.default, z: controlConfig.z.default })
 /** show or hide the control element(slider) on HUD. */
 const viewControlsEnabled = ref(false)
 /** what value to control for the control element */

--- a/packages/stage-ui-three/src/stores/view-control.ts
+++ b/packages/stage-ui-three/src/stores/view-control.ts
@@ -75,7 +75,7 @@ const viewControlMode = ref<SupportedControl>('cameraDistance')
  *  @param value optional, will reset the value to its default if not provided
  */
 function set(key: SupportedControl, value?: number) {
-  const clamped = value ? clampMinMax(value, defaultControlConfig[key].min, defaultControlConfig[key].max) : null
+  const clamped = value !== undefined ? clampMinMax(value, defaultControlConfig[key].min, defaultControlConfig[key].max) : undefined
   switch (key) {
     case 'x':
       modelOffset.value.x = clamped ?? defaultControlConfig.x.default

--- a/packages/stage-ui-three/src/stores/view-control.ts
+++ b/packages/stage-ui-three/src/stores/view-control.ts
@@ -1,9 +1,11 @@
 import { useLocalStorage } from '@vueuse/core'
 import { ref } from 'vue'
 
+import { useThreeCamera } from './camera'
+
 export const supportedControl = ['x', 'y', 'z', 'cameraDistance', 'cameraFOV'] as const
-type SupportedControl = typeof supportedControl[number]
-interface ControlConfig { min: number, max: number, step: number, default: number, format: (val: number) => string }
+export type SupportedControl = typeof supportedControl[number]
+interface ControlConfig { min: number, max: number, step: number, default: number, buttonText: string, format: (val: number) => string }
 
 const formatDecimal2Meters = (val: number) => `${val.toFixed(2)}m`
 
@@ -14,6 +16,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 10,
     step: 0.01,
     default: 0,
+    buttonText: 'X',
     format: formatDecimal2Meters,
   },
   y: {
@@ -21,6 +24,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 10,
     step: 0.01,
     default: 0,
+    buttonText: 'Y',
     format: formatDecimal2Meters,
   },
   z: {
@@ -28,6 +32,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 10,
     step: 0.01,
     default: 0,
+    buttonText: 'Z',
     format: formatDecimal2Meters,
   },
   cameraDistance: {
@@ -35,6 +40,7 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 10,
     step: 0.01,
     default: 1,
+    buttonText: 'Dis',
     format: formatDecimal2Meters,
   },
   cameraFOV: {
@@ -42,17 +48,12 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     max: 120,
     step: 1,
     default: 40,
+    buttonText: 'FOV',
     format: (val: number) => `${val.toFixed(0)}°`,
   },
 }
 
-/** camera field of view, in degrees. */
-const cameraFOV = useLocalStorage('settings/stage-ui-three/cameraFOV', 40)
-/**
- * euclidean distance between the model center and the camera center, in meters.
- * setting this value will move the camera along the axis.
- */
-const cameraDistance = useLocalStorage('settings/stage-ui-three/cameraDistance', 1)
+const { cameraDistance, cameraFOV } = useThreeCamera()
 /** model position from the scene origin, in meters. */
 const modelOffset = useLocalStorage('settings/stage-ui-three/modelOffset', { x: 0, y: 0, z: 0 })
 /** show or hide the control element(slider) on HUD. */
@@ -61,25 +62,26 @@ const viewControlsEnabled = ref(false)
 const viewControlMode = ref<SupportedControl>('cameraDistance')
 
 /**
- * reset the given control to its default value.
- *  @param key the control to reset
+ * set the given control to the given value.
+ *  @param key the control to set
+ *  @param value optional, will reset the value to its default if not provided
  */
-function reset(key: SupportedControl) {
+function set(key: SupportedControl, value?: number) {
   switch (key) {
     case 'x':
-      modelOffset.value.x = controlConfig.x.default
+      modelOffset.value.x = value ?? controlConfig.x.default
       break
     case 'y':
-      modelOffset.value.y = controlConfig.y.default
+      modelOffset.value.y = value ?? controlConfig.y.default
       break
     case 'z':
-      modelOffset.value.z = controlConfig.z.default
+      modelOffset.value.z = value ?? controlConfig.z.default
       break
     case 'cameraDistance':
-      cameraDistance.value = controlConfig.cameraDistance.default
+      cameraDistance.value = value ?? controlConfig.cameraDistance.default
       break
     case 'cameraFOV':
-      cameraFOV.value = controlConfig.cameraFOV.default
+      cameraFOV.value = value ?? controlConfig.cameraFOV.default
       break
   }
 }
@@ -98,6 +100,6 @@ export function useThreeViewControl() {
     viewControlMode,
 
     /** reset the given control to its default value. */
-    reset,
+    set,
   }
 }

--- a/packages/stage-ui-three/src/stores/view-control.ts
+++ b/packages/stage-ui-three/src/stores/view-control.ts
@@ -5,11 +5,11 @@ import { DEFAULT_CAMERA_DISTANCE, DEFAULT_CAMERA_FOV, useThreeCamera } from './c
 
 export const supportedControl = ['x', 'y', 'z', 'cameraDistance', 'cameraFOV'] as const
 export type SupportedControl = typeof supportedControl[number]
-interface ControlConfig { min: number, max: number, step: number, default: number, buttonText: string, format: (val: number) => string }
+interface ControlConfig { min: number, max: number, step: number, default: number, buttonText: string }
 
-const formatDecimal2Meters = (val: number) => `${val.toFixed(2)}m`
+const formatMetersD2 = (val: number) => `${val.toFixed(2)}m`
 
-export const controlConfig: Record<SupportedControl, ControlConfig> = {
+export const defaultControlConfig: Record<SupportedControl, ControlConfig> = {
   // TODO: allow user to set the min/max value
   x: {
     min: -10,
@@ -17,7 +17,6 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.01,
     default: 0,
     buttonText: 'X',
-    format: formatDecimal2Meters,
   },
   y: {
     min: -10,
@@ -25,7 +24,6 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.01,
     default: 0,
     buttonText: 'Y',
-    format: formatDecimal2Meters,
   },
   z: {
     min: -10,
@@ -33,7 +31,6 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.01,
     default: 0,
     buttonText: 'Z',
-    format: formatDecimal2Meters,
   },
   cameraDistance: {
     min: 0,
@@ -41,7 +38,6 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 0.01,
     default: DEFAULT_CAMERA_DISTANCE,
     buttonText: 'Dis',
-    format: formatDecimal2Meters,
   },
   cameraFOV: {
     min: 10,
@@ -49,14 +45,26 @@ export const controlConfig: Record<SupportedControl, ControlConfig> = {
     step: 1,
     default: DEFAULT_CAMERA_FOV,
     buttonText: 'FOV',
-    format: (val: number) => `${val.toFixed(0)}°`,
   },
 }
 
+export const formatter: Record<SupportedControl, (val: number) => string> = {
+  x: formatMetersD2,
+  y: formatMetersD2,
+  z: formatMetersD2,
+  cameraDistance: formatMetersD2,
+  cameraFOV: (val: number) => `${val.toFixed(0)}°`,
+}
+const clampMinMax = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
 const { cameraDistance, cameraFOV } = useThreeCamera()
+const controlConfig = ref(defaultControlConfig)
 /** model position from the scene origin, in meters. */
-const modelOffset = useLocalStorage('settings/stage-ui-three/modelOffset', { x: controlConfig.x.default, y: controlConfig.y.default, z: controlConfig.z.default })
-/** show or hide the control element(slider) on HUD. */
+const modelOffset = useLocalStorage('settings/stage-ui-three/modelOffset', { x: defaultControlConfig.x.default, y: defaultControlConfig.y.default, z: defaultControlConfig.z.default })
+/**
+ * show or hide the control element(slider) on HUD.
+ *  also enable/disable camera panning.
+ */
 const viewControlsEnabled = ref(false)
 /** what value to control for the control element */
 const viewControlMode = ref<SupportedControl>('cameraDistance')
@@ -67,21 +75,22 @@ const viewControlMode = ref<SupportedControl>('cameraDistance')
  *  @param value optional, will reset the value to its default if not provided
  */
 function set(key: SupportedControl, value?: number) {
+  const clamped = value ? clampMinMax(value, defaultControlConfig[key].min, defaultControlConfig[key].max) : null
   switch (key) {
     case 'x':
-      modelOffset.value.x = value ?? controlConfig.x.default
+      modelOffset.value.x = clamped ?? defaultControlConfig.x.default
       break
     case 'y':
-      modelOffset.value.y = value ?? controlConfig.y.default
+      modelOffset.value.y = clamped ?? defaultControlConfig.y.default
       break
     case 'z':
-      modelOffset.value.z = value ?? controlConfig.z.default
+      modelOffset.value.z = clamped ?? defaultControlConfig.z.default
       break
     case 'cameraDistance':
-      cameraDistance.value = value ?? controlConfig.cameraDistance.default
+      cameraDistance.value = clamped ?? defaultControlConfig.cameraDistance.default
       break
     case 'cameraFOV':
-      cameraFOV.value = value ?? controlConfig.cameraFOV.default
+      cameraFOV.value = clamped ?? defaultControlConfig.cameraFOV.default
       break
   }
 }
@@ -98,7 +107,7 @@ export function useThreeViewControl() {
     viewControlsEnabled,
     /** what value to control for the control element */
     viewControlMode,
-
+    controlConfig,
     /** reset the given control to its default value. */
     set,
   }

--- a/packages/stage-ui-three/vitest.config.ts
+++ b/packages/stage-ui-three/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
@@ -24,7 +24,7 @@ const { askPermission } = useAudioDevice()
 const screenSafeArea = useScreenSafeArea()
 
 useResizeObserver(document.documentElement, () => screenSafeArea.update())
-watch([showDialog], (show) => {
+watch(showDialog, (show) => {
   if (show)
     askPermission()
 })

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
@@ -13,7 +13,6 @@ const props = defineProps<{
   overlayBlur?: boolean
   granted?: boolean
   transcription?: boolean
-  volumeLevel?: number
   toggleTranscription?: () => void
 }>()
 
@@ -45,7 +44,6 @@ onMounted(() => screenSafeArea.update())
         </VisuallyHidden>
         <HearingConfig
           :granted="props.granted"
-          :volume-level="props.volumeLevel"
           :transcription="props.transcription"
           @toggle-transcription="() => toggleTranscription?.()"
         />
@@ -77,7 +75,6 @@ onMounted(() => screenSafeArea.update())
         />
         <HearingConfig
           :granted="props.granted"
-          :volume-level="props.volumeLevel"
           :transcription="props.transcription"
           @toggle-transcription="() => toggleTranscription?.()"
         />

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
@@ -2,10 +2,11 @@
 import { useResizeObserver, useScreenSafeArea } from '@vueuse/core'
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, DialogTrigger, VisuallyHidden } from 'reka-ui'
 import { DrawerContent, DrawerHandle, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'vaul-vue'
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
 
 import HearingConfig from './hearing-config.vue'
 
+import { useAudioDevice } from '../../../../composables'
 import { useBreakpoints } from '../../../../composables/use-breakpoints'
 
 const props = defineProps<{
@@ -19,9 +20,14 @@ const props = defineProps<{
 const showDialog = defineModel('show', { type: Boolean, default: false, required: false })
 
 const { isDesktop } = useBreakpoints()
+const { askPermission } = useAudioDevice()
 const screenSafeArea = useScreenSafeArea()
 
 useResizeObserver(document.documentElement, () => screenSafeArea.update())
+watch([showDialog], (show) => {
+  if (show)
+    askPermission()
+})
 onMounted(() => screenSafeArea.update())
 </script>
 
@@ -43,8 +49,7 @@ onMounted(() => screenSafeArea.update())
           <DialogTitle>Hearing Input</DialogTitle>
         </VisuallyHidden>
         <HearingConfig
-          :granted="props.granted"
-          :transcription="props.transcription"
+          :granted="props.granted" :transcription="props.transcription"
           @toggle-transcription="() => toggleTranscription?.()"
         />
         <slot name="extra" />

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config-dialog.vue
@@ -12,7 +12,9 @@ const props = defineProps<{
   overlayDim?: boolean
   overlayBlur?: boolean
   granted?: boolean
+  transcription?: boolean
   volumeLevel?: number
+  toggleTranscription?: () => void
 }>()
 
 const showDialog = defineModel('show', { type: Boolean, default: false, required: false })
@@ -44,6 +46,8 @@ onMounted(() => screenSafeArea.update())
         <HearingConfig
           :granted="props.granted"
           :volume-level="props.volumeLevel"
+          :transcription="props.transcription"
+          @toggle-transcription="() => toggleTranscription?.()"
         />
         <slot name="extra" />
       </DialogContent>
@@ -74,6 +78,8 @@ onMounted(() => screenSafeArea.update())
         <HearingConfig
           :granted="props.granted"
           :volume-level="props.volumeLevel"
+          :transcription="props.transcription"
+          @toggle-transcription="() => toggleTranscription?.()"
         />
         <slot name="extra" />
       </DrawerContent>

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config.vue
@@ -3,19 +3,20 @@ import { Button, Callout, FieldCombobox } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 
-import { useAudioAnalyzer } from '../../../../composables'
+import { useAudioAnalyzer, useAudioDevice } from '../../../../composables'
 import { useSettingsAudioDevice } from '../../../../stores'
 
 const props = withDefaults(defineProps<{
-  granted?: boolean
+  granted?: boolean // permission status on OS level
   transcription?: boolean
 }>(), {
   granted: false,
 })
 
 const emit = defineEmits(['toggleTranscription'])
-
-const { enabled, selectedAudioInput, audioInputs } = storeToRefs(useSettingsAudioDevice())
+const deviceStore = useSettingsAudioDevice()
+const { enabled, selectedAudioInput } = storeToRefs(deviceStore)
+const { audioInputs, permissionGranted, askPermission } = useAudioDevice()
 const { volumeLevel } = useAudioAnalyzer()
 
 const autoSend = defineModel<boolean>('autoSend')
@@ -27,8 +28,10 @@ const ringEnabledClass = computed(() => enabled.value
 function toggleHearingEnabled() {
   if (enabled.value)
     return enabled.value = false
-  if (!enabled.value && selectedAudioInput.value !== '')
-    enabled.value = true
+  if (selectedAudioInput.value !== '' && permissionGranted.value)
+    return enabled.value = true
+  if (!permissionGranted.value)
+    return askPermission().then(() => { enabled.value = true })
 }
 </script>
 

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config.vue
@@ -3,20 +3,20 @@ import { Button, Callout, FieldCombobox } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 
+import { useAudioAnalyzer } from '../../../../composables'
 import { useSettingsAudioDevice } from '../../../../stores'
 
 const props = withDefaults(defineProps<{
   granted?: boolean
-  volumeLevel?: number
   transcription?: boolean
 }>(), {
   granted: false,
-  volumeLevel: 0,
 })
 
 const emit = defineEmits(['toggleTranscription'])
 
 const { enabled, selectedAudioInput, audioInputs } = storeToRefs(useSettingsAudioDevice())
+const { volumeLevel } = useAudioAnalyzer()
 
 const autoSend = defineModel<boolean>('autoSend')
 const ringEnabledClass = computed(() => enabled.value
@@ -40,17 +40,17 @@ function toggleHearingEnabled() {
         <!-- Rings (scale + opacity follow volume) -->
         <div
           class="absolute left-1/2 top-1/2 h-20 w-20 rounded-full transition-all duration-150 -translate-x-1/2 -translate-y-1/2"
-          :style="{ transform: `translate(-50%, -50%) scale(${1 + (props.volumeLevel / 100) * 0.35})`, opacity: String(0.25 + (props.volumeLevel / 100) * 0.25) }"
+          :style="{ transform: `translate(-50%, -50%) scale(${1 + (volumeLevel / 100) * 0.35})`, opacity: String(0.25 + (volumeLevel / 100) * 0.25) }"
           :class="ringEnabledClass"
         />
         <div
           class="absolute left-1/2 top-1/2 h-24 w-24 rounded-full transition-all duration-200 -translate-x-1/2 -translate-y-1/2"
-          :style="{ transform: `translate(-50%, -50%) scale(${1.2 + (props.volumeLevel / 100) * 0.55})`, opacity: String(0.15 + (props.volumeLevel / 100) * 0.2) }"
+          :style="{ transform: `translate(-50%, -50%) scale(${1.2 + (volumeLevel / 100) * 0.55})`, opacity: String(0.15 + (volumeLevel / 100) * 0.2) }"
           :class="enabled ? 'bg-primary-500/10 dark:bg-primary-600/15' : 'bg-neutral-300/10 dark:bg-neutral-700/10'"
         />
         <div
           class="absolute left-1/2 top-1/2 h-28 w-28 rounded-full transition-all duration-300 -translate-x-1/2 -translate-y-1/2"
-          :style="{ transform: `translate(-50%, -50%) scale(${1.5 + (props.volumeLevel / 100) * 0.8})`, opacity: String(0.08 + (props.volumeLevel / 100) * 0.15) }"
+          :style="{ transform: `translate(-50%, -50%) scale(${1.5 + (volumeLevel / 100) * 0.8})`, opacity: String(0.08 + (volumeLevel / 100) * 0.15) }"
           :class="enabled ? 'bg-primary-500/5 dark:bg-primary-600/10' : 'bg-neutral-300/5 dark:bg-neutral-700/5'"
         />
 

--- a/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/audio-input/hearing-config.vue
@@ -31,7 +31,7 @@ function toggleHearingEnabled() {
   if (selectedAudioInput.value !== '' && permissionGranted.value)
     return enabled.value = true
   if (!permissionGranted.value)
-    return askPermission().then(() => { enabled.value = true })
+    return askPermission().then(() => { enabled.value = permissionGranted.value })
 }
 </script>
 

--- a/packages/stage-ui/src/components/scenarios/settings/model-settings/preview-stage.vue
+++ b/packages/stage-ui/src/components/scenarios/settings/model-settings/preview-stage.vue
@@ -5,7 +5,7 @@ import { Live2DScene } from '@proj-airi/stage-ui-live2d'
 import { ThreeScene, useModelStore } from '@proj-airi/stage-ui-three'
 import { useMouse } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 
 import { useSettings } from '../../../../stores/settings'
 import {
@@ -29,6 +29,8 @@ const live2dSceneRef = ref<{ canvasElement: () => HTMLCanvasElement | undefined 
 const vrmSceneRef = ref<{ canvasElement: () => HTMLCanvasElement | undefined }>()
 const live2dComponentState = ref<'pending' | 'loading' | 'mounted'>('pending')
 const vrmPreviewStageInstanceId = `model-settings-preview-stage:${Math.random().toString(36).slice(2, 10)}`
+
+provide('previewStage', true)
 
 const {
   live2dDisableFocus,

--- a/packages/stage-ui/src/composables/audio/audio-analyzer.ts
+++ b/packages/stage-ui/src/composables/audio/audio-analyzer.ts
@@ -1,16 +1,16 @@
 import { onUnmounted, ref } from 'vue'
 
+const amplification = 3 // Amplification factor for volume visualization
+
+const volumeLevel = ref(0) // 0-100
+const error = ref<string>()
+
 export function useAudioAnalyzer() {
   const analyzer = ref<AnalyserNode>()
   const dataArray = ref<Uint8Array<ArrayBuffer>>()
   const animationFrame = ref<number>()
 
   const onAnalyzerUpdateHooks = ref<Array<(volumeLevel: number) => void | Promise<void>>>([])
-
-  const volumeLevel = ref(0) // 0-100
-  const error = ref<string>()
-
-  const amplification = 3 // Amplification factor for volume visualization
 
   function onAnalyzerUpdate(callback: (volumeLevel: number) => void | Promise<void>) {
     onAnalyzerUpdateHooks.value.push(callback)

--- a/packages/stage-ui/src/composables/audio/audio-device.ts
+++ b/packages/stage-ui/src/composables/audio/audio-device.ts
@@ -2,9 +2,8 @@ import { useDevicesList, useUserMedia } from '@vueuse/core'
 import { computed, nextTick, ref, watch } from 'vue'
 
 export function useAudioDevice(requestPermission: boolean = false) {
-  const devices = useDevicesList({ constraints: { audio: true }, requestPermissions: requestPermission })
-  const audioInputs = computed(() => devices.audioInputs.value)
-  const selectedAudioInput = ref<string>(devices.audioInputs.value.find(device => device.deviceId === 'default')?.deviceId || '')
+  const { audioInputs, permissionGranted, ensurePermissions } = useDevicesList({ constraints: { audio: true }, requestPermissions: requestPermission })
+  const selectedAudioInput = ref<string>(audioInputs.value.find(device => device.deviceId === 'default')?.deviceId || '')
   const deviceConstraints = computed<MediaStreamConstraints>(() => ({
     audio: {
       deviceId: { exact: selectedAudioInput.value },
@@ -16,13 +15,13 @@ export function useAudioDevice(requestPermission: boolean = false) {
   const { stream, stop: stopStream, start: startStream } = useUserMedia({ constraints: deviceConstraints, enabled: false, autoSwitch: true })
 
   watch(audioInputs, () => {
-    if (!selectedAudioInput.value && audioInputs.value.length > 0) {
+    if (selectedAudioInput.value === '' && audioInputs.value.length > 0) {
       selectedAudioInput.value = audioInputs.value.find(input => input.deviceId === 'default')?.deviceId || audioInputs.value[0].deviceId
     }
   })
 
   function askPermission() {
-    return devices.ensurePermissions()
+    return ensurePermissions()
       .then(() => nextTick())
       .then(() => {
         if (audioInputs.value.length > 0 && !selectedAudioInput.value) {
@@ -40,6 +39,7 @@ export function useAudioDevice(requestPermission: boolean = false) {
     selectedAudioInput,
     stream,
     deviceConstraints,
+    permissionGranted,
 
     askPermission,
     startStream,

--- a/packages/stage-ui/src/stores/settings/audio-device.ts
+++ b/packages/stage-ui/src/stores/settings/audio-device.ts
@@ -27,13 +27,16 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
 
   // permissionGranted from vueuse does not track revocation yet.
   // implement it manually.
-  navigator?.permissions?.query({ name: 'microphone' }).then((status) => {
-    microphonePermissionStatus = status // existing one cleaned up by GC
-    status.onchange = () => {
-      if (status.state === 'denied' || status.state === 'prompt')
-        audioInputEnabled.value = false
-    }
-  }).catch(e => console.info(`Unable to track microphone permission: ${e}`))
+  try {
+    navigator?.permissions?.query({ name: 'microphone' }).then((status) => {
+      microphonePermissionStatus = status // existing one cleaned up by GC
+      status.onchange = () => {
+        if (status.state === 'denied' || status.state === 'prompt')
+          audioInputEnabled.value = false
+      }
+    })
+  }
+  catch (e) { console.info(`Unable to track microphone permission: ${e}`) }
   void microphonePermissionStatus // suppress unused variable lint
   function initialize() {
     const hasSelectedInput = selectedAudioInputPersist.value

--- a/packages/stage-ui/src/stores/settings/audio-device.ts
+++ b/packages/stage-ui/src/stores/settings/audio-device.ts
@@ -4,17 +4,19 @@ import { watch } from 'vue'
 
 import { useAudioDevice } from '../../composables/audio'
 
+let microphonePermissionStatus: PermissionStatus
+
 export const useSettingsAudioDevice = defineStore('settings-audio-devices', () => {
   const { audioInputs, deviceConstraints, selectedAudioInput: selectedAudioInputNonPersist, startStream, stopStream, stream, askPermission } = useAudioDevice()
 
   const selectedAudioInputPersist = useLocalStorageManualReset<string>('settings/audio/input', selectedAudioInputNonPersist.value)
-  const selectedAudioInputEnabledPersist = useLocalStorageManualReset<boolean>('settings/audio/input/enabled', false)
+  const audioInputEnabled = useLocalStorageManualReset<boolean>('settings/audio/input/enabled', false)
 
   watch(selectedAudioInputPersist, (newValue) => {
     selectedAudioInputNonPersist.value = newValue
   })
 
-  watch(selectedAudioInputEnabledPersist, (val) => {
+  watch(audioInputEnabled, (val) => {
     if (val) {
       startStream()
     }
@@ -23,14 +25,25 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
     }
   })
 
+  // permissionGranted from vueuse does not track revocation yet.
+  // implement it manually.
+  navigator.permissions.query({ name: 'microphone' }).then((status) => {
+    microphonePermissionStatus = status
+    status.onchange = () => {
+      console.info(`status changed to ${status.state}`)
+      if (status.state === 'denied' || status.state === 'prompt')
+        audioInputEnabled.value = false
+    }
+  })
+  microphonePermissionStatus // suppress unused variable lint
   function initialize() {
     const hasSelectedInput = selectedAudioInputPersist.value
       && audioInputs.value.some(device => device.deviceId === selectedAudioInputPersist.value)
 
-    if (selectedAudioInputEnabledPersist.value && hasSelectedInput) {
+    if (audioInputEnabled.value && hasSelectedInput) {
       startStream()
     }
-    if (selectedAudioInputNonPersist.value && !selectedAudioInputEnabledPersist.value) {
+    if (selectedAudioInputNonPersist.value && !audioInputEnabled.value) {
       selectedAudioInputPersist.value = selectedAudioInputNonPersist.value
     }
   }
@@ -38,7 +51,7 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
   function resetState() {
     selectedAudioInputPersist.reset()
     selectedAudioInputNonPersist.value = ''
-    selectedAudioInputEnabledPersist.reset()
+    audioInputEnabled.reset()
     stopStream()
   }
 
@@ -46,7 +59,7 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
     audioInputs,
     deviceConstraints,
     selectedAudioInput: selectedAudioInputPersist,
-    enabled: selectedAudioInputEnabledPersist,
+    enabled: audioInputEnabled,
 
     stream,
 

--- a/packages/stage-ui/src/stores/settings/audio-device.ts
+++ b/packages/stage-ui/src/stores/settings/audio-device.ts
@@ -35,7 +35,7 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
         audioInputEnabled.value = false
     }
   }).catch(e => console.info(`Unable to track microphone permission: ${e}`))
-  microphonePermissionStatus // suppress unused variable lint
+  void microphonePermissionStatus // suppress unused variable lint
   function initialize() {
     const hasSelectedInput = selectedAudioInputPersist.value
       && audioInputs.value.some(device => device.deviceId === selectedAudioInputPersist.value)

--- a/packages/stage-ui/src/stores/settings/audio-device.ts
+++ b/packages/stage-ui/src/stores/settings/audio-device.ts
@@ -27,14 +27,14 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
 
   // permissionGranted from vueuse does not track revocation yet.
   // implement it manually.
-  navigator.permissions.query({ name: 'microphone' }).then((status) => {
+  navigator?.permissions?.query({ name: 'microphone' }).then((status) => {
     microphonePermissionStatus = status
     status.onchange = () => {
       console.info(`status changed to ${status.state}`)
       if (status.state === 'denied' || status.state === 'prompt')
         audioInputEnabled.value = false
     }
-  })
+  }).catch(e => console.info(`Unable to track microphone permission: ${e}`))
   microphonePermissionStatus // suppress unused variable lint
   function initialize() {
     const hasSelectedInput = selectedAudioInputPersist.value

--- a/packages/stage-ui/src/stores/settings/audio-device.ts
+++ b/packages/stage-ui/src/stores/settings/audio-device.ts
@@ -28,9 +28,8 @@ export const useSettingsAudioDevice = defineStore('settings-audio-devices', () =
   // permissionGranted from vueuse does not track revocation yet.
   // implement it manually.
   navigator?.permissions?.query({ name: 'microphone' }).then((status) => {
-    microphonePermissionStatus = status
+    microphonePermissionStatus = status // existing one cleaned up by GC
     status.onchange = () => {
-      console.info(`status changed to ${status.state}`)
       if (status.state === 'denied' || status.state === 'prompt')
         audioInputEnabled.value = false
     }

--- a/packages/ui/src/components/form/range/round-range.vue
+++ b/packages/ui/src/components/form/range/round-range.vue
@@ -64,11 +64,13 @@ function handleInput(e: Event) {
 }
 
 function onWheelInput(ev: WheelEvent) {
-  let valueAfter = 0
+  if (ev.deltaY === 0)
+    return
+  let valueAfter = modelValue.value
   if (ev.deltaY < 0)
-    valueAfter = modelValue.value += props.step * (shiftPressed.value ? 50 : 1)
+    valueAfter += props.step * (shiftPressed.value ? 50 : 1)
   if (ev.deltaY > 0)
-    valueAfter = modelValue.value -= props.step * (shiftPressed.value ? 50 : 1)
+    valueAfter -= props.step * (shiftPressed.value ? 50 : 1)
   modelValue.value = Math.min(Math.max(valueAfter, props.min), props.max)
 }
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1456,7 +1456,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@24.12.2)
+        version: 2.0.0(@types/node@25.6.0)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.2.1)
@@ -1495,7 +1495,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -1531,10 +1531,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: ^0.1.7
-        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -1561,7 +1561,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -1594,7 +1594,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -1615,31 +1615,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: ^4.0.0
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: ^1.3.2
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: ^4.1.0
-        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: ^1.2.1
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: ^3.1.2
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -3646,6 +3646,9 @@ importers:
       '@types/three':
         specifier: ^0.184.0
         version: 0.184.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -3710,6 +3713,9 @@ importers:
       '@types/three':
         specifier: ^0.184.0
         version: 0.184.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -19825,9 +19831,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 25.6.0
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -20711,31 +20717,6 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.9.3)
-    optionalDependencies:
-      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/compiler-dom'
-      - eslint
-      - rollup
-      - supports-color
-      - typescript
-
-  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
-      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
-      '@intlify/shared': 11.3.2
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
-      fast-glob: 3.3.3
-      pathe: 2.0.3
-      picocolors: 1.1.1
-      unplugin: 2.3.11
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -22727,34 +22708,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      ofetch: 1.5.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
-    dependencies:
-      ofetch: 1.5.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      yauzl: 3.3.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -23656,7 +23613,6 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
-    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -24322,12 +24278,6 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.9.3)
-
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -24629,15 +24579,6 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
-
-  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      sirv: 3.0.2
-      vue: 3.5.32(typescript@5.9.3)
-    optionalDependencies:
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -26780,7 +26721,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -26788,7 +26729,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -32698,8 +32639,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2:
-    optional: true
+  undici-types@7.19.2: {}
 
   undici@6.24.1: {}
 
@@ -32811,6 +32751,11 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
+    dependencies:
+      '@unocss/preset-mini': 66.6.8
+      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -32907,14 +32852,6 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    optionalDependencies:
-      esbuild: 0.27.2
-      rolldown: 1.0.0-rc.16
-      rollup: 4.60.1
-      unplugin: 2.3.11
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -32946,19 +32883,6 @@ snapshots:
       esbuild: 0.27.2
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      ci-info: 4.4.0
-      git-url-parse: 16.1.0
-      simple-git: 3.36.0
-      unplugin: 2.3.11
-    optionalDependencies:
-      esbuild: 0.27.2
-      rollup: 4.60.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33070,17 +32994,6 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      unplugin: 3.0.0
-      yaml: 2.8.3
-    optionalDependencies:
-      esbuild: 0.27.2
-      rolldown: 1.0.0-rc.16
-      rollup: 4.60.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33313,21 +33226,11 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      birpc: 2.9.0
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
-  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -33374,21 +33277,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      ansis: 4.2.0
-      debug: 4.4.3(supports-color@10.2.2)
-      error-stack-parser-es: 1.0.5
-      ohash: 2.0.11
-      open: 10.2.0
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      unplugin-utils: 0.3.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -33420,13 +33308,6 @@ snapshots:
       - typescript
       - ws
 
-  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      supports-color: 10.2.2
-      undici: 8.1.0
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -33445,20 +33326,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
-    dependencies:
-      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
-      '@vue/devtools-kit': 8.1.1
-      '@vue/devtools-shared': 8.1.1
-      sirv: 3.0.2
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - supports-color
-      - vue
-
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -33473,21 +33340,6 @@ snapshots:
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
-      '@vue/compiler-dom': 3.5.32
-      kolorist: 1.8.0
-      magic-string: 0.30.21
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -33500,16 +33352,6 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      fast-glob: 3.3.3
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.9.3)
-      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -33764,54 +33606,6 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
-      vue: 3.5.32(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@rspack/core'
-      - '@vueuse/core'
-      - esbuild
-      - rolldown
-      - rollup
-      - typescript
-      - vite
-      - vue-tsc
-      - webpack
-
-  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
-    dependencies:
-      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
-      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
-      unplugin: 2.3.11
-      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24414,9 +24414,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1456,7 +1456,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.2.1)
@@ -1495,7 +1495,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -1531,10 +1531,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: ^0.1.7
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -1561,7 +1561,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -1594,7 +1594,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -1615,31 +1615,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: ^4.0.0
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: ^1.3.2
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: ^4.1.0
-        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: ^1.2.1
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: ^3.1.2
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -19831,9 +19831,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -20717,6 +20717,31 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -22708,10 +22733,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -23613,6 +23662,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -24278,6 +24328,12 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -24579,6 +24635,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -26721,7 +26786,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -26729,7 +26794,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -32639,7 +32704,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@6.24.1: {}
 
@@ -32751,11 +32817,6 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -32852,6 +32913,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -32883,6 +32952,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -32994,6 +33076,17 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33226,11 +33319,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -33277,6 +33380,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -33308,6 +33426,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -33326,6 +33451,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -33340,6 +33479,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -33352,6 +33506,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -33606,6 +33770,54 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
+  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->
#1696 was merged prematurely with bugs. This PR is a follow-up patch.
- fix: `SliderControl` is guarded against `sceneMutationLocked` for VRM stage. Values cannot be changed when the model has not finished loading.
- fix: wheel event with `deltaY === 0` is ignored.
- fix: portrait mode can toggle transcription. bug from #1685 .
- feat: `OrbitControls` is disabled when controls are not enabled to prevent accidental camera movement. 
- refactor: control elements are now generated programmatically.
- refactor: camera-related parameters are extracted.
- refactor: state drilling on `OrbitControl` is reduced.
- refactor: state drilling of `volumeLevel` is reduced, `volumeLevel` is shared among users of the composable.

behavior change:
- microphone permission is requested upon `HearingConfig` dialog or drawer opening, and when toggling on hearing inside `HearingConfig`.
- audio input is disabled automatically when permission is revoked.

other notes:
- on chrome, microphone is only available in secure contexts. remote development, for example, dev server on PC and the page is opened on mobile, will cause the audio device list to be empty.
- on chrome android, transcription via Web Speech API appears to be configured successfully, but never return sentence delta or complete sentence.
- on firefox, AudioWorklet is only available in secure contexts. remote development will cause the API to be undefined and "crashes" the page.
## Linked Issues
maybe related: #1806
<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
