### PR TITLE
fix(stage-tamagotchi): keep chat sync alive across stage routes

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/App.vue
+++ b/apps/stage-tamagotchi/src/renderer/App.vue
@@ -51,6 +51,7 @@ import {
 import { initializeElectronAuthCallbackBridge } from './bridges/electron-auth-callback'
 import { initializeStageThreeRuntimeTraceBridge } from './bridges/stage-three-runtime-trace'
 import { useLanguage } from './composables/use-language'
+import { createChatSyncWindowLifecycle } from './stores/chat-sync-lifecycle'
 import { useTamagotchiMcpToolsStore } from './stores/mcp-tools'
 import { useTamagotchiPluginToolsStore } from './stores/plugin-tools'
 import { useServerChannelSettingsStore } from './stores/settings/server-channel'
@@ -96,6 +97,7 @@ const getMainLocale = useElectronEventaInvoke(i18nGetLocale)
 const setLocale = useElectronEventaInvoke(i18nSetLocale)
 const getGodotStageStatus = useElectronEventaInvoke(electronGodotStageGetStatus)
 const syncArtistryConfig = useElectronEventaInvoke(artistrySyncConfig)
+const chatSyncLifecycle = createChatSyncWindowLifecycle(route.path)
 const isChatWindowRoute = () => route.path === '/chat'
 const isGodotStageRoute = () => route.path === '/' || route.path.startsWith('/settings')
 const isWidgetsWindowRoute = () => route.path === '/widgets'
@@ -196,6 +198,8 @@ context.value.on(electronGodotStageStatusChanged, (event) => {
 })
 
 onMounted(async () => {
+  chatSyncLifecycle.initialize()
+
   // NOTICE: Issue #1658
   // When Electron restarts, renderer localStorage may not be flushed to disk.
   // The store's onMounted hook falls back to navigator.language, which triggers
@@ -254,6 +258,10 @@ onMounted(async () => {
 
   // Preload local inference models (Kokoro TTS, etc.) in background after a delay
   inferencePreload.triggerPreload()
+})
+
+onUnmounted(() => {
+  chatSyncLifecycle.dispose()
 })
 
 watch(themeColorsHue, () => {

--- a/apps/stage-tamagotchi/src/renderer/pages/chat.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/chat.vue
@@ -1,20 +1,6 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
-
 import InteractiveArea from '../components/InteractiveArea.vue'
 import WindowTitleBar from '../components/Window/TitleBar.vue'
-
-import { useChatSyncStore } from '../stores/chat-sync'
-
-const chatSyncStore = useChatSyncStore()
-
-onMounted(() => {
-  chatSyncStore.initialize('follower')
-})
-
-onUnmounted(() => {
-  chatSyncStore.dispose()
-})
 </script>
 
 <template>

--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -406,7 +406,6 @@ watch(enabled, async (val) => {
 }, { immediate: true })
 
 onMounted(() => {
-  chatSyncStore.initialize('authority')
   if (onboardingStore.needsOnboarding) {
     openOnboarding()
   }
@@ -418,7 +417,6 @@ onUnmounted(() => {
     ownerInstanceId: modelSettingsRuntimeOwnerInstanceId,
   })
   stopAudioInteraction()
-  chatSyncStore.dispose()
 })
 
 watch(stream, async (currentStream) => {

--- a/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.test.ts
@@ -52,12 +52,24 @@ describe('createChatSyncWindowLifecycle', async () => {
     expect(chatSyncStoreMock.dispose).not.toHaveBeenCalled()
   })
 
-  it('initializes as authority for settings routes', () => {
+  it('does not initialize chat sync for settings windows', () => {
+    const lifecycle = createChatSyncWindowLifecycle('/', '#/settings')
+
+    lifecycle.initialize()
+    lifecycle.dispose()
+
+    expect(chatSyncStoreMock.initialize).not.toHaveBeenCalled()
+    expect(chatSyncStoreMock.dispose).not.toHaveBeenCalled()
+  })
+
+  it('does not initialize chat sync for nested settings windows', () => {
     const lifecycle = createChatSyncWindowLifecycle('/', '#/settings/unrelated')
 
     lifecycle.initialize()
+    lifecycle.dispose()
 
-    expect(chatSyncStoreMock.initialize).toHaveBeenCalledWith('authority')
+    expect(chatSyncStoreMock.initialize).not.toHaveBeenCalled()
+    expect(chatSyncStoreMock.dispose).not.toHaveBeenCalled()
   })
 
   it('normalizes hash query strings when resolving the initial route', () => {

--- a/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const chatSyncStoreMock = vi.hoisted(() => ({
+  dispose: vi.fn(),
+  initialize: vi.fn(),
+}))
+
+vi.mock('./chat-sync', () => ({
+  useChatSyncStore: () => chatSyncStoreMock,
+}))
+
+describe('createChatSyncWindowLifecycle', async () => {
+  const {
+    createChatSyncWindowLifecycle,
+    resolveInitialChatSyncRoutePath,
+  } = await import('./chat-sync-lifecycle')
+
+  beforeEach(() => {
+    chatSyncStoreMock.dispose.mockClear()
+    chatSyncStoreMock.initialize.mockClear()
+  })
+
+  it('issue #1743: keeps main window chat sync owned by the renderer root', () => {
+    // https://github.com/moeru-ai/airi/issues/1743
+    const lifecycle = createChatSyncWindowLifecycle('/', '')
+
+    lifecycle.initialize()
+    lifecycle.dispose()
+
+    expect(chatSyncStoreMock.initialize).toHaveBeenCalledWith('authority')
+    expect(chatSyncStoreMock.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('issue #1743: resolves chat windows from the initial hash before router readiness', () => {
+    // https://github.com/moeru-ai/airi/issues/1743
+    const lifecycle = createChatSyncWindowLifecycle('/', '#/chat')
+
+    lifecycle.initialize()
+    lifecycle.dispose()
+
+    expect(chatSyncStoreMock.initialize).toHaveBeenCalledWith('follower')
+    expect(chatSyncStoreMock.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not initialize chat sync for unrelated windows', () => {
+    const lifecycle = createChatSyncWindowLifecycle('/', '#/widgets')
+
+    lifecycle.initialize()
+    lifecycle.dispose()
+
+    expect(chatSyncStoreMock.initialize).not.toHaveBeenCalled()
+    expect(chatSyncStoreMock.dispose).not.toHaveBeenCalled()
+  })
+
+  it('initializes as authority for settings routes', () => {
+    const lifecycle = createChatSyncWindowLifecycle('/', '#/settings/unrelated')
+
+    lifecycle.initialize()
+
+    expect(chatSyncStoreMock.initialize).toHaveBeenCalledWith('authority')
+  })
+
+  it('normalizes hash query strings when resolving the initial route', () => {
+    expect(resolveInitialChatSyncRoutePath('/', '#/chat?source=tray')).toBe('/chat')
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.ts
@@ -1,0 +1,46 @@
+import { useChatSyncStore } from './chat-sync'
+
+type ChatSyncWindowRole = 'authority' | 'follower'
+
+function normalizeRoutePath(routePath: string) {
+  const [path = ''] = routePath.split(/[?#]/)
+  return path || '/'
+}
+
+export function resolveInitialChatSyncRoutePath(routePath: string, hash = globalThis.location?.hash ?? '') {
+  const hashPath = hash.startsWith('#') ? hash.slice(1) : ''
+  return normalizeRoutePath(hashPath || routePath)
+}
+
+function resolveChatSyncWindowRole(routePath: string): ChatSyncWindowRole | null {
+  const path = normalizeRoutePath(routePath)
+  if (path === '/' || path.startsWith('/settings'))
+    return 'authority'
+  if (path === '/chat')
+    return 'follower'
+  return null
+}
+
+/**
+ * Owns chat-sync BroadcastChannel lifecycle for one Electron renderer window.
+ *
+ * The role is captured from the initial window route and must be initialized
+ * from the renderer root. Route pages should not dispose the channel because
+ * in-window navigation can unmount them while the BrowserWindow is still alive.
+ */
+export function createChatSyncWindowLifecycle(routePath: string, hash?: string) {
+  const chatSyncStore = useChatSyncStore()
+  const role = resolveChatSyncWindowRole(resolveInitialChatSyncRoutePath(routePath, hash))
+
+  return {
+    role,
+    initialize() {
+      if (role)
+        chatSyncStore.initialize(role)
+    },
+    dispose() {
+      if (role)
+        chatSyncStore.dispose()
+    },
+  }
+}

--- a/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.ts
@@ -14,7 +14,7 @@ export function resolveInitialChatSyncRoutePath(routePath: string, hash = global
 
 function resolveChatSyncWindowRole(routePath: string): ChatSyncWindowRole | null {
   const path = normalizeRoutePath(routePath)
-  if (path === '/' || path.startsWith('/settings'))
+  if (path === '/')
     return 'authority'
   if (path === '/chat')
     return 'follower'


### PR DESCRIPTION
## Description
- Move chat-sync BroadcastChannel ownership from the `/` and `/chat` route components into the renderer root so route navigation no longer disposes the channel while the BrowserWindow is still alive.
- Resolve the initial chat-sync role from the hash route before router readiness so chat windows still initialize as followers.
- Add lifecycle tests for the authority/follower route detection.

## Linked Issues
Closes #1743

## Additional Context
Validation:
- `pnpm exec eslint apps/stage-tamagotchi/src/renderer/App.vue apps/stage-tamagotchi/src/renderer/pages/index.vue apps/stage-tamagotchi/src/renderer/pages/chat.vue apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.ts apps/stage-tamagotchi/src/renderer/stores/chat-sync-lifecycle.test.ts`
- `pnpm -F @proj-airi/stage-tamagotchi exec vitest run src/renderer/stores/chat-sync-lifecycle.test.ts src/renderer/stores/chat-sync.test.ts`
- `pnpm run build:packages`
- `pnpm -F @proj-airi/stage-tamagotchi typecheck`
- `pnpm -F @proj-airi/stage-tamagotchi run build`
