### PR TITLE
feat(providers): add Google Gemini TTS provider

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1206,6 +1206,9 @@ pages:
       fireworks:
         description: fireworks.ai
         title: Fireworks.ai
+      google-gemini-audio-speech:
+        description: aistudio.google.com
+        title: Google Gemini
       microsoft-speech:
         description: speech.microsoft.com
         fields:

--- a/packages/stage-pages/src/pages/settings/modules/consciousness.vue
+++ b/packages/stage-pages/src/pages/settings/modules/consciousness.vue
@@ -71,7 +71,7 @@ function handleDeleteProvider(providerId: string) {
           <fieldset
             v-if="persistedChatProvidersMetadata.length > 0"
             flex="~ row gap-4"
-            min-w-0 of-x-auto scroll-smooth
+            min-w-0 overflow-x-auto scroll-smooth
             role="radiogroup"
           >
             <RadioCardSimple

--- a/packages/stage-pages/src/pages/settings/modules/hearing.vue
+++ b/packages/stage-pages/src/pages/settings/modules/hearing.vue
@@ -534,7 +534,7 @@ onUnmounted(() => {
             <fieldset
               v-if="configuredTranscriptionProvidersMetadata.length > 0"
               flex="~ row gap-4"
-              min-w-0 of-x-auto scroll-smooth
+              min-w-0 overflow-x-auto scroll-smooth
               role="radiogroup"
             >
               <RadioCardSimple

--- a/packages/stage-pages/src/pages/settings/modules/speech.vue
+++ b/packages/stage-pages/src/pages/settings/modules/speech.vue
@@ -271,7 +271,7 @@ function handleDeleteProvider(providerId: string) {
           <div max-w-full>
             <fieldset
               v-if="configuredSpeechProvidersMetadata.length > 0" flex="~ row gap-4"
-              min-w-0 of-x-auto scroll-smooth role="radiogroup"
+              min-w-0 overflow-x-auto scroll-smooth role="radiogroup"
             >
               <RadioCardSimple
                 v-for="metadata in configuredSpeechProvidersMetadata"

--- a/packages/stage-pages/src/pages/settings/modules/vision.vue
+++ b/packages/stage-pages/src/pages/settings/modules/vision.vue
@@ -94,7 +94,7 @@ function formatRelativeTime(timestamp: number | null) {
         <div :class="['max-w-full']">
           <fieldset
             v-if="persistedChatProvidersMetadata.length > 0"
-            :class="['flex', 'min-w-0', 'flex-row', 'gap-4', 'of-x-auto', 'scroll-smooth']"
+            :class="['flex', 'min-w-0', 'flex-row', 'gap-4', 'overflow-x-auto', 'scroll-smooth']"
             role="radiogroup"
           >
             <RadioCardSimple

--- a/packages/stage-pages/src/pages/settings/providers/speech/google-gemini-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/google-gemini-audio-speech.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import type { SpeechProvider } from '@xsai-ext/providers/utils'
+
+import {
+  Alert,
+  SpeechPlayground,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { FieldCombobox, FieldRange } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const speechStore = useSpeechStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore)
+const { t } = useI18n()
+
+interface GoogleGeminiSpeechProviderConfig {
+  apiKey?: string
+  baseUrl?: string
+  model?: string
+  voice?: string
+  temperature?: number
+}
+
+const providerId = 'google-gemini-audio-speech'
+const defaultModel = 'gemini-2.5-flash-preview-tts'
+
+const config = computed(() => providers.value[providerId] as GoogleGeminiSpeechProviderConfig | undefined)
+
+function ensureProviderConfig(): GoogleGeminiSpeechProviderConfig {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+
+  return providers.value[providerId] as GoogleGeminiSpeechProviderConfig
+}
+
+const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
+const modelOptions = computed(() => {
+  return (providerModels.value.length > 0 ? providerModels.value : []).map(model => ({
+    value: model.id,
+    label: model.name,
+  }))
+})
+
+const availableVoices = computed(() => speechStore.availableVoices[providerId] || [])
+
+const model = computed({
+  get: () => config.value?.model || defaultModel,
+  set: (value) => {
+    ensureProviderConfig().model = value
+  },
+})
+
+const temperature = computed({
+  get: () => config.value?.temperature ?? 1.0,
+  set: (value) => {
+    ensureProviderConfig().temperature = value
+  },
+})
+
+const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
+
+onMounted(async () => {
+  ensureProviderConfig()
+
+  if (!config.value?.model)
+    model.value = defaultModel
+
+  await providersStore.loadModelsForConfiguredProviders()
+  await providersStore.fetchModelsForProvider(providerId)
+  await speechStore.loadVoicesForProvider(providerId)
+})
+
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize speech provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = modelId || model.value || defaultModel
+  const voiceToUse = voiceId || '' as string
+
+  return await speechStore.speech(
+    provider,
+    modelToUse,
+    input,
+    voiceToUse,
+    providerConfig,
+  )
+}
+
+const {
+  isValidating,
+  isValid,
+  validationMessage,
+  forceValid,
+} = useProviderValidation(providerId)
+</script>
+
+<template>
+  <SpeechProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+  >
+    <template #voice-settings>
+      <FieldCombobox
+        v-model="model"
+        label="Model"
+        description="Select the Gemini TTS model to use for speech generation"
+        :options="modelOptions"
+        placeholder="Select a Gemini model..."
+      />
+      <FieldRange
+        v-model="temperature"
+        label="Temperature"
+        description="Controls randomness in speech generation. Lower values make speech more predictable, higher values make it more creative."
+        :min="0"
+        :max="2"
+        :step="0.1"
+        :format-value="(value) => value.toFixed(1)"
+      />
+    </template>
+
+    <template #playground>
+      <SpeechPlayground
+        :available-voices="availableVoices"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="apiKeyConfigured"
+        :voices-loading="speechStore.isLoadingSpeechProviderVoices"
+        default-text="Hello! This is a test of the Google Gemini Speech."
+      />
+    </template>
+
+    <template #advanced-settings>
+      <Alert v-if="!isValid && isValidating === 0 && validationMessage" type="error">
+        <template #title>
+          <div class="w-full flex items-center justify-between">
+            <span>{{ t('settings.dialogs.onboarding.validationFailed') }}</span>
+            <button
+              type="button"
+              class="ml-2 rounded bg-red-100 px-2 py-0.5 text-xs text-red-600 font-medium transition-colors dark:bg-red-800/30 hover:bg-red-200 dark:text-red-300 dark:hover:bg-red-700/40"
+              @click="forceValid"
+            >
+              {{ t('settings.pages.providers.common.continueAnyway') }}
+            </button>
+          </div>
+        </template>
+        <template v-if="validationMessage" #content>
+          <div class="whitespace-pre-wrap break-all">
+            {{ validationMessage }}
+          </div>
+        </template>
+      </Alert>
+      <Alert v-if="isValid && isValidating === 0" type="success">
+        <template #title>
+          {{ t('settings.dialogs.onboarding.validationSuccess') }}
+        </template>
+      </Alert>
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -55,6 +55,7 @@ import { useAuthStore } from './auth'
 import { createAliyunNLSProvider as createAliyunNlsStreamProvider } from './providers/aliyun/stream-transcription'
 import { convertProviderDefinitionsToMetadata } from './providers/converters'
 import { models as elevenLabsModels } from './providers/elevenlabs/list-models'
+import { buildGoogleGeminiSpeechProvider } from './providers/google-gemini-speech'
 import { buildOpenAICompatibleProvider } from './providers/openai-compatible-builder'
 import { buildOpenRouterAudioSpeechProvider } from './providers/openrouter/audio-speech'
 import { createWebSpeechAPIProvider } from './providers/web-speech-api'
@@ -2236,6 +2237,7 @@ export const useProvidersStore = defineStore('providers', () => {
         },
       },
     },
+    'google-gemini-audio-speech': buildGoogleGeminiSpeechProvider(v => baseUrlValidator.value(v)),
   }
 
   // Progressive migration bridge:

--- a/packages/stage-ui/src/stores/providers/google-gemini-speech.test.ts
+++ b/packages/stage-ui/src/stores/providers/google-gemini-speech.test.ts
@@ -1,0 +1,372 @@
+import type { SpeechProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import type { ModelInfo, VoiceInfo } from '../providers'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildGoogleGeminiSpeechProvider } from './google-gemini-speech'
+
+function createBaseUrlValidator() {
+  return (baseUrl: unknown) => {
+    if (!baseUrl || typeof baseUrl !== 'string' || baseUrl.length === 0) {
+      return { errors: [new Error('Base URL is required.')], reason: 'Base URL is required.', valid: false }
+    }
+    // Simulate the real isUrl check: a bare word without scheme is invalid
+    if (typeof baseUrl === 'string' && !baseUrl.startsWith('http')) {
+      return { errors: [new Error('Base URL is not absolute.')], reason: 'Base URL is not absolute.', valid: false }
+    }
+    return null
+  }
+}
+
+const baseUrlValidator = createBaseUrlValidator()
+
+function buildProvider() {
+  return buildGoogleGeminiSpeechProvider(baseUrlValidator)
+}
+
+async function getSpeechProvider(config: Record<string, unknown>): Promise<SpeechProviderWithExtraOptions<string, Record<string, unknown>>> {
+  const metadata = buildProvider()
+  return (await metadata.createProvider(config)) as SpeechProviderWithExtraOptions<string, Record<string, unknown>>
+}
+
+describe('googleGeminiSpeech provider metadata', () => {
+  const metadata = buildProvider()
+
+  it('has the correct provider ID', () => {
+    expect(metadata.id).toBe('google-gemini-audio-speech')
+  })
+
+  it('is in the speech category', () => {
+    expect(metadata.category).toBe('speech')
+  })
+
+  it('has text-to-speech task', () => {
+    expect(metadata.tasks).toContain('text-to-speech')
+  })
+
+  it('has a name and description', () => {
+    expect(metadata.name).toBe('Google Gemini')
+    expect(metadata.description).toBe('aistudio.google.com')
+  })
+
+  it('has the correct i18n keys', () => {
+    expect(metadata.nameKey).toBe('settings.pages.providers.provider.google-gemini-audio-speech.title')
+    expect(metadata.descriptionKey).toBe('settings.pages.providers.provider.google-gemini-audio-speech.description')
+  })
+
+  it('has default options with baseUrl', () => {
+    const defaults = metadata.defaultOptions?.()
+    expect(defaults?.baseUrl).toBe('https://generativelanguage.googleapis.com/v1beta/')
+  })
+})
+
+describe('googleGeminiSpeech listModels', () => {
+  const metadata = buildProvider()
+
+  it('returns three Gemini TTS models', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    expect(models).toHaveLength(3)
+  })
+
+  it('includes gemini-2.5-flash-preview-tts', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    expect(models?.map((m: ModelInfo) => m.id)).toContain('gemini-2.5-flash-preview-tts')
+  })
+
+  it('includes gemini-2.5-pro-preview-tts', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    expect(models?.map((m: ModelInfo) => m.id)).toContain('gemini-2.5-pro-preview-tts')
+  })
+
+  it('includes gemini-3.1-flash-tts-preview', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    expect(models?.map((m: ModelInfo) => m.id)).toContain('gemini-3.1-flash-tts-preview')
+  })
+
+  it('each model has the correct provider ID', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    for (const model of models ?? []) {
+      expect(model.provider).toBe('google-gemini-audio-speech')
+    }
+  })
+})
+
+describe('googleGeminiSpeech listVoices', () => {
+  const metadata = buildProvider()
+
+  it('returns 30 voices', async () => {
+    const voices = await metadata.capabilities.listVoices?.({})
+    expect(voices).toHaveLength(30)
+  })
+
+  it('includes Kore voice', async () => {
+    const voices = await metadata.capabilities.listVoices?.({})
+    expect(voices?.map((v: VoiceInfo) => v.id)).toContain('Kore')
+  })
+
+  it('each voice has compatibleModels with all three models', async () => {
+    const voices = await metadata.capabilities.listVoices?.({})
+    for (const voice of voices ?? []) {
+      expect(voice.compatibleModels).toEqual([
+        'gemini-2.5-flash-preview-tts',
+        'gemini-2.5-pro-preview-tts',
+        'gemini-3.1-flash-tts-preview',
+      ])
+    }
+  })
+
+  it('each voice has the correct provider ID', async () => {
+    const voices = await metadata.capabilities.listVoices?.({})
+    for (const voice of voices ?? []) {
+      expect(voice.provider).toBe('google-gemini-audio-speech')
+    }
+  })
+
+  it('each voice has a description', async () => {
+    const voices = await metadata.capabilities.listVoices?.({})
+    for (const voice of voices ?? []) {
+      expect(voice.description).toBeTruthy()
+    }
+  })
+})
+
+describe('googleGeminiSpeech validation', () => {
+  const metadata = buildProvider()
+
+  it('fails validation without API key', async () => {
+    const result = await metadata.validators.validateProviderConfig({})
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e: any) => e.message?.includes('API Key'))).toBe(true)
+  })
+
+  it('fails validation with empty API key string', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: '' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('fails validation with whitespace-only API key', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: '   ' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('passes validation with a valid API key', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: 'test-api-key' })
+    expect(result.valid).toBe(true)
+  })
+
+  it('uses baseUrl validator when baseUrl is provided', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: 'k', baseUrl: 'invalid' })
+    expect(result.valid).toBe(false)
+  })
+})
+
+describe('googleGeminiSpeech request construction', () => {
+  it('creates a speech provider with correct shape', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key', baseUrl: 'https://example.com/v1beta' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+
+    expect(speechResult.model).toBe('gemini-2.5-flash-preview-tts')
+    expect(speechResult.baseURL).toBe('https://example.com/v1beta/')
+    expect(typeof speechResult.fetch).toBe('function')
+  })
+
+  it('uses default model when none specified', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('' as any)
+    expect(speechResult.model).toBe('gemini-2.5-flash-preview-tts')
+  })
+
+  it('uses default base URL when none specified', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    expect(speechResult.baseURL).toBe('https://generativelanguage.googleapis.com/v1beta/')
+  })
+
+  it('spreads extra options into speech() return value', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts', { temperature: 0.7 })
+    expect(speechResult.temperature).toBe(0.7)
+  })
+
+  it('explicit model argument takes precedence over options.model', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts', { model: 'gemini-2.5-pro-preview-tts' })
+    expect(speechResult.model).toBe('gemini-2.5-flash-preview-tts')
+  })
+
+  it('fetch adapter throws when body is missing', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await expect(fetchFn(new URL('http://test'), {})).rejects.toThrow('Invalid request body')
+  })
+
+  it('fetch adapter throws when input text is missing', async () => {
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await expect(fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'test-model' }),
+    })).rejects.toThrow('Missing input text')
+  })
+
+  it('fetch adapter constructs correct Gemini URL', async () => {
+    const mockResponse = new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ inlineData: { data: 'AAAA' } }] } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'test-key', baseUrl: 'https://example.com/v1beta' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Hello', voice: 'Kore' }),
+    })
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://example.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-goog-api-key': 'test-key',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    )
+  })
+
+  it('fetch adapter sends correct Gemini request body', async () => {
+    const mockResponse = new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ inlineData: { data: 'AAAA' } }] } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'test-key', baseUrl: 'https://example.com/v1beta' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Hello from AIRI', voice: 'Kore' }),
+    })
+
+    const callArg = (globalThis.fetch as any).mock.calls[0][1]
+    const requestBody = JSON.parse(callArg.body)
+
+    expect(requestBody.generationConfig.responseModalities).toEqual(['AUDIO'])
+    expect(requestBody.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName).toBe('Kore')
+    expect(requestBody.contents[0].parts[0].text).toBe('Hello from AIRI')
+  })
+
+  it('includes temperature in generationConfig when provided', async () => {
+    const mockResponse = new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ inlineData: { data: 'AAAA' } }] } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Test', voice: 'Kore', temperature: 0.7 }),
+    })
+
+    const callArg = (globalThis.fetch as any).mock.calls[0][1]
+    const requestBody = JSON.parse(callArg.body)
+
+    expect(requestBody.generationConfig.temperature).toBe(0.7)
+  })
+
+  it('omits temperature from generationConfig when not provided', async () => {
+    const mockResponse = new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ inlineData: { data: 'AAAA' } }] } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Test', voice: 'Kore' }),
+    })
+
+    const callArg = (globalThis.fetch as any).mock.calls[0][1]
+    const requestBody = JSON.parse(callArg.body)
+
+    expect(requestBody.generationConfig.temperature).toBeUndefined()
+  })
+})
+
+describe('googleGeminiSpeech audio conversion', () => {
+  it('returns WAV audio from Gemini response', async () => {
+    const pcmBase64 = btoa('\x00\x00\x00\x00')
+    const mockResponse = new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ inlineData: { data: pcmBase64 } }] } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    const response = await fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Test', voice: 'Kore' }),
+    })
+
+    expect(response.headers.get('Content-Type')).toBe('audio/wav')
+
+    const buffer = await response.arrayBuffer()
+    const bytes = new Uint8Array(buffer)
+
+    // RIFF header
+    expect(String.fromCharCode(bytes[0])).toBe('R')
+    expect(String.fromCharCode(bytes[1])).toBe('I')
+    expect(String.fromCharCode(bytes[2])).toBe('F')
+    expect(String.fromCharCode(bytes[3])).toBe('F')
+
+    // WAVE format
+    expect(String.fromCharCode(bytes[8])).toBe('W')
+    expect(String.fromCharCode(bytes[9])).toBe('A')
+    expect(String.fromCharCode(bytes[10])).toBe('V')
+    expect(String.fromCharCode(bytes[11])).toBe('E')
+  })
+
+  it('throws when Gemini response has no audio data', async () => {
+    const mockResponse = new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ text: 'no audio here' }] } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'test-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await expect(fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Test', voice: 'Kore' }),
+    })).rejects.toThrow('Gemini TTS response missing audio data')
+  })
+
+  it('throws when Gemini API returns non-OK status', async () => {
+    const mockResponse = new Response('Unauthorized', { status: 401 })
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+
+    const provider = await getSpeechProvider({ apiKey: 'bad-key' })
+    const speechResult = provider.speech('gemini-2.5-flash-preview-tts')
+    const fetchFn = speechResult.fetch!
+
+    await expect(fetchFn(new URL('http://test'), {
+      body: JSON.stringify({ model: 'gemini-2.5-flash-preview-tts', input: 'Test', voice: 'Kore' }),
+    })).rejects.toThrow('Gemini TTS request failed: 401')
+  })
+})

--- a/packages/stage-ui/src/stores/providers/google-gemini-speech.ts
+++ b/packages/stage-ui/src/stores/providers/google-gemini-speech.ts
@@ -1,0 +1,265 @@
+import type { SpeechProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import type { ModelInfo, ProviderMetadata, VoiceInfo } from '../providers'
+
+const PROVIDER_ID = 'google-gemini-audio-speech'
+const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta'
+const DEFAULT_MODEL = 'gemini-2.5-flash-preview-tts'
+
+const GOOGLE_GEMINI_TTS_MODELS = [
+  'gemini-2.5-flash-preview-tts',
+  'gemini-2.5-pro-preview-tts',
+  'gemini-3.1-flash-tts-preview',
+] as const
+
+const GOOGLE_GEMINI_TTS_VOICES: [string, string][] = [
+  ['Zephyr', 'Bright'],
+  ['Puck', 'Upbeat'],
+  ['Charon', 'Informative'],
+  ['Kore', 'Firm'],
+  ['Fenrir', 'Excitable'],
+  ['Leda', 'Youthful'],
+  ['Orus', 'Firm'],
+  ['Aoede', 'Breezy'],
+  ['Callirrhoe', 'Easy-going'],
+  ['Autonoe', 'Bright'],
+  ['Enceladus', 'Breathy'],
+  ['Iapetus', 'Clear'],
+  ['Umbriel', 'Easy-going'],
+  ['Algieba', 'Smooth'],
+  ['Despina', 'Smooth'],
+  ['Erinome', 'Clear'],
+  ['Algenib', 'Gravelly'],
+  ['Rasalgethi', 'Informative'],
+  ['Laomedeia', 'Upbeat'],
+  ['Achernar', 'Soft'],
+  ['Alnilam', 'Firm'],
+  ['Schedar', 'Even'],
+  ['Gacrux', 'Mature'],
+  ['Pulcherrima', 'Forward'],
+  ['Achird', 'Friendly'],
+  ['Zubenelgenubi', 'Casual'],
+  ['Vindemiatrix', 'Gentle'],
+  ['Sadachbia', 'Lively'],
+  ['Sadaltager', 'Knowledgeable'],
+  ['Sulafat', 'Warm'],
+]
+
+/** Wraps raw PCM16 mono data in a minimal WAV container. */
+function wrapPCM16InWAV(pcmBytes: Uint8Array, sampleRate = 24000): Uint8Array {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8)
+  const blockAlign = numChannels * (bitsPerSample / 8)
+  const header = new ArrayBuffer(44)
+  const view = new DataView(header)
+
+  const writeStr = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++)
+      view.setUint8(offset + i, str.charCodeAt(i))
+  }
+
+  writeStr(0, 'RIFF')
+  view.setUint32(4, 36 + pcmBytes.length, true)
+  writeStr(8, 'WAVE')
+
+  writeStr(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, numChannels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, byteRate, true)
+  view.setUint16(32, blockAlign, true)
+  view.setUint16(34, bitsPerSample, true)
+
+  writeStr(36, 'data')
+  view.setUint32(40, pcmBytes.length, true)
+
+  const wav = new Uint8Array(44 + pcmBytes.length)
+  wav.set(new Uint8Array(header), 0)
+  wav.set(pcmBytes, 44)
+  return wav
+}
+
+/** Decodes a base64 string into a Uint8Array. */
+function base64ToBytes(base64: string): Uint8Array {
+  const binaryString = atob(base64)
+  const bytes = new Uint8Array(binaryString.length)
+  for (let i = 0; i < binaryString.length; i++)
+    bytes[i] = binaryString.charCodeAt(i)
+  return bytes
+}
+
+function normalizeBaseUrl(value: unknown): string {
+  let base = typeof value === 'string' ? value.trim() : ''
+  if (!base)
+    base = DEFAULT_BASE_URL
+  if (base.endsWith('/'))
+    base = base.slice(0, -1)
+  return base
+}
+
+function normalizeApiKey(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/**
+ * Custom fetch adapter that translates an OpenAI-compatible TTS request
+ * into a Gemini generateContent call with AUDIO response modality.
+ */
+function createAudioFetch(apiKey: string, baseUrl: string) {
+  return async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (!init?.body || typeof init.body !== 'string')
+      throw new Error('Invalid request body')
+
+    const body = JSON.parse(init.body)
+    const model = body.model as string
+    const input = body.input as string
+    const temperature = typeof body.temperature === 'number' ? body.temperature : undefined
+
+    if (!input)
+      throw new Error('Missing input text for Gemini TTS')
+    if (!model)
+      throw new Error('Missing model for Gemini TTS')
+
+    function buildGenerationConfig(): Record<string, unknown> {
+      const voiceConfig: Record<string, unknown> = {
+        prebuiltVoiceConfig: {
+          voiceName: (body.voice as string) || 'Kore',
+        },
+      }
+
+      return {
+        responseModalities: ['AUDIO'],
+        speechConfig: { voiceConfig },
+        ...(temperature !== undefined ? { temperature } : {}),
+      }
+    }
+
+    const response = await globalThis.fetch(`${baseUrl}/models/${model}:generateContent`, {
+      method: 'POST',
+      headers: {
+        'x-goog-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              { text: input },
+            ],
+          },
+        ],
+        generationConfig: buildGenerationConfig(),
+      }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '')
+      throw new Error(`Gemini TTS request failed: ${response.status} ${errorText}`)
+    }
+
+    const json = await response.json()
+    const audioBase64 = json.candidates?.[0]?.content?.parts?.find(
+      (part: { inlineData?: { data?: string } }) => part.inlineData,
+    )?.inlineData?.data
+
+    if (!audioBase64) {
+      throw new Error('Gemini TTS response missing audio data')
+    }
+
+    const pcmBytes = base64ToBytes(audioBase64)
+    const wavBytes = wrapPCM16InWAV(pcmBytes)
+
+    // NOTICE: wrapPCM16InWAV always creates a fresh Uint8Array, so .buffer is the full
+    // backing ArrayBuffer (not a subarray view into a larger buffer). The `as ArrayBuffer`
+    // cast is needed because .buffer returns ArrayBufferLike in newer TypeScript.
+    return new Response(wavBytes.buffer as ArrayBuffer, {
+      status: 200,
+      headers: { 'Content-Type': 'audio/wav' },
+    })
+  }
+}
+
+function createSpeechProvider(apiKey: string, baseUrl: string): SpeechProviderWithExtraOptions<string, Record<string, unknown>> {
+  return {
+    speech: (model?: string, options?: Record<string, unknown>) => ({
+      baseURL: `${baseUrl}/`,
+      fetch: createAudioFetch(apiKey, baseUrl),
+      ...options,
+      model: model || (options?.model as string | undefined) || DEFAULT_MODEL,
+    }),
+  }
+}
+
+function listModels(): ModelInfo[] {
+  return GOOGLE_GEMINI_TTS_MODELS.map(id => ({
+    id,
+    name: id
+      .split('-')
+      .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' '),
+    provider: PROVIDER_ID,
+    description: 'Gemini API text-to-speech model',
+    capabilities: ['text-to-speech'],
+  } satisfies ModelInfo))
+}
+
+function listVoices(): VoiceInfo[] {
+  return GOOGLE_GEMINI_TTS_VOICES.map(([voiceName, style]) => ({
+    id: voiceName,
+    name: voiceName,
+    provider: PROVIDER_ID,
+    description: style,
+    languages: [{ code: 'auto', title: 'Auto' }],
+    compatibleModels: [...GOOGLE_GEMINI_TTS_MODELS],
+  } satisfies VoiceInfo))
+}
+
+export function buildGoogleGeminiSpeechProvider(
+  baseUrlValidator: (baseUrl: unknown) => { errors: unknown[], reason: string, valid: boolean } | null | undefined,
+): ProviderMetadata {
+  return {
+    id: PROVIDER_ID,
+    category: 'speech',
+    tasks: ['text-to-speech', 'tts'],
+    nameKey: 'settings.pages.providers.provider.google-gemini-audio-speech.title',
+    name: 'Google Gemini',
+    descriptionKey: 'settings.pages.providers.provider.google-gemini-audio-speech.description',
+    description: 'aistudio.google.com',
+    icon: 'i-lobe-icons:gemini',
+    iconColor: 'i-lobe-icons:gemini-color',
+    defaultOptions: () => ({
+      baseUrl: `${DEFAULT_BASE_URL}/`,
+    }),
+    createProvider: async (config: Record<string, unknown>) => {
+      const apiKey = normalizeApiKey(config.apiKey)
+      const baseUrl = normalizeBaseUrl(config.baseUrl)
+      return createSpeechProvider(apiKey, baseUrl)
+    },
+    capabilities: {
+      listModels: async () => listModels(),
+      listVoices: async () => listVoices(),
+    },
+    validators: {
+      chatPingCheckAvailable: false,
+      validateProviderConfig: (config: Record<string, unknown>) => {
+        const errors: Error[] = []
+        if (!normalizeApiKey(config.apiKey))
+          errors.push(new Error('API Key is required.'))
+
+        if (config.baseUrl) {
+          const res = baseUrlValidator(config.baseUrl)
+          if (res)
+            return res
+        }
+
+        return {
+          errors,
+          reason: errors.map(e => e.message).join(', '),
+          valid: errors.length === 0,
+        }
+      },
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1453,7 +1453,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.2.1)
@@ -1492,7 +1492,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -1528,10 +1528,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: ^0.1.7
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -1558,7 +1558,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -1591,7 +1591,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -1612,31 +1612,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: ^4.0.0
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: ^1.3.2
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: ^4.1.0
-        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: ^1.2.1
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: ^3.1.2
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -19916,9 +19916,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -20802,6 +20802,31 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -22790,10 +22815,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -23744,6 +23793,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -24409,6 +24459,12 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -24489,9 +24545,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:
@@ -24710,6 +24766,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -26852,7 +26917,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -26860,7 +26925,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -32787,7 +32852,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@6.24.1: {}
 
@@ -32899,11 +32965,6 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -32988,6 +33049,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -33019,6 +33088,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33130,6 +33212,17 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33362,11 +33455,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -33413,6 +33516,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -33444,6 +33562,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -33462,6 +33587,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -33476,6 +33615,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -33488,6 +33642,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -33742,6 +33906,54 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
+  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

This PR adds a Google Gemini API text-to-speech provider to AIRI's speech provider list.

It supports Gemini TTS models through the Gemini generateContent API with audio response modality, using Gemini's prebuilt voice names. Includes a provider detail page with model/voice/temperature controls and a test playground.

### Included
- Google Gemini speech provider metadata (ID: `google-gemini-audio-speech`)
- Provider detail page at `/settings/providers/speech/google-gemini-audio-speech` (v1 file-based route)
- Static Gemini TTS model list (`gemini-3.1-flash-tts-preview`, `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`)
- Static Gemini prebuilt voice list (30 voices from Gemini docs)
- API key / base URL validation
- Gemini generateContent TTS request handling via custom fetch adapter
- PCM16-to-WAV conversion for browser playback compatibility
- Temperature control (0.0-2.0, conditionally passed to `generationConfig.temperature`)
- Card UI polish: matching icon (`i-lobe-icons:gemini` + `i-lobe-icons:gemini-color`) and description (`aistudio.google.com`) with chat Gemini card, removed Paid/Cloud tags
- Fixed provider card overflow across 4 module pages (`of-x-auto` → `overflow-x-auto`)

### Note: speakingRate removed
`speakingRate` was initially included but has been removed because `gemini-3.1-flash-tts-preview` rejects it as an unknown field in `prebuiltVoiceConfig`. Temperature is preserved and works across all models.

### Out of scope
- Google Cloud Text-to-Speech
- Vertex AI
- Gemini Live API
- Speech-to-text / transcription
- Realtime streaming
- Multi-speaker UI

## Test plan

- [x] 33 unit tests pass (provider metadata, model/voice lists, validation, request construction, temperature inclusion/omission, audio conversion, error handling)
- [x] `pnpm lint` — 0 errors on changed files
- [x] TypeScript — 0 new errors
- [x] Browser verification: temperature slider renders correctly, gemini-3.1 is in model dropdown, no speakingRate slider

## Additional Context

The Gemini generateContent API uses a different request shape than the OpenAI TTS API (`/v1/audio/speech`). This provider follows the same custom fetch adapter pattern used by OpenRouter audio-speech and MiMo providers to translate AIRI's OpenAI-compatible speech contract into the vendor-specific API format.

Temperature is only included in the API request when explicitly set by the user, avoiding unnecessary override of API defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)