### PR TITLE
chore(docs): keep AtomGit acknowledgement in Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,6 @@ flowchart TD
 
 ## Acknowledgements
 
-- [AtomGit](https://gitcode.com/moeru-ai/airi): for hosting AIRI in mainland China and helping local users access the project and Release downloads faster.
 - [Reka UI](https://github.com/unovue/reka-ui): for designing the documentation site, the new landing page is based on this, as well as implementing a massive amount of UI components. (shadcn-vue is using Reka UI as the headless, do checkout!)
 - [pixiv/ChatVRM](https://github.com/pixiv/ChatVRM)
 - [josephrocca/ChatVRM-js: A JS conversion/adaptation of parts of the ChatVRM (TypeScript) code for standalone use in OpenCharacters and elsewhere](https://github.com/josephrocca/ChatVRM-js)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -456,7 +456,6 @@ flowchart TD
 
 ## Remerciements
 
-- [AtomGit](https://gitcode.com/moeru-ai/airi) : pour l'hébergement d'AIRI en Chine continentale et l'accès plus rapide au projet ainsi qu'aux téléchargements des Release pour les utilisateurs locaux.
 - [Reka UI](https://github.com/unovue/reka-ui) : pour la conception du site de documentation, la nouvelle page d'accueil est basée sur celui-ci, ainsi que l’implémentation de nombreux composants UI (shadcn-vue utilise Reka UI comme headless)
 - [pixiv/ChatVRM](https://github.com/pixiv/ChatVRM)
 - [josephrocca/ChatVRM-js : conversion/adaptation JS de parties du code ChatVRM (TypeScript) pour utilisation autonome dans OpenCharacters et ailleurs](https://github.com/josephrocca/ChatVRM-js)

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -458,7 +458,6 @@ flowchart TD
 
 ## 謝辞
 
-- [AtomGit](https://gitcode.com/moeru-ai/airi): 中国本土で AIRI をホストし、現地ユーザーがプロジェクトや Release のダウンロードへより速くアクセスできるよう支援してくれています。
 - [Reka UI](https://github.com/unovue/reka-ui): ドキュメントサイトのデザイン。新しいランディングページもここをベースに、膨大な UI コンポーネントに感謝。（shadcn-vue は headless として Reka UI を採用、ぜひチェックを）
 - [pixiv/ChatVRM](https://github.com/pixiv/ChatVRM)
 - [josephrocca/ChatVRM-js: A JS conversion/adaptation of parts of the ChatVRM (TypeScript) code for standalone use in OpenCharacters and elsewhere](https://github.com/josephrocca/ChatVRM-js)

--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -491,7 +491,6 @@ flowchart TD
 
 ## 감사의 말
 
-- [AtomGit](https://gitcode.com/moeru-ai/airi): 중국 본토에서 AIRI를 호스팅하여 현지 사용자가 프로젝트와 Release 다운로드에 더 빠르게 접근할 수 있도록 도와주고 있습니다.
 - [Reka UI](https://github.com/unovue/reka-ui): 문서 사이트 디자인에 활용, 새로운 랜딩 페이지도 이를 기반으로 하며, 수많은 UI 컴포넌트 구현에 감사합니다. (shadcn-vue가 Reka UI를 헤드리스로 사용하고 있으니 확인해 보세요!)
 - [pixiv/ChatVRM](https://github.com/pixiv/ChatVRM)
 - [josephrocca/ChatVRM-js: A JS conversion/adaptation of parts of the ChatVRM (TypeScript) code for standalone use in OpenCharacters and elsewhere](https://github.com/josephrocca/ChatVRM-js)

--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -455,7 +455,6 @@ flowchart TD
 
 ## Благодарности
 
-- [AtomGit](https://gitcode.com/moeru-ai/airi): за размещение AIRI в материковом Китае и помощь местным пользователям с более быстрым доступом к проекту и загрузкам Release.
 - [Reka UI](https://github.com/unovue/reka-ui): за дизайн сайта документации, новая посадочная страница основана на этом, а также реализация огромного количества UI-компонентов. (shadcn-vue использует Reka UI как headless, проверьте!)
 - [pixiv/ChatVRM](https://github.com/pixiv/ChatVRM)
 - [josephrocca/ChatVRM-js: A JS conversion/adaptation of parts of the ChatVRM (TypeScript) code for standalone use in OpenCharacters and elsewhere](https://github.com/josephrocca/ChatVRM-js)

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -452,7 +452,6 @@ flowchart TD
 
 ## Lời cảm ơn
 
-- [AtomGit](https://gitcode.com/moeru-ai/airi): đã lưu trữ AIRI tại Trung Quốc đại lục, giúp người dùng địa phương truy cập dự án và tải Release nhanh hơn.
 - [Reka UI](https://github.com/unovue/reka-ui): Đã thiết kế trang tài liệu, trang chủ mới cũng dựa trên dự án này, đồng thời triển khai rất nhiều thành phần trong giao diện. (shadcn-vue sử dụng Reka UI làm headless, bạn nên xem qua!)
 - [pixiv/ChatVRM](https://github.com/pixiv/ChatVRM)
 - [josephrocca/ChatVRM-js: A JS conversion/adaptation of parts of the ChatVRM (TypeScript) code for standalone use in OpenCharacters and elsewhere](https://github.com/josephrocca/ChatVRM-js)


### PR DESCRIPTION
## Summary
- keep the AtomGit/GitCode acknowledgement only in the Simplified Chinese README
- remove the same acknowledgement from other translated README files

## Checks
- `git diff --check upstream/main...HEAD`
