### PR TITLE
fix(server-runtime): ignore duplicate websocket listener

### DIFF
--- a/apps/stage-tamagotchi/electron.vite.config.ts
+++ b/apps/stage-tamagotchi/electron.vite.config.ts
@@ -69,6 +69,8 @@ export default defineConfig({
     resolve: {
       alias: {
         '@proj-airi/i18n': resolve(join(import.meta.dirname, '..', '..', 'packages', 'i18n', 'src')),
+        '@proj-airi/server-runtime/server': resolve(join(import.meta.dirname, '..', '..', 'packages', 'server-runtime', 'src', 'server', 'index.ts')),
+        '@proj-airi/server-runtime': resolve(join(import.meta.dirname, '..', '..', 'packages', 'server-runtime', 'src', 'index.ts')),
       },
     },
   },

--- a/packages/server-runtime/src/server.test.ts
+++ b/packages/server-runtime/src/server.test.ts
@@ -90,6 +90,19 @@ describe('createServer', async () => {
     await retryStart
   })
 
+  it('treats EADDRINUSE as an existing listener instead of failing startup', async () => {
+    const server = createServer({ hostname: '127.0.0.1', port: 6121 })
+
+    const startTask = server.start()
+    const error = new Error('listen EADDRINUSE: address already in use 127.0.0.1:6121') as NodeJS.ErrnoException
+    error.code = 'EADDRINUSE'
+    serveMocks.rejectServe(error)
+
+    await expect(startTask).resolves.toBeUndefined()
+    expect(serveMocks.disposeCall).toHaveBeenCalledTimes(1)
+    expect(serveMocks.closeCall).toHaveBeenCalledWith(true)
+  })
+
   it('merges nested config updates instead of replacing sibling logger settings', async () => {
     const server = createServer({
       hostname: '127.0.0.1',

--- a/packages/server-runtime/src/server/index.ts
+++ b/packages/server-runtime/src/server/index.ts
@@ -32,6 +32,13 @@ export interface Server {
   updateConfig: (newOptions: ServerOptions) => void
 }
 
+function isAddressInUseError(error: unknown) {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as NodeJS.ErrnoException).code === 'EADDRINUSE'
+}
+
 /**
  * Collects local IP addresses that can be used to reach the server from the LAN.
  *
@@ -189,6 +196,10 @@ export function createServer(opts?: ServerOptions): Server {
         serverInstance = null
         h3App.dispose()
         await instance.close(true).catch(() => {})
+        if (isAddressInUseError(error)) {
+          log.withError(error).warn('WebSocket server port already in use, assuming an existing listener is available')
+          return
+        }
         log.withError(error).error('failed to start WebSocket server')
         throw error
       }


### PR DESCRIPTION
## Summary

- Treat EADDRINUSE during server-runtime WebSocket startup as an existing listener so config sync does not enter an apply/restore error loop.
- Add a regression test for the duplicate-listener startup path.
- Point stage-tamagotchi Electron main dev aliases at server-runtime source so dev uses the patched source instead of stale dist output.

## Testing

- pnpm exec vitest run packages/server-runtime/src/server.test.ts
- pnpm -F @proj-airi/server-runtime typecheck
- pnpm -F @proj-airi/stage-tamagotchi typecheck
- pnpm exec eslint apps/stage-tamagotchi/electron.vite.config.ts packages/server-runtime/src/server/index.ts packages/server-runtime/src/server.test.ts