### PR TITLE
fix(stage): safelist settings entry icons

### DIFF
--- a/docs/ai/context/plans/2026-05-09-character-cards-cloud-sync-design.md
+++ b/docs/ai/context/plans/2026-05-09-character-cards-cloud-sync-design.md
@@ -60,8 +60,8 @@ Server `characters` 表（[`apps/server/src/schemas/characters.ts`](../../../app
 新建文件 `apps/server/src/schemas/user-characters.ts`：
 
 ```ts
-import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
 import type { AiriCard } from '@proj-airi/stage-ui/types/airi-card'
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
 
 import { index, jsonb, pgTable, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core'
 
@@ -112,11 +112,11 @@ export type UserActiveCharacter = InferSelectModel<typeof userActiveCharacter>
 `useAiriCardStore` 现有 `cards: Map<string, AiriCard>` + `activeCardId: string` 不变。新增 internal：
 
 ```ts
-type SyncOp = { kind: 'upsert' | 'delete', clientId: string }
+interface SyncOp { kind: 'upsert' | 'delete', clientId: string }
 
 interface SyncState {
   status: 'offline' | 'unauthenticated' | 'syncing' | 'synced' | 'error'
-  pendingOps: Map<string, SyncOp>           // by clientId, 最后一笔操作覆盖前面
+  pendingOps: Map<string, SyncOp> // by clientId, 最后一笔操作覆盖前面
   lastSyncedAt: number | null
   lastError: string | null
 }

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -155,6 +155,17 @@ export function sharedUnoConfig() {
     safelist: [
       ...'prose prose-sm m-auto text-left'.split(' '),
       ...safelistAllPrimaryBackgrounds(),
+      'i-solar:armchair-2-bold-duotone',
+      'i-solar:battery-charge-bold-duotone',
+      'i-solar:box-minimalistic-bold-duotone',
+      'i-solar:database-bold-duotone',
+      'i-solar:emoji-funny-square-bold-duotone',
+      'i-solar:filters-bold-duotone',
+      'i-solar:layers-bold-duotone',
+      'i-solar:leaf-bold-duotone',
+      'i-solar:people-nearby-bold-duotone',
+      'i-solar:user-circle-bold-duotone',
+      'i-solar:wi-fi-router-bold-duotone',
     ],
     // hyoban/unocss-preset-shadcn: Use shadcn ui with UnoCSS
     // https://github.com/hyoban/unocss-preset-shadcn


### PR DESCRIPTION
  ## Summary

  - Safelist settings entry icons used through route meta.
  - Fix settings home entry icons missing on first render before visiting child settings pages.

  ## Details

  Settings home entries render `IconItem` icons from `route.meta.icon` through a dynamic `:class` binding. UnoCSS may
  not generate those icon utilities on the initial settings page render because the classes are only present as route
  metadata, so the icons appear only after navigating into pages that contain static icon usages.

  This adds a focused safelist for settings entry icons in `uno.config.ts`.

  ## Testing

  - `pnpm exec moeru-lint uno.config.ts`
  - `pnpm -F @proj-airi/stage-tamagotchi typecheck`
  - `pnpm -F @proj-airi/stage-pages typecheck`