### PR TITLE
docs(readme): refresh release download links

### DIFF
--- a/.github/workflows/update-post-release-readme-urls.yml
+++ b/.github/workflows/update-post-release-readme-urls.yml
@@ -3,11 +3,12 @@ name: Update (Post Release) README URLs
 on:
   release:
     types:
+      - published
       - released
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g., v0.9.0-alpha.7)'
+        description: 'Release tag (e.g., v0.10.2)'
         required: true
         type: string
 
@@ -16,6 +17,8 @@ permissions:
 
 jobs:
   update:
+    # Keep prereleases from replacing the stable README download buttons.
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -48,7 +48,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -34,7 +34,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -50,7 +50,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -35,7 +35,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -51,7 +51,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"

--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -32,7 +32,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -48,7 +48,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"

--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -32,7 +32,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -48,7 +48,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -32,7 +32,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -48,7 +48,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -34,7 +34,7 @@
 
 <p float="left" align="center">
   <!-- readme-section:release-binary-windows -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-windows-x64-setup.exe">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-windows-x64-setup.exe">
     <picture>
       <source
         width="33%"
@@ -50,7 +50,7 @@
     </picture>
   </a>
   <!-- readme-section:release-binary-macos -->
-  <a href="https://github.com/moeru-ai/airi/releases/download/v0.9.0/AIRI-0.9.0-darwin-arm64.dmg">
+  <a href="https://github.com/moeru-ai/airi/releases/download/v0.10.2/AIRI-0.10.2-darwin-arm64.dmg">
     <picture>
       <source
         width="33%"


### PR DESCRIPTION
## Summary

- Update README desktop download buttons from v0.9.0 assets to the current v0.10.2 release assets.
- Apply the same Windows/macOS link refresh across localized README files.
- Add the `published` release activity to cover stable releases published from drafts, while gating out prereleases so alpha/beta tags cannot rewrite stable README download buttons.

## Self-review

- Scope is limited to README download URLs and the existing post-release URL updater workflow.
- Verified the latest GitHub release exposes `AIRI-0.10.2-windows-x64-setup.exe` and `AIRI-0.10.2-darwin-arm64.dmg`.
- Verified no stale `v0.9.0` / `AIRI-0.9.0` README download links remain in the touched README files.
- Verified automatic release-triggered updates now skip `github.event.release.prerelease`; manual dispatch remains available for explicit updates.

## Verification

- `git diff --check upstream/main...HEAD`
- `gh api repos/moeru-ai/airi/releases/latest --jq ' .assets[].browser_download_url ' | rg 'AIRI-0\\.10\\.2-(windows-x64-setup\\.exe|darwin-arm64\\.dmg)$'`\n- `rg -n "v0\\.9\\.0|AIRI-0\\.9\\.0|static-cn-proj-airi.*versions/v" README.md docs/README*.md .github/workflows/update-post-release-readme-urls.yml` exits 1 because there are no stale matches.\n- `pnpm typecheck` previously failed on existing `packages/plugin-sdk-tamagotchi` type errors around `registerToolsetPrompt` / `ToolsetPromptManifest`.\n- `pnpm lint` previously reported existing repo-wide lint errors; none are in the touched README/workflow files.