### PR TITLE
fix(ci): open PR for sponsors updates

### DIFF
--- a/.github/workflows/sponsors-svg.yml
+++ b/.github/workflows/sponsors-svg.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -35,7 +36,36 @@ jobs:
       - name: Generate sponsors svg
         run: pnpm run sponsors:generate
 
-      - uses: stefanzweifel/git-auto-commit-action@v6
-        with:
-          commit_message: 'chore: update sponsors svg'
-          commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+      - name: Create or update sponsors PR
+        env:
+          GH_TOKEN: ${{ secrets.PAT_SLASH_COMMAND_DISPATCH || github.token }}
+          SPONSORS_BRANCH: automation/update-sponsors-svg
+        run: |
+          if [ -z "$(git status --porcelain -- docs/content/public/assets/sponsors)" ]; then
+            echo "No sponsors asset changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git fetch origin "${SPONSORS_BRANCH}:refs/remotes/origin/${SPONSORS_BRANCH}" || true
+          git checkout -B "$SPONSORS_BRANCH"
+          git add docs/content/public/assets/sponsors
+          git commit -m "chore: update sponsors svg"
+          git push --force-with-lease origin "$SPONSORS_BRANCH"
+
+          if gh pr view "$SPONSORS_BRANCH" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh pr edit "$SPONSORS_BRANCH" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "chore: update sponsors svg" \
+              --body "This PR updates generated SponsorKit assets from the scheduled sponsors workflow."
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$SPONSORS_BRANCH" \
+              --title "chore: update sponsors svg" \
+              --body "This PR updates generated SponsorKit assets from the scheduled sponsors workflow."
+          fi


### PR DESCRIPTION
## Summary

- change the sponsors workflow to create or update a generated-assets PR instead of pushing directly to `main`
- publish generated SponsorKit assets to `automation/update-sponsors-svg`
- use the existing `PAT_SLASH_COMMAND_DISPATCH` token when available so the generated PR can trigger downstream checks, with `github.token` as a fallback

## Why

The sponsors generation step now succeeds, but direct pushes to `main` are rejected by repository rules because required checks are expected. A PR-based update path keeps generated assets behind the normal branch protection flow.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sponsors-svg.yml"); puts "yaml ok"'`
- `ruby -e 'require "yaml"; wf=YAML.load_file(".github/workflows/sponsors-svg.yml"); run=wf.fetch("jobs").fetch("generate").fetch("steps").find { |s| s["name"] == "Create or update sponsors PR" }.fetch("run"); IO.popen(["bash", "-n"], "w") { |io| io.write(run) }; abort "bash -n failed" unless $?.success?; puts "bash syntax ok"'`
- `git diff --check`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec moeru-lint .github/workflows/sponsors-svg.yml` (workflow file is ignored by repo lint config; command exited 0 with ignored-file warning)
