### PR TITLE
chore(ci): auto-merge sponsors updates

### DIFF
--- a/.github/workflows/sponsors-svg.yml
+++ b/.github/workflows/sponsors-svg.yml
@@ -36,14 +36,22 @@ jobs:
       - name: Generate sponsors svg
         run: pnpm run sponsors:generate
 
+      - name: Remove private SponsorKit cache
+        run: rm -f docs/content/public/assets/sponsors/.cache.json
+
       - name: Create or update sponsors PR
         env:
-          GH_TOKEN: ${{ secrets.PAT_SLASH_COMMAND_DISPATCH || github.token }}
+          GH_TOKEN: ${{ secrets.PAT_SLASH_COMMAND_DISPATCH }}
           SPONSORS_BRANCH: automation/update-sponsors-svg
         run: |
           if [ -z "$(git status --porcelain -- docs/content/public/assets/sponsors)" ]; then
             echo "No sponsors asset changes to publish."
             exit 0
+          fi
+
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::PAT_SLASH_COMMAND_DISPATCH is required so generated sponsors PRs trigger required checks."
+            exit 1
           fi
 
           git config user.name "github-actions[bot]"
@@ -52,20 +60,34 @@ jobs:
 
           git fetch origin "${SPONSORS_BRANCH}:refs/remotes/origin/${SPONSORS_BRANCH}" || true
           git checkout -B "$SPONSORS_BRANCH"
-          git add docs/content/public/assets/sponsors
+          git add docs/content/public/assets/sponsors/sponsors.json docs/content/public/assets/sponsors/sponsors.svg
           git commit -m "chore: update sponsors svg"
           git push --force-with-lease origin "$SPONSORS_BRANCH"
 
-          if gh pr view "$SPONSORS_BRANCH" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh pr edit "$SPONSORS_BRANCH" \
+          PR_NUMBER="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$SPONSORS_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" \
               --repo "$GITHUB_REPOSITORY" \
               --title "chore: update sponsors svg" \
               --body "This PR updates generated SponsorKit assets from the scheduled sponsors workflow."
+            PR_TARGET="$PR_NUMBER"
           else
-            gh pr create \
+            PR_TARGET="$(gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head "$SPONSORS_BRANCH" \
               --title "chore: update sponsors svg" \
-              --body "This PR updates generated SponsorKit assets from the scheduled sponsors workflow."
+              --body "This PR updates generated SponsorKit assets from the scheduled sponsors workflow.")"
           fi
+
+          gh pr merge "$PR_TARGET" \
+            --repo "$GITHUB_REPOSITORY" \
+            --auto \
+            --squash \
+            --delete-branch


### PR DESCRIPTION
## Summary

- request auto-merge for generated sponsors update PRs after creating or updating them
- keep branch protection intact by letting required checks complete before GitHub merges the PR

## Why

The sponsors workflow now creates a PR instead of pushing directly to `main`, but without auto-merge each scheduled run still needs a maintainer to click merge. This keeps the PR/checks flow while making the update path unattended when repository rules allow auto-merge.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sponsors-svg.yml"); puts "yaml ok"'`
- `ruby -e 'require "yaml"; wf=YAML.load_file(".github/workflows/sponsors-svg.yml"); run=wf.fetch("jobs").fetch("generate").fetch("steps").find { |s| s["name"] == "Create or update sponsors PR" }.fetch("run"); IO.popen(["bash", "-n"], "w") { |io| io.write(run) }; abort "bash -n failed" unless $?.success?; puts "bash syntax ok"'`
- `git diff --check`
- `pnpm install --frozen-lockfile --ignore-scripts`
