### PR TITLE
fix(telegram-bot): skip empty structured messages

### DIFF
--- a/services/telegram-bot/src/bots/telegram/agent/actions/send-message.test.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/send-message.test.ts
@@ -45,6 +45,16 @@ describe('parseMayStructuredMessage', () => {
     expect(result).toMatchObject({ messages: [text], reply_to_message_id: undefined })
   })
 
+  it('should return null when structured output has an empty messages array', () => {
+    const result = parseMayStructuredMessage('{"messages":[]}')
+    expect(result).toBeNull()
+  })
+
+  it('should return null when structured output has only blank messages', () => {
+    const result = parseMayStructuredMessage('{"messages":["", "   "]}')
+    expect(result).toBeNull()
+  })
+
   it('should return an array of messages from multi-line elements of input', () => {
     const result = parseMayStructuredMessage(`{"messages": [
 "Hello,

--- a/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
+++ b/services/telegram-bot/src/bots/telegram/agent/actions/send-message.ts
@@ -26,7 +26,8 @@ export function parseMayStructuredMessage(responseText: string) {
     logger.withField('text', JSON.stringify(responseText)).withField('result', result).log('Multiple messages detected')
 
     const parsedResponse = parse(result[0]) as ({ messages?: unknown, reply_to_message_id?: unknown } | undefined)
-    const messages = Array.isArray(parsedResponse?.messages)
+    const hasMessagesArray = Array.isArray(parsedResponse?.messages)
+    const messages = hasMessagesArray
       ? parsedResponse.messages.filter((message): message is string => typeof message === 'string' && message.trim() !== '')
       : []
     const replyToMessageId = typeof parsedResponse?.reply_to_message_id === 'string'
@@ -35,6 +36,10 @@ export function parseMayStructuredMessage(responseText: string) {
 
     if (messages.length > 0) {
       return { messages, reply_to_message_id: replyToMessageId }
+    }
+
+    if (hasMessagesArray) {
+      return null
     }
 
     return { messages: [responseText], reply_to_message_id: replyToMessageId }


### PR DESCRIPTION
## Summary
- Treat an explicit structured `messages` array with no sendable text as a no-op.
- Preserve the existing raw-text fallback for omitted or non-array `messages` fields.
- Add regression coverage for empty and blank-only structured message arrays.

## Why
The Telegram bot system prompt documents that the model can ignore a response by returning an object with an empty `messages` array. Before this change, `parseMayStructuredMessage('{"messages":[]}')` fell back to sending the raw JSON text instead of using the existing `sendMessage` no-op branch.

## Validation
- `git diff --check`
- Isolated parser behavior check for normal message, omitted `messages` fallback, non-array fallback, empty array no-op, and blank-only array no-op.

Note: I also attempted the targeted Vitest command, but this sparse clone could not install the test dependencies because repeated `pnpm install --frozen-lockfile --ignore-scripts --filter @proj-airi/telegram-bot...` runs failed with npm registry `ECONNRESET` fetch errors before `vitest` was available.
