### PR TITLE
fix(tamagotchi): include stream state in chat sync snapshots

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/stores/chat-sync.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/chat-sync.test.ts
@@ -72,6 +72,8 @@ interface MockState {
   setSessionMessages: ReturnType<typeof vi.fn>
   getSessionMessages: ReturnType<typeof vi.fn>
   ingest: ReturnType<typeof vi.fn>
+  sending: Ref<boolean>
+  streamingMessage: Ref<{ role: string, content: string, slices: unknown[], tool_results: unknown[], createdAt?: number }>
 }
 
 let mockState: MockState
@@ -94,13 +96,13 @@ vi.mock('@proj-airi/stage-ui/stores/chat/session-store', () => ({
 
 vi.mock('@proj-airi/stage-ui/stores/chat/stream-store', () => ({
   useChatStreamStore: () => ({
-    streamingMessage: ref({ role: 'assistant', content: '', slices: [], tool_results: [] }),
+    streamingMessage: mockState.streamingMessage,
   }),
 }))
 
 vi.mock('@proj-airi/stage-ui/stores/chat', () => ({
   useChatOrchestratorStore: () => ({
-    sending: ref(false),
+    sending: mockState.sending,
     ingest: mockState.ingest,
   }),
 }))
@@ -170,6 +172,8 @@ describe('useChatSyncStore authority ingest failures', async () => {
     const ingest = vi.fn(async () => {
       throw new Error('Remote sent 403 response: {"error":{"message":"This model is not available in your region.","code":403}}')
     })
+    const sending = ref(false)
+    const streamingMessage = ref({ role: 'assistant', content: '', slices: [], tool_results: [] })
 
     mockState = {
       activeSessionId,
@@ -179,6 +183,8 @@ describe('useChatSyncStore authority ingest failures', async () => {
       setSessionMessages,
       getSessionMessages,
       ingest,
+      sending,
+      streamingMessage,
     }
 
     vi.stubGlobal('BroadcastChannel', MockBroadcastChannel)
@@ -367,6 +373,63 @@ describe('useChatSyncStore authority ingest failures', async () => {
     })
 
     peer.close()
+    store.dispose()
+  })
+
+  /**
+   * @example
+   * it('returns the active stream state when a follower requests its initial snapshot', async () => {
+   *   // authority is mid-response
+   *   // follower request receives both session and stream state in one full snapshot
+   * })
+   */
+  it('returns session and stream state together for late-joining followers', async () => {
+    mockState.sending.value = true
+    mockState.streamingMessage.value = {
+      role: 'assistant',
+      content: 'partial answer',
+      slices: [{ type: 'text', text: 'partial answer' }],
+      tool_results: [],
+      createdAt: 123,
+    }
+
+    const store = useChatSyncStore()
+    store.initialize('authority')
+
+    const follower = new MockBroadcastChannel('airi:stage-tamagotchi:chat-sync')
+    const received: unknown[] = []
+    follower.addEventListener('message', ((event: MessageEvent) => {
+      received.push(event.data)
+    }) as EventListener)
+
+    follower.postMessage({
+      type: 'request-snapshot',
+      requestId: 'req-snapshot',
+      senderId: 'follower',
+    })
+
+    await vi.waitFor(() => {
+      expect(received).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          type: 'full-snapshot',
+          authorityId: expect.any(String),
+          snapshot: expect.objectContaining({
+            session: expect.objectContaining({
+              activeSessionId: 'session-1',
+            }),
+            stream: expect.objectContaining({
+              sending: true,
+              streamingMessage: expect.objectContaining({
+                content: 'partial answer',
+                createdAt: 123,
+              }),
+            }),
+          }),
+        }),
+      ]))
+    })
+
+    follower.close()
     store.dispose()
   })
 

--- a/apps/stage-tamagotchi/src/renderer/stores/chat-sync.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/chat-sync.ts
@@ -37,6 +37,11 @@ interface StreamSnapshotPayload {
   streamingMessage: StreamingAssistantMessage
 }
 
+interface FullSnapshotPayload {
+  session: SessionSnapshotPayload
+  stream: StreamSnapshotPayload
+}
+
 interface IngestCommandPayload {
   text: string
   attachments?: AttachmentPayload[]
@@ -55,6 +60,7 @@ type ChatSyncMessage
     | { type: 'request-snapshot', requestId: string, senderId: string }
     | { type: 'session-snapshot', authorityId: string, snapshot: SessionSnapshotPayload }
     | { type: 'stream-snapshot', authorityId: string, snapshot: StreamSnapshotPayload }
+    | { type: 'full-snapshot', authorityId: string, snapshot: FullSnapshotPayload }
     | { type: 'command', authorityId?: string, requestId: string, senderId: string, command: 'ingest', payload: IngestCommandPayload }
     | { type: 'command', authorityId?: string, requestId: string, senderId: string, command: 'retry', payload: RetryCommandPayload }
     | { type: 'command', authorityId?: string, requestId: string, senderId: string, command: 'cleanup', payload: { sessionId?: string } }
@@ -223,6 +229,20 @@ export const useChatSyncStore = defineStore('stage-tamagotchi:chat-sync', () => 
       type: 'stream-snapshot',
       authorityId: instanceId,
       snapshot: buildStreamSnapshot(),
+    })
+  }
+
+  function broadcastFullSnapshot() {
+    if (mode.value !== 'authority')
+      return
+
+    post({
+      type: 'full-snapshot',
+      authorityId: instanceId,
+      snapshot: {
+        session: buildSessionSnapshot(),
+        stream: buildStreamSnapshot(),
+      },
     })
   }
 
@@ -446,7 +466,7 @@ export const useChatSyncStore = defineStore('stage-tamagotchi:chat-sync', () => 
         return
       case 'request-snapshot':
         if (mode.value === 'authority')
-          broadcastSessionSnapshot()
+          broadcastFullSnapshot()
         return
       case 'session-snapshot':
         if (mode.value !== 'follower')
@@ -459,6 +479,13 @@ export const useChatSyncStore = defineStore('stage-tamagotchi:chat-sync', () => 
           return
         authorityId.value = message.authorityId
         applyStreamSnapshot(message.snapshot)
+        return
+      case 'full-snapshot':
+        if (mode.value !== 'follower')
+          return
+        authorityId.value = message.authorityId
+        applySessionSnapshot(message.snapshot.session)
+        applyStreamSnapshot(message.snapshot.stream)
         return
       case 'command':
         void handleCommand(message)


### PR DESCRIPTION
## Summary
- Return a single `full-snapshot` for `request-snapshot` that contains both chat session state and stream state.
- Apply full snapshots on follower windows by restoring session data and the current `sending` / `streamingMessage` together.
- Add a regression test for a follower joining while the authority window is already streaming a response.

## Why
`request-snapshot` previously only triggered a `session-snapshot`. A follower that joins while the authority is already sending can recover the persisted chat history, but it may miss the in-progress `streamingMessage` until a later stream-state broadcast. The chat history UI uses `sending` and `streamingMessage` to render the active assistant bubble, so the initial snapshot should include both pieces of state.

## Validation
- `git diff --check`

Targeted Vitest was attempted in this sparse checkout, but `vitest` is not installed. Installing dependencies was blocked by repeated npm registry `ECONNRESET` failures, so the test could not be executed locally here.
