### PR TITLE
chore(stage-tamagotchi-godot): use stable path for main scene

### DIFF
--- a/engines/stage-tamagotchi-godot/project.godot
+++ b/engines/stage-tamagotchi-godot/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="stage-tamagotchi-godot"
-run/main_scene="uid://c4t68p7ibkjxg"
+run/main_scene="res://scenes/stage-root.tscn"
 config/features=PackedStringArray("4.6", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
<img width="1369" height="741" alt="img_v3_0211v_f750f17c-2681-4cc1-8e39-489771d1e8xx" src="https://github.com/user-attachments/assets/adc6114b-6c26-4dee-ad6b-1f3b6f9fe0ef" />

use a stable path so that the main scene can be resolved in a fresh clone env