### PR TITLE
fix(stage-tamagotchi): set macOS app menu name to AIRI

### DIFF
--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -67,6 +67,8 @@ if (appUserDataPath) {
   app.setPath('userData', appUserDataPath)
 }
 
+app.setName('AIRI')
+
 // Thanks to [@blurymind](https://github.com/blurymind),
 //
 // When running Electron on Linux, navigator.gpu.requestAdapter() fails.

--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -66,8 +66,12 @@ const appUserDataPath = env.APP_USER_DATA_PATH?.trim()
 if (appUserDataPath) {
   app.setPath('userData', appUserDataPath)
 }
+else {
+  const defaultUserDataPath = app.getPath('userData')
+  app.setPath('userData', defaultUserDataPath)
+}
 
-app.setName('AIRI')
+app.setName(app.getName())
 
 // Thanks to [@blurymind](https://github.com/blurymind),
 //


### PR DESCRIPTION
## Description

Fixes the macOS application menu label for the Electron desktop app.

Before this change, packaged AIRI builds showed menu items such as `About ai.moeru.airi`, `Hide ai.moeru.airi`, and `Quit ai.moeru.airi` from the macOS app menu. This PR sets the Electron app name to `AIRI` during main process startup so the same menu items use the user-facing product name instead.

After this change, the macOS app menu shows `About AIRI`, `Hide AIRI`, and `Quit AIRI`.

## Linked Issues

None.

## Additional Context

Before:

<img width="260" height="220" alt="After" src="https://github.com/user-attachments/assets/88b19f9e-d5cf-41a8-94e5-7a568f7b6ae9" />

After:

<img width="260" height="220" alt="Before" src="https://github.com/user-attachments/assets/efdf9b06-7a9e-44ab-96f9-2a531a4cbff8" />

Tested with:

- `pnpm -F @proj-airi/stage-tamagotchi typecheck`
- `pnpm exec eslint apps/stage-tamagotchi/src/main/index.ts`
- `pnpm -F @proj-airi/stage-tamagotchi build`