### PR TITLE
fix(ui-server-auth): clarify social-only email sign-in hint

### DIFF
--- a/apps/ui-server-auth/src/pages/sign-in.vue
+++ b/apps/ui-server-auth/src/pages/sign-in.vue
@@ -149,7 +149,7 @@ async function handleIdentify(event: Event) {
     if (result.exists && !result.hasPassword) {
       // User signed up via a social provider only. Stay on the identifier step
       // so the OAuth buttons remain visible, and steer them there with a hint.
-      errorMessage.value = t('server.auth.signIn.error.authFailed')
+      errorMessage.value = t('server.auth.signIn.error.socialOnlyNoPassword')
       // NOTICE:
       // We avoid disclosing *which* social provider they used here. The
       // generic OAuth button row is right below; users who registered via
@@ -277,7 +277,7 @@ async function handleEmailSignUp(event: Event) {
          when there's nothing to show; the role swaps to alert when populated. -->
     <div
       :class="[
-        'mb-2 max-w-xs w-full min-h-[1.25rem] text-center text-sm',
+        'mb-2 max-w-sm w-full min-h-[1.25rem] text-center text-sm',
         errorMessage ? 'text-red-500' : 'text-transparent select-none',
       ]"
       :role="errorMessage ? 'alert' : undefined"

--- a/packages/i18n/src/locales/en/server/auth.yaml
+++ b/packages/i18n/src/locales/en/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Sign in failed
     unknown: An unknown error occurred
-    authFailed: Authentication failed. Please try again.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: Please enter a valid email address.
   footer:

--- a/packages/i18n/src/locales/es/server/auth.yaml
+++ b/packages/i18n/src/locales/es/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Error en el inicio de sesión
     unknown: S produjo un error inesperado
-    authFailed: La autenticación ha fallado. Por favor inténtelo otra vez.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Las contraseñas no coinciden.
     invalidEmail: Por favor, introduzca una dirección de correo electrónico válida.
   footer:

--- a/packages/i18n/src/locales/fr/server/auth.yaml
+++ b/packages/i18n/src/locales/fr/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Sign in failed
     unknown: An unknown error occurred
-    authFailed: Authentication failed. Please try again.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: Please enter a valid email address.
   footer:

--- a/packages/i18n/src/locales/ja/server/auth.yaml
+++ b/packages/i18n/src/locales/ja/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Sign in failed
     unknown: An unknown error occurred
-    authFailed: Authentication failed. Please try again.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: Please enter a valid email address.
   footer:

--- a/packages/i18n/src/locales/ko/server/auth.yaml
+++ b/packages/i18n/src/locales/ko/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: 가입 실패
     unknown: 알 수 없는 오류가 발생했습니다
-    authFailed: 인증에 실패했습니다. 다시 시도해 주세요.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: Please enter a valid email address.
   footer:

--- a/packages/i18n/src/locales/ru/server/auth.yaml
+++ b/packages/i18n/src/locales/ru/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Войти не удалось
     unknown: Произошла неизвестная ошибка
-    authFailed: Аутентификация не пройдена. Пожалуйста, попробуйте снова.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Пароли не совпадают.
     invalidEmail: Пожалуйста, введите действительный email.
   footer:

--- a/packages/i18n/src/locales/vi/server/auth.yaml
+++ b/packages/i18n/src/locales/vi/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Sign in failed
     unknown: An unknown error occurred
-    authFailed: Authentication failed. Please try again.
+    socialOnlyNoPassword: This email was registered with Google or GitHub. Sign in with a button below; you can add a password in account settings after signing in.
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: Please enter a valid email address.
   footer:

--- a/packages/i18n/src/locales/zh-Hans/server/auth.yaml
+++ b/packages/i18n/src/locales/zh-Hans/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: 登录失败
     unknown: 发生了未知错误
-    authFailed: Authentication failed. Please try again.
+    socialOnlyNoPassword: 该邮箱通过 Google 或 GitHub 注册，请用下方按钮登录，登录后可在设置中添加密码。
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: 请输入有效格式的电子邮件地址
   footer:

--- a/packages/i18n/src/locales/zh-Hant/server/auth.yaml
+++ b/packages/i18n/src/locales/zh-Hant/server/auth.yaml
@@ -60,7 +60,7 @@ signIn:
   error:
     fallback: Sign in failed
     unknown: An unknown error occurred
-    authFailed: Authentication failed. Please try again.
+    socialOnlyNoPassword: 此電子郵件透過 Google 或 GitHub 註冊，請用下方按鈕登入，登入後可在設定中新增密碼。
     passwordMismatch: Password and confirmation do not match.
     invalidEmail: Please enter a valid email address.
   footer:


### PR DESCRIPTION
## Summary

- Replace misleading `authFailed` copy on the sign-in identify step when `check-email` finds an existing Google/GitHub-only account (no password credential).
- Add `server.auth.signIn.error.socialOnlyNoPassword` with localized **zh-Hans** / **zh-Hant** strings; **ja/ko/es/fr/ru/vi** temporarily use the English text for community follow-up.
- Widen the sign-in error banner from `max-w-xs` to `max-w-sm` so the hint wraps more cleanly.

## Test plan

- [ ] `pnpm -F @proj-airi/ui-server-auth build` (if testing via `apps/server` on `:3000`)
- [ ] Open `/auth/sign-in`, enter an email registered with Google/GitHub only → see `socialOnlyNoPassword` hint (not “Authentication failed”)
- [ ] Confirm OAuth buttons remain on the identify step
- [ ] Switch locale to zh-Hans / zh-Hant and verify localized copy


Made with [Cursor](https://cursor.com)