### PR TITLE
chore(server): remove unused CLIENT_URL from env template

### DIFF
--- a/apps/server/.env
+++ b/apps/server/.env
@@ -12,7 +12,6 @@ AUTH_GITHUB_CLIENT_SECRET=""
 STRIPE_SECRET_KEY=""
 STRIPE_WEBHOOK_SECRET=""
 
-CLIENT_URL=""
 API_SERVER_URL=""
 
 # Comma-separated browser origins for CORS (/api/*) and Stripe return URLs.


### PR DESCRIPTION
## Summary

- Remove dead `CLIENT_URL` from `apps/server/.env` — it was dropped from `env.ts` in #1376 and is no longer read anywhere in the server.
- Auth trusted origins now come from `API_SERVER_URL`, `ADDITIONAL_TRUSTED_ORIGINS`, request Origin/Referer, and localhost wildcards (`getAuthTrustedOrigins`).
- Stripe / origin-less client redirects use `WEB_APP_URL` instead.

## Test plan

- [x] Confirmed no `CLIENT_URL` references remain in the repo (grep)
- [ ] N/A — env template only; no runtime behavior change


Made with [Cursor](https://cursor.com)