### PR TITLE
fix(i18n): restore localized retry labels

### DIFF
--- a/packages/i18n/src/locales/fr/stage.yaml
+++ b/packages/i18n/src/locales/fr/stage.yaml
@@ -1,6 +1,6 @@
 chat:
   actions:
-    retry: Retry
+    retry: Réessayer
   message:
     character-name:
       airi: AIRI

--- a/packages/i18n/src/locales/ja/stage.yaml
+++ b/packages/i18n/src/locales/ja/stage.yaml
@@ -1,6 +1,6 @@
 chat:
   actions:
-    retry: Retry
+    retry: 再試行
   message:
     character-name:
       airi: AIRI

--- a/packages/i18n/src/locales/ko/stage.yaml
+++ b/packages/i18n/src/locales/ko/stage.yaml
@@ -1,6 +1,6 @@
 chat:
   actions:
-    retry: Retry
+    retry: 다시 시도
   message:
     character-name:
       airi: AIRI

--- a/packages/i18n/src/locales/vi/stage.yaml
+++ b/packages/i18n/src/locales/vi/stage.yaml
@@ -1,6 +1,6 @@
 chat:
   actions:
-    retry: Retry
+    retry: Thử lại
   message:
     character-name:
       airi: AIRI

--- a/packages/i18n/src/locales/zh-Hant/stage.yaml
+++ b/packages/i18n/src/locales/zh-Hant/stage.yaml
@@ -1,6 +1,6 @@
 chat:
   actions:
-    retry: Retry
+    retry: 重試
   message:
     character-name:
       airi: AIRI


### PR DESCRIPTION
## Summary
- restore localized `chat.actions.retry` labels in the stage UI for French, Japanese, Korean, Vietnamese, and Traditional Chinese
- keep the change limited to existing locale string values

## Why
Current `main` still shows the English `Retry` label in these non-English stage locale files, while neighboring locales and the settings translations already use localized retry labels.

## Validation
- `git diff --check origin/main...HEAD`
- local assertion that each changed locale has a localized `retry` value and no longer has `retry: Retry`
