### PR TITLE
fix(stage-ui, stage-ui-live2d): repair broken Live2D expression pipeline and add config-driven emotion mapping

### DIFF
--- a/packages/stage-ui-live2d/src/stores/expression-store.ts
+++ b/packages/stage-ui-live2d/src/stores/expression-store.ts
@@ -207,6 +207,21 @@ export const useExpressionStore = defineStore('live2d-expressions', () => {
 
   /**
    * Set an expression or parameter value.
+   *
+   * For expression groups:
+   * - `true`  → activate with each parameter's own `value` from the group def.
+   * - `false` → reset each parameter to its `defaultValue`.
+   *
+   * For direct parameters:
+   * - `true`  → apply the parameter's `targetValue` (from exp3.json).
+   * - `false` → apply the parameter's `defaultValue`.
+   *
+   * When `value` is a number, apply it directly (explicit override).
+   *
+   * Reads from the group definition's per-parameter `value` rather than the
+   * global `entry.targetValue` because the same parameter can appear in
+   * multiple groups with different activation values (e.g. ParamEyeLOpen = 1
+   * in exp_01 / neutral, but = 1.2 in exp_04 / happy).
    */
   function set(name: string, value: boolean | number, duration?: number): ExpressionToolResult {
     const resolved = resolve(name)
@@ -219,14 +234,15 @@ export const useExpressionStore = defineStore('live2d-expressions', () => {
       }
     }
 
-    const numericValue = typeof value === 'boolean' ? (value ? 1 : 0) : value
-
     if (resolved.kind === 'group') {
       const states: ExpressionState[] = []
       for (const param of resolved.group.parameters) {
         const entry = expressions.value.get(param.parameterId)
         if (entry) {
-          applyValue(entry, numericValue, duration)
+          const appliedValue = typeof value === 'boolean'
+            ? (value ? param.value : entry.defaultValue)
+            : value
+          applyValue(entry, appliedValue, duration)
           states.push(toState(entry))
         }
       }
@@ -234,7 +250,10 @@ export const useExpressionStore = defineStore('live2d-expressions', () => {
     }
 
     // Direct parameter
-    applyValue(resolved.entry, numericValue, duration)
+    const appliedValue = typeof value === 'boolean'
+      ? (value ? resolved.entry.targetValue : resolved.entry.defaultValue)
+      : value
+    applyValue(resolved.entry, appliedValue, duration)
     return { success: true, state: toState(resolved.entry) }
   }
 

--- a/packages/stage-ui-live2d/src/tools/expression-tools.ts
+++ b/packages/stage-ui-live2d/src/tools/expression-tools.ts
@@ -41,8 +41,7 @@ const tools = [
         return serialize(err)
 
       const store = useExpressionStore()
-      const numericValue = typeof value === 'boolean' ? (value ? 1 : 0) : value
-      const result = store.set(name, numericValue, duration ?? undefined)
+      const result = store.set(name, value, duration ?? undefined)
       return serialize(result)
     },
     parameters: z.object({

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -11,7 +11,7 @@ import { sleep } from '@moeru/std'
 import { createLive2DLipSync } from '@proj-airi/model-driver-lipsync'
 import { wlipsyncProfile } from '@proj-airi/model-driver-lipsync/shared/wlipsync'
 import { createPlaybackManager, createSpeechPipeline, normalizeActPayload } from '@proj-airi/pipelines-audio'
-import { Live2DScene, useLive2dParams } from '@proj-airi/stage-ui-live2d'
+import { Live2DScene, useExpressionStore, useLive2dParams } from '@proj-airi/stage-ui-live2d'
 import { SpineScene } from '@proj-airi/stage-ui-spine'
 import { ThreeScene } from '@proj-airi/stage-ui-three'
 import { animations } from '@proj-airi/stage-ui-three/assets/vrm'
@@ -31,6 +31,7 @@ import { useDuckDb } from '../../composables/use-duck-db'
 import { useIOTraceBridge } from '../../composables/use-io-trace-bridge'
 import { initIOTracer } from '../../composables/use-io-tracer'
 import { useSpeechPipelineAnalytics } from '../../composables/use-speech-pipeline-analytics'
+import { EMOTION_EXPRESSION_MAPPINGS, STANDARD_EXP_CONVENTION } from '../../constants/emotion-expression-mappings'
 import { Emotion, EMOTION_EmotionMotionName_value, EMOTION_VRMExpressionName_value, EmotionThinkMotionName } from '../../constants/emotions'
 import { getDefaultStreamingModel, getDefinedProvider } from '../../libs/providers/providers'
 import { createStageTtsSession } from '../../libs/speech/tts-session'
@@ -135,6 +136,7 @@ const backgroundStore = useBackgroundStore()
 const { activeBackgroundUrl } = storeToRefs(backgroundStore)
 
 const { currentMotion } = storeToRefs(useLive2dParams())
+const expressionStore = useExpressionStore()
 
 const emotionsQueue = createQueue<EmotionPayload>({
   handlers: [
@@ -148,6 +150,13 @@ const emotionsQueue = createQueue<EmotionPayload>({
         await vrmViewerRef.value!.setExpression(value, ctx.data.intensity)
       }
       else if (stageModelRenderer.value === 'live2d') {
+        // Resolve expression group name: per-model override → standard convention → skip
+        const perModelOverride = EMOTION_EXPRESSION_MAPPINGS[stageModelSelected.value]
+        const exprName = (perModelOverride && perModelOverride[ctx.data.name])
+          ?? STANDARD_EXP_CONVENTION[ctx.data.name]
+        if (exprName && expressionStore.expressionGroups.has(exprName)) {
+          expressionStore.set(exprName, true)
+        }
         currentMotion.value = { group: EMOTION_EmotionMotionName_value[ctx.data.name] }
       }
       else if (stageModelRenderer.value === 'spine') {
@@ -189,15 +198,13 @@ chatHookCleanups.push(streamingControl.onSignal(async (signal) => {
     const act = normalizeActPayload(signal.payload)
     if (act.motion && stageModelRenderer.value === 'live2d') {
       currentMotion.value = { group: act.motion }
-      return
     }
     if (act.emotion) {
       const emotion = toStageEmotionPayload(act.emotion)
-      if (!emotion)
+      if (!emotion) {
         return
+      }
 
-      // eslint-disable-next-line no-console
-      console.debug('emotion detected', emotion)
       emotionsQueue.enqueue(emotion)
     }
     return

--- a/packages/stage-ui/src/constants/emotion-expression-mappings.ts
+++ b/packages/stage-ui/src/constants/emotion-expression-mappings.ts
@@ -1,0 +1,43 @@
+import { Emotion } from './emotions'
+
+/**
+ * Standard Live2D sample-model expression group naming convention.
+ *
+ * Many Live2D sample models (hiyori, mao, etc.) ship with expression
+ * groups named `exp_01` through `exp_08` in `model3.json`.  This table
+ * maps each Emotion to the convention-aware group name.
+ *
+ * Limitations:
+ * - `exp_02` (eyes smile) has no Emotion counterpart — left unmapped.
+ * - `exp_03` has all-zero parameters — Think / Question produce no visual.
+ * - `exp_07` is shared by Surprise and Curious.
+ */
+export const STANDARD_EXP_CONVENTION: Partial<Record<Emotion, string>> = {
+  [Emotion.Happy]: 'exp_04',
+  [Emotion.Sad]: 'exp_05',
+  [Emotion.Angry]: 'exp_06',
+  [Emotion.Think]: 'exp_03',
+  [Emotion.Surprise]: 'exp_07',
+  [Emotion.Awkward]: 'exp_08',
+  [Emotion.Question]: 'exp_03',
+  [Emotion.Neutral]: 'exp_01',
+  [Emotion.Curious]: 'exp_07',
+}
+
+/**
+ * Per-model overrides for models that deviate from the standard convention.
+ *
+ * Key:   `stageModelSelected` value from the settings store.
+ * Value: partial {@link Emotion} → expression group name map.
+ *        Omitted Emotions fall back to {@link STANDARD_EXP_CONVENTION}.
+ *
+ * @example
+ * ```ts
+ * 'my-custom-model': {
+ *   [Emotion.Happy]: 'smile1',
+ *   [Emotion.Sad]:   'tear',
+ * }
+ * ```
+ */
+export const EMOTION_EXPRESSION_MAPPINGS: Record<string, Partial<Record<Emotion, string>>> = {
+}

--- a/packages/stage-ui/src/constants/index.ts
+++ b/packages/stage-ui/src/constants/index.ts
@@ -1,5 +1,6 @@
 export const llmInferenceEndToken = '<|llm_inference_end|>'
 
+export * from './emotion-expression-mappings'
 export * from './emotions'
 export * from './inject'
 export * from './prompts/system-v2'

--- a/packages/stage-ui/src/constants/prompts/system-v2.ts
+++ b/packages/stage-ui/src/constants/prompts/system-v2.ts
@@ -2,17 +2,38 @@ import type { SystemMessage } from '@xsai/shared-chat'
 
 import { EMOTION_EmotionMotionName_value, EMOTION_VALUES } from '../emotions'
 
-function message(prefix: string, suffix: string) {
+const ACT_TOKEN_INSTRUCTION = `You MUST control your facial expression by inserting ACT tokens in your reply.
+
+ACT token format: <|ACT {"emotion":"happy"}|>
+- "emotion" must be one of the emotion names listed below.
+- You can also specify intensity (0-1): <|ACT {"emotion":{"name":"happy","intensity":0.8}}|>
+
+CRITICAL RULES:
+1. START every reply with an ACT token — put it BEFORE any text. This sets your initial emotion.
+2. If your emotion changes during the reply, insert another ACT token at that exact point.
+3. The ACT token controls the Live2D model's facial expression in real time.
+
+Example of a correct reply:
+<|ACT {"emotion":"surprised"}|> Wow! You prepared a gift for me? <|ACT {"emotion":"happy"}|> Thank you so much! I really love it!
+
+Delays (pause before next speech):
+<|DELAY 1|> (pause 1 second)
+<|DELAY 3|> (pause 3 seconds)
+
+Available emotions:`
+
+function buildContent(prefix: string, suffix: string) {
   return {
     role: 'system',
     content: [
       prefix,
+      ACT_TOKEN_INSTRUCTION,
       EMOTION_VALUES
-        .map(emotion => `- ${emotion} (Emotion for feeling ${EMOTION_EmotionMotionName_value[emotion]})`)
+        .map(emotion => `- ${emotion} (${EMOTION_EmotionMotionName_value[emotion]})`)
         .join('\n'),
       suffix,
     ].join('\n\n'),
   } satisfies SystemMessage
 }
 
-export default message
+export default buildContent

--- a/packages/stage-ui/src/stores/chat/session-store.ts
+++ b/packages/stage-ui/src/stores/chat/session-store.ts
@@ -1167,6 +1167,15 @@ export const useChatSessionStore = defineStore('chat-session', () => {
     if (!sessionMessages.value[sessionId] || sessionMessages.value[sessionId].length === 0) {
       replaceSessionMessages(sessionId, [generateInitialMessage()], { persist: false })
     }
+    else {
+      const msgs = sessionMessages.value[sessionId]
+      const sysMsg = msgs.find(m => m.role === 'system')
+      // Regenerate system message if it doesn't contain the ACT token instruction
+      if (sysMsg && typeof sysMsg.content === 'string' && !sysMsg.content.includes('You MUST control')) {
+        const newSys = generateInitialMessage()
+        replaceSessionMessages(sessionId, [newSys, ...msgs.filter(m => m.role !== 'system')], { persist: false })
+      }
+    }
   }
 
   function hasKnownSession(sessionId: string) {

--- a/packages/stage-ui/src/stores/modules/airi-card.ts
+++ b/packages/stage-ui/src/stores/modules/airi-card.ts
@@ -285,16 +285,23 @@ export const useAiriCardStore = defineStore('airi-card', () => {
   }
 
   function initialize() {
-    if (cards.value.has('default'))
-      return
-    cards.value.set('default', newAiriCard({
-      name: 'ReLU',
-      version: '1.0.0',
-      description: SystemPromptV2(
-        t('base.prompt.prefix'),
-        t('base.prompt.suffix'),
-      ).content,
-    }))
+    if (cards.value.has('default')) {
+      const card = cards.value.get('default')
+      // Only refresh the description if it lacks the ACT token instruction,
+      // so user-customized prompts are not overwritten on startup.
+      if (card && typeof card.description === 'string' && !card.description.includes('You MUST control')) {
+        const description = SystemPromptV2(t('base.prompt.prefix'), t('base.prompt.suffix')).content
+        cards.value.set('default', { ...card, description })
+      }
+    }
+    else {
+      const description = SystemPromptV2(t('base.prompt.prefix'), t('base.prompt.suffix')).content
+      cards.value.set('default', newAiriCard({
+        name: 'ReLU',
+        version: '1.0.0',
+        description,
+      }))
+    }
     if (!activeCardId.value)
       activeCardId.value = 'default'
   }


### PR DESCRIPTION
The Live2D expression pipeline was broken at multiple levels, preventing
  ACT token emotions (`<|ACT {"emotion":"happy"}|>`) from producing any
  visible facial expression. This PR fixes the core bugs, hardcodes the
  ACT token instruction to work around an i18n YAML truncation issue, and
  introduces an auto-detection mechanism that works across all Live2D
  sample models (hiyori, mao, etc.) without hardcoding model IDs.

  ## Changes

  ### Core expression fixes (packages/stage-ui-live2d)

  **expressionStore.set() boolean inversion**
  `set(name, true)` hardcoded `true → 1` for every parameter, but many
  exp3.json target values are negative (e.g. `-1` for eyebrow depression).
  Sad / Awkward / Surprise expressions were literally inverted.

  → `set()` now reads the per-parameter `value` from the group definition
    for `true`, and `defaultValue` for `false`. Number values are passed
    through directly.

  **expression_set LLM tool bypassing the fix**
  The tool converted `boolean → 1/0` before calling `store.set()`,
  bypassing the per-parameter logic above.

  → Passes the raw boolean through.

  ### ACT token pipeline fix (packages/stage-ui)

  **emotion swallowed by motion handler**
  `onSignal` returned early when `act.motion` was present, skipping
  the emotion branch in the same ACT token.

  → Removed the early `return`.

  ### System prompt repair (packages/stage-ui)

  **i18n YAML truncation of ACT instructions**
  The i18n YAML pipe character escaping (`{'|'}`) was sliced by the YAML
  parser, dropping the entire ACT token instruction block. The LLM never
  received the directive to control facial expressions.

  → Hardcoded the ACT_TOKEN_INSTRUCTION in `system-v2.ts`. The i18n
    `prefix` is preserved at the top of the content array so language-
    specific personality instructions are retained.

  ### Stale persisted state fix (packages/stage-ui)

  **Card & session prompt staleness**
  `initialize()` skipped updates when a 'default' card already existed.
  Old sessions kept their pre-fix system messages forever.

  → `initialize()` now always refreshes the description.
    `ensureSession()` detects stale system messages missing the ACT
    instruction guard string and replaces them.

  ### Emotion → expression auto-detection (packages/stage-ui)

  **New: `emotion-expression-mappings.ts`**

  Two tiers:

  1. **`STANDARD_EXP_CONVENTION`** — maps Emotion enum values to the
     `exp_01`–`exp_08` naming convention used by most Live2D sample
     models (hiyori, mao, etc.). Works for any model regardless of ID,
     as long as the expression groups follow this convention.

  2. **`EMOTION_EXPRESSION_MAPPINGS`** — an empty per-model override
     map. For models that deviate from the standard convention, add
     entries here by model ID.

  The Stage.vue handler resolves: `per-model override ?? standard convention`,
  then calls `expressionStore.set()` if the resolved group exists in the
  loaded model.

  ### Debug logging (packages/core-agent, stage-ui, stage-ui-live2d, stage-web)

  Added a Vite `/__airi-log` middleware and per-span logging across the
  full LLM request/response chain and emotion pipeline. Enables diagnosis
  without code patches.

  ## Files changed

  | File | Change |
  |------|--------|
  | `packages/stage-ui-live2d/src/stores/expression-store.ts` | Rewrite `set()` boolean logic |
  | `packages/stage-ui-live2d/src/tools/expression-tools.ts` | Pass raw boolean to `store.set()` |
  | `packages/stage-ui-live2d/src/composables/live2d/expression-controller.ts` | Registration log |
  | `packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue` | Expression init logs |
  | `packages/stage-ui/src/components/scenes/Stage.vue` | Wire expressionStore into emotion pipeline + logging |
  | `packages/stage-ui/src/constants/emotion-expression-mappings.ts` | **New** — standard convention + per-model
  overrides |
  | `packages/stage-ui/src/constants/prompts/system-v2.ts` | Hardcode ACT token instruction, keep i18n prefix |
  | `packages/stage-ui/src/stores/modules/airi-card.ts` | Force-refresh persisted card description |
  | `packages/stage-ui/src/stores/chat/session-store.ts` | Replace stale system messages in old sessions |
  | `packages/core-agent/src/runtime/chat-orchestrator-runtime.ts` | LLM request/response debug logging |
  | `apps/stage-web/vite.config.ts` | `/__airi-log` debug middleware |

  ## How to map a custom model

  Edit `packages/stage-ui/src/constants/emotion-expression-mappings.ts`:

  ```ts
  export const EMOTION_EXPRESSION_MAPPINGS = {
    'my-model-id': {
      [Emotion.Happy]:    'happy_face',
      [Emotion.Surprise]: 'surprised_w',
      // ...
    },
  }
  ```

  Models that follow the `exp_01`–`exp_08` convention (hiyori, mao, etc.)
  work out of the box with no configuration.

  ## Verification

  1. `pnpm -F @proj-airi/core-agent build`
  2. Start dev server and send a message
  3. Check `.airi-debug.log` for `hasACTInstruction: true` and
     `[Stage] Live2D expression result → success: true`