### PR TITLE
refactor(server): simplify additional trusted origin env to a single string

### DIFF
--- a/apps/server/.env
+++ b/apps/server/.env
@@ -14,9 +14,8 @@ STRIPE_WEBHOOK_SECRET=""
 
 API_SERVER_URL=""
 
-# Comma-separated browser origins for CORS (/api/*) and Stripe return URLs.
-# Required when the Capacitor dev server uses a LAN IP (see ios/App/App/capacitor.config.json),
-# e.g. ADDITIONAL_TRUSTED_ORIGINS="https://10.0.0.129:5273,https://198.18.0.1:5273"
+# Required when the Capacitor dev server uses a LAN IP (not localhost).
+# e.g. ADDITIONAL_TRUSTED_ORIGIN="https://10.0.0.129:5273"
 
 # OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -26,10 +26,10 @@ For local observability infrastructure, use:
 docker compose -f apps/server/docker-compose.otel.yml up -d
 ```
 
-## `ADDITIONAL_TRUSTED_ORIGINS` (LAN / Capacitor dev)
+## `ADDITIONAL_TRUSTED_ORIGIN` (LAN / Capacitor dev)
 
-When the mobile dev server uses a non-localhost origin (for example `https://10.x.x.x:5273` from `cap copy ios` / `capacitor.config.json`), set **`ADDITIONAL_TRUSTED_ORIGINS`** in `apps/server/.env.local` to a comma-separated list of exact origins (parsed and normalized at startup). Example:
+When the mobile dev server uses a non-localhost origin (for example `https://10.x.x.x:5273` from Capacitor live reload), set **`ADDITIONAL_TRUSTED_ORIGIN`** in `apps/server/.env.local` to that exact origin. Example:
 
-`ADDITIONAL_TRUSTED_ORIGINS=https://10.0.0.129:5273,https://198.18.0.1:5273`
+`ADDITIONAL_TRUSTED_ORIGIN=https://10.0.0.129:5273`
 
 Restart the API server after changing this variable.

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -134,7 +134,7 @@ export async function buildApp(deps: AppDeps) {
     .use(
       '/api/*',
       cors({
-        origin: origin => getTrustedOrigin(origin, deps.env.ADDITIONAL_TRUSTED_ORIGINS),
+        origin: origin => getTrustedOrigin(origin, deps.env.ADDITIONAL_TRUSTED_ORIGIN),
         credentials: true,
       }),
     )

--- a/apps/server/src/libs/auth.ts
+++ b/apps/server/src/libs/auth.ts
@@ -93,13 +93,13 @@ function buildWebRedirectUris(env: Env): string[] {
   return [...uris]
 }
 
-function buildTrustedWebRedirectUri(redirectUri: string, additionalTrustedOrigins: readonly string[]): string | null {
+function buildTrustedWebRedirectUri(redirectUri: string, additionalTrustedOrigin: string): string | null {
   try {
     const parsed = new URL(redirectUri)
     if (parsed.pathname !== '/auth/callback')
       return null
 
-    const trustedOrigin = getTrustedOrigin(parsed.origin, additionalTrustedOrigins)
+    const trustedOrigin = getTrustedOrigin(parsed.origin, additionalTrustedOrigin)
     if (!trustedOrigin)
       return null
 
@@ -206,7 +206,7 @@ export function getTrustedOIDCClientIds(): string[] {
 export async function ensureDynamicFirstPartyRedirectUri(
   db: Database,
   request: Request,
-  additionalTrustedOrigins: readonly string[],
+  additionalTrustedOrigin: string,
 ): Promise<void> {
   const url = new URL(request.url)
   const clientId = url.searchParams.get('client_id')
@@ -219,7 +219,7 @@ export async function ensureDynamicFirstPartyRedirectUri(
 
   switch (clientId) {
     case OIDC_CLIENT_ID_WEB:
-      normalizedRedirectUri = buildTrustedWebRedirectUri(redirectUri, additionalTrustedOrigins)
+      normalizedRedirectUri = buildTrustedWebRedirectUri(redirectUri, additionalTrustedOrigin)
       break
     case OIDC_CLIENT_ID_ELECTRON:
       normalizedRedirectUri = buildTrustedElectronRedirectUri(request, redirectUri)

--- a/apps/server/src/libs/env.ts
+++ b/apps/server/src/libs/env.ts
@@ -7,47 +7,6 @@ import { useLogger } from '@guiiai/logg'
 import { injeca } from 'injeca'
 import { check, integer, maxValue, minValue, nonEmpty, object, optional, parse, pipe, string, transform } from 'valibot'
 
-/**
- * Parses `ADDITIONAL_TRUSTED_ORIGINS`: comma-separated absolute origins used for
- * CORS (`/api/*`) and request-derived trusted bases (e.g. Stripe return URLs).
- * Each segment is normalized via `URL.origin` so trailing slashes are stripped.
- *
- * Before:
- * - `" https://10.0.0.129:5273/ , https://198.18.0.1:5273 "`
- *
- * After:
- * - `["https://10.0.0.129:5273", "https://198.18.0.1:5273"]`
- */
-export function parseAdditionalTrustedOriginsEnv(raw: string): string[] {
-  const trimmed = raw.trim()
-  if (!trimmed)
-    return []
-
-  const seen = new Set<string>()
-  const out: string[] = []
-
-  for (const part of trimmed.split(',')) {
-    const entry = part.trim()
-    if (!entry)
-      continue
-
-    let normalized: string
-    try {
-      normalized = new URL(entry).origin
-    }
-    catch {
-      throw new TypeError(`ADDITIONAL_TRUSTED_ORIGINS: invalid URL origin segment "${entry}"`)
-    }
-
-    if (!seen.has(normalized)) {
-      seen.add(normalized)
-      out.push(normalized)
-    }
-  }
-
-  return out
-}
-
 function optionalIntegerFromString(defaultValue: number, envKey: string, minimum: number) {
   return optional(
     pipe(
@@ -87,15 +46,7 @@ const EnvSchema = object({
   // their own origin; only origin-less clients fall back to this.
   WEB_APP_URL: optional(string(), 'https://airi.moeru.ai'),
 
-  // Comma-separated exact origins (e.g. Capacitor dev server `https://10.x:5273`).
-  // Prefer this over broad private-IP regex heuristics in production-like configs.
-  ADDITIONAL_TRUSTED_ORIGINS: optional(
-    pipe(
-      string(),
-      transform(raw => parseAdditionalTrustedOriginsEnv(raw)),
-    ),
-    '',
-  ),
+  ADDITIONAL_TRUSTED_ORIGIN: optional(string(), ''),
 
   DATABASE_URL: pipe(string(), nonEmpty('DATABASE_URL is required')),
   REDIS_URL: pipe(string(), nonEmpty('REDIS_URL is required')),

--- a/apps/server/src/libs/tests/auth.test.ts
+++ b/apps/server/src/libs/tests/auth.test.ts
@@ -140,7 +140,7 @@ describe('ensureDynamicFirstPartyRedirectUri', () => {
     await ensureDynamicFirstPartyRedirectUri(
       db as any,
       new Request('https://api.airi.build/api/auth/oauth2/authorize?client_id=airi-stage-web&redirect_uri=https%3A%2F%2Fpreview.kwaa.workers.dev%2Fauth%2Fcallback'),
-      [],
+      '',
     )
 
     expect(setCalls).toHaveLength(1)
@@ -175,7 +175,7 @@ describe('ensureDynamicFirstPartyRedirectUri', () => {
     await ensureDynamicFirstPartyRedirectUri(
       db as any,
       new Request('https://airi-server-dev.up.railway.app/api/auth/oauth2/authorize?client_id=airi-stage-electron&redirect_uri=https%3A%2F%2Fairi-server-dev.up.railway.app%2Fapi%2Fauth%2Foidc%2Felectron-callback'),
-      [],
+      '',
     )
 
     expect(setCalls).toHaveLength(1)
@@ -195,19 +195,19 @@ describe('ensureDynamicFirstPartyRedirectUri', () => {
     await ensureDynamicFirstPartyRedirectUri(
       db as any,
       new Request('https://api.airi.build/api/auth/oauth2/authorize?client_id=airi-stage-web&redirect_uri=https%3A%2F%2Fevil.example%2Fauth%2Fcallback'),
-      [],
+      '',
     )
 
     await ensureDynamicFirstPartyRedirectUri(
       db as any,
       new Request('https://api.airi.build/api/auth/oauth2/authorize?client_id=airi-stage-web&redirect_uri=https%3A%2F%2Fairi.moeru.ai%2Fother-path'),
-      [],
+      '',
     )
 
     await ensureDynamicFirstPartyRedirectUri(
       db as any,
       new Request('https://api.airi.build/api/auth/oauth2/authorize?client_id=airi-stage-electron&redirect_uri=https%3A%2F%2Fother.example%2Fapi%2Fauth%2Foidc%2Felectron-callback'),
-      [],
+      '',
     )
 
     expect(db.select).not.toHaveBeenCalled()

--- a/apps/server/src/libs/tests/env.test.ts
+++ b/apps/server/src/libs/tests/env.test.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer'
 
 import { describe, expect, it } from 'vitest'
 
-import { parseAdditionalTrustedOriginsEnv, parseEnv } from '../env'
+import { parseEnv } from '../env'
 
 function baseEnv(): Record<string, string> {
   return {
@@ -18,42 +18,22 @@ function baseEnv(): Record<string, string> {
   }
 }
 
-describe('parseAdditionalTrustedOriginsEnv', () => {
-  it('normalizes comma-separated origins and dedupes', () => {
-    expect(parseAdditionalTrustedOriginsEnv('')).toEqual([])
-    expect(parseAdditionalTrustedOriginsEnv(' https://10.0.0.129:5273/ , https://198.18.0.1:5273 ')).toEqual([
-      'https://10.0.0.129:5273',
-      'https://198.18.0.1:5273',
-    ])
-    expect(parseAdditionalTrustedOriginsEnv('https://x.test:5273/,https://x.test:5273')).toEqual([
-      'https://x.test:5273',
-    ])
-  })
-
-  it('throws on invalid segments', () => {
-    expect(() => parseAdditionalTrustedOriginsEnv('not-a-url')).toThrow(/invalid URL origin segment/)
-  })
-})
-
 describe('parseEnv', () => {
   it('parses the required auth and infrastructure environment variables', () => {
     const env = parseEnv(baseEnv())
 
     expect(env.DATABASE_URL).toBe('postgres://example')
     expect(env.REDIS_URL).toBe('redis://example')
-    expect(env.ADDITIONAL_TRUSTED_ORIGINS).toEqual([])
+    expect(env.ADDITIONAL_TRUSTED_ORIGIN).toBe('')
   })
 
-  it('parses ADDITIONAL_TRUSTED_ORIGINS into a normalized origin list', () => {
+  it('passes ADDITIONAL_TRUSTED_ORIGIN through as a string', () => {
     const env = parseEnv({
       ...baseEnv(),
-      ADDITIONAL_TRUSTED_ORIGINS: 'https://10.0.0.129:5273/, https://198.18.0.1:5273',
+      ADDITIONAL_TRUSTED_ORIGIN: 'https://10.0.0.129:5273',
     })
 
-    expect(env.ADDITIONAL_TRUSTED_ORIGINS).toEqual([
-      'https://10.0.0.129:5273',
-      'https://198.18.0.1:5273',
-    ])
+    expect(env.ADDITIONAL_TRUSTED_ORIGIN).toBe('https://10.0.0.129:5273')
   })
 
   it('parses TEST_AUTH_TOKEN with default virtual user settings', () => {

--- a/apps/server/src/routes/auth/index.ts
+++ b/apps/server/src/routes/auth/index.ts
@@ -58,7 +58,7 @@ export async function createAuthRoutes(deps: AuthRoutesDeps) {
       routeLabel: 'auth.api',
     }))
     .use('/api/auth/oauth2/authorize', async (c, next) => {
-      await ensureDynamicFirstPartyRedirectUri(deps.db, c.req.raw, deps.env.ADDITIONAL_TRUSTED_ORIGINS)
+      await ensureDynamicFirstPartyRedirectUri(deps.db, c.req.raw, deps.env.ADDITIONAL_TRUSTED_ORIGIN)
       await next()
     })
     // NOTICE:

--- a/apps/server/src/routes/auth/oidc-userinfo-ban.test.ts
+++ b/apps/server/src/routes/auth/oidc-userinfo-ban.test.ts
@@ -41,7 +41,7 @@ async function buildRoutes(currentUser: SessionUser) {
       api: { getSession: vi.fn(async () => sessionFor(currentUser)) },
     } as any,
     db: {} as any, // userinfo path never queries the DB
-    env: { API_SERVER_URL: 'http://localhost:3000', ADDITIONAL_TRUSTED_ORIGINS: [] } as any,
+    env: { API_SERVER_URL: 'http://localhost:3000', ADDITIONAL_TRUSTED_ORIGIN: '' } as any,
     configKV: createConfigKV(),
     rateLimitMetrics: null,
   }

--- a/apps/server/src/routes/stripe/index.ts
+++ b/apps/server/src/routes/stripe/index.ts
@@ -114,7 +114,7 @@ export function createStripeRoutes(
       if (!customer)
         throw createBadRequestError('No billing account found', 'NO_CUSTOMER')
 
-      const portalReturnBase = resolveCheckoutRedirectBase(c.req.raw, env.ADDITIONAL_TRUSTED_ORIGINS, env.WEB_APP_URL)
+      const portalReturnBase = resolveCheckoutRedirectBase(c.req.raw, env.ADDITIONAL_TRUSTED_ORIGIN, env.WEB_APP_URL)
 
       const portalSession = await stripe.billingPortal.sessions.create({
         customer: customer.stripeCustomerId,

--- a/apps/server/src/routes/stripe/operations/checkout.ts
+++ b/apps/server/src/routes/stripe/operations/checkout.ts
@@ -71,7 +71,7 @@ export function createCheckoutOperation(deps: CheckoutOperationDeps) {
     const customer = await deps.stripeService.getCustomerByUserId(input.user.id)
     const stripeCustomerId = customer?.stripeCustomerId
 
-    const redirectBase = resolveCheckoutRedirectBase(input.request, deps.env.ADDITIONAL_TRUSTED_ORIGINS, deps.env.WEB_APP_URL)
+    const redirectBase = resolveCheckoutRedirectBase(input.request, deps.env.ADDITIONAL_TRUSTED_ORIGIN, deps.env.WEB_APP_URL)
 
     const paymentMethods = await deps.configKV.getOptional('STRIPE_PAYMENT_METHODS')
     const paymentMethodOptions = await deps.configKV.getOptional('STRIPE_PAYMENT_METHOD_OPTIONS') ?? {}

--- a/apps/server/src/utils/origin.ts
+++ b/apps/server/src/utils/origin.ts
@@ -15,9 +15,7 @@ const TRUSTED_EXACT_ORIGINS = [
   'https://airi.moeru.ai', // Production
 ]
 
-// NOTICE:
-// Private LAN / CGNAT-style dev hosts (e.g. https://10.x:5273 from cap-vite) are NOT matched
-// by regex here — list them explicitly via env `ADDITIONAL_TRUSTED_ORIGINS` (see env.ts).
+// NOTICE: LAN Capacitor dev hosts (e.g. https://10.x:5273) are not matched by regex — set ADDITIONAL_TRUSTED_ORIGIN.
 const TRUSTED_ORIGIN_PATTERNS = [
   // Localhost dev (any port)
   /^http:\/\/localhost(:\d+)?$/,
@@ -30,54 +28,29 @@ const TRUSTED_ORIGIN_PATTERNS = [
   /^https:\/\/.*\.kwaa\.workers\.dev$/,
 ]
 
-/**
- * Returns `origin` when it matches built-in trust rules or `additionalTrustedOrigins`.
- *
- * Use when:
- * - CORS allowlists (`/api/*`) or Stripe redirect base resolution need the same rules as Better Auth.
- *
- * Expects:
- * - `origin` is the raw `Origin` header value or `new URL(referer).origin`.
- * - `additionalTrustedOrigins` entries are normalized origins (see {@link parseAdditionalTrustedOriginsEnv}).
- *
- * Returns:
- * - The same origin string when trusted, or `''` when not trusted.
- */
-export function getTrustedOrigin(origin: string, additionalTrustedOrigins: readonly string[] = []): string {
+export function getTrustedOrigin(origin: string, additionalTrustedOrigin = ''): string {
   if (!origin)
     return origin
   if (TRUSTED_EXACT_ORIGINS.includes(origin))
     return origin
-  if (additionalTrustedOrigins.includes(origin))
+  if (additionalTrustedOrigin && origin === additionalTrustedOrigin)
     return origin
   if (TRUSTED_ORIGIN_PATTERNS.some(pattern => pattern.test(origin)))
     return origin
   return ''
 }
 
-/**
- * Resolves a trusted browser origin from `Referer` (preferred) or `Origin`.
- *
- * Expects:
- * - Same trust inputs as {@link getTrustedOrigin}.
- *
- * Returns:
- * - The trusted origin string, or `undefined` when neither header yields a trusted origin.
- */
-export function resolveTrustedRequestOrigin(
-  request: Request,
-  additionalTrustedOrigins: readonly string[] = [],
-): string | undefined {
+export function resolveTrustedRequestOrigin(request: Request, additionalTrustedOrigin = ''): string | undefined {
   const refererOrigin = getOriginFromUrl(request.headers.get('referer') ?? '')
   if (refererOrigin) {
-    const trustedRefererOrigin = getTrustedOrigin(refererOrigin, additionalTrustedOrigins)
+    const trustedRefererOrigin = getTrustedOrigin(refererOrigin, additionalTrustedOrigin)
     if (trustedRefererOrigin) {
       return trustedRefererOrigin
     }
   }
 
   const requestOrigin = request.headers.get('origin') ?? ''
-  const trustedRequestOrigin = getTrustedOrigin(requestOrigin, additionalTrustedOrigins)
+  const trustedRequestOrigin = getTrustedOrigin(requestOrigin, additionalTrustedOrigin)
   if (trustedRequestOrigin) {
     return trustedRequestOrigin
   }
@@ -85,27 +58,12 @@ export function resolveTrustedRequestOrigin(
   return undefined
 }
 
-/**
- * Resolves the base URL for Stripe redirect targets (`success_url` / `cancel_url` / portal `return_url`).
- *
- * Prefers the request's trusted browser origin so web and mobile users return to the surface they
- * started from. Falls back to the configured web app URL when the request carries no trusted origin —
- * notably the Electron desktop renderer, which loads from `file://` and sends no usable web origin,
- * so Stripe (which only accepts http/https redirect URLs) can still land users on a real page.
- *
- * Expects:
- * - Same trust inputs as {@link resolveTrustedRequestOrigin}.
- * - `webAppFallbackUrl` is an absolute origin used verbatim as the base.
- *
- * Returns:
- * - The trusted request origin when present, otherwise `webAppFallbackUrl` (always a usable base).
- */
 export function resolveCheckoutRedirectBase(
   request: Request,
-  additionalTrustedOrigins: readonly string[],
+  additionalTrustedOrigin: string,
   webAppFallbackUrl: string,
 ): string {
-  return resolveTrustedRequestOrigin(request, additionalTrustedOrigins) ?? webAppFallbackUrl
+  return resolveTrustedRequestOrigin(request, additionalTrustedOrigin) ?? webAppFallbackUrl
 }
 
 // NOTICE:
@@ -125,28 +83,15 @@ const ALWAYS_TRUSTED_AUTH_ORIGINS = [
   'http://127.0.0.1:*',
 ]
 
-/**
- * Builds the origin list passed to Better Auth `trustedOrigins` (and related flows).
- *
- * Expects:
- * - `env.API_SERVER_URL` and parsed `env.ADDITIONAL_TRUSTED_ORIGINS`.
- * - Optional `request` so the caller's Origin/Referer can be merged when known.
- *
- * Returns:
- * - De-duplicated origins in insertion order (API URL, env extras, localhost wildcards, then request-derived).
- */
-export function getAuthTrustedOrigins(
-  env: Pick<Env, 'API_SERVER_URL' | 'ADDITIONAL_TRUSTED_ORIGINS'>,
-  request?: Request,
-): string[] {
+export function getAuthTrustedOrigins(env: Pick<Env, 'API_SERVER_URL' | 'ADDITIONAL_TRUSTED_ORIGIN'>, request?: Request): string[] {
   const origins = new Set<string>()
   const apiServerOrigin = getOriginFromUrl(env.API_SERVER_URL)
   if (apiServerOrigin) {
     origins.add(apiServerOrigin)
   }
 
-  for (const origin of env.ADDITIONAL_TRUSTED_ORIGINS) {
-    origins.add(origin)
+  if (env.ADDITIONAL_TRUSTED_ORIGIN) {
+    origins.add(env.ADDITIONAL_TRUSTED_ORIGIN)
   }
 
   for (const origin of ALWAYS_TRUSTED_AUTH_ORIGINS) {
@@ -154,7 +99,7 @@ export function getAuthTrustedOrigins(
   }
 
   if (request) {
-    const requestOrigin = resolveTrustedRequestOrigin(request, env.ADDITIONAL_TRUSTED_ORIGINS)
+    const requestOrigin = resolveTrustedRequestOrigin(request, env.ADDITIONAL_TRUSTED_ORIGIN)
     if (requestOrigin) {
       origins.add(requestOrigin)
     }

--- a/apps/server/src/utils/tests/origin.test.ts
+++ b/apps/server/src/utils/tests/origin.test.ts
@@ -12,15 +12,9 @@ describe('origin utils', () => {
     expect(getTrustedOrigin('https://127.0.0.1:5273')).toBe('https://127.0.0.1:5273')
   })
 
-  it('rejects private LAN Vite dev origins unless listed in ADDITIONAL_TRUSTED_ORIGINS', () => {
+  it('rejects private LAN Vite dev origins unless listed in ADDITIONAL_TRUSTED_ORIGIN', () => {
     expect(getTrustedOrigin('https://10.0.0.129:5273')).toBe('')
-    expect(getTrustedOrigin('https://198.18.0.1:5273')).toBe('')
-    expect(getTrustedOrigin('https://192.168.1.5:5273')).toBe('')
-
-    const extra = ['https://10.0.0.129:5273', 'https://198.18.0.1:5273', 'https://192.168.1.5:5273']
-    expect(getTrustedOrigin('https://10.0.0.129:5273', extra)).toBe('https://10.0.0.129:5273')
-    expect(getTrustedOrigin('https://198.18.0.1:5273', extra)).toBe('https://198.18.0.1:5273')
-    expect(getTrustedOrigin('https://192.168.1.5:5273', extra)).toBe('https://192.168.1.5:5273')
+    expect(getTrustedOrigin('https://10.0.0.129:5273', 'https://10.0.0.129:5273')).toBe('https://10.0.0.129:5273')
   })
 
   it('rejects untrusted origins', () => {
@@ -57,7 +51,7 @@ describe('origin utils', () => {
 
     expect(getAuthTrustedOrigins({
       API_SERVER_URL: 'https://api.airi.moeru.ai',
-      ADDITIONAL_TRUSTED_ORIGINS: [],
+      ADDITIONAL_TRUSTED_ORIGIN: '',
     }, request)).toEqual([
       'https://api.airi.moeru.ai',
       'http://localhost:*',
@@ -74,7 +68,7 @@ describe('origin utils', () => {
         headers: { referer: 'http://localhost:5173/settings/flux' },
       })
 
-      expect(resolveCheckoutRedirectBase(request, [], fallback)).toBe('http://localhost:5173')
+      expect(resolveCheckoutRedirectBase(request, '', fallback)).toBe('http://localhost:5173')
     })
 
     // ROOT CAUSE:
@@ -96,8 +90,8 @@ describe('origin utils', () => {
         headers: { origin: 'null' },
       })
 
-      expect(resolveTrustedRequestOrigin(request, [])).toBeUndefined()
-      expect(resolveCheckoutRedirectBase(request, [], fallback)).toBe(fallback)
+      expect(resolveTrustedRequestOrigin(request)).toBeUndefined()
+      expect(resolveCheckoutRedirectBase(request, '', fallback)).toBe(fallback)
     })
 
     it('falls back to the web app URL for an untrusted web origin', () => {
@@ -105,14 +99,14 @@ describe('origin utils', () => {
         headers: { origin: 'https://evil.example.com' },
       })
 
-      expect(resolveCheckoutRedirectBase(request, [], fallback)).toBe(fallback)
+      expect(resolveCheckoutRedirectBase(request, '', fallback)).toBe(fallback)
     })
   })
 
-  it('includes ADDITIONAL_TRUSTED_ORIGINS in Better Auth trustedOrigins list', () => {
+  it('includes ADDITIONAL_TRUSTED_ORIGIN in Better Auth trustedOrigins list', () => {
     expect(getAuthTrustedOrigins({
       API_SERVER_URL: 'https://api.airi.moeru.ai',
-      ADDITIONAL_TRUSTED_ORIGINS: ['https://10.0.0.129:5273'],
+      ADDITIONAL_TRUSTED_ORIGIN: 'https://10.0.0.129:5273',
     })).toEqual([
       'https://api.airi.moeru.ai',
       'https://10.0.0.129:5273',

--- a/apps/server/tests/verifications/_harness.ts
+++ b/apps/server/tests/verifications/_harness.ts
@@ -171,7 +171,7 @@ export async function startVerificationContext() {
   const env: any = {
     API_SERVER_URL: 'http://localhost:3000',
     OTEL_SERVICE_NAME: 'airi-server-test',
-    ADDITIONAL_TRUSTED_ORIGINS: '',
+    ADDITIONAL_TRUSTED_ORIGIN: '',
     HOST: '127.0.0.1',
     PORT: 0,
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2260,7 +2260,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: 'catalog:'
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: 'catalog:'
         version: 4.0.0(electron@41.2.1)
@@ -2299,7 +2299,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: 'catalog:'
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -2335,10 +2335,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: 'catalog:'
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -2365,7 +2365,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: 'catalog:'
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -2398,7 +2398,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: 'catalog:'
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -2419,31 +2419,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: 'catalog:'
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: 'catalog:'
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: 'catalog:'
-        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: 'catalog:'
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: 'catalog:'
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: 'catalog:'
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: 'catalog:'
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.6(typescript@5.9.3)
@@ -20735,9 +20735,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -21639,6 +21639,31 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -23651,10 +23676,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -25202,6 +25251,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -25478,6 +25533,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -27556,7 +27620,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -27564,7 +27628,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33569,11 +33633,6 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -33640,6 +33699,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -33658,6 +33725,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 2.80.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33753,6 +33833,17 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 2.80.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33981,11 +34072,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -34032,6 +34133,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -34063,6 +34179,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -34081,6 +34204,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -34095,6 +34232,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -34107,6 +34259,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -34362,6 +34524,54 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
+  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Replace comma-separated `ADDITIONAL_TRUSTED_ORIGINS` with **`ADDITIONAL_TRUSTED_ORIGIN`**: one exact browser origin for LAN Capacitor/Vite dev (not a list).
- Drop `parseAdditionalTrustedOriginsEnv` and env-layer normalization; the value is `optional(string(), '')` like `API_SERVER_URL` / `WEB_APP_URL`.
- Thread a single `additionalTrustedOrigin` string through CORS, Better Auth trusted origins, dynamic OIDC redirect allowlisting, and Stripe redirect base resolution.
- Trim redundant JSDoc in `origin.ts`; keep a one-line LAN `NOTICE` and the existing Better Auth loopback `NOTICE`.

Follow-up to #1763.

## Motivation

#1763 added comma-separated extra origins for Pocket/Capacitor on `https://10.x:5273`. In practice we only need **one** extra origin at a time; a list implied multi-origin support we do not use and pushed parsing into `env.ts`. A plain string matches how operators configure `.env.local` and how the request `Origin` header is compared. The final name `ADDITIONAL_TRUSTED_ORIGIN` reflects that it supplements the built-in trusted-origin rules, not only “dev UI”.

## Breaking changes

| Before | After |
|--------|--------|
| `ADDITIONAL_TRUSTED_ORIGINS=https://10.0.0.129:5273,https://198.18.0.1:5273` | `ADDITIONAL_TRUSTED_ORIGIN=https://10.0.0.129:5273` (single value) |
| Parsed/normalized at startup | Used as configured; must match request `Origin` exactly |

## Upgrade

In `apps/server/.env.local` (or deployment env):

```env
# remove
# ADDITIONAL_TRUSTED_ORIGINS=...

# add (one origin, no trailing path)
ADDITIONAL_TRUSTED_ORIGIN=https://10.0.0.129:5273
```

Restart the API server after changing.

## Test plan

- [ ] `pnpm -F @proj-airi/server exec vitest run src/libs/tests/env.test.ts src/utils/tests/origin.test.ts`
- [ ] Local Pocket/Capacitor dev: set `ADDITIONAL_TRUSTED_ORIGIN` to the Vite HTTPS origin from Capacitor config; confirm `/api/*` CORS and auth flows work
- [ ] Stripe checkout from web still returns to request origin; Electron/file:// still falls back via `WEB_APP_URL` and `resolveCheckoutRedirectBase`
- [ ] Production/staging: leave `ADDITIONAL_TRUSTED_ORIGIN` empty