### PR TITLE
fix(stage-ui): limit provider validation to listed providers only

### DIFF
--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2436,11 +2436,15 @@ export const useProvidersStore = defineStore('providers', () => {
       }))
   }
 
-  // Call initially and watch for changes
-  watch(providerCredentials, updateConfigurationStatus, { deep: true, immediate: true })
-  startPeriodicRuntimeValidation()
+  async function refreshListedProviderValidation() {
+    await updateConfigurationStatus()
+    startPeriodicRuntimeValidation()
+  }
 
-  watch(() => authState.isAuthenticated, updateConfigurationStatus)
+  // Call initially and watch for changes
+  watch(providerCredentials, refreshListedProviderValidation, { deep: true, immediate: true })
+  watch(addedProviders, refreshListedProviderValidation, { deep: true })
+  watch(() => authState.isAuthenticated, refreshListedProviderValidation)
 
   // Available providers (only those that are properly configured)
   const availableProviders = computed(() => Object.keys(providerMetadata).filter(providerId => providerRuntimeState.value[providerId]?.isConfigured))

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2402,6 +2402,9 @@ export const useProvidersStore = defineStore('providers', () => {
       if (!providerMetadata[providerId] || intervalMs <= 0)
         continue
 
+      if (!shouldListProvider(providerId))
+        continue
+
       if (providerRevalidationLoops.has(providerId)) {
         continue
       }
@@ -2414,11 +2417,10 @@ export const useProvidersStore = defineStore('providers', () => {
     }
   }
 
-  // Update configuration status for all configured providers
+  // Update configuration status for listed providers only.
   async function updateConfigurationStatus() {
     await Promise.all(Object.entries(providerMetadata)
-      // TODO: ignore un-configured provider
-      // .filter(([_, provider]) => provider.configured)
+      .filter(([providerId]) => shouldListProvider(providerId))
       .map(async ([providerId]) => {
         try {
           if (providerRuntimeState.value[providerId]) {

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2273,7 +2273,7 @@ export const useProvidersStore = defineStore('providers', () => {
   // const validatedCredentials = ref<Record<string, string>>({})
   const providerRuntimeState = ref<Record<string, ProviderRuntimeState>>({})
   const providerValidationInFlight = new Map<string, Promise<boolean>>()
-  const providerRevalidationLoops = new Map<string, { resume: () => void }>()
+  const providerRevalidationLoops = new Map<string, { pause: () => void, resume: () => void }>()
 
   // Server-driven availability overrides for providers whose visibility can
   // only be decided at runtime from the backend (e.g. the streaming TTS
@@ -2397,6 +2397,27 @@ export const useProvidersStore = defineStore('providers', () => {
   // Initialize all providers
   Object.keys(providerMetadata).forEach(initializeProvider)
 
+  function stopRevalidationLoop(providerId: string) {
+    const loop = providerRevalidationLoops.get(providerId)
+    if (!loop)
+      return
+    loop.pause()
+    providerRevalidationLoops.delete(providerId)
+  }
+
+  function reconcileUnlistedProviders() {
+    for (const providerId of Object.keys(providerMetadata)) {
+      if (shouldListProvider(providerId))
+        continue
+      stopRevalidationLoop(providerId)
+      const runtimeState = providerRuntimeState.value[providerId]
+      if (!runtimeState)
+        continue
+      runtimeState.isConfigured = false
+      runtimeState.validatedCredentialHash = undefined
+    }
+  }
+
   function startPeriodicRuntimeValidation() {
     for (const [providerId, intervalMs] of providerValidationIntervalMsById.entries()) {
       if (!providerMetadata[providerId] || intervalMs <= 0)
@@ -2420,7 +2441,7 @@ export const useProvidersStore = defineStore('providers', () => {
   // Update configuration status for listed providers only.
   async function updateConfigurationStatus() {
     await Promise.all(Object.entries(providerMetadata)
-      .filter(([providerId]) => shouldListProvider(providerId))
+      .filter(([providerId]) => shouldListProvider(providerId) || providerId === 'browser-web-speech-api')
       .map(async ([providerId]) => {
         try {
           if (providerRuntimeState.value[providerId]) {
@@ -2437,6 +2458,7 @@ export const useProvidersStore = defineStore('providers', () => {
   }
 
   async function refreshListedProviderValidation() {
+    reconcileUnlistedProviders()
     await updateConfigurationStatus()
     startPeriodicRuntimeValidation()
   }
@@ -2506,7 +2528,9 @@ export const useProvidersStore = defineStore('providers', () => {
     providerRuntimeState.value = {}
 
     Object.keys(providerMetadata).forEach(initializeProvider)
-    await updateConfigurationStatus()
+    providerRevalidationLoops.forEach(loop => loop.pause())
+    providerRevalidationLoops.clear()
+    await refreshListedProviderValidation()
   }
 
   // Function to fetch models for a specific provider


### PR DESCRIPTION
## Summary

- `updateConfigurationStatus` only runs `validateProvider` for providers where `shouldListProvider` is true (added in settings or credentials differ from defaults).
- `startPeriodicRuntimeValidation` uses the same filter so interval-based revalidation (e.g. LM Studio) does not hit localhost for providers the user never added.
- Removes the old TODO and the previous “validate all providers on startup” behavior that caused noise (e.g. Ollama/LM Studio on cold load).

We do not set `providerMetadata[id].configured` after validation because metadata is the static provider catalog, while probe results are per-browser runtime state. `providerRuntimeState.isConfigured` is already the source of truth; UI reads it via computed projection. Writing into metadata would duplicate that flag and drift from `isConfigured`.

## Test plan

- [ ] Cold-load stage-web: no HTTP to `11434` / `1234` unless LM Studio/Ollama (or similar) is listed.
- [ ] Add/list a local provider, configure base URL: startup or credential watch should probe; periodic revalidation only for that provider.
- [ ] Open LM Studio settings page only (not listed): requests may still come from `useProviderValidation` on that page; store-wide probe should not include `lm-studio` until listed.
- [ ] `pnpm -F @proj-airi/stage-ui typecheck`


Made with [Cursor](https://cursor.com)