### PR TITLE
feat(server): send survey email after first payment

### DIFF
--- a/apps/server/drizzle/0018_hesitant_karen_page.sql
+++ b/apps/server/drizzle/0018_hesitant_karen_page.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "community_survey_invite_email" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"stripe_session_id" text NOT NULL,
+	"to_email" text,
+	"survey_url" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"failure_reason" text,
+	"attempt_count" integer DEFAULT 1 NOT NULL,
+	"sent_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "community_survey_invite_email_user_id_unique" UNIQUE("user_id"),
+	CONSTRAINT "community_survey_invite_email_stripe_session_id_unique" UNIQUE("stripe_session_id")
+);

--- a/apps/server/drizzle/meta/0018_snapshot.json
+++ b/apps/server/drizzle/meta/0018_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "62e2578e-592c-40a5-85e3-b527aeee5eb8",
-  "prevId": "37ccaf38-4e30-4edc-a41a-325327701805",
+  "id": "fff6247b-5d19-4541-8ca1-5a5465c920b4",
+  "prevId": "5b4c6661-809a-4b03-8e48-b1c17d3e6ab3",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1807,6 +1807,104 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.community_survey_invite_email": {
+      "name": "community_survey_invite_email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_email": {
+          "name": "to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_url": {
+          "name": "survey_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_survey_invite_email_user_id_unique": {
+          "name": "community_survey_invite_email_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "community_survey_invite_email_stripe_session_id_unique": {
+          "name": "community_survey_invite_email_stripe_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.flux_transaction": {
       "name": "flux_transaction",
       "schema": "",
@@ -2185,6 +2283,443 @@
         }
       },
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_alias_routes": {
+      "name": "capability_alias_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "router_model_id": {
+          "name": "router_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool": {
+          "name": "pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capability_alias_routes_alias_model_pool_uidx": {
+          "name": "capability_alias_routes_alias_model_pool_uidx",
+          "columns": [
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "router_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pool",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capability_alias_routes_alias_id_capability_aliases_id_fk": {
+          "name": "capability_alias_routes_alias_id_capability_aliases_id_fk",
+          "tableFrom": "capability_alias_routes",
+          "tableTo": "capability_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_aliases": {
+      "name": "capability_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_enabled": {
+          "name": "fallback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "load_balancing_enabled": {
+          "name": "load_balancing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capability_aliases_surface_alias_uidx": {
+          "name": "capability_aliases_surface_alias_uidx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_catalog_tts_models": {
+      "name": "provider_catalog_tts_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "router_model_id": {
+          "name": "router_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_catalog_tts_models_router_model_uidx": {
+          "name": "provider_catalog_tts_models_router_model_uidx",
+          "columns": [
+            {
+              "expression": "router_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_catalog_tts_voices": {
+      "name": "provider_catalog_tts_voices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tts_model_id": {
+          "name": "tts_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_voice_id": {
+          "name": "provider_voice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "preview_audio_url": {
+          "name": "preview_audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provider-sync'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_catalog_tts_voices_model_voice_uidx": {
+          "name": "provider_catalog_tts_voices_model_voice_uidx",
+          "columns": [
+            {
+              "expression": "tts_model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_voice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_catalog_tts_voices_tts_model_id_provider_catalog_tts_models_id_fk": {
+          "name": "provider_catalog_tts_voices_tts_model_id_provider_catalog_tts_models_id_fk",
+          "tableFrom": "provider_catalog_tts_voices",
+          "tableTo": "provider_catalog_tts_models",
+          "columnsFrom": [
+            "tts_model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -2916,6 +3451,102 @@
           ]
         }
       },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_packs": {
+      "name": "voice_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_id": {
+          "name": "voice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_voice_id": {
+          "name": "upstream_voice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tts_model_id": {
+          "name": "tts_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1782912836523,
       "tag": "0017_nappy_dagger",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1783672548587,
+      "tag": "0018_hesitant_karen_page",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -46,6 +46,7 @@ function createTestDeps() {
     fluxTransactionService: {} as any,
     stripeService: {} as any,
     billingService: {} as any,
+    communitySurveyService: {} as any,
     adminFluxGrantsService: {} as any,
     adminRouterConfigService: {} as any,
     adminUsersService: {} as any,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -13,6 +13,7 @@ import type { BillingService } from './services/domain/billing/billing-service'
 import type { FluxMeter } from './services/domain/billing/flux-meter'
 import type { CharacterService } from './services/domain/characters'
 import type { ChatService } from './services/domain/chats'
+import type { CommunitySurveyService } from './services/domain/community-survey'
 import type { FluxService } from './services/domain/flux'
 import type { FluxTransactionService } from './services/domain/flux-transaction'
 import type { LlmRouterService } from './services/domain/llm-router'
@@ -83,6 +84,7 @@ import { createBillingService } from './services/domain/billing/billing-service'
 import { createFluxMeter } from './services/domain/billing/flux-meter'
 import { createCharacterService } from './services/domain/characters'
 import { createChatService } from './services/domain/chats'
+import { createCommunitySurveyService } from './services/domain/community-survey'
 import { createFluxService } from './services/domain/flux'
 import { createFluxTransactionService } from './services/domain/flux-transaction'
 import { createConcurrencyLedger, createConfigSyncSubscriber, createLlmRouterService } from './services/domain/llm-router'
@@ -108,6 +110,7 @@ interface AppDeps {
   fluxTransactionService: FluxTransactionService
   stripeService: StripeService
   billingService: BillingService
+  communitySurveyService: CommunitySurveyService
   adminFluxGrantsService: AdminFluxGrantsService
   adminRouterConfigService: AdminRouterConfigService
   adminUsersService: AdminUsersService
@@ -398,7 +401,7 @@ export async function buildApp(deps: AppDeps) {
     /**
      * Stripe routes.
      */
-    .route('/api/v1/stripe', createStripeRoutes(deps.fluxService, deps.stripeService, deps.billingService, deps.configKV, deps.env, deps.redis, deps.otel?.revenue, deps.otel?.rateLimit, deps.productEventService))
+    .route('/api/v1/stripe', createStripeRoutes(deps.fluxService, deps.stripeService, deps.billingService, deps.configKV, deps.env, deps.redis, deps.otel?.revenue, deps.otel?.rateLimit, deps.productEventService, deps.communitySurveyService))
 
     /**
      * Admin routes — guarded by the `adminGuard` role check (`role === 'admin'`,
@@ -592,6 +595,11 @@ export async function createApp() {
       fromEmail: dependsOn.env.RESEND_FROM_EMAIL,
       fromName: dependsOn.env.RESEND_FROM_NAME,
     }, undefined, dependsOn.otel?.email),
+  })
+
+  const communitySurveyService = injeca.provide('services:communitySurvey', {
+    dependsOn: { db, configKV, emailService },
+    build: ({ dependsOn }) => createCommunitySurveyService(dependsOn.db, dependsOn.configKV, dependsOn.emailService),
   })
 
   const posthogSink = injeca.provide('services:posthogSink', {
@@ -808,6 +816,7 @@ export async function createApp() {
     productEventService,
     stripeService,
     billingService,
+    communitySurveyService,
     adminFluxGrantsService,
     adminRouterConfigService,
     adminUsersService,
@@ -851,6 +860,7 @@ export async function createApp() {
     stripeService: resolved.stripeService,
     voicePackService: resolved.voicePackService,
     billingService: resolved.billingService,
+    communitySurveyService: resolved.communitySurveyService,
     adminFluxGrantsService: resolved.adminFluxGrantsService,
     adminRouterConfigService: resolved.adminRouterConfigService,
     adminUsersService: resolved.adminUsersService,

--- a/apps/server/src/routes/stripe/index.ts
+++ b/apps/server/src/routes/stripe/index.ts
@@ -4,6 +4,7 @@ import type { Env } from '../../libs/env'
 import type { RateLimitMetrics, RevenueMetrics } from '../../otel'
 import type { ConfigKVService } from '../../services/adapters/config-kv'
 import type { BillingService } from '../../services/domain/billing/billing-service'
+import type { CommunitySurveyService } from '../../services/domain/community-survey'
 import type { FluxService } from '../../services/domain/flux'
 import type { ProductEventService } from '../../services/domain/product-events'
 import type { StripeService } from '../../services/domain/stripe'
@@ -47,6 +48,7 @@ export function createStripeRoutes(
   metrics?: RevenueMetrics | null,
   rateLimitMetrics?: RateLimitMetrics | null,
   productEventService?: ProductEventService,
+  communitySurveyService?: CommunitySurveyService | null,
 ) {
   const stripe = env.STRIPE_SECRET_KEY ? new Stripe(env.STRIPE_SECRET_KEY) : null
   const priceCatalog = stripe ? createStripePriceCatalog(stripe, redis) : null
@@ -59,6 +61,7 @@ export function createStripeRoutes(
     billingService,
     metrics,
     productEventService,
+    communitySurveyService,
   })
 
   return new Hono<HonoEnv>()

--- a/apps/server/src/routes/stripe/operations/webhook.ts
+++ b/apps/server/src/routes/stripe/operations/webhook.ts
@@ -2,6 +2,7 @@ import type Stripe from 'stripe'
 
 import type { RevenueMetrics } from '../../../otel'
 import type { BillingService } from '../../../services/domain/billing/billing-service'
+import type { CommunitySurveyService } from '../../../services/domain/community-survey'
 import type { FluxService } from '../../../services/domain/flux'
 import type { ProductAction, ProductEventService } from '../../../services/domain/product-events'
 import type { StripeService } from '../../../services/domain/stripe'
@@ -31,6 +32,7 @@ export interface WebhookOperationDeps {
   billingService: BillingService
   metrics?: RevenueMetrics | null
   productEventService?: ProductEventService
+  communitySurveyService?: CommunitySurveyService | null
 }
 
 export interface WebhookOperationInput {
@@ -86,6 +88,7 @@ export function createWebhookOperation(deps: WebhookOperationDeps) {
         // processed the checkout. Malformed sessions (missing userId,
         // invalid fluxAmount) take the early-return path above.
         if (result.processed) {
+          await sendPaidSurveyInviteSafely(deps.communitySurveyService, event.data.object)
           const userId = event.data.object.metadata?.userId
           if (userId) {
             const fluxAmount = Number(event.data.object.metadata?.fluxAmount)
@@ -163,6 +166,24 @@ export function createWebhookOperation(deps: WebhookOperationDeps) {
     }
 
     return { received: true }
+  }
+}
+
+/**
+ * Sends the paid survey invite without failing Stripe fulfillment.
+ */
+async function sendPaidSurveyInviteSafely(
+  communitySurveyService: CommunitySurveyService | null | undefined,
+  session: Stripe.Checkout.Session,
+): Promise<void> {
+  if (!communitySurveyService)
+    return
+
+  try {
+    await communitySurveyService.sendPaidSurveyInviteForCheckout(session)
+  }
+  catch (error) {
+    logger.withFields({ sessionId: session.id }).warn(`Paid survey invite failed after checkout fulfillment: ${errorMessageFromUnknown(error)}`)
   }
 }
 

--- a/apps/server/src/routes/stripe/route.test.ts
+++ b/apps/server/src/routes/stripe/route.test.ts
@@ -5,6 +5,8 @@ import type { FluxService } from '../../services/domain/flux'
 import type { StripeService } from '../../services/domain/stripe'
 import type { HonoEnv } from '../../types/hono'
 
+import Stripe from 'stripe'
+
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -60,6 +62,12 @@ function createMockBillingService(): BillingService {
     creditFluxFromStripeCheckout: vi.fn(async () => ({ applied: true, balanceAfter: 500 })),
     creditFluxFromInvoice: vi.fn(async () => ({ applied: true, balanceAfter: 500 })),
   } as any
+}
+
+function createMockCommunitySurveyService() {
+  return {
+    sendPaidSurveyInviteForCheckout: vi.fn(async () => ({ sent: true })),
+  }
 }
 
 function createMockConfigKV(overrides: Record<string, any> = {}): ConfigKVService {
@@ -153,8 +161,9 @@ function createTestApp(
   billingService: BillingService,
   configKV: ConfigKVService,
   envOverrides: Record<string, any> = {},
+  communitySurveyService = createMockCommunitySurveyService(),
 ) {
-  const routes = createStripeRoutes(fluxService, stripeService, billingService, configKV, { ...testEnv, ...envOverrides }, createMockRedis())
+  const routes = createStripeRoutes(fluxService, stripeService, billingService, configKV, { ...testEnv, ...envOverrides }, createMockRedis(), undefined, undefined, undefined, communitySurveyService as any)
   const app = new Hono<HonoEnv>()
 
   app.onError((err, c) => {
@@ -179,6 +188,16 @@ function createTestApp(
 
   app.route('/api/v1/stripe', routes)
   return app
+}
+
+function createSignedStripeWebhookPayload(event: Record<string, any>) {
+  const payload = JSON.stringify(event)
+  const signature = Stripe.webhooks.generateTestHeaderString({
+    payload,
+    secret: testEnv.STRIPE_WEBHOOK_SECRET,
+  })
+
+  return { payload, signature }
 }
 
 // --- Tests ---
@@ -417,6 +436,116 @@ describe('stripeRoutes', () => {
   })
 
   describe('pOST /api/v1/stripe/webhook', () => {
+    it('sends the paid survey invite after checkout fulfillment succeeds', async () => {
+      const communitySurveyService = createMockCommunitySurveyService()
+      const billingService = createMockBillingService()
+      const app = createTestApp(
+        createMockFluxService(),
+        createMockStripeService(),
+        billingService,
+        createMockConfigKV(),
+        {},
+        communitySurveyService,
+      )
+
+      const { payload, signature } = createSignedStripeWebhookPayload({
+        id: 'evt_checkout_completed',
+        object: 'event',
+        type: 'checkout.session.completed',
+        created: 1710000000,
+        data: {
+          object: {
+            id: 'cs_paid_survey',
+            object: 'checkout.session',
+            mode: 'payment',
+            status: 'complete',
+            payment_status: 'paid',
+            amount_total: 500,
+            currency: 'usd',
+            customer: 'cus_paid_survey',
+            customer_email: 'paid@example.com',
+            customer_details: { email: 'paid@example.com' },
+            metadata: {
+              userId: 'user-1',
+              fluxAmount: '50',
+            },
+          },
+        },
+      })
+
+      const res = await app.request('/api/v1/stripe/webhook', {
+        method: 'POST',
+        headers: { 'stripe-signature': signature },
+        body: payload,
+      })
+
+      expect(res.status).toBe(200)
+      expect(billingService.creditFluxFromStripeCheckout).toHaveBeenCalledWith(expect.objectContaining({
+        stripeEventId: 'evt_checkout_completed',
+        userId: 'user-1',
+        stripeSessionId: 'cs_paid_survey',
+      }))
+      expect(communitySurveyService.sendPaidSurveyInviteForCheckout).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'cs_paid_survey',
+        customer_email: 'paid@example.com',
+      }))
+    })
+
+    it('does not fail the Stripe webhook when the paid survey invite fails', async () => {
+      const communitySurveyService = {
+        sendPaidSurveyInviteForCheckout: vi.fn(async () => {
+          throw new Error('resend unavailable')
+        }),
+      }
+      const billingService = createMockBillingService()
+      const app = createTestApp(
+        createMockFluxService(),
+        createMockStripeService(),
+        billingService,
+        createMockConfigKV(),
+        {},
+        communitySurveyService,
+      )
+
+      const { payload, signature } = createSignedStripeWebhookPayload({
+        id: 'evt_checkout_completed_survey_failure',
+        object: 'event',
+        type: 'checkout.session.completed',
+        created: 1710000000,
+        data: {
+          object: {
+            id: 'cs_paid_survey_failure',
+            object: 'checkout.session',
+            mode: 'payment',
+            status: 'complete',
+            payment_status: 'paid',
+            amount_total: 500,
+            currency: 'usd',
+            customer: 'cus_paid_survey_failure',
+            customer_email: 'paid@example.com',
+            customer_details: { email: 'paid@example.com' },
+            metadata: {
+              userId: 'user-1',
+              fluxAmount: '50',
+            },
+          },
+        },
+      })
+
+      const res = await app.request('/api/v1/stripe/webhook', {
+        method: 'POST',
+        headers: { 'stripe-signature': signature },
+        body: payload,
+      })
+
+      expect(res.status).toBe(200)
+      expect(billingService.creditFluxFromStripeCheckout).toHaveBeenCalledWith(expect.objectContaining({
+        stripeEventId: 'evt_checkout_completed_survey_failure',
+        stripeSessionId: 'cs_paid_survey_failure',
+      }))
+      expect(communitySurveyService.sendPaidSurveyInviteForCheckout).toHaveBeenCalledOnce()
+    })
+
     it('returns 400 when signature is missing', async () => {
       const app = createTestApp(
         createMockFluxService(),

--- a/apps/server/src/schemas/community.ts
+++ b/apps/server/src/schemas/community.ts
@@ -1,0 +1,25 @@
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+
+import { nanoid } from '../utils/id'
+
+/**
+ * Survey invite emails sent after paid Stripe checkout fulfillment.
+ */
+export const communitySurveyInviteEmail = pgTable('community_survey_invite_email', {
+  id: text('id').primaryKey().$defaultFn(() => nanoid()),
+  userId: text('user_id').notNull().unique(),
+  stripeSessionId: text('stripe_session_id').notNull().unique(),
+  toEmail: text('to_email'),
+  surveyUrl: text('survey_url'),
+  status: text('status').notNull().default('pending'),
+  failureReason: text('failure_reason'),
+  attemptCount: integer('attempt_count').notNull().default(1),
+  sentAt: timestamp('sent_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+})
+
+export type CommunitySurveyInviteEmail = InferSelectModel<typeof communitySurveyInviteEmail>
+export type NewCommunitySurveyInviteEmail = InferInsertModel<typeof communitySurveyInviteEmail>

--- a/apps/server/src/schemas/index.ts
+++ b/apps/server/src/schemas/index.ts
@@ -1,6 +1,7 @@
 export * from './accounts'
 export * from './characters'
 export * from './chats'
+export * from './community'
 export * from './flux'
 export * from './flux-transaction'
 export * from './llm-request-log'

--- a/apps/server/src/services/adapters/config-kv.ts
+++ b/apps/server/src/services/adapters/config-kv.ts
@@ -2,7 +2,7 @@ import type Redis from 'ioredis'
 import type { InferOutput } from 'valibot'
 
 import { errorMessageFrom } from '@moeru/std'
-import { any, array, boolean, check, nonEmpty, number, object, optional, parse, picklist, pipe, record, regex, string } from 'valibot'
+import { any, array, boolean, check, nonEmpty, number, object, optional, parse, picklist, pipe, record, regex, string, url } from 'valibot'
 
 import { createServiceUnavailableError } from '../../utils/error'
 import { configRedisKey } from '../../utils/redis-keys'
@@ -147,6 +147,12 @@ const ConfigEntrySchemas = {
   // No default — absent lets Stripe auto-select payment methods via Dashboard config
   STRIPE_PAYMENT_METHODS: optional(array(string())),
   STRIPE_PAYMENT_METHOD_OPTIONS: optional(record(string(), any()), {}),
+  // Optional paid-user survey URL sent from the Stripe checkout webhook after
+  // fulfillment. Missing means the post-payment survey email is disabled.
+  COMMUNITY_SURVEY_URL: optional(pipe(string(), nonEmpty('COMMUNITY_SURVEY_URL must not be empty'), url('COMMUNITY_SURVEY_URL must be a valid URL'))),
+  COMMUNITY_SURVEY_EMAIL_SUBJECT: optional(pipe(string(), nonEmpty('COMMUNITY_SURVEY_EMAIL_SUBJECT must not be empty'))),
+  COMMUNITY_SURVEY_EMAIL_HTML: optional(pipe(string(), nonEmpty('COMMUNITY_SURVEY_EMAIL_HTML must not be empty'))),
+  COMMUNITY_SURVEY_EMAIL_TEXT: optional(pipe(string(), nonEmpty('COMMUNITY_SURVEY_EMAIL_TEXT must not be empty'))),
   // model id → (BCP-47 locale → recommended voice id). Outer key is either a
   // router TTS model id (LLM_ROUTER_CONFIG.tts.models key) for REST or a
   // streaming api_resource_id (e.g. `seed-tts-2.0`) for the streaming surface.

--- a/apps/server/src/services/adapters/email.test.ts
+++ b/apps/server/src/services/adapters/email.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createEmailService } from './email'
+
+describe('emailService', () => {
+  it('passes the survey invite idempotency key to Resend', async () => {
+    const send = vi.fn(async () => ({ data: { id: 'email_1' }, error: null, headers: null }))
+
+    const service = createEmailService({
+      apiKey: 're_test',
+      fromEmail: 'noreply@example.com',
+      fromName: 'Project AIRI',
+    }, undefined, undefined, () => ({ emails: { send } }))
+
+    await service.sendCommunitySurveyInvite({
+      to: 'paid@example.com',
+      subject: '__configured_subject__',
+      html: '<p>__configured_html__</p>',
+      text: '__configured_text__',
+      idempotencyKey: 'community-survey:user-1',
+    })
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ['paid@example.com'],
+        subject: '__configured_subject__',
+        html: '<p>__configured_html__</p>',
+        text: '__configured_text__',
+      }),
+      { idempotencyKey: 'community-survey:user-1' },
+    )
+  })
+})

--- a/apps/server/src/services/adapters/email.ts
+++ b/apps/server/src/services/adapters/email.ts
@@ -28,6 +28,8 @@ export interface EmailPayload {
   html: string
   /** Plain-text body. Required for spam-filter parity and accessibility. */
   text: string
+  /** Provider-side idempotency key for retryable transactional emails. */
+  idempotencyKey?: string
 }
 
 /**
@@ -49,6 +51,7 @@ export interface EmailService {
   sendPasswordReset: (params: { to: string, url: string }) => Promise<void>
   sendMagicLink: (params: { to: string, url: string }) => Promise<void>
   sendChangeEmailConfirmation: (params: { to: string, newEmail: string, url: string }) => Promise<void>
+  sendCommunitySurveyInvite: (params: { to: string, subject: string, html: string, text: string, idempotencyKey: string }) => Promise<void>
   /**
    * Send the irreversible-action confirmation for `user.deleteUser` flow.
    *
@@ -67,6 +70,11 @@ interface EmailConfig {
   fromEmail: string
   fromName?: string
 }
+
+interface EmailClient {
+  emails: Pick<Resend['emails'], 'send'>
+}
+type CreateEmailClient = (apiKey: string) => EmailClient
 
 /**
  * Format an RFC 5322 display-name + address pair for the `From` header.
@@ -93,8 +101,14 @@ function formatFrom(config: EmailConfig): string {
  * - `RESEND_API_KEY` is set in env. When empty, `send` throws an `ApiError`
  *   instead of silently dropping mail — Better Auth surfaces it back to the
  *   caller so frontend can show a clear "email service not configured" error.
+ * - `createClient` is overridden only at the external provider boundary in tests.
  */
-export function createEmailService(config: EmailConfig, logger: Logger = useLogger('email'), metrics?: EmailMetrics | null): EmailService {
+export function createEmailService(
+  config: EmailConfig,
+  logger: Logger = useLogger('email'),
+  metrics?: EmailMetrics | null,
+  createClient: CreateEmailClient = apiKey => new Resend(apiKey),
+): EmailService {
   // NOTICE:
   // Construct Resend lazily so the server can boot in environments where the
   // RESEND_API_KEY is intentionally empty (e.g. local dev that never exercises
@@ -103,8 +117,8 @@ export function createEmailService(config: EmailConfig, logger: Logger = useLogg
   // keys; explicit guard keeps the failure mode visible at the call site.
   // Source: node_modules/.pnpm/resend@*/node_modules/resend/dist/index.cjs
   // Removal condition: when we make RESEND_API_KEY required at env-parse time.
-  let client: Resend | null = null
-  function getClient(): Resend {
+  let client: EmailClient | null = null
+  function getClient(): EmailClient {
     if (!client) {
       if (!config.apiKey) {
         throw new ApiError(
@@ -113,7 +127,7 @@ export function createEmailService(config: EmailConfig, logger: Logger = useLogg
           'Email service not configured (RESEND_API_KEY is missing).',
         )
       }
-      client = new Resend(config.apiKey)
+      client = createClient(config.apiKey)
     }
     return client
   }
@@ -123,13 +137,17 @@ export function createEmailService(config: EmailConfig, logger: Logger = useLogg
   async function send(payload: EmailPayload, template: string = 'unknown'): Promise<void> {
     const startedAt = Date.now()
     try {
-      const { error } = await getClient().emails.send({
-        from,
-        to: [payload.to],
-        subject: payload.subject,
-        html: payload.html,
-        text: payload.text,
-      })
+      const sendOptions = payload.idempotencyKey ? { idempotencyKey: payload.idempotencyKey } : undefined
+      const { error } = await getClient().emails.send(
+        {
+          from,
+          to: [payload.to],
+          subject: payload.subject,
+          html: payload.html,
+          text: payload.text,
+        },
+        sendOptions,
+      )
 
       if (error) {
         logger.withFields({ to: payload.to, subject: payload.subject, errorName: error.name }).error(error.message)
@@ -185,6 +203,15 @@ export function createEmailService(config: EmailConfig, logger: Logger = useLogg
         html: renderChangeEmailHtml(url, newEmail),
         text: renderChangeEmailText(url, newEmail),
       }, 'change_email')
+    },
+    async sendCommunitySurveyInvite({ to, subject, html, text, idempotencyKey }) {
+      await send({
+        to,
+        subject,
+        html,
+        text,
+        idempotencyKey,
+      }, 'community_survey')
     },
     async sendDeleteAccountVerification({ to, url }) {
       await send({

--- a/apps/server/src/services/domain/community-survey.test.ts
+++ b/apps/server/src/services/domain/community-survey.test.ts
@@ -1,0 +1,370 @@
+import type { Database } from '../../libs/db'
+import type { ConfigKVService } from '../adapters/config-kv'
+import type { EmailService } from '../adapters/email'
+
+import { eq } from 'drizzle-orm'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mockDB } from '../../libs/mock-db'
+import { createCommunitySurveyService } from './community-survey'
+
+import * as schema from '../../schemas'
+
+/**
+ * Create a config service with optional survey email runtime content.
+ */
+function createMockConfigKV(surveyUrl: string | null, overrides: Record<string, string | null> = {}): ConfigKVService {
+  const values: Record<string, string | null> = {
+    COMMUNITY_SURVEY_URL: surveyUrl,
+    COMMUNITY_SURVEY_EMAIL_SUBJECT: '__configured_subject__',
+    COMMUNITY_SURVEY_EMAIL_HTML: '<p>__configured_html__ {{surveyUrl}}</p>',
+    COMMUNITY_SURVEY_EMAIL_TEXT: '__configured_text__ {{surveyUrl}}',
+    ...overrides,
+  }
+
+  return {
+    getOptional: vi.fn(async (key: string) => {
+      return values[key] ?? null
+    }),
+    getOrThrow: vi.fn(),
+    get: vi.fn(),
+    set: vi.fn(),
+  } as any
+}
+
+/**
+ * Create an email service spy for survey invite delivery tests.
+ */
+function createMockEmailService(): EmailService {
+  const email: EmailService = {
+    send: vi.fn(async () => undefined),
+    sendVerification: vi.fn(),
+    sendPasswordReset: vi.fn(),
+    sendMagicLink: vi.fn(),
+    sendChangeEmailConfirmation: vi.fn(),
+    sendCommunitySurveyInvite: vi.fn(async ({ to, subject, html, text, idempotencyKey }) => {
+      await email.send({
+        to,
+        subject,
+        html,
+        text,
+        idempotencyKey,
+      })
+    }),
+    sendDeleteAccountVerification: vi.fn(),
+  }
+  return email
+}
+
+describe('communitySurveyService', () => {
+  let db: Database
+
+  beforeAll(async () => {
+    db = await mockDB(schema)
+  })
+
+  beforeEach(async () => {
+    await db.delete(schema.communitySurveyInviteEmail)
+  })
+
+  it('sends one survey invite email per Stripe checkout session', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+
+    const session = {
+      id: 'cs_survey_once',
+      metadata: { userId: 'user-survey-1' },
+      customer_email: 'paid@example.com',
+      customer_details: { email: 'paid@example.com' },
+      payment_status: 'paid',
+    }
+
+    const first = await service.sendPaidSurveyInviteForCheckout(session as any)
+    const second = await service.sendPaidSurveyInviteForCheckout(session as any)
+
+    expect(first).toEqual({ sent: true })
+    expect(second).toEqual({ sent: false, reason: 'already_sent' })
+    expect(email.send).toHaveBeenCalledTimes(1)
+    expect(email.send).toHaveBeenCalledWith(expect.objectContaining({
+      to: 'paid@example.com',
+      subject: '__configured_subject__',
+      text: '__configured_text__ https://example.com/survey',
+      html: '<p>__configured_html__ https://example.com/survey</p>',
+    }))
+    expect(email.sendCommunitySurveyInvite).toHaveBeenCalledWith({
+      to: 'paid@example.com',
+      subject: '__configured_subject__',
+      text: '__configured_text__ https://example.com/survey',
+      html: '<p>__configured_html__ https://example.com/survey</p>',
+      idempotencyKey: 'community-survey:user-survey-1',
+    })
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.stripeSessionId, 'cs_survey_once'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.status).toBe('sent')
+    expect(rows[0]?.sentAt).toBeInstanceOf(Date)
+  })
+
+  it('skips survey invite email when checkout payment is not paid', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+
+    const result = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_unpaid_survey',
+      metadata: { userId: 'user-survey-unpaid' },
+      customer_email: 'paid@example.com',
+      payment_status: 'unpaid',
+    } as any)
+
+    expect(result).toEqual({ sent: false, reason: 'payment_not_paid' })
+    expect(email.send).not.toHaveBeenCalled()
+  })
+
+  it('sends the survey invite only for the first paid checkout per user', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+
+    const first = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_first_payment',
+      metadata: { userId: 'user-survey-repeat' },
+      customer_email: 'repeat@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    const second = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_second_payment',
+      metadata: { userId: 'user-survey-repeat' },
+      customer_email: 'repeat@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(first).toEqual({ sent: true })
+    expect(second).toEqual({ sent: false, reason: 'already_sent' })
+    expect(email.send).toHaveBeenCalledTimes(1)
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-repeat'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.stripeSessionId).toBe('cs_first_payment')
+  })
+
+  it('retries delivery after the previous email attempt failed', async () => {
+    const email = createMockEmailService()
+    vi.mocked(email.sendCommunitySurveyInvite)
+      .mockRejectedValueOnce(new Error('resend unavailable'))
+      .mockResolvedValueOnce(undefined)
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+
+    const session = {
+      id: 'cs_retry_failed',
+      metadata: { userId: 'user-survey-failed-retry' },
+      customer_email: 'retry@example.com',
+      payment_status: 'paid',
+    }
+
+    await expect(service.sendPaidSurveyInviteForCheckout(session as any)).rejects.toThrow('resend unavailable')
+
+    const retry = await service.sendPaidSurveyInviteForCheckout(session as any)
+
+    expect(retry).toEqual({ sent: true })
+    expect(email.sendCommunitySurveyInvite).toHaveBeenCalledTimes(2)
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-failed-retry'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.status).toBe('sent')
+    expect(rows[0]?.failureReason).toBeNull()
+    expect(rows[0]?.attemptCount).toBe(2)
+  })
+
+  it('does not let a later checkout retry the first checkout survey invite', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+
+    await db.insert(schema.communitySurveyInviteEmail).values({
+      userId: 'user-survey-failed-first-payment',
+      stripeSessionId: 'cs_first_failed',
+      toEmail: 'first-failed@example.com',
+      surveyUrl: 'https://example.com/survey',
+      status: 'failed',
+      failureReason: 'resend unavailable',
+      attemptCount: 1,
+    })
+
+    const result = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_later_payment',
+      metadata: { userId: 'user-survey-failed-first-payment' },
+      customer_email: 'first-failed@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(result).toEqual({ sent: false, reason: 'already_pending' })
+    expect(email.sendCommunitySurveyInvite).not.toHaveBeenCalled()
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-failed-first-payment'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.stripeSessionId).toBe('cs_first_failed')
+    expect(rows[0]?.status).toBe('failed')
+    expect(rows[0]?.attemptCount).toBe(1)
+  })
+
+  it('reclaims a stale pending invite so crash-before-send can recover', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+    const staleUpdatedAt = new Date(Date.now() - 20 * 60 * 1000)
+
+    await db.insert(schema.communitySurveyInviteEmail).values({
+      userId: 'user-survey-stale-pending',
+      stripeSessionId: 'cs_stale_original',
+      toEmail: 'stale@example.com',
+      surveyUrl: 'https://example.com/survey',
+      status: 'pending',
+      attemptCount: 1,
+      updatedAt: staleUpdatedAt,
+    })
+
+    const result = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_stale_original',
+      metadata: { userId: 'user-survey-stale-pending' },
+      customer_email: 'stale@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(result).toEqual({ sent: true })
+    expect(email.sendCommunitySurveyInvite).toHaveBeenCalledTimes(1)
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-stale-pending'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.stripeSessionId).toBe('cs_stale_original')
+    expect(rows[0]?.status).toBe('sent')
+    expect(rows[0]?.attemptCount).toBe(2)
+  })
+
+  it('skips delivery when the survey URL is not configured', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV(null),
+      email,
+    )
+
+    const result = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_no_survey_url',
+      metadata: { userId: 'user-survey-2' },
+      customer_email: 'paid@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(result).toEqual({ sent: false, reason: 'survey_url_missing' })
+    expect(email.send).not.toHaveBeenCalled()
+
+    const retryFromLaterPayment = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_later_after_survey_url_missing',
+      metadata: { userId: 'user-survey-2' },
+      customer_email: 'paid@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(retryFromLaterPayment).toEqual({ sent: false, reason: 'already_pending' })
+    expect(email.send).not.toHaveBeenCalled()
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-2'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.stripeSessionId).toBe('cs_no_survey_url')
+    expect(rows[0]?.status).toBe('failed')
+    expect(rows[0]?.failureReason).toBe('Community survey URL missing')
+  })
+
+  it('claims the first paid checkout when the customer email is missing', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey'),
+      email,
+    )
+
+    const result = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_no_customer_email',
+      metadata: { userId: 'user-survey-no-email' },
+      payment_status: 'paid',
+    } as any)
+
+    expect(result).toEqual({ sent: false, reason: 'customer_email_missing' })
+    expect(email.send).not.toHaveBeenCalled()
+
+    const retryFromLaterPayment = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_later_after_customer_email_missing',
+      metadata: { userId: 'user-survey-no-email' },
+      customer_email: 'paid@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(retryFromLaterPayment).toEqual({ sent: false, reason: 'already_pending' })
+    expect(email.send).not.toHaveBeenCalled()
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-no-email'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.stripeSessionId).toBe('cs_no_customer_email')
+    expect(rows[0]?.status).toBe('failed')
+    expect(rows[0]?.failureReason).toBe('Checkout session missing customer email')
+  })
+
+  it('skips delivery when private survey email content is not configured', async () => {
+    const email = createMockEmailService()
+    const service = createCommunitySurveyService(
+      db,
+      createMockConfigKV('https://example.com/survey', {
+        COMMUNITY_SURVEY_EMAIL_HTML: null,
+      }),
+      email,
+    )
+
+    const result = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_no_survey_email_content',
+      metadata: { userId: 'user-survey-private-template' },
+      customer_email: 'paid@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(result).toEqual({ sent: false, reason: 'email_template_missing' })
+    expect(email.send).not.toHaveBeenCalled()
+
+    const retryFromLaterPayment = await service.sendPaidSurveyInviteForCheckout({
+      id: 'cs_later_after_template_missing',
+      metadata: { userId: 'user-survey-private-template' },
+      customer_email: 'paid@example.com',
+      payment_status: 'paid',
+    } as any)
+
+    expect(retryFromLaterPayment).toEqual({ sent: false, reason: 'already_pending' })
+    expect(email.send).not.toHaveBeenCalled()
+
+    const rows = await db.select().from(schema.communitySurveyInviteEmail).where(eq(schema.communitySurveyInviteEmail.userId, 'user-survey-private-template'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.stripeSessionId).toBe('cs_no_survey_email_content')
+    expect(rows[0]?.status).toBe('failed')
+    expect(rows[0]?.failureReason).toBe('Community survey email content missing')
+  })
+})

--- a/apps/server/src/services/domain/community-survey.ts
+++ b/apps/server/src/services/domain/community-survey.ts
@@ -1,0 +1,260 @@
+import type Stripe from 'stripe'
+
+import type { Database } from '../../libs/db'
+import type { ConfigKVService } from '../adapters/config-kv'
+import type { EmailService } from '../adapters/email'
+
+import { useLogger } from '@guiiai/logg'
+import { errorMessageFrom } from '@moeru/std'
+import { and, eq, lte, or, sql } from 'drizzle-orm'
+
+import * as schema from '../../schemas/community'
+
+const logger = useLogger('community-survey')
+
+type SurveyInviteResult
+  = | { sent: true }
+    | { sent: false, reason: 'already_pending' | 'already_sent' | 'customer_email_missing' | 'email_template_missing' | 'payment_not_paid' | 'survey_url_missing' | 'user_id_missing' }
+
+interface SurveyInviteClaim {
+  claimed: boolean
+  reason?: 'already_pending' | 'already_sent'
+}
+
+interface SurveyInviteEmailContent {
+  subject: string
+  html: string
+  text: string
+}
+
+const surveyUrlPlaceholder = '{{surveyUrl}}'
+
+/**
+ * Build the provider-side idempotency key for a user's first paid survey invite.
+ */
+function buildSurveyInviteIdempotencyKey(userId: string): string {
+  return `community-survey:${userId}`
+}
+
+/**
+ * Render private runtime-configured survey email content.
+ *
+ * Before:
+ * - `"Open: {{surveyUrl}}"`
+ *
+ * After:
+ * - `"Open: https://example.com/survey"`
+ */
+function renderSurveyInviteEmailContent(template: SurveyInviteEmailContent, surveyUrl: string): SurveyInviteEmailContent {
+  return {
+    subject: template.subject.trim(),
+    html: template.html.replaceAll(surveyUrlPlaceholder, surveyUrl),
+    text: template.text.replaceAll(surveyUrlPlaceholder, surveyUrl),
+  }
+}
+
+/**
+ * Create the paid-community survey service.
+ *
+ * Use when:
+ * - A Stripe checkout webhook has already fulfilled the user's paid benefit.
+ * - The survey email should be delivered for the user's first paid checkout only.
+ *
+ * Expects:
+ * - `COMMUNITY_SURVEY_URL` is configured in ConfigKV when this flow is enabled.
+ * - Stripe checkout sessions carry `metadata.userId` from checkout creation.
+ *
+ * Returns:
+ * - A service that claims an idempotency row before sending email.
+ */
+export function createCommunitySurveyService(
+  db: Database,
+  configKV: ConfigKVService,
+  email: EmailService,
+) {
+  /**
+   * Claim one checkout session for survey invite delivery.
+   */
+  async function claimInvite(input: {
+    userId: string
+    stripeSessionId: string
+    toEmail: string | null
+    surveyUrl: string | null
+  }): Promise<SurveyInviteClaim> {
+    const now = new Date()
+    // A process can crash after writing `pending` but before calling Resend.
+    // Ten minutes is long enough to avoid normal in-flight duplicate webhook
+    // races while still letting Stripe retries recover the stuck row quickly.
+    const stalePendingBefore = new Date(now.getTime() - 10 * 60 * 1000)
+    const [inserted] = await db.insert(schema.communitySurveyInviteEmail)
+      .values({
+        userId: input.userId,
+        stripeSessionId: input.stripeSessionId,
+        toEmail: input.toEmail,
+        surveyUrl: input.surveyUrl,
+        status: 'pending',
+        attemptCount: 1,
+      })
+      .onConflictDoNothing({ target: schema.communitySurveyInviteEmail.userId })
+      .returning()
+
+    if (inserted)
+      return { claimed: true }
+
+    const [retry] = await db.update(schema.communitySurveyInviteEmail)
+      .set({
+        toEmail: input.toEmail,
+        surveyUrl: input.surveyUrl,
+        status: 'pending',
+        failureReason: null,
+        attemptCount: sql`${schema.communitySurveyInviteEmail.attemptCount} + 1`,
+        updatedAt: now,
+      })
+      .where(and(
+        eq(schema.communitySurveyInviteEmail.userId, input.userId),
+        eq(schema.communitySurveyInviteEmail.stripeSessionId, input.stripeSessionId),
+        or(
+          eq(schema.communitySurveyInviteEmail.status, 'failed'),
+          and(
+            eq(schema.communitySurveyInviteEmail.status, 'pending'),
+            lte(schema.communitySurveyInviteEmail.updatedAt, stalePendingBefore),
+          ),
+        ),
+      ))
+      .returning()
+
+    if (retry)
+      return { claimed: true }
+
+    const existing = await db.query.communitySurveyInviteEmail.findFirst({
+      where: eq(schema.communitySurveyInviteEmail.userId, input.userId),
+    })
+
+    return {
+      claimed: false,
+      reason: existing?.status === 'sent' ? 'already_sent' : 'already_pending',
+    }
+  }
+
+  /**
+   * Mark a claimed survey invite as sent.
+   */
+  async function markSent(stripeSessionId: string): Promise<void> {
+    const now = new Date()
+    await db.update(schema.communitySurveyInviteEmail)
+      .set({
+        status: 'sent',
+        sentAt: now,
+        failureReason: null,
+        updatedAt: now,
+      })
+      .where(eq(schema.communitySurveyInviteEmail.stripeSessionId, stripeSessionId))
+  }
+
+  /**
+   * Mark a claimed survey invite as failed so Stripe webhook retries can send it again.
+   */
+  async function markFailed(stripeSessionId: string, failureReason: string): Promise<void> {
+    await db.update(schema.communitySurveyInviteEmail)
+      .set({
+        status: 'failed',
+        failureReason,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.communitySurveyInviteEmail.stripeSessionId, stripeSessionId))
+  }
+
+  /**
+   * Load private email content from runtime config so copy never lands in PRs.
+   */
+  async function loadEmailContent(surveyUrl: string): Promise<SurveyInviteEmailContent | null> {
+    const [subject, html, text] = await Promise.all([
+      configKV.getOptional('COMMUNITY_SURVEY_EMAIL_SUBJECT'),
+      configKV.getOptional('COMMUNITY_SURVEY_EMAIL_HTML'),
+      configKV.getOptional('COMMUNITY_SURVEY_EMAIL_TEXT'),
+    ])
+
+    if (!subject?.trim() || !html?.trim() || !text?.trim())
+      return null
+
+    return renderSurveyInviteEmailContent({ subject, html, text }, surveyUrl)
+  }
+
+  return {
+    /**
+     * Send the survey invite for one paid checkout session.
+     *
+     * Use when:
+     * - `checkout.session.completed` has passed the payment fulfillment checks.
+     *
+     * Expects:
+     * - A customer email is present on the Checkout Session.
+     *
+     * Returns:
+     * - `{ sent: true }` only when this call actually submits the email.
+     */
+    async sendPaidSurveyInviteForCheckout(session: Stripe.Checkout.Session): Promise<SurveyInviteResult> {
+      if (session.payment_status !== 'paid')
+        return { sent: false, reason: 'payment_not_paid' }
+
+      const userId = session.metadata?.userId
+      if (!userId) {
+        logger.withFields({ sessionId: session.id }).warn('Checkout session missing userId; skipping survey invite email')
+        return { sent: false, reason: 'user_id_missing' }
+      }
+
+      const surveyUrl = (await configKV.getOptional('COMMUNITY_SURVEY_URL'))?.trim() || null
+      const toEmail = session.customer_details?.email || session.customer_email
+      const claim = await claimInvite({
+        userId,
+        stripeSessionId: session.id,
+        toEmail: toEmail ?? null,
+        surveyUrl,
+      })
+      if (!claim.claimed)
+        return { sent: false, reason: claim.reason ?? 'already_pending' }
+
+      if (!surveyUrl) {
+        const message = 'Community survey URL missing'
+        logger.withFields({ userId, sessionId: session.id }).warn(`${message}; skipping survey invite email`)
+        await markFailed(session.id, message)
+        return { sent: false, reason: 'survey_url_missing' }
+      }
+
+      if (!toEmail) {
+        const message = 'Checkout session missing customer email'
+        logger.withFields({ userId, sessionId: session.id }).warn(`${message}; skipping survey invite email`)
+        await markFailed(session.id, message)
+        return { sent: false, reason: 'customer_email_missing' }
+      }
+
+      const emailContent = await loadEmailContent(surveyUrl)
+      if (!emailContent) {
+        const message = 'Community survey email content missing'
+        logger.withFields({ userId, sessionId: session.id }).warn(`${message}; skipping survey invite email`)
+        await markFailed(session.id, message)
+        return { sent: false, reason: 'email_template_missing' }
+      }
+
+      try {
+        await email.sendCommunitySurveyInvite({
+          to: toEmail,
+          subject: emailContent.subject,
+          html: emailContent.html,
+          text: emailContent.text,
+          idempotencyKey: buildSurveyInviteIdempotencyKey(userId),
+        })
+        await markSent(session.id)
+        logger.withFields({ userId, sessionId: session.id, toEmail }).log('Sent paid community survey invite')
+        return { sent: true }
+      }
+      catch (error) {
+        const message = errorMessageFrom(error) ?? 'Unknown community survey email error'
+        await markFailed(session.id, message)
+        throw error
+      }
+    },
+  }
+}
+
+export type CommunitySurveyService = ReturnType<typeof createCommunitySurveyService>


### PR DESCRIPTION
## Summary

- Send a runtime-configured community survey email after a user's first successful Stripe payment fulfillment.
- Store a `community_survey_invite_email` claim row keyed by `user_id` so later payments do not send another invite.
- Keep the private email copy out of the PR by reading subject/html/text from ConfigKV and replacing `{{surveyUrl}}` at send time.
- Pass a stable Resend idempotency key and isolate survey email failures from the Stripe fulfillment webhook response.

## Behavior

- Only `payment_status === 'paid'` checkout sessions are considered.
- The first paid checkout with a `metadata.userId` claims the survey invite slot even if URL/email/template config is missing.
- Later checkout sessions for the same user do not take over the first-payment invite.
- Retrying the same Stripe checkout session can recover failed or stale pending delivery.

## Required runtime config

- `COMMUNITY_SURVEY_URL`
- `COMMUNITY_SURVEY_EMAIL_SUBJECT`
- `COMMUNITY_SURVEY_EMAIL_HTML`
- `COMMUNITY_SURVEY_EMAIL_TEXT`

The HTML/text templates can include `{{surveyUrl}}`.

## Validation

- `pnpm exec vitest run apps/server/src/app.test.ts apps/server/src/services/domain/community-survey.test.ts apps/server/src/routes/stripe/route.test.ts apps/server/src/services/adapters/config-kv.test.ts apps/server/src/services/adapters/email.test.ts`
- `pnpm -F @proj-airi/server typecheck`
- `pnpm exec moeru-lint apps/server/src/routes/stripe/route.test.ts apps/server/src/services/domain/community-survey.ts apps/server/src/services/domain/community-survey.test.ts apps/server/src/services/adapters/email.ts apps/server/src/services/adapters/email.test.ts apps/server/src/services/adapters/config-kv.ts apps/server/src/app.ts apps/server/src/app.test.ts apps/server/src/schemas/community.ts apps/server/src/schemas/index.ts`
- `git diff --check`

Repo-wide checks still have existing unrelated failures locally in `pnpm typecheck` / `pnpm lint`, including `vue-router/auto-routes` missing `routes` in stage apps and existing lint debt outside this PR's touched files.