### PR TITLE
fix(stage-ui): restore default stage model when saved model is missing

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/App.vue
+++ b/apps/stage-tamagotchi/src/renderer/App.vue
@@ -197,9 +197,8 @@ function createFullStageRuntime() {
       cardStore.initialize()
 
       await displayModelsStore.loadDisplayModelsFromIndexedDB()
-      await settingsStore.initializeStageModel()
-      await settingsAudioDeviceStore.initialize()
-
+      // NOTICE: Restore the Godot renderer before model recovery so deleted custom VRM ids
+      // fall back to a VRM preset instead of the built-in Live2D preset.
       if (isGodotStageRoute()) {
         try {
           syncGodotStageRenderer(await getGodotStageStatus())
@@ -208,6 +207,8 @@ function createFullStageRuntime() {
           console.warn('[App] Failed to fetch Godot stage status:', error)
         }
       }
+      await settingsStore.initializeStageModel()
+      await settingsAudioDeviceStore.initialize()
 
       const serverChannelConfig = await getServerChannelConfig()
       serverChannelSettingsStore.tlsConfig = serverChannelConfig.tlsConfig ?? null

--- a/packages/stage-ui/src/stores/settings/stage-model.test.ts
+++ b/packages/stage-ui/src/stores/settings/stage-model.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('localforage', () => ({
+  default: {
+    getItem: vi.fn(async () => undefined),
+    iterate: vi.fn(async () => undefined),
+    removeItem: vi.fn(async () => undefined),
+    setItem: vi.fn(async (_key: string, value: unknown) => value),
+  },
+}))
+
+/**
+ * @example
+ * describe('settings stage model store', () => {})
+ */
+describe('settings stage model store', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  /**
+   * @example
+   * it('recovers stale custom model selections to the default preset', async () => {})
+   */
+  it('recovers stale custom model selections to the default preset', async () => {
+    // ROOT CAUSE:
+    //
+    // If localStorage points at a custom display-model id that IndexedDB no longer has,
+    // updateStageModel resolved no model and switched the renderer to "disabled".
+    // The tamagotchi main page waits for the stage component to report "mounted",
+    // but no renderer component mounts for the disabled state, leaving the loading
+    // overlay visible forever.
+    //
+    // We fixed this by restoring the built-in Live2D preset when a persisted custom
+    // model id can no longer be resolved.
+    localStorage.setItem('settings/stage/model', 'display-model-missing-from-indexeddb')
+
+    const { createPinia, setActivePinia } = await import('pinia')
+    setActivePinia(createPinia())
+    const { useSettingsStageModel } = await import('./stage-model')
+    const store = useSettingsStageModel()
+
+    expect(store.stageModelSelected).toBe('display-model-missing-from-indexeddb')
+
+    await store.initializeStageModel()
+
+    expect(store.stageModelSelected).toBe('preset-live2d-1')
+    expect(store.stageModelRenderer).toBe('live2d')
+    expect(store.stageModelSelectedDisplayModel?.id).toBe('preset-live2d-1')
+    expect(store.stageModelSelectedUrl).toContain('hiyori_pro_zh.zip')
+  })
+
+  /**
+   * @example
+   * it('recovers stale custom model selections to the default VRM preset while Godot is active', async () => {})
+   */
+  it('recovers stale custom model selections to the default VRM preset while Godot is active', async () => {
+    // ROOT CAUSE:
+    //
+    // If the Electron Godot stage was already running during bootstrap and the
+    // persisted custom display-model id no longer existed, updateStageModel restored
+    // the Live2D default preset. The settings/models Godot watcher then tried to send
+    // that resolved Live2D model through the Godot scene-input path, which only accepts
+    // VRM models and surfaced "Godot Stage currently supports VRM models only."
+    //
+    // We fixed this by resolving stale model selections to the default VRM preset when
+    // the active renderer has already been restored as "godot".
+    localStorage.setItem('settings/stage/model', 'display-model-missing-from-indexeddb')
+
+    const { createPinia, setActivePinia } = await import('pinia')
+    setActivePinia(createPinia())
+    const { useSettingsStageModel } = await import('./stage-model')
+    const store = useSettingsStageModel()
+
+    store.setStageModelRenderer('godot')
+
+    await store.initializeStageModel()
+
+    expect(store.stageModelSelected).toBe('preset-vrm-1')
+    expect(store.stageModelRenderer).toBe('godot')
+    expect(store.stageModelSelectedDisplayModel?.id).toBe('preset-vrm-1')
+    expect(store.stageModelSelectedUrl).toContain('AvatarSample_A.vrm')
+  })
+})

--- a/packages/stage-ui/src/stores/settings/stage-model.ts
+++ b/packages/stage-ui/src/stores/settings/stage-model.ts
@@ -10,12 +10,15 @@ import { DisplayModelFormat, useDisplayModelsStore } from '../display-models'
 export type StageModelRenderer = 'live2d' | 'vrm' | 'spine' | 'godot' | 'disabled' | undefined
 type BuiltInStageModelRenderer = Exclude<StageModelRenderer, 'godot'>
 
+const defaultLive2dStageModelId = 'preset-live2d-1'
+const defaultGodotStageModelId = 'preset-vrm-1'
+
 export const useSettingsStageModel = defineStore('settings-stage-model', () => {
   const displayModelsStore = useDisplayModelsStore()
   let stageModelUpdateSequence = 0
   const stageModelStorageKey = 'settings/stage/model'
 
-  const stageModelSelectedState = useLocalStorageManualReset<string>(stageModelStorageKey, 'preset-live2d-1')
+  const stageModelSelectedState = useLocalStorageManualReset<string>(stageModelStorageKey, defaultLive2dStageModelId)
   const stageModelSelected = computed<string>({
     get: () => stageModelSelectedState.value,
     set: (value) => {
@@ -59,9 +62,16 @@ export const useSettingsStageModel = defineStore('settings-stage-model', () => {
     }
   }
 
+  function resolveDefaultStageModelId(): string {
+    if (stageModelRenderer.value === 'godot')
+      return defaultGodotStageModelId
+
+    return defaultLive2dStageModelId
+  }
+
   async function updateStageModel() {
     const requestId = ++stageModelUpdateSequence
-    const selectedModelId = stageModelSelectedState.value
+    let selectedModelId = stageModelSelectedState.value
 
     if (!selectedModelId) {
       replaceStageModelUrl(undefined)
@@ -72,7 +82,23 @@ export const useSettingsStageModel = defineStore('settings-stage-model', () => {
       return
     }
 
-    const model = await displayModelsStore.getDisplayModel(selectedModelId)
+    let model = await displayModelsStore.getDisplayModel(selectedModelId)
+    if (requestId !== stageModelUpdateSequence)
+      return
+
+    const defaultStageModelId = resolveDefaultStageModelId()
+    const shouldRestoreDefaultSelection = !model && selectedModelId !== defaultStageModelId
+    if (shouldRestoreDefaultSelection) {
+      const defaultModel = await displayModelsStore.getDisplayModel(defaultStageModelId)
+      if (requestId !== stageModelUpdateSequence)
+        return
+
+      if (defaultModel) {
+        selectedModelId = defaultStageModelId
+        model = defaultModel
+      }
+    }
+
     if (requestId !== stageModelUpdateSequence)
       return
 
@@ -104,6 +130,8 @@ export const useSettingsStageModel = defineStore('settings-stage-model', () => {
     }
 
     stageModelSelectedDisplayModel.value = model
+    if (shouldRestoreDefaultSelection)
+      stageModelSelectedState.value = defaultStageModelId
   }
 
   function setStageModelRenderer(renderer: StageModelRenderer) {


### PR DESCRIPTION
## Summary

Fixes the tamagotchi app getting stuck on the loading screen when `localStorage` points to a custom stage model that no longer exists in IndexedDB.

## Changes

- Adds a shared default stage model id, `preset-live2d-1`.
- Falls back to the default Live2D model when the saved stage model cannot be resolved.
- Persists the restored default selection back to `localStorage`.
- Adds a regression test for missing persisted model data.

## Root Cause

The renderer could become `disabled` when `settings/stage/model` referenced a stale custom model id. Since no valid stage renderer was mounted, the app stayed on the loading screen.

## Testing

- `pnpm -F @proj-airi/stage-ui exec vitest run src/stores/settings/stage-model.test.ts`
- `pnpm -F @proj-airi/stage-ui typecheck`
- `pnpm exec moeru-lint packages/stage-ui/src/stores/settings/stage-model.ts packages/stage-ui/src/stores/settings/stage-model.test.ts`
- Verified `pnpm dev:tamagotchi` loads successfully with the default Hiyori model.

Note: root `pnpm lint` still reports existing unrelated repo-wide issues.