### PR TITLE
docs: add winget install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@
 > Heavily inspired by [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> On Windows, you can also install AIRI with [Scoop](https://scoop.sh/):
+> On Windows, you can also install AIRI with [winget](https://learn.microsoft.com/windows/package-manager/winget/) or [Scoop](https://scoop.sh/):
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/README.md
+++ b/README.md
@@ -136,10 +136,15 @@
 > Heavily inspired by [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> On Windows, you can also install AIRI with [winget](https://learn.microsoft.com/windows/package-manager/winget/) or [Scoop](https://scoop.sh/):
+> On Windows, you can also install AIRI with [winget](https://learn.microsoft.com/windows/package-manager/winget/):
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> Or install AIRI with [Scoop](https://scoop.sh/):
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -135,10 +135,15 @@
 > Fortement inspiré par [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> Sous Windows, vous pouvez installer AIRI avec [winget](https://learn.microsoft.com/windows/package-manager/winget/) ou [Scoop](https://scoop.sh/) :
+> Sous Windows, vous pouvez installer AIRI avec [winget](https://learn.microsoft.com/windows/package-manager/winget/) :
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> Ou installer AIRI avec [Scoop](https://scoop.sh/) :
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -135,9 +135,10 @@
 > Fortement inspiré par [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> Sous Windows, vous pouvez également installer AIRI avec [Scoop](https://scoop.sh/) :
+> Sous Windows, vous pouvez installer AIRI avec [winget](https://learn.microsoft.com/windows/package-manager/winget/) ou [Scoop](https://scoop.sh/) :
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -135,10 +135,15 @@
 > [Neuro-sama](https://www.youtube.com/@Neurosama) に大きな影響を受けました
 
 > [!TIP]
-> Windows では、[winget](https://learn.microsoft.com/windows/package-manager/winget/) または [Scoop](https://scoop.sh/) で AIRI をインストールできます：
+> Windows では、[winget](https://learn.microsoft.com/windows/package-manager/winget/) で AIRI をインストールできます：
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> または、[Scoop](https://scoop.sh/) で AIRI をインストールできます：
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -135,9 +135,10 @@
 > [Neuro-sama](https://www.youtube.com/@Neurosama) に大きな影響を受けました
 
 > [!TIP]
-> Windows では、[Scoop](https://scoop.sh/) でも AIRI をインストールできます：
+> Windows では、[winget](https://learn.microsoft.com/windows/package-manager/winget/) または [Scoop](https://scoop.sh/) で AIRI をインストールできます：
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -135,9 +135,10 @@
 > [Neuro-sama](https://www.youtube.com/@Neurosama)에서 큰 영감을 받았습니다
 
 > [!TIP]
-> Windows에서는 [Scoop](https://scoop.sh/)으로도 AIRI를 설치할 수 있습니다:
+> Windows에서는 [winget](https://learn.microsoft.com/windows/package-manager/winget/) 또는 [Scoop](https://scoop.sh/)으로 AIRI를 설치할 수 있습니다:
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.ko-KR.md
+++ b/docs/README.ko-KR.md
@@ -135,10 +135,15 @@
 > [Neuro-sama](https://www.youtube.com/@Neurosama)에서 큰 영감을 받았습니다
 
 > [!TIP]
-> Windows에서는 [winget](https://learn.microsoft.com/windows/package-manager/winget/) 또는 [Scoop](https://scoop.sh/)으로 AIRI를 설치할 수 있습니다:
+> Windows에서는 [winget](https://learn.microsoft.com/windows/package-manager/winget/)으로 AIRI를 설치할 수 있습니다:
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> 또는 [Scoop](https://scoop.sh/)으로 AIRI를 설치할 수 있습니다:
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -135,9 +135,10 @@
 > Сильно вдохновлено [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> В Windows AIRI также можно установить с помощью [Scoop](https://scoop.sh/):
+> В Windows AIRI можно установить с помощью [winget](https://learn.microsoft.com/windows/package-manager/winget/) или [Scoop](https://scoop.sh/):
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.ru-RU.md
+++ b/docs/README.ru-RU.md
@@ -135,10 +135,15 @@
 > Сильно вдохновлено [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> В Windows AIRI можно установить с помощью [winget](https://learn.microsoft.com/windows/package-manager/winget/) или [Scoop](https://scoop.sh/):
+> В Windows AIRI можно установить с помощью [winget](https://learn.microsoft.com/windows/package-manager/winget/):
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> Или установить AIRI через [Scoop](https://scoop.sh/):
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -135,10 +135,15 @@
 > Lấy cảm hứng mạnh mẽ từ [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> Trên Windows, bạn có thể cài AIRI bằng [winget](https://learn.microsoft.com/windows/package-manager/winget/) hoặc [Scoop](https://scoop.sh/):
+> Trên Windows, bạn có thể cài AIRI bằng [winget](https://learn.microsoft.com/windows/package-manager/winget/):
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> Hoặc cài AIRI bằng [Scoop](https://scoop.sh/):
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -135,9 +135,10 @@
 > Lấy cảm hứng mạnh mẽ từ [Neuro-sama](https://www.youtube.com/@Neurosama)
 
 > [!TIP]
-> Trên Windows, bạn cũng có thể cài AIRI bằng [Scoop](https://scoop.sh/):
+> Trên Windows, bạn có thể cài AIRI bằng [winget](https://learn.microsoft.com/windows/package-manager/winget/) hoặc [Scoop](https://scoop.sh/):
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -135,9 +135,10 @@
 > 深受 [Neuro-sama](https://www.youtube.com/@Neurosama) 启发
 
 > [!TIP]
-> 在 Windows 上，你也可以使用 [Scoop](https://scoop.sh/) 安装 AIRI：
+> 在 Windows 上，你也可以使用 [winget](https://learn.microsoft.com/windows/package-manager/winget/) 或 [Scoop](https://scoop.sh/) 安装 AIRI：
 >
 > ```powershell
+> winget install MoeruAI.AIRI
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -135,10 +135,15 @@
 > 深受 [Neuro-sama](https://www.youtube.com/@Neurosama) 启发
 
 > [!TIP]
-> 在 Windows 上，你也可以使用 [winget](https://learn.microsoft.com/windows/package-manager/winget/) 或 [Scoop](https://scoop.sh/) 安装 AIRI：
+> 在 Windows 上，你也可以使用 [winget](https://learn.microsoft.com/windows/package-manager/winget/) 安装 AIRI：
 >
 > ```powershell
 > winget install MoeruAI.AIRI
+> ```
+>
+> 或者使用 [Scoop](https://scoop.sh/) 安装 AIRI：
+>
+> ```powershell
 > scoop bucket add airi https://github.com/moeru-ai/airi
 > scoop install airi/airi
 > ```


### PR DESCRIPTION
## Summary
- Add the `winget install MoeruAI.AIRI` command to the root README Windows install tip.
- Mirror the same winget command in the localized README files covered by the issue.

Closes #1913

## Validation
- `grep -n -B 5 -A 5 "MoeruAI\.AIRI" README.md docs/README.*.md`
- `git diff --check`
