### PR TITLE
feat(stage-ui): upgrade MiniMax default model to M3

### DIFF
--- a/packages/stage-ui/src/libs/providers/providers/minimax/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/minimax/index.ts
@@ -31,52 +31,22 @@ type MinimaxGlobalConfig = z.input<typeof minimaxGlobalConfigSchema>
 
 const minimaxModels: ModelInfo[] = [
   {
+    id: 'MiniMax-M3',
+    name: 'MiniMax M3',
+    provider: 'minimax',
+    description: 'Latest flagship model with 512K context, 128K max output, and image input support',
+  },
+  {
     id: 'MiniMax-M2.7',
     name: 'MiniMax M2.7',
     provider: 'minimax',
-    description: 'Latest flagship model with enhanced reasoning and coding',
+    description: 'Previous flagship model with strong reasoning and coding',
   },
   {
     id: 'MiniMax-M2.7-highspeed',
     name: 'MiniMax M2.7 Highspeed',
     provider: 'minimax',
     description: 'High-speed version of M2.7 for low-latency scenarios',
-  },
-  {
-    id: 'MiniMax-M2.5',
-    name: 'MiniMax M2.5',
-    provider: 'minimax',
-    description: 'Top performance and cost-effectiveness for complex tasks',
-  },
-  {
-    id: 'MiniMax-M2.5-highspeed',
-    name: 'MiniMax M2.5 Highspeed',
-    provider: 'minimax',
-    description: 'M2.5 high-speed version with same quality',
-  },
-  {
-    id: 'MiniMax-M2.1',
-    name: 'MiniMax M2.1',
-    provider: 'minimax',
-    description: 'Strong multilingual programming capabilities',
-  },
-  {
-    id: 'MiniMax-M2.1-highspeed',
-    name: 'MiniMax M2.1 Highspeed',
-    provider: 'minimax',
-    description: 'M2.1 high-speed version with same quality',
-  },
-  {
-    id: 'M2-her',
-    name: 'MiniMax M2-her',
-    provider: 'minimax',
-    description: 'Specialized for roleplay and multi-turn dialogue',
-  },
-  {
-    id: 'MiniMax-M2',
-    name: 'MiniMax M2',
-    provider: 'minimax',
-    description: 'Designed for efficient coding and agent workflows',
   },
 ]
 


### PR DESCRIPTION
## Summary

Upgrade MiniMax chat provider configuration to make MiniMax-M3 the new default model.

## Changes

- Add `MiniMax-M3` to the model selection list as the new default (first entry)
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for backward compatibility
- Remove deprecated older variants from the list: `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `M2-her`, `MiniMax-M2`

Scope is limited to `packages/stage-ui/src/libs/providers/providers/minimax/index.ts`. The TTS provider (`minimax-speech`) is untouched, and the volcengine-coding-plan provider which exposes a `minimax-m2.5` proxy entry is also untouched (it lives behind that vendor's ARK gateway).

## Why

MiniMax-M3 is the new flagship model with 512K context, 128K max output, and image input support. The older M2.5/M2.1/M2 lines are no longer the recommended path; M2.7 remains available as a stable previous-flagship alternative.

## Testing

- Static verification: scanned the repo for references to removed model IDs (`MiniMax-M2.5`, `M2-her`, etc.) — none remain outside this provider file
- Model list shape unchanged (still `ModelInfo[]`); only the entries inside the array changed
- Both `minimax` (CN) and `minimax-global` providers share the same `minimaxModels` array, so the upgrade applies to both