### PR TITLE
feat(stage-ui): draft rwkv-local provider (contract-agnostic parts)

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1280,8 +1280,8 @@ pages:
             description: RWKV-7 World 0.4B, full precision (FP16)
           rwkv7-world-1b5-int8:
             description: RWKV-7 World 1.5B, Int8 quantized - balances quality and GPU memory
-          rwkv7-world-2b9-nf4:
-            description: RWKV-7 World 2.9B, NF4 quantized - most capable, highest GPU memory
+          rwkv7-world-3b-nf4:
+            description: RWKV-7 World 3B, NF4 quantized - most capable, highest GPU memory (downloads the full ~5.9 GB FP16 weights, then quantizes on-device)
         title: RWKV (Local)
       fireworks:
         description: fireworks.ai

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1274,14 +1274,14 @@ pages:
               label: Model Selection
               description: Smaller models load faster and use less GPU memory; larger models are more capable.
         models:
-          rwkv7-world-100m-fp16:
-            description: RWKV-7 World 0.1B, full precision (FP16) - fastest to load, lowest quality
-          rwkv7-world-400m-fp16:
-            description: RWKV-7 World 0.4B, full precision (FP16)
-          rwkv7-world-1b5-int8:
-            description: RWKV-7 World 1.5B, Int8 quantized - balances quality and GPU memory
-          rwkv7-world-3b-nf4:
-            description: RWKV-7 World 3B, NF4 quantized - most capable, highest GPU memory (downloads the full ~5.9 GB FP16 weights, then quantizes on-device)
+          rwkv7-g1-100m-fp16:
+            description: RWKV-7 G1 0.1B, full precision (FP16) - fastest to load, lowest quality
+          rwkv7-g1-400m-fp16:
+            description: RWKV-7 G1 0.4B, full precision (FP16)
+          rwkv7-g1-1b5-int8:
+            description: RWKV-7 G1 1.5B, Int8 quantized - balances quality and GPU memory
+          rwkv7-g1-2b9-nf4:
+            description: RWKV-7 G1 2.9B, NF4 quantized - most capable, highest GPU memory (downloads the full ~5.9 GB FP16 weights, then quantizes on-device)
         title: RWKV (Local)
       fireworks:
         description: fireworks.ai

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1266,6 +1266,23 @@ pages:
           default-text: Hello! This is a test of the Kokoro text-to-speech system.
           title: Voice Playground
         title: Kokoro TTS (Local)
+      rwkv-local:
+        description: Local chat using RWKV models running entirely in your browser via WebGPU.
+        fields:
+          field:
+            model:
+              label: Model Selection
+              description: Smaller models load faster and use less GPU memory; larger models are more capable.
+        models:
+          rwkv7-world-100m-fp16:
+            description: RWKV-7 World 0.1B, full precision (FP16) - fastest to load, lowest quality
+          rwkv7-world-400m-fp16:
+            description: RWKV-7 World 0.4B, full precision (FP16)
+          rwkv7-world-1b5-int8:
+            description: RWKV-7 World 1.5B, Int8 quantized - balances quality and GPU memory
+          rwkv7-world-2b9-nf4:
+            description: RWKV-7 World 2.9B, NF4 quantized - most capable, highest GPU memory
+        title: RWKV (Local)
       fireworks:
         description: fireworks.ai
         title: Fireworks.ai

--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -62,6 +62,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@cryscan/web-rwkv-wasm": "^0.10.20",
     "@date-fns/utc": "^2.1.1",
     "@formkit/auto-animate": "^0.9.0",
     "@huggingface/transformers": "^3.8.1",

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -55,6 +55,7 @@ import { getKokoroAdapter } from '../libs/inference/adapters/kokoro'
 import { getProviderValidationIntervalMs, listProviders as listDefinedProviders, ProviderValidationCheck } from '../libs/providers'
 import { resolveProviderSourceMetadata } from '../libs/providers/source-metadata'
 import { getDefaultKokoroModel, KOKORO_MODELS, kokoroModelsToModelInfo } from '../workers/kokoro/constants'
+import { getDefaultRwkvModel, RWKV_MODELS, rwkvModelsToModelInfo } from '../workers/rwkv/constants'
 import { useAuthStore } from './auth'
 import { createAliyunNLSProvider as createAliyunNlsStreamProvider } from './providers/aliyun/stream-transcription'
 import { convertProviderDefinitionsToMetadata } from './providers/converters'
@@ -2223,6 +2224,95 @@ export const useProvidersStore = defineStore('providers', () => {
             return {
               errors: [new Error(`Invalid model: ${model}`)],
               reason: `Invalid model. Must be one of: ${KOKORO_MODELS.map(m => m.id).join(', ')}`,
+              valid: false,
+            }
+          }
+
+          return {
+            errors: [],
+            reason: '',
+            valid: true,
+          }
+        },
+      },
+    },
+    'rwkv-local': {
+      id: 'rwkv-local',
+      category: 'chat',
+      tasks: ['chat'],
+      nameKey: 'settings.pages.providers.provider.rwkv-local.title',
+      name: 'RWKV (Local)',
+      descriptionKey: 'settings.pages.providers.provider.rwkv-local.description',
+      description: 'Local chat using RWKV models running in-browser via WebGPU.',
+      icon: 'i-lobe-icons:rwkv',
+      deployment: 'local',
+      pricing: 'free',
+
+      // web-rwkv's compute path is WebGPU-only — there is no WASM/CPU fallback
+      // for inference — so without `navigator.gpu` nothing is runnable. Gate
+      // availability on real WebGPU support (mirrors isBrowserAndMemoryEnough's
+      // WebGPU probe, but RWKV cannot fall back to the deviceMemory path).
+      isAvailableBy: isWebGPUSupported,
+
+      defaultOptions: () => {
+        const capabilities = getCachedWebGPUCapabilities()
+        const hasWebGPU = capabilities?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
+        return {
+          model: getDefaultRwkvModel(hasWebGPU) ?? '',
+        }
+      },
+
+      createProvider: async (_config) => {
+        // TODO(#1917): wire to the RWKV worker adapter once the inference-worker
+        // @moeru/eventa contract lands.
+        //
+        // NOTICE:
+        // This provider's contract-agnostic surface (metadata, model catalog,
+        // i18n, validation, WebGPU gating) is drafted here, but the actual
+        // in-browser generation requires a `workers/rwkv/worker.ts` + a
+        // `libs/inference/adapters/rwkv.ts` that speak the worker↔main wire
+        // contract. That contract is being rewritten from the hand-rolled
+        // postMessage protocol to an @moeru/eventa contract in PR #1917
+        // (deletes libs/inference/worker-manager.ts), so the adapter is
+        // deliberately built on top of that branch to avoid throwaway work.
+        // Until then `isAvailableBy` (WebGPU) keeps this selectable only where
+        // it could eventually run; selecting + invoking it surfaces this error.
+        // Removal condition: implement the worker + adapter on #1917's contract
+        // and return a ChatProvider whose `fetch` streams from the adapter.
+        throw new Error('RWKV local provider is not wired yet: the in-browser worker/adapter is pending the inference-worker contract migration (PR #1917).')
+      },
+
+      capabilities: {
+        listModels: async (_config: Record<string, unknown>) => {
+          const caps = getCachedWebGPUCapabilities()
+          const hasWebGPU = caps?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
+          return rwkvModelsToModelInfo(hasWebGPU, t)
+        },
+
+        loadModel: async (_config: Record<string, unknown>) => {
+          // TODO(#1917): load the safetensors weights + vocab in the RWKV worker
+          // via the adapter once the eventa contract lands (see createProvider).
+          throw new Error('RWKV local provider is not wired yet: model loading is pending the inference-worker contract migration (PR #1917).')
+        },
+      },
+
+      validators: {
+        chatPingCheckAvailable: false,
+        validateProviderConfig: (config) => {
+          const model = config.model as string
+
+          if (!model) {
+            return {
+              errors: [new Error('No model selected')],
+              reason: 'Please select a model from the dropdown menu',
+              valid: false,
+            }
+          }
+
+          if (!RWKV_MODELS.some(m => m.id === model)) {
+            return {
+              errors: [new Error(`Invalid model: ${model}`)],
+              reason: `Invalid model. Must be one of: ${RWKV_MODELS.map(m => m.id).join(', ')}`,
               valid: false,
             }
           }

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2267,19 +2267,22 @@ export const useProvidersStore = defineStore('providers', () => {
         // @moeru/eventa contract lands.
         //
         // NOTICE:
-        // This provider's contract-agnostic surface (metadata, model catalog,
-        // i18n, validation, WebGPU gating) is drafted here, but the actual
-        // in-browser generation requires a `workers/rwkv/worker.ts` + a
-        // `libs/inference/adapters/rwkv.ts` that speak the worker↔main wire
-        // contract. That contract is being rewritten from the hand-rolled
-        // postMessage protocol to an @moeru/eventa contract in PR #1917
-        // (deletes libs/inference/worker-manager.ts), so the adapter is
-        // deliberately built on top of that branch to avoid throwaway work.
+        // The worker side is now implemented: `workers/rwkv/worker.ts` runs the
+        // engine (`engine.ts`: load + Cache-Storage weight caching + web-rwkv
+        // prefix-state caching + streaming generate) behind a transport-agnostic
+        // port (`transport.ts`). The remaining gap is the *main-side* adapter:
+        // a transport client that drives that worker, plus chat-template
+        // formatting (messages -> RWKV `User:/Assistant:` prompt) and an
+        // xsai-compatible ChatProvider whose `fetch` streams token deltas.
+        // That adapter is deliberately built on PR #1917's eventa contract
+        // (which deletes libs/inference/worker-manager.ts) rather than the
+        // hand-rolled protocol, so only `transport.ts`'s postMessage binding is
+        // swapped — the engine and ops stay as-is.
         // Until then `isAvailableBy` (WebGPU) keeps this selectable only where
         // it could eventually run; selecting + invoking it surfaces this error.
-        // Removal condition: implement the worker + adapter on #1917's contract
+        // Removal condition: implement the main-side adapter on #1917's contract
         // and return a ChatProvider whose `fetch` streams from the adapter.
-        throw new Error('RWKV local provider is not wired yet: the in-browser worker/adapter is pending the inference-worker contract migration (PR #1917).')
+        throw new Error('RWKV local provider is not wired yet: the main-thread adapter is pending the inference-worker contract migration (PR #1917).')
       },
 
       capabilities: {

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -2270,10 +2270,11 @@ export const useProvidersStore = defineStore('providers', () => {
         // The worker side is now implemented: `workers/rwkv/worker.ts` runs the
         // engine (`engine.ts`: load + Cache-Storage weight caching + web-rwkv
         // prefix-state caching + streaming generate) behind a transport-agnostic
-        // port (`transport.ts`). The remaining gap is the *main-side* adapter:
-        // a transport client that drives that worker, plus chat-template
-        // formatting (messages -> RWKV `User:/Assistant:` prompt) and an
-        // xsai-compatible ChatProvider whose `fetch` streams token deltas.
+        // port (`transport.ts`), and `prompt.ts` flattens an OpenAI `Message[]`
+        // into the G1 chat template. The remaining gap is the *main-side*
+        // adapter: a transport client that drives the worker and an
+        // xsai-compatible ChatProvider whose `fetch` reads the request
+        // `messages`, calls `formatG1Prompt`, and streams the token deltas back.
         // That adapter is deliberately built on PR #1917's eventa contract
         // (which deletes libs/inference/worker-manager.ts) rather than the
         // hand-rolled protocol, so only `transport.ts`'s postMessage binding is

--- a/packages/stage-ui/src/workers/rwkv/constants.test.ts
+++ b/packages/stage-ui/src/workers/rwkv/constants.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDefaultRwkvModel, RWKV_MODELS, rwkvModelsToModelInfo } from './constants'
+
+describe('rwkvModelsToModelInfo', () => {
+  /**
+   * @example
+   * rwkvModelsToModelInfo(true) // -> one ModelInfo per catalog entry
+   */
+  it('maps every catalog entry to a provider-scoped ModelInfo when WebGPU is available', () => {
+    const infos = rwkvModelsToModelInfo(true)
+
+    expect(infos).toHaveLength(RWKV_MODELS.length)
+    expect(infos.map(i => i.id)).toEqual(RWKV_MODELS.map(m => m.id))
+    expect(infos.every(i => i.provider === 'rwkv-local')).toBe(true)
+  })
+
+  /**
+   * @example
+   * rwkvModelsToModelInfo(false) // -> []
+   */
+  it('returns an empty list without WebGPU because web-rwkv has no CPU/WASM compute path', () => {
+    expect(rwkvModelsToModelInfo(false)).toEqual([])
+  })
+
+  /**
+   * @example
+   * rwkvModelsToModelInfo(true, k => k.toUpperCase())
+   */
+  it('uses the translator for descriptions and falls back to the raw key without one', () => {
+    const translated = rwkvModelsToModelInfo(true, () => 'translated')
+    expect(translated[0].description).toBe('translated')
+
+    const untranslated = rwkvModelsToModelInfo(true)
+    expect(untranslated[0].description).toBe(RWKV_MODELS[0].descriptionKey)
+  })
+})
+
+describe('getDefaultRwkvModel', () => {
+  /**
+   * @example
+   * getDefaultRwkvModel(true) // -> 'rwkv7-world-100m-fp16'
+   */
+  it('defaults to the smallest f16 checkpoint when WebGPU is available', () => {
+    const id = getDefaultRwkvModel(true)
+
+    expect(id).toBe('rwkv7-world-100m-fp16')
+    expect(RWKV_MODELS.some(m => m.id === id)).toBe(true)
+  })
+
+  /**
+   * @example
+   * getDefaultRwkvModel(false) // -> undefined
+   */
+  it('returns undefined without WebGPU because nothing is runnable', () => {
+    expect(getDefaultRwkvModel(false)).toBeUndefined()
+  })
+})

--- a/packages/stage-ui/src/workers/rwkv/constants.test.ts
+++ b/packages/stage-ui/src/workers/rwkv/constants.test.ts
@@ -39,12 +39,12 @@ describe('rwkvModelsToModelInfo', () => {
 describe('getDefaultRwkvModel', () => {
   /**
    * @example
-   * getDefaultRwkvModel(true) // -> 'rwkv7-world-100m-fp16'
+   * getDefaultRwkvModel(true) // -> 'rwkv7-g1-100m-fp16'
    */
   it('defaults to the smallest f16 checkpoint when WebGPU is available', () => {
     const id = getDefaultRwkvModel(true)
 
-    expect(id).toBe('rwkv7-world-100m-fp16')
+    expect(id).toBe('rwkv7-g1-100m-fp16')
     expect(RWKV_MODELS.some(m => m.id === id)).toBe(true)
   })
 

--- a/packages/stage-ui/src/workers/rwkv/constants.ts
+++ b/packages/stage-ui/src/workers/rwkv/constants.ts
@@ -63,10 +63,16 @@ export const RWKV_VOCAB_URL = 'https://raw.githubusercontent.com/cryscan/web-rwk
 // `quantization` here only reduces *VRAM*, not *download size*. web-rwkv reads
 // f16 `safetensors` and quantizes on-device at load time (`Session.from_reader`,
 // see workers/rwkv/engine.ts), so an `int8`/`nf4` entry still downloads the full
-// f16 weights below (~3 GB for 1.5B, ~5.9 GB for 3B) before quantizing in the GPU.
+// f16 weights below (~3 GB for 1.5B, ~5.9 GB for 2.9B) before quantizing in the GPU.
 // The catalog records the *intent*; the worker resolves layer counts at load.
-// Source/context: cgisky/RWKV-x070-Ai00 world_v3 f16 safetensors (the Ai00/web-rwkv
-// author's host) and https://github.com/cryscan/web-rwkv-puzzles.
+//
+// These are the RWKV-7 "G1" reasoning-tuned checkpoints (the series the model
+// authors recommend for chat over the base World models), in web-rwkv-ready f16
+// safetensors. The lineup mixes the latest sub-iteration available per size
+// (g1d/g1/g1g) — exact checkpoint dates are encoded in the URLs. Prompting must
+// follow the G1x chat templates (see workers/rwkv/prompt.ts).
+// Source/context: mollysama/rwkv-mobile-models `WebRWKV/` (web-rwkv-prepared)
+// and https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v7/RWKV7-G1x-templates.txt.
 export const RWKV_MODELS = [
   // NOTICE:
   // Model ids are intentionally dot-free (`100m`, not `0.1b`). The
@@ -74,40 +80,40 @@ export const RWKV_MODELS = [
   // vue-i18n splits paths on `.`, so a dot in the id would resolve to a wrong
   // nested key. Human-readable sizes live in `name`/`params` instead.
   {
-    id: 'rwkv7-world-100m-fp16',
-    name: 'RWKV-7 World 0.1B (FP16)',
+    id: 'rwkv7-g1-100m-fp16',
+    name: 'RWKV-7 G1 0.1B (FP16)',
     version: 'v7',
     params: '0.1B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/0.1B/0.1B-20241210-ctx4096.st',
+    modelUrl: 'https://huggingface.co/mollysama/rwkv-mobile-models/resolve/main/WebRWKV/rwkv7-g1d-0.1b-20260129-ctx8192.st',
     quantization: 'fp16',
-    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-100m-fp16.description',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-g1-100m-fp16.description',
   },
   {
-    id: 'rwkv7-world-400m-fp16',
-    name: 'RWKV-7 World 0.4B (FP16)',
+    id: 'rwkv7-g1-400m-fp16',
+    name: 'RWKV-7 G1 0.4B (FP16)',
     version: 'v7',
     params: '0.4B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/0.4B/0.4B-20250107-ctx4096.st',
+    modelUrl: 'https://huggingface.co/mollysama/rwkv-mobile-models/resolve/main/WebRWKV/rwkv7-g1-0.4b-20250324-ctx4096.st',
     quantization: 'fp16',
-    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-400m-fp16.description',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-g1-400m-fp16.description',
   },
   {
-    id: 'rwkv7-world-1b5-int8',
-    name: 'RWKV-7 World 1.5B (Int8)',
+    id: 'rwkv7-g1-1b5-int8',
+    name: 'RWKV-7 G1 1.5B (Int8)',
     version: 'v7',
     params: '1.5B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/1.5B/1.5B-20250127-ctx4096.st',
+    modelUrl: 'https://huggingface.co/mollysama/rwkv-mobile-models/resolve/main/WebRWKV/rwkv7-g1g-1.5b-20260526-ctx8192.st',
     quantization: 'int8',
-    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-1b5-int8.description',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-g1-1b5-int8.description',
   },
   {
-    id: 'rwkv7-world-3b-nf4',
-    name: 'RWKV-7 World 3B (NF4)',
+    id: 'rwkv7-g1-2b9-nf4',
+    name: 'RWKV-7 G1 2.9B (NF4)',
     version: 'v7',
-    params: '3B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/3b/3B-20250210-ctx4k.st',
+    params: '2.9B',
+    modelUrl: 'https://huggingface.co/mollysama/rwkv-mobile-models/resolve/main/WebRWKV/rwkv7-g1g-2.9b-20260526-ctx8192.st',
     quantization: 'nf4',
-    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-3b-nf4.description',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-g1-2b9-nf4.description',
   },
 ] as const satisfies readonly RwkvModel[]
 
@@ -152,5 +158,5 @@ export function getDefaultRwkvModel(hasWebGPU: boolean): RwkvModelId | undefined
   if (!hasWebGPU)
     return undefined
 
-  return 'rwkv7-world-100m-fp16'
+  return 'rwkv7-g1-100m-fp16'
 }

--- a/packages/stage-ui/src/workers/rwkv/constants.ts
+++ b/packages/stage-ui/src/workers/rwkv/constants.ts
@@ -53,21 +53,20 @@ export interface RwkvModel {
  * Shared RWKV "World" tokenizer vocabulary.
  *
  * All RWKV World checkpoints share the same trie tokenizer vocab; web-rwkv's
- * `Tokenizer` is constructed from this JSON string.
+ * `Tokenizer` is constructed from this JSON string. This is the same
+ * `rwkv_vocab_v20230424.json` that powers the official `web-rwkv-puzzles`
+ * demos.
  */
-export const RWKV_VOCAB_URL = 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/rwkv_vocab_v20230424.json'
+export const RWKV_VOCAB_URL = 'https://raw.githubusercontent.com/cryscan/web-rwkv-puzzles/main/assets/rwkv_vocab_v20230424.json'
 
 // NOTICE:
-// The `modelUrl`/`RWKV_VOCAB_URL` values below are provisional starting points
-// based on the web-rwkv / web-rwkv-puzzles demo checkpoints (f16 safetensors).
-// They MUST be confirmed against the canonical hosting the package author
-// recommends before this provider ships, because:
-//   - web-rwkv requires f16 `safetensors` (not the PyTorch `.pth` weights that
-//     BlinkDL publishes), so a conversion/mirror host is required;
-//   - exact filenames and the World vocab revision differ between releases.
-// Source/context: README of @cryscan/web-rwkv-wasm@0.10.20 ("Models are f16
-// safetensors files (RWKV v4/v5/v6/v7)") and https://github.com/cryscan/web-rwkv.
-// Removal condition: replace with the author-confirmed URLs and delete this note.
+// `quantization` here only reduces *VRAM*, not *download size*. web-rwkv reads
+// f16 `safetensors` and quantizes on-device at load time (`Session.from_reader`,
+// see workers/rwkv/engine.ts), so an `int8`/`nf4` entry still downloads the full
+// f16 weights below (~3 GB for 1.5B, ~5.9 GB for 3B) before quantizing in the GPU.
+// The catalog records the *intent*; the worker resolves layer counts at load.
+// Source/context: cgisky/RWKV-x070-Ai00 world_v3 f16 safetensors (the Ai00/web-rwkv
+// author's host) and https://github.com/cryscan/web-rwkv-puzzles.
 export const RWKV_MODELS = [
   // NOTICE:
   // Model ids are intentionally dot-free (`100m`, not `0.1b`). The
@@ -79,7 +78,7 @@ export const RWKV_MODELS = [
     name: 'RWKV-7 World 0.1B (FP16)',
     version: 'v7',
     params: '0.1B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-0.1B-v2.8.st',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/0.1B/0.1B-20241210-ctx4096.st',
     quantization: 'fp16',
     descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-100m-fp16.description',
   },
@@ -88,7 +87,7 @@ export const RWKV_MODELS = [
     name: 'RWKV-7 World 0.4B (FP16)',
     version: 'v7',
     params: '0.4B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-0.4B-v2.9.st',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/0.4B/0.4B-20250107-ctx4096.st',
     quantization: 'fp16',
     descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-400m-fp16.description',
   },
@@ -97,18 +96,18 @@ export const RWKV_MODELS = [
     name: 'RWKV-7 World 1.5B (Int8)',
     version: 'v7',
     params: '1.5B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-1.5B-v3.st',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/1.5B/1.5B-20250127-ctx4096.st',
     quantization: 'int8',
     descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-1b5-int8.description',
   },
   {
-    id: 'rwkv7-world-2b9-nf4',
-    name: 'RWKV-7 World 2.9B (NF4)',
+    id: 'rwkv7-world-3b-nf4',
+    name: 'RWKV-7 World 3B (NF4)',
     version: 'v7',
-    params: '2.9B',
-    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-2.9B-v3.st',
+    params: '3B',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-x070-Ai00/resolve/main/world_v3/3b/3B-20250210-ctx4k.st',
     quantization: 'nf4',
-    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-2b9-nf4.description',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-3b-nf4.description',
   },
 ] as const satisfies readonly RwkvModel[]
 

--- a/packages/stage-ui/src/workers/rwkv/constants.ts
+++ b/packages/stage-ui/src/workers/rwkv/constants.ts
@@ -1,0 +1,157 @@
+/**
+ * web-rwkv (RWKV) in-browser inference constants.
+ *
+ * Mirrors the shape of `workers/kokoro/constants.ts`: a static catalog of
+ * selectable models plus pure helpers that turn that catalog into the
+ * provider-facing `ModelInfo[]` and pick a sensible default. None of this
+ * touches the worker/main wire contract, so it is unaffected by the
+ * inference-worker migration in PR #1917 (which only rewrites the transport
+ * between the inference adapters and their worker entry points).
+ *
+ * Package: `@cryscan/web-rwkv-wasm` - a pure-WebGPU RWKV implementation. The
+ * compute path is WebGPU-only (there is no WASM/CPU fallback for inference),
+ * so every model here requires `navigator.gpu`.
+ */
+
+/**
+ * Quantization strategy for a web-rwkv session.
+ *
+ * web-rwkv quantizes *by layer count from layer 0* (`Session.from_reader`
+ * takes `quant` / `quant_nf4` / `quant_sf4` = the number of Int8 / NF4 / SF4
+ * layers). The concrete layer counts depend on the loaded model's
+ * `info().num_layer`, which is only known after the weights are read, so the
+ * catalog records the *intent* and the worker resolves it to layer counts at
+ * load time.
+ *
+ * - `'fp16'`: full f16, no quantization (`0, 0, 0`).
+ * - `'int8'`: quantize all layers to Int8 - roughly half the VRAM of f16.
+ * - `'nf4'`: quantize all layers to NF4 - smallest footprint, lowest fidelity.
+ */
+export type RwkvQuantization = 'fp16' | 'int8' | 'nf4'
+
+/**
+ * A selectable RWKV checkpoint.
+ */
+export interface RwkvModel {
+  /** Stable model identifier used as the provider model id. */
+  id: string
+  /** Human-readable name shown in the model picker. */
+  name: string
+  /** RWKV architecture version of the checkpoint. */
+  version: 'v4' | 'v5' | 'v6' | 'v7'
+  /** Approximate parameter count, for display only (e.g. `'0.1B'`). */
+  params: string
+  /** URL of the f16 `safetensors` weights to fetch. */
+  modelUrl: string
+  /** Quantization applied when creating the session. */
+  quantization: RwkvQuantization
+  /** i18n key for the model description. */
+  descriptionKey: string
+}
+
+/**
+ * Shared RWKV "World" tokenizer vocabulary.
+ *
+ * All RWKV World checkpoints share the same trie tokenizer vocab; web-rwkv's
+ * `Tokenizer` is constructed from this JSON string.
+ */
+export const RWKV_VOCAB_URL = 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/rwkv_vocab_v20230424.json'
+
+// NOTICE:
+// The `modelUrl`/`RWKV_VOCAB_URL` values below are provisional starting points
+// based on the web-rwkv / web-rwkv-puzzles demo checkpoints (f16 safetensors).
+// They MUST be confirmed against the canonical hosting the package author
+// recommends before this provider ships, because:
+//   - web-rwkv requires f16 `safetensors` (not the PyTorch `.pth` weights that
+//     BlinkDL publishes), so a conversion/mirror host is required;
+//   - exact filenames and the World vocab revision differ between releases.
+// Source/context: README of @cryscan/web-rwkv-wasm@0.10.20 ("Models are f16
+// safetensors files (RWKV v4/v5/v6/v7)") and https://github.com/cryscan/web-rwkv.
+// Removal condition: replace with the author-confirmed URLs and delete this note.
+export const RWKV_MODELS = [
+  // NOTICE:
+  // Model ids are intentionally dot-free (`100m`, not `0.1b`). The
+  // `descriptionKey` derived from the id is a vue-i18n message path, and
+  // vue-i18n splits paths on `.`, so a dot in the id would resolve to a wrong
+  // nested key. Human-readable sizes live in `name`/`params` instead.
+  {
+    id: 'rwkv7-world-100m-fp16',
+    name: 'RWKV-7 World 0.1B (FP16)',
+    version: 'v7',
+    params: '0.1B',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-0.1B-v2.8.st',
+    quantization: 'fp16',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-100m-fp16.description',
+  },
+  {
+    id: 'rwkv7-world-400m-fp16',
+    name: 'RWKV-7 World 0.4B (FP16)',
+    version: 'v7',
+    params: '0.4B',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-0.4B-v2.9.st',
+    quantization: 'fp16',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-400m-fp16.description',
+  },
+  {
+    id: 'rwkv7-world-1b5-int8',
+    name: 'RWKV-7 World 1.5B (Int8)',
+    version: 'v7',
+    params: '1.5B',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-1.5B-v3.st',
+    quantization: 'int8',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-1b5-int8.description',
+  },
+  {
+    id: 'rwkv7-world-2b9-nf4',
+    name: 'RWKV-7 World 2.9B (NF4)',
+    version: 'v7',
+    params: '2.9B',
+    modelUrl: 'https://huggingface.co/cgisky/RWKV-safetensors-fp16/resolve/main/RWKV-x070-World-2.9B-v3.st',
+    quantization: 'nf4',
+    descriptionKey: 'settings.pages.providers.provider.rwkv-local.models.rwkv7-world-2b9-nf4.description',
+  },
+] as const satisfies readonly RwkvModel[]
+
+/** Union of valid RWKV model ids. */
+export type RwkvModelId = typeof RWKV_MODELS[number]['id']
+
+/**
+ * Convert the RWKV catalog to provider-facing `ModelInfo`.
+ *
+ * Before:
+ * - `RWKV_MODELS` entries (catalog rows with i18n description keys)
+ *
+ * After:
+ * - `ModelInfo[]` with translated descriptions, scoped to the `rwkv-local`
+ *   provider. When WebGPU is unavailable the list is empty, because web-rwkv
+ *   has no non-WebGPU compute path.
+ *
+ * @param hasWebGPU - Whether `navigator.gpu` is usable; gates the whole list.
+ * @param t - Optional translator; falls back to the raw i18n key when absent.
+ */
+export function rwkvModelsToModelInfo(hasWebGPU: boolean, t?: (key: string) => string) {
+  if (!hasWebGPU)
+    return []
+
+  return RWKV_MODELS.map(model => ({
+    id: model.id,
+    name: model.name,
+    provider: 'rwkv-local',
+    description: t ? t(model.descriptionKey) : model.descriptionKey,
+  }))
+}
+
+/**
+ * Pick the default model for the current device.
+ *
+ * Prefers the smallest f16 checkpoint so the first run downloads and compiles
+ * quickly; returns `undefined` when WebGPU is unavailable (nothing is runnable).
+ *
+ * @param hasWebGPU - Whether `navigator.gpu` is usable.
+ */
+export function getDefaultRwkvModel(hasWebGPU: boolean): RwkvModelId | undefined {
+  if (!hasWebGPU)
+    return undefined
+
+  return 'rwkv7-world-100m-fp16'
+}

--- a/packages/stage-ui/src/workers/rwkv/engine.ts
+++ b/packages/stage-ui/src/workers/rwkv/engine.ts
@@ -1,0 +1,322 @@
+/**
+ * web-rwkv inference engine (worker-side, transport-agnostic).
+ *
+ * Owns the full in-browser RWKV lifecycle against `@cryscan/web-rwkv-wasm`:
+ *
+ * - **load**: fetch f16 `safetensors` + the World vocab (Cache Storage backed),
+ *   derive the layer count, resolve the catalog quantization to per-scheme
+ *   layer counts, and build a `Session` (which quantizes on the GPU) + `Tokenizer`.
+ * - **cache**: web-rwkv's built-in prefix cache — `checkout` reuses the state of
+ *   a shared token prefix across turns, `cache` repopulates it after each turn,
+ *   so re-sending a growing conversation only runs the new suffix.
+ * - **generate**: the autoregressive sampling loop (`run` → `transform` →
+ *   `softmax` → `sample`), streaming decoded tokens and stopping on the
+ *   end-of-text token, a stop sequence, or the token cap.
+ *
+ * The engine knows nothing about how requests arrive; see `transport.ts` for
+ * the wire binding and `worker.ts` for the wiring.
+ */
+
+import type { RwkvQuantization } from './constants'
+import type { SafetensorsHeader } from './safetensors'
+import type {
+  RwkvFinishReason,
+  RwkvGenerateDelta,
+  RwkvGenerateRequest,
+  RwkvGenerateResult,
+  RwkvLoadProgress,
+  RwkvModelInfo,
+} from './types'
+
+import init, {
+  NucleusSampler,
+  Session,
+  SessionType,
+  Tensor,
+  TensorReader,
+  Tokenizer,
+} from '@cryscan/web-rwkv-wasm'
+import wasmUrl from '@cryscan/web-rwkv-wasm/web_rwkv_wasm_bg.wasm?url'
+
+import {
+  deriveNumLayer,
+  parseSafetensorsHeader,
+  resolveQuantLayerCounts,
+} from './safetensors'
+import { fetchCached, fetchCachedText } from './weights'
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/** Everything the engine needs to load one checkpoint. */
+export interface RwkvLoadDescriptor {
+  /** URL of the f16 `safetensors` weights. */
+  modelUrl: string
+  /** URL of the World tokenizer vocab JSON. */
+  vocabUrl: string
+  /** Quantization to apply on-device (reduces VRAM, not download size). */
+  quantization: RwkvQuantization
+}
+
+export interface RwkvLoadOptions {
+  /** Aborts the download/compile. */
+  signal?: AbortSignal
+  /** Receives streamed load progress. */
+  onProgress?: (progress: RwkvLoadProgress) => void
+}
+
+export interface RwkvGenerateOptions {
+  /** Aborts generation between tokens. */
+  signal?: AbortSignal
+  /** Receives each decoded token as it is produced. */
+  onToken?: (delta: RwkvGenerateDelta) => void
+}
+
+/** The web-rwkv engine instance. Assumes calls are serialized by the caller. */
+export interface RwkvEngine {
+  load: (descriptor: RwkvLoadDescriptor, options?: RwkvLoadOptions) => Promise<RwkvModelInfo>
+  generate: (request: RwkvGenerateRequest, options?: RwkvGenerateOptions) => Promise<RwkvGenerateResult>
+  unload: () => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Module-level constants kept near usage
+// ---------------------------------------------------------------------------
+
+/**
+ * The RWKV World end-of-text token. Generation stops when it is sampled.
+ * (Token 0 in `rwkv_vocab_v20230424.json`.)
+ */
+const END_OF_TEXT_TOKEN = 0
+
+/** ModelVersion enum (0..3) → catalog version label, indexed by the enum value. */
+const VERSION_NAMES = ['v4', 'v5', 'v6', 'v7'] as const
+
+/** Conversational sampling defaults (mirrors the web-rwkv-puzzles chat demo). */
+const SAMPLING_DEFAULTS = {
+  temperature: 1.0,
+  topP: 0.5,
+  presencePenalty: 0.4,
+  countPenalty: 0.4,
+  penaltyDecay: 0.996,
+} as const
+
+// ---------------------------------------------------------------------------
+// wasm initialization (once per worker)
+// ---------------------------------------------------------------------------
+
+let wasmReady: Promise<unknown> | null = null
+
+/** Instantiate the wasm module exactly once; subsequent calls share the promise. */
+function ensureWasm(): Promise<unknown> {
+  if (!wasmReady)
+    wasmReady = init({ module_or_path: wasmUrl })
+  return wasmReady
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a web-rwkv engine.
+ *
+ * Use when:
+ * - Standing up the RWKV worker (one engine per worker).
+ *
+ * Expects:
+ * - A WebGPU-capable context; web-rwkv has no CPU/WASM compute fallback.
+ * - Serialized calls — a single `Session` is shared, and its GPU state is not
+ *   reentrant across overlapping `generate` calls.
+ *
+ * Returns:
+ * - `{ load, generate, unload }` over closure-held wasm handles.
+ */
+export function createRwkvEngine(): RwkvEngine {
+  let session: Session | null = null
+  let tokenizer: Tokenizer | null = null
+  let info: RwkvModelInfo | null = null
+
+  const textEncoder = new TextEncoder()
+
+  function dispose(): void {
+    session?.free()
+    tokenizer?.free()
+    session = null
+    tokenizer = null
+    info = null
+  }
+
+  async function load(descriptor: RwkvLoadDescriptor, options?: RwkvLoadOptions): Promise<RwkvModelInfo> {
+    await ensureWasm()
+    // Free any previously loaded checkpoint before downloading the next.
+    dispose()
+
+    const { signal, onProgress } = options ?? {}
+
+    const weights = await fetchCached(descriptor.modelUrl, {
+      signal,
+      onProgress: p => onProgress?.({ phase: 'download-weights', percent: toPercent(p.loaded, p.total), loaded: p.loaded, total: p.total }),
+    })
+    throwIfAborted(signal)
+
+    const vocab = await fetchCachedText(descriptor.vocabUrl, {
+      signal,
+      onProgress: p => onProgress?.({ phase: 'download-vocab', percent: toPercent(p.loaded, p.total), loaded: p.loaded, total: p.total }),
+    })
+    throwIfAborted(signal)
+
+    // Compile + quantize on the GPU. Indeterminate (no byte stream to track).
+    onProgress?.({ phase: 'compile', percent: -1 })
+
+    const header = parseSafetensorsHeader(weights)
+    const numLayer = deriveNumLayer(header.entries.map(entry => entry.name))
+    const counts = resolveQuantLayerCounts(descriptor.quantization, numLayer)
+    const reader = buildReader(weights, header)
+
+    session = await Session.from_reader(reader, counts.int8, counts.nf4, counts.sf4, SessionType.Chat)
+    tokenizer = new Tokenizer(vocab)
+    info = snapshotInfo(session)
+    return info
+  }
+
+  async function generate(request: RwkvGenerateRequest, options?: RwkvGenerateOptions): Promise<RwkvGenerateResult> {
+    if (!session || !tokenizer)
+      throw new Error('RWKV model not loaded. Call load() first.')
+
+    const { signal, onToken } = options ?? {}
+    const maxTokens = request.maxTokens ?? 256
+    const stopSequences = (request.stopSequences ?? []).filter(Boolean)
+    const sampling = { ...SAMPLING_DEFAULTS, ...request.sampling }
+
+    // ModelInfo is a wasm handle; keep it alive for the sampler, free at the end.
+    const modelInfo = session.info()
+    const sampler = new NucleusSampler(
+      modelInfo,
+      sampling.temperature,
+      sampling.topP,
+      sampling.presencePenalty,
+      sampling.countPenalty,
+      sampling.penaltyDecay,
+    )
+
+    try {
+      const logits = new Float32Array(modelInfo.num_vocab)
+      const probs = new Float32Array(modelInfo.num_vocab)
+      const state = new Float32Array(session.state_len())
+
+      if (request.fresh)
+        session.clear_cache()
+
+      const promptTokens = tokenizer.encode(textEncoder.encode(request.prompt))
+
+      // Reuse the cached prefix: `checkout` fills `state`/`logits` for the
+      // longest matching prefix and returns its length, so we only run the rest.
+      const cutoff = session.checkout(promptTokens, state, logits)
+      session.load(state)
+      let tokens = promptTokens.slice(cutoff)
+
+      // A streaming decoder so multi-byte UTF-8 split across tokens is correct.
+      const decoder = new TextDecoder()
+      const generated: number[] = []
+      let text = ''
+      let finishReason: RwkvFinishReason = 'length'
+
+      for (let i = 0; i < maxTokens; i++) {
+        throwIfAborted(signal)
+
+        if (tokens.length > 0)
+          await session.run(tokens, logits)
+
+        sampler.transform(logits)
+        await session.softmax(logits, probs)
+        const token = sampler.sample(probs)
+
+        if (token === END_OF_TEXT_TOKEN) {
+          finishReason = 'eos'
+          break
+        }
+
+        sampler.update(Uint32Array.of(token))
+        generated.push(token)
+
+        const piece = decoder.decode(tokenizer.decode(Uint32Array.of(token)), { stream: true })
+        if (piece) {
+          text += piece
+          onToken?.({ token, text: piece })
+        }
+
+        const matched = stopSequences.find(seq => text.includes(seq))
+        if (matched) {
+          text = text.slice(0, text.indexOf(matched))
+          finishReason = 'stop'
+          break
+        }
+
+        tokens = Uint32Array.of(token)
+      }
+
+      text += decoder.decode() // flush any bytes buffered mid-codepoint
+
+      // Repopulate the prefix cache with the *full* turn (prompt + response) so
+      // the next turn can reuse this entire context, not just the prompt.
+      const fullHistory = Uint32Array.from([...promptTokens, ...generated])
+      await session.back(state)
+      session.cache(fullHistory, state, logits)
+
+      return { text, tokens: generated.length, finishReason }
+    }
+    finally {
+      sampler.free()
+      modelInfo.free()
+    }
+  }
+
+  async function unload(): Promise<void> {
+    dispose()
+  }
+
+  return { load, generate, unload }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a web-rwkv `TensorReader` by slicing each tensor out of the buffer. */
+function buildReader(buffer: ArrayBuffer, header: SafetensorsHeader): TensorReader {
+  const tensors = header.entries.map(entry => new Tensor(
+    entry.name,
+    Uint32Array.from(entry.shape),
+    buffer.slice(header.dataStart + entry.start, header.dataStart + entry.end),
+  ))
+  return new TensorReader(tensors)
+}
+
+/** Copy the scalar `ModelInfo` fields the main thread needs, then free the handle. */
+function snapshotInfo(loaded: Session): RwkvModelInfo {
+  const modelInfo = loaded.info()
+  try {
+    return {
+      numLayer: modelInfo.num_layer,
+      numVocab: modelInfo.num_vocab,
+      numEmb: modelInfo.num_emb,
+      version: VERSION_NAMES[modelInfo.version] ?? 'v7',
+    }
+  }
+  finally {
+    modelInfo.free()
+  }
+}
+
+/** Bytes → 0-100 percent, or -1 when the total is unknown. */
+function toPercent(loaded: number, total: number): number {
+  return total > 0 ? Math.round((loaded / total) * 100) : -1
+}
+
+/** Throw a DOM `AbortError` if the signal is already aborted. */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted)
+    throw new DOMException('The operation was aborted', 'AbortError')
+}

--- a/packages/stage-ui/src/workers/rwkv/engine.ts
+++ b/packages/stage-ui/src/workers/rwkv/engine.ts
@@ -45,10 +45,6 @@ import {
 } from './safetensors'
 import { fetchCached, fetchCachedText } from './weights'
 
-// ---------------------------------------------------------------------------
-// Public surface
-// ---------------------------------------------------------------------------
-
 /** Everything the engine needs to load one checkpoint. */
 export interface RwkvLoadDescriptor {
   /** URL of the f16 `safetensors` weights. */
@@ -80,10 +76,6 @@ export interface RwkvEngine {
   unload: () => Promise<void>
 }
 
-// ---------------------------------------------------------------------------
-// Module-level constants kept near usage
-// ---------------------------------------------------------------------------
-
 /**
  * The RWKV World end-of-text token. Generation stops when it is sampled.
  * (Token 0 in `rwkv_vocab_v20230424.json`.)
@@ -102,10 +94,6 @@ const SAMPLING_DEFAULTS = {
   penaltyDecay: 0.996,
 } as const
 
-// ---------------------------------------------------------------------------
-// wasm initialization (once per worker)
-// ---------------------------------------------------------------------------
-
 let wasmReady: Promise<unknown> | null = null
 
 /** Instantiate the wasm module exactly once; subsequent calls share the promise. */
@@ -114,10 +102,6 @@ function ensureWasm(): Promise<unknown> {
     wasmReady = init({ module_or_path: wasmUrl })
   return wasmReady
 }
-
-// ---------------------------------------------------------------------------
-// Engine
-// ---------------------------------------------------------------------------
 
 /**
  * Create a web-rwkv engine.
@@ -279,10 +263,6 @@ export function createRwkvEngine(): RwkvEngine {
 
   return { load, generate, unload }
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 /** Build a web-rwkv `TensorReader` by slicing each tensor out of the buffer. */
 function buildReader(buffer: ArrayBuffer, header: SafetensorsHeader): TensorReader {

--- a/packages/stage-ui/src/workers/rwkv/prompt.test.ts
+++ b/packages/stage-ui/src/workers/rwkv/prompt.test.ts
@@ -1,0 +1,111 @@
+import type { Message } from '@xsai/shared-chat'
+
+import { describe, expect, it } from 'vitest'
+
+import { formatG1Prompt } from './prompt'
+
+describe('formatG1Prompt', () => {
+  /**
+   * @example
+   * formatG1Prompt([{ role: 'user', content: 'hi' }]).prompt // -> 'User: hi\n\nAssistant:'
+   */
+  it('renders a single user turn ending at the Assistant cue', () => {
+    const { prompt, stop } = formatG1Prompt([{ role: 'user', content: 'hi' }])
+
+    expect(prompt).toBe('User: hi\n\nAssistant:')
+    expect(stop).toEqual(['\n\nUser:', '\n\nSystem:'])
+  })
+
+  /**
+   * @example
+   * formatG1Prompt([{ role: 'system', ... }, { role: 'user', ... }]).prompt
+   */
+  it('prefixes a system turn before the user turn', () => {
+    const messages: Message[] = [
+      { role: 'system', content: 'You are AIRI.' },
+      { role: 'user', content: 'Hello' },
+    ]
+
+    expect(formatG1Prompt(messages).prompt).toBe('System: You are AIRI.\n\nUser: Hello\n\nAssistant:')
+  })
+
+  /**
+   * @example
+   * formatG1Prompt([user, assistant, user]).prompt // -> joins turns with \n\n
+   */
+  it('joins a multi-turn history with blank lines and re-opens Assistant', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello!' },
+      { role: 'user', content: 'How are you?' },
+    ]
+
+    expect(formatG1Prompt(messages).prompt).toBe(
+      'User: Hi\n\nAssistant: Hello!\n\nUser: How are you?\n\nAssistant:',
+    )
+  })
+
+  /**
+   * @example
+   * formatG1Prompt([{ role: 'user', content: 'a\r\n\n\nb  ' }]) // -> 'User: a\nb'
+   */
+  it('cleans system/user inputs: CRLF, collapsed blank lines, trimmed', () => {
+    const { prompt } = formatG1Prompt([{ role: 'user', content: 'Line A\r\n\n\nLine B  ' }])
+
+    expect(prompt).toBe('User: Line A\nLine B\n\nAssistant:')
+  })
+
+  /**
+   * @example
+   * formatG1Prompt(msgs, { think: 'think' }).prompt // -> ends with 'Assistant: <think'
+   */
+  it('primes a real reasoning block in think mode', () => {
+    const { prompt } = formatG1Prompt([{ role: 'user', content: 'Why?' }], { think: 'think' })
+
+    expect(prompt.endsWith('Assistant: <think')).toBe(true)
+  })
+
+  /**
+   * @example
+   * formatG1Prompt(msgs, { think: 'fake' }).prompt // -> ends with 'Assistant: <think>\n</think>'
+   */
+  it('emits an empty pre-closed block in fake-think mode', () => {
+    const { prompt } = formatG1Prompt([{ role: 'user', content: 'Why?' }], { think: 'fake' })
+
+    expect(prompt.endsWith('Assistant: <think>\n</think>')).toBe(true)
+  })
+
+  /**
+   * @example
+   * formatG1Prompt([{ role: 'tool', content: '{...}', tool_call_id: 't1' }])
+   */
+  it('folds a tool result into a User Function output turn', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Weather?' },
+      { role: 'tool', content: '{"temp":20}', tool_call_id: 't1' },
+    ]
+
+    expect(formatG1Prompt(messages).prompt).toBe(
+      'User: Weather?\n\nUser: Function output:\n{"temp":20}\n\nAssistant:',
+    )
+  })
+
+  /**
+   * @example
+   * formatG1Prompt([{ role: 'user', content: [textPart, imagePart] }])
+   */
+  it('extracts text from content parts and drops non-text parts', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe ' },
+          { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+          { type: 'text', text: 'this' },
+        ],
+      },
+    ]
+
+    expect(formatG1Prompt(messages).prompt).toBe('User: Describe this\n\nAssistant:')
+  })
+})

--- a/packages/stage-ui/src/workers/rwkv/prompt.ts
+++ b/packages/stage-ui/src/workers/rwkv/prompt.ts
@@ -1,0 +1,163 @@
+/**
+ * RWKV-7 "G1" chat-prompt formatting.
+ *
+ * RWKV is a text-completion model: it has no notion of a `messages` array, only
+ * a single prompt string. The G1-series checkpoints were trained on a specific
+ * `System:/User:/Assistant:` layout, so a local chat provider must flatten the
+ * OpenAI-style `Message[]` it receives (the same array `streamText` sends every
+ * other provider) into that layout before handing it to the worker. This module
+ * is that flattening — pure and transport-agnostic, so the deferred main-side
+ * adapter (PR #1917) can consume it directly.
+ *
+ * Reference: https://github.com/BlinkDL/RWKV-LM/blob/main/RWKV-v7/RWKV7-G1x-templates.txt
+ *
+ * Layout:
+ *   System: {sys}\n\nUser: {u1}\n\nAssistant: {a1}\n\nUser: {u2}\n\nAssistant:
+ *
+ * The trailing `Assistant:` (optionally with a `<think>` cue) is the generation
+ * point; generation then stops at the next `\n\nUser:`/`\n\nSystem:` turn or the
+ * end-of-text token.
+ */
+
+import type { Message } from '@xsai/shared-chat'
+
+/**
+ * Think-mode cue appended after the final `Assistant:`.
+ *
+ * - `'none'`: answer directly (no reasoning trace).
+ * - `'think'`: open a reasoning block (`<think`) so the model reasons first;
+ *   matches the template's recommended real-thinking cue.
+ * - `'fake'`: emit an empty, pre-closed reasoning block (`<think>\n</think>`),
+ *   which the template notes gives "nice results and fast" by skipping reasoning.
+ */
+export type RwkvThinkMode = 'none' | 'think' | 'fake'
+
+export interface RwkvPromptOptions {
+  /**
+   * Whether/how to prime a reasoning block.
+   * @default 'none'
+   */
+  think?: RwkvThinkMode
+}
+
+/** A formatted RWKV prompt plus the stop sequences that bound its completion. */
+export interface RwkvPrompt {
+  /** The full prompt string ending at the `Assistant:` generation point. */
+  prompt: string
+  /** Decoded substrings that must end generation (the next turn header). */
+  stop: string[]
+}
+
+/**
+ * Stop at the start of the next turn so the model can't role-play the user.
+ * `\n\n` precedes every turn header in the G1 layout.
+ */
+const STOP_SEQUENCES = ['\n\nUser:', '\n\nSystem:'] as const
+
+/** Turn headers per role, kept beside the formatter that emits them. */
+const ROLE_HEADERS = { system: 'System', user: 'User', assistant: 'Assistant' } as const
+
+/**
+ * Format an OpenAI-style message history into a G1 chat prompt.
+ *
+ * Use when:
+ * - Driving a G1-series RWKV checkpoint from a `Message[]` (the local chat
+ *   provider's request body).
+ *
+ * Expects:
+ * - Messages in chronological order. The final turn is normally a `user`
+ *   message; this function always appends the `Assistant:` generation cue, so
+ *   the caller does not pre-seed an empty assistant turn.
+ *
+ * Returns:
+ * - `{ prompt, stop }` ready for the engine: `prompt` ends at `Assistant:`
+ *   (plus any think cue), and `stop` holds the next-turn headers.
+ */
+export function formatG1Prompt(messages: Message[], options?: RwkvPromptOptions): RwkvPrompt {
+  const turns: string[] = []
+
+  for (const message of messages) {
+    const rendered = renderTurn(message)
+    if (rendered)
+      turns.push(rendered)
+  }
+
+  // The trailing assistant cue is where generation begins. `'none'` leaves the
+  // header open ("Assistant:"); the think modes prime a reasoning block.
+  const assistantCue = options?.think === 'think'
+    ? 'Assistant: <think'
+    : options?.think === 'fake'
+      ? 'Assistant: <think>\n</think>'
+      : 'Assistant:'
+
+  turns.push(assistantCue)
+
+  return { prompt: turns.join('\n\n'), stop: [...STOP_SEQUENCES] }
+}
+
+/**
+ * Render one message as a `Role: content` turn, or `''` to skip it.
+ *
+ * Tool results are folded into a `User:` turn as `Function output:` to match the
+ * function-call examples in the G1 templates; assistant history is kept verbatim
+ * (only trimmed), while system/user inputs are cleaned (see {@link cleanInput}).
+ */
+function renderTurn(message: Message): string {
+  const text = contentToText(message.content)
+
+  switch (message.role) {
+    case 'system':
+    case 'developer':
+      return `${ROLE_HEADERS.system}: ${cleanInput(text)}`
+    case 'user':
+      return `${ROLE_HEADERS.user}: ${cleanInput(text)}`
+    case 'assistant':
+      return `${ROLE_HEADERS.assistant}: ${text.trim()}`
+    case 'tool':
+      return `${ROLE_HEADERS.user}: Function output:\n${cleanInput(text)}`
+    default:
+      return ''
+  }
+}
+
+/**
+ * Minimal structural shape shared by every message content part: each variant
+ * carries a `type`, and only text parts carry `text`. Using this instead of the
+ * role-specific unions lets one extractor handle system/user/assistant/tool
+ * content (which differ — assistant content may include refusal parts or be
+ * absent) without `any`.
+ */
+interface ContentPartLike { type: string, text?: string }
+
+/**
+ * Flatten message content (string, content-part array, or absent) to plain text.
+ *
+ * RWKV G1 is text-only, so non-text parts (images, audio, files, refusals) are
+ * dropped and only `text` parts are concatenated.
+ */
+function contentToText(content: string | readonly ContentPartLike[] | undefined): string {
+  if (content == null)
+    return ''
+  if (typeof content === 'string')
+    return content
+  return content
+    .filter(part => part.type === 'text')
+    .map(part => part.text ?? '')
+    .join('')
+}
+
+/**
+ * Normalize a system/user input for the G1 templates.
+ *
+ * The templates require collapsing blank lines and trimming so stray newlines
+ * never look like a turn boundary (`re.sub(r'\n{2,}', '\n', txt.replace('\r\n','\n')).strip()`).
+ *
+ * Before:
+ * - "Hello\r\n\n\n  world  "
+ *
+ * After:
+ * - "Hello\nworld"
+ */
+function cleanInput(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\n{2,}/g, '\n').trim()
+}

--- a/packages/stage-ui/src/workers/rwkv/safetensors.test.ts
+++ b/packages/stage-ui/src/workers/rwkv/safetensors.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveNumLayer, parseSafetensorsHeader, resolveQuantLayerCounts } from './safetensors'
+
+/**
+ * Build a minimal but valid `safetensors` buffer from a header object:
+ * an 8-byte little-endian u64 header length, the JSON header, then a zeroed
+ * data region sized to the largest tensor end offset.
+ *
+ * @example
+ * buildSafetensors({ 'w': { shape: [2], data_offsets: [0, 4] } })
+ */
+function buildSafetensors(header: Record<string, unknown>): ArrayBuffer {
+  const json = new TextEncoder().encode(JSON.stringify(header))
+  const dataLength = Object.values(header)
+    .map(v => (v as { data_offsets?: [number, number] }).data_offsets?.[1] ?? 0)
+    .reduce((max, end) => Math.max(max, end), 0)
+
+  const buffer = new ArrayBuffer(8 + json.byteLength + dataLength)
+  const view = new DataView(buffer)
+  view.setBigUint64(0, BigInt(json.byteLength), true)
+  new Uint8Array(buffer, 8, json.byteLength).set(json)
+  return buffer
+}
+
+const FIXTURE = {
+  '__metadata__': { format: 'pt' },
+  'emb.weight': { dtype: 'F16', shape: [10, 4], data_offsets: [0, 80] },
+  'blocks.0.att.key.weight': { dtype: 'F16', shape: [4, 4], data_offsets: [80, 112] },
+  'blocks.1.att.key.weight': { dtype: 'F16', shape: [4, 4], data_offsets: [112, 144] },
+  'head.weight': { dtype: 'F16', shape: [4, 10], data_offsets: [144, 224] },
+}
+
+describe('parseSafetensorsHeader', () => {
+  /**
+   * @example
+   * parseSafetensorsHeader(buildSafetensors(FIXTURE)).entries.length // -> 4
+   */
+  it('returns every tensor entry except __metadata__', () => {
+    const { entries } = parseSafetensorsHeader(buildSafetensors(FIXTURE))
+
+    expect(entries).toHaveLength(4)
+    expect(entries.map(e => e.name)).not.toContain('__metadata__')
+    expect(entries[0]).toEqual({ name: 'emb.weight', shape: [10, 4], start: 0, end: 80 })
+  })
+
+  /**
+   * @example
+   * parseSafetensorsHeader(buf).dataStart // -> 8 + headerByteLength
+   */
+  it('reports dataStart as 8 + the JSON header byte length', () => {
+    const headerBytes = new TextEncoder().encode(JSON.stringify(FIXTURE)).byteLength
+    const { dataStart } = parseSafetensorsHeader(buildSafetensors(FIXTURE))
+
+    expect(dataStart).toBe(8 + headerBytes)
+  })
+})
+
+describe('deriveNumLayer', () => {
+  /**
+   * @example
+   * deriveNumLayer(['blocks.0.x', 'blocks.1.x']) // -> 2
+   */
+  it('returns max(blocks.{i}) + 1 across tensor names', () => {
+    const { entries } = parseSafetensorsHeader(buildSafetensors(FIXTURE))
+    expect(deriveNumLayer(entries.map(e => e.name))).toBe(2)
+  })
+
+  /**
+   * @example
+   * deriveNumLayer(['emb.weight', 'head.weight']) // -> 0
+   */
+  it('returns 0 when there are no block tensors', () => {
+    expect(deriveNumLayer(['emb.weight', 'head.weight'])).toBe(0)
+  })
+})
+
+describe('resolveQuantLayerCounts', () => {
+  /**
+   * @example
+   * resolveQuantLayerCounts('fp16', 24) // -> { int8: 0, nf4: 0, sf4: 0 }
+   */
+  it('maps fp16 to no quantized layers', () => {
+    expect(resolveQuantLayerCounts('fp16', 24)).toEqual({ int8: 0, nf4: 0, sf4: 0 })
+  })
+
+  /**
+   * @example
+   * resolveQuantLayerCounts('int8', 24) // -> { int8: 24, nf4: 0, sf4: 0 }
+   */
+  it('maps int8 to all layers as Int8', () => {
+    expect(resolveQuantLayerCounts('int8', 24)).toEqual({ int8: 24, nf4: 0, sf4: 0 })
+  })
+
+  /**
+   * @example
+   * resolveQuantLayerCounts('nf4', 32) // -> { int8: 0, nf4: 32, sf4: 0 }
+   */
+  it('maps nf4 to all layers as NF4', () => {
+    expect(resolveQuantLayerCounts('nf4', 32)).toEqual({ int8: 0, nf4: 32, sf4: 0 })
+  })
+})

--- a/packages/stage-ui/src/workers/rwkv/safetensors.ts
+++ b/packages/stage-ui/src/workers/rwkv/safetensors.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure `safetensors` parsing + quantization planning for web-rwkv.
+ *
+ * web-rwkv consumes f16 `safetensors` via a `TensorReader`, and quantizes by
+ * layer count from layer 0 at `Session.from_reader` time. Both of those need
+ * facts that live in the file header (the tensor table) and the catalog (the
+ * quantization intent) — neither needs the GPU or the wasm runtime. Keeping
+ * that logic here, free of any `@cryscan/web-rwkv-wasm` import, makes it unit
+ * testable and keeps the wasm-touching code in `engine.ts` thin.
+ */
+
+import type { RwkvQuantization } from './constants'
+
+/** One tensor entry from a parsed `safetensors` header. */
+export interface SafetensorsEntry {
+  /** Tensor name, e.g. `blocks.0.att.key.weight`. */
+  name: string
+  /** Tensor shape (row-major). */
+  shape: number[]
+  /** Start byte offset of the tensor, relative to the data segment. */
+  start: number
+  /** End byte offset (exclusive) of the tensor, relative to the data segment. */
+  end: number
+}
+
+/** Result of parsing a `safetensors` header. */
+export interface SafetensorsHeader {
+  /** Tensor table, excluding the `__metadata__` pseudo-entry. */
+  entries: SafetensorsEntry[]
+  /** Absolute byte offset where tensor data begins (`8 + headerLength`). */
+  dataStart: number
+}
+
+/**
+ * Parse the leading header of a `safetensors` buffer.
+ *
+ * Use when:
+ * - You have the raw `.safetensors` bytes and need the tensor table + the
+ *   offset where tensor data starts (to slice tensors or count layers).
+ *
+ * Expects:
+ * - `buffer` is a complete `safetensors` file: an 8-byte little-endian u64
+ *   header length, then that many bytes of JSON, then the tensor data.
+ *
+ * Returns:
+ * - `entries` in header order (minus `__metadata__`) and the absolute
+ *   `dataStart` offset.
+ */
+export function parseSafetensorsHeader(buffer: ArrayBuffer): SafetensorsHeader {
+  const view = new DataView(buffer)
+  // safetensors prefixes the file with a little-endian u64 header length.
+  const headerLength = Number(view.getBigUint64(0, true))
+  const json = new TextDecoder().decode(new Uint8Array(buffer, 8, headerLength))
+  const header = JSON.parse(json) as Record<string, { shape: number[], data_offsets: [number, number] }>
+
+  const entries: SafetensorsEntry[] = []
+  for (const [name, info] of Object.entries(header)) {
+    if (name === '__metadata__')
+      continue
+    const [start, end] = info.data_offsets
+    entries.push({ name, shape: info.shape, start, end })
+  }
+
+  return { entries, dataStart: 8 + headerLength }
+}
+
+/**
+ * Derive the transformer layer count from a checkpoint's tensor names.
+ *
+ * web-rwkv needs the layer count *up front* to quantize "all layers"
+ * (`Session.from_reader` takes layer counts, but `ModelInfo.num_layer` only
+ * exists after a `Session` is built — a chicken-and-egg). RWKV checkpoints name
+ * every per-layer weight `blocks.{i}.…`, so the count is `max(i) + 1`.
+ *
+ * Before:
+ * - ['emb.weight', 'blocks.0.att.key.weight', 'blocks.1.att.key.weight', 'head.weight']
+ *
+ * After:
+ * - 2
+ */
+export function deriveNumLayer(tensorNames: Iterable<string>): number {
+  let maxIndex = -1
+  for (const name of tensorNames) {
+    const match = /^blocks\.(\d+)\./.exec(name)
+    if (!match)
+      continue
+    const index = Number(match[1])
+    if (index > maxIndex)
+      maxIndex = index
+  }
+  return maxIndex + 1
+}
+
+/**
+ * web-rwkv layer counts for `Session.from_reader(reader, quant, quant_nf4, quant_sf4, ty)`.
+ *
+ * Each field is the number of layers (from layer 0) to quantize with that
+ * scheme; the rest stay f16. `0/0/0` is full f16.
+ */
+export interface QuantLayerCounts {
+  /** `quant`: number of `Int8` layers. */
+  int8: number
+  /** `quant_nf4`: number of `NF4` layers. */
+  nf4: number
+  /** `quant_sf4`: number of `SF4` layers. */
+  sf4: number
+}
+
+/**
+ * Resolve a catalog quantization *intent* to concrete web-rwkv layer counts.
+ *
+ * The catalog records `'fp16' | 'int8' | 'nf4'`; web-rwkv wants per-scheme
+ * layer counts. We quantize the whole model uniformly, so the chosen scheme
+ * gets `numLayer` and the others get `0`.
+ *
+ * Before:
+ * - ('int8', 24)
+ *
+ * After:
+ * - { int8: 24, nf4: 0, sf4: 0 }
+ */
+export function resolveQuantLayerCounts(quantization: RwkvQuantization, numLayer: number): QuantLayerCounts {
+  switch (quantization) {
+    case 'int8':
+      return { int8: numLayer, nf4: 0, sf4: 0 }
+    case 'nf4':
+      return { int8: 0, nf4: numLayer, sf4: 0 }
+    case 'fp16':
+      return { int8: 0, nf4: 0, sf4: 0 }
+  }
+}

--- a/packages/stage-ui/src/workers/rwkv/transport.test.ts
+++ b/packages/stage-ui/src/workers/rwkv/transport.test.ts
@@ -32,7 +32,7 @@ function createFakeEndpoint() {
 const flush = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
 
 const READY = {
-  modelId: 'rwkv7-world-100m-fp16',
+  modelId: 'rwkv7-g1-100m-fp16',
   quantization: 'fp16',
   info: { numLayer: 2, numVocab: 10, numEmb: 4, version: 'v7' },
 } as const
@@ -55,7 +55,7 @@ describe('createMessagePortTransport', () => {
     }
 
     createMessagePortTransport(endpoint).serve(ops)
-    send({ kind: 'invoke', id: '1', op: 'load', payload: { modelId: 'rwkv7-world-100m-fp16' } })
+    send({ kind: 'invoke', id: '1', op: 'load', payload: { modelId: 'rwkv7-g1-100m-fp16' } })
     await flush()
 
     expect(posted[0]).toEqual({ kind: 'chunk', id: '1', chunk: { phase: 'compile', percent: 50 } })
@@ -124,7 +124,7 @@ describe('createMessagePortTransport', () => {
     }
 
     createMessagePortTransport(endpoint).serve(ops)
-    send({ kind: 'invoke', id: '4', op: 'load', payload: { modelId: 'rwkv7-world-100m-fp16' } })
+    send({ kind: 'invoke', id: '4', op: 'load', payload: { modelId: 'rwkv7-g1-100m-fp16' } })
     await flush()
 
     expect(posted).toContainEqual({ kind: 'error', id: '4', name: 'Error', message: 'model not found' })

--- a/packages/stage-ui/src/workers/rwkv/transport.test.ts
+++ b/packages/stage-ui/src/workers/rwkv/transport.test.ts
@@ -1,0 +1,132 @@
+import type { InboundMessage, MessageEndpoint, OutboundMessage, RwkvWorkerOps } from './transport'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMessagePortTransport } from './transport'
+
+/**
+ * A fake {@link MessageEndpoint} that captures outbound messages and lets a
+ * test push inbound ones, standing in for the worker's `globalThis`.
+ *
+ * @example
+ * const { endpoint, posted, send } = createFakeEndpoint()
+ * send({ kind: 'invoke', id: '1', op: 'unload' })
+ */
+function createFakeEndpoint() {
+  let listener: ((event: MessageEvent<InboundMessage>) => void) | null = null
+  const posted: OutboundMessage[] = []
+
+  const endpoint: MessageEndpoint = {
+    postMessage: message => posted.push(message),
+    addEventListener: (_type, handler) => { listener = handler },
+  }
+
+  const send = (message: InboundMessage): void => {
+    listener?.({ data: message } as MessageEvent<InboundMessage>)
+  }
+
+  return { endpoint, posted, send }
+}
+
+/** Let queued microtasks/timers settle so async dispatch completes. */
+const flush = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
+
+const READY = {
+  modelId: 'rwkv7-world-100m-fp16',
+  quantization: 'fp16',
+  info: { numLayer: 2, numVocab: 10, numEmb: 4, version: 'v7' },
+} as const
+
+describe('createMessagePortTransport', () => {
+  /**
+   * @example
+   * send({ kind: 'invoke', id: '1', op: 'load', payload: { modelId } })
+   * // -> posts a 'chunk' then a 'result'
+   */
+  it('forwards an emit as a chunk and the resolved value as a result', async () => {
+    const { endpoint, posted, send } = createFakeEndpoint()
+    const ops: RwkvWorkerOps = {
+      load: async (request, context) => {
+        context.emit({ phase: 'compile', percent: 50 })
+        return { ...READY, modelId: request.modelId }
+      },
+      generate: async () => ({ text: '', tokens: 0, finishReason: 'length' }),
+      unload: async () => {},
+    }
+
+    createMessagePortTransport(endpoint).serve(ops)
+    send({ kind: 'invoke', id: '1', op: 'load', payload: { modelId: 'rwkv7-world-100m-fp16' } })
+    await flush()
+
+    expect(posted[0]).toEqual({ kind: 'chunk', id: '1', chunk: { phase: 'compile', percent: 50 } })
+    expect(posted[1]).toEqual({ kind: 'result', id: '1', result: READY })
+  })
+
+  /**
+   * @example
+   * send invoke generate, then send cancel with the same id // -> aborts the op
+   */
+  it('aborts the matching operation on a cancel message', async () => {
+    const { endpoint, posted, send } = createFakeEndpoint()
+    const onAbort = vi.fn()
+    const ops: RwkvWorkerOps = {
+      load: async () => READY,
+      generate: (_request, context) => new Promise((_resolve, reject) => {
+        context.signal.addEventListener('abort', () => {
+          onAbort()
+          reject(new DOMException('The operation was aborted', 'AbortError'))
+        })
+      }),
+      unload: async () => {},
+    }
+
+    createMessagePortTransport(endpoint).serve(ops)
+    send({ kind: 'invoke', id: '2', op: 'generate', payload: { prompt: 'hi' } })
+    await flush()
+    send({ kind: 'cancel', id: '2' })
+    await flush()
+
+    expect(onAbort).toHaveBeenCalledOnce()
+    expect(posted).toContainEqual({ kind: 'error', id: '2', name: 'AbortError', message: 'The operation was aborted' })
+  })
+
+  /**
+   * @example
+   * send({ kind: 'invoke', id: '3', op: 'unload' }) // -> result null
+   */
+  it('acknowledges unload with a null result', async () => {
+    const { endpoint, posted, send } = createFakeEndpoint()
+    const unload = vi.fn(async () => {})
+    const ops: RwkvWorkerOps = {
+      load: async () => READY,
+      generate: async () => ({ text: '', tokens: 0, finishReason: 'length' }),
+      unload,
+    }
+
+    createMessagePortTransport(endpoint).serve(ops)
+    send({ kind: 'invoke', id: '3', op: 'unload' })
+    await flush()
+
+    expect(unload).toHaveBeenCalledOnce()
+    expect(posted).toContainEqual({ kind: 'result', id: '3', result: null })
+  })
+
+  /**
+   * @example
+   * a throwing op // -> posts an 'error' carrying the name and message
+   */
+  it('reports a thrown error as an error message', async () => {
+    const { endpoint, posted, send } = createFakeEndpoint()
+    const ops: RwkvWorkerOps = {
+      load: async () => { throw new Error('model not found') },
+      generate: async () => ({ text: '', tokens: 0, finishReason: 'length' }),
+      unload: async () => {},
+    }
+
+    createMessagePortTransport(endpoint).serve(ops)
+    send({ kind: 'invoke', id: '4', op: 'load', payload: { modelId: 'rwkv7-world-100m-fp16' } })
+    await flush()
+
+    expect(posted).toContainEqual({ kind: 'error', id: '4', name: 'Error', message: 'model not found' })
+  })
+})

--- a/packages/stage-ui/src/workers/rwkv/transport.ts
+++ b/packages/stage-ui/src/workers/rwkv/transport.ts
@@ -1,0 +1,202 @@
+/**
+ * Worker-side transport abstraction for the web-rwkv worker.
+ *
+ * ## Why this exists
+ *
+ * The repo's inference workers are mid-migration: the hand-rolled `postMessage`
+ * protocol (`libs/inference/protocol.ts` + `worker-manager.ts`) is being
+ * replaced by a typed `@moeru/eventa` RPC contract (PR #1917). Rather than
+ * couple the RWKV engine to whichever transport happens to be current, the
+ * engine speaks to this small, transport-agnostic port:
+ *
+ * - An {@link Operation} is a request → terminal-result async function that may
+ *   stream intermediate chunks (load progress, generated tokens) via its
+ *   {@link OperationContext} and observe cancellation via `ctx.signal`.
+ * - {@link RwkvWorkerOps} is the worker's full surface (load / generate / unload).
+ * - A {@link RwkvWorkerTransport} binds those ops to a concrete wire.
+ *
+ * Exactly one binding ships today — {@link createMessagePortTransport}, over a
+ * `postMessage` endpoint with its own minimal, self-contained envelope. It is
+ * the *only* seam that PR #1917 needs to replace (with an eventa binding); the
+ * engine, the ops, and every domain type stay untouched.
+ *
+ * Call stack (worker entry):
+ *
+ * worker.ts
+ *   -> {@link createMessagePortTransport}
+ *     -> transport.serve({@link RwkvWorkerOps})
+ *       -> Operation(request, {@link OperationContext})  // engine.load / engine.generate
+ */
+
+import type {
+  RwkvGenerateDelta,
+  RwkvGenerateRequest,
+  RwkvGenerateResult,
+  RwkvLoadProgress,
+  RwkvLoadRequest,
+  RwkvLoadResult,
+} from './types'
+
+import { errorMessageFrom } from '@moeru/std'
+
+// ---------------------------------------------------------------------------
+// Transport-agnostic operation abstraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-operation handle passed to an {@link Operation}.
+ *
+ * @param TChunk - The intermediate chunk type this operation streams.
+ */
+export interface OperationContext<TChunk> {
+  /** Emit an intermediate chunk (load progress, or a generated token). */
+  emit: (chunk: TChunk) => void
+  /** Aborts when the caller cancels *this* operation. */
+  signal: AbortSignal
+}
+
+/**
+ * A request → terminal-result async function that may stream chunks meanwhile.
+ *
+ * @param TRequest - Inbound request payload.
+ * @param TChunk - Intermediate streamed chunk type.
+ * @param TResult - Terminal result payload.
+ */
+export type Operation<TRequest, TChunk, TResult>
+  = (request: TRequest, context: OperationContext<TChunk>) => Promise<TResult>
+
+/**
+ * The web-rwkv worker's full operation surface.
+ *
+ * `load` and `generate` are server-streaming (progress chunks / token deltas
+ * precede the terminal result); `unload` is a plain request → ack.
+ */
+export interface RwkvWorkerOps {
+  load: Operation<RwkvLoadRequest, RwkvLoadProgress, RwkvLoadResult>
+  generate: Operation<RwkvGenerateRequest, RwkvGenerateDelta, RwkvGenerateResult>
+  unload: () => Promise<void>
+}
+
+/** Binds an {@link RwkvWorkerOps} implementation to a concrete wire. */
+export interface RwkvWorkerTransport {
+  /** Begin routing inbound messages to `ops`. Call once. */
+  serve: (ops: RwkvWorkerOps) => void
+}
+
+// ---------------------------------------------------------------------------
+// postMessage binding (the seam PR #1917 swaps for an eventa binding)
+// ---------------------------------------------------------------------------
+
+/** Names of the streaming operations carried by the wire envelope. */
+type StreamingOpName = 'load' | 'generate'
+
+/**
+ * Inbound wire messages (main → worker).
+ *
+ * NOTICE:
+ * This envelope is intentionally self-contained — it does NOT import the
+ * `libs/inference/protocol.ts` message types, because that module is being
+ * removed by PR #1917. When the eventa contract lands, replace this whole
+ * binding (not the ops/engine) with an eventa-backed one.
+ */
+export type InboundMessage
+  = | { kind: 'invoke', id: string, op: 'load', payload: RwkvLoadRequest }
+    | { kind: 'invoke', id: string, op: 'generate', payload: RwkvGenerateRequest }
+    | { kind: 'invoke', id: string, op: 'unload' }
+    | { kind: 'cancel', id: string }
+
+/** Outbound wire messages (worker → main). */
+export type OutboundMessage
+  = | { kind: 'chunk', id: string, chunk: RwkvLoadProgress | RwkvGenerateDelta }
+    | { kind: 'result', id: string, result: RwkvLoadResult | RwkvGenerateResult | null }
+    | { kind: 'error', id: string, name: string, message: string }
+
+/**
+ * Minimal `postMessage`-style endpoint.
+ *
+ * Matches both a `DedicatedWorkerGlobalScope` (the real worker) and a fake
+ * object in tests, so the binding never reaches for a global directly.
+ */
+export interface MessageEndpoint {
+  postMessage: (message: OutboundMessage) => void
+  addEventListener: (type: 'message', listener: (event: MessageEvent<InboundMessage>) => void) => void
+}
+
+/**
+ * Build the `postMessage` transport binding.
+ *
+ * Use when:
+ * - Wiring the RWKV worker entry to its host scope (`globalThis`), or driving
+ *   the worker from a unit test via a fake {@link MessageEndpoint}.
+ *
+ * Expects:
+ * - `endpoint` delivers inbound {@link InboundMessage}s and accepts outbound
+ *   ones. Callers serialize their own invokes (the engine is single-GPU and
+ *   not reentrant); concurrent streaming invokes are not multiplexed safely.
+ *
+ * Returns:
+ * - A {@link RwkvWorkerTransport} whose `serve` routes each invoke to the
+ *   matching op, forwards `emit` as `chunk` messages, the resolved value as a
+ *   `result`, and any throw (including `AbortError`) as an `error`.
+ */
+export function createMessagePortTransport(endpoint: MessageEndpoint): RwkvWorkerTransport {
+  // Per-invoke abort controllers, keyed by request id, so a `cancel` message
+  // can signal the exact in-flight operation.
+  const inflight = new Map<string, AbortController>()
+
+  function serve(ops: RwkvWorkerOps): void {
+    endpoint.addEventListener('message', (event) => {
+      const message = event.data
+      if (message.kind === 'cancel') {
+        inflight.get(message.id)?.abort()
+        return
+      }
+      // kind === 'invoke'
+      void dispatch(ops, message)
+    })
+  }
+
+  async function dispatch(ops: RwkvWorkerOps, message: Extract<InboundMessage, { kind: 'invoke' }>): Promise<void> {
+    const { id } = message
+    const controller = new AbortController()
+    inflight.set(id, controller)
+
+    try {
+      if (message.op === 'unload') {
+        await ops.unload()
+        endpoint.postMessage({ kind: 'result', id, result: null })
+        return
+      }
+
+      const result = await runStreaming(ops, message, id, controller.signal)
+      endpoint.postMessage({ kind: 'result', id, result })
+    }
+    catch (error) {
+      endpoint.postMessage({
+        kind: 'error',
+        id,
+        name: error instanceof Error ? error.name : 'Error',
+        message: errorMessageFrom(error) ?? 'Unknown worker error',
+      })
+    }
+    finally {
+      inflight.delete(id)
+    }
+  }
+
+  function runStreaming(
+    ops: RwkvWorkerOps,
+    message: Extract<InboundMessage, { kind: 'invoke', op: StreamingOpName }>,
+    id: string,
+    signal: AbortSignal,
+  ): Promise<RwkvLoadResult | RwkvGenerateResult> {
+    const emit = (chunk: RwkvLoadProgress | RwkvGenerateDelta): void => {
+      endpoint.postMessage({ kind: 'chunk', id, chunk })
+    }
+    if (message.op === 'load')
+      return ops.load(message.payload, { emit, signal })
+    return ops.generate(message.payload, { emit, signal })
+  }
+
+  return { serve }
+}

--- a/packages/stage-ui/src/workers/rwkv/transport.ts
+++ b/packages/stage-ui/src/workers/rwkv/transport.ts
@@ -39,10 +39,6 @@ import type {
 
 import { errorMessageFrom } from '@moeru/std'
 
-// ---------------------------------------------------------------------------
-// Transport-agnostic operation abstraction
-// ---------------------------------------------------------------------------
-
 /**
  * Per-operation handle passed to an {@link Operation}.
  *
@@ -83,9 +79,7 @@ export interface RwkvWorkerTransport {
   serve: (ops: RwkvWorkerOps) => void
 }
 
-// ---------------------------------------------------------------------------
-// postMessage binding (the seam PR #1917 swaps for an eventa binding)
-// ---------------------------------------------------------------------------
+// postMessage binding (the seam PR #1917 swaps for an eventa binding).
 
 /** Names of the streaming operations carried by the wire envelope. */
 type StreamingOpName = 'load' | 'generate'
@@ -151,7 +145,6 @@ export function createMessagePortTransport(endpoint: MessageEndpoint): RwkvWorke
         inflight.get(message.id)?.abort()
         return
       }
-      // kind === 'invoke'
       void dispatch(ops, message)
     })
   }

--- a/packages/stage-ui/src/workers/rwkv/types.ts
+++ b/packages/stage-ui/src/workers/rwkv/types.ts
@@ -1,0 +1,140 @@
+/**
+ * web-rwkv worker domain types.
+ *
+ * These describe the *what* of the worker's operations (load a model, generate
+ * text) independently of *how* requests and responses travel between the main
+ * thread and the worker. The transport (see `transport.ts`) carries these
+ * shapes; the engine (see `engine.ts`) produces them. Keeping them here lets
+ * the transport binding be swapped (hand-rolled `postMessage` today, the
+ * `@moeru/eventa` contract from PR #1917 tomorrow) without touching the engine.
+ */
+
+import type { RwkvModel, RwkvModelId, RwkvQuantization } from './constants'
+
+/**
+ * Sampling configuration for one generation request.
+ *
+ * Maps 1:1 onto web-rwkv's `NucleusSampler` constructor arguments; every field
+ * is optional and falls back to a conversational default in the engine.
+ */
+export interface RwkvSamplingOptions {
+  /**
+   * Softmax temperature, applied as `prob^(1/temp)`.
+   * @default 1.0
+   */
+  temperature?: number
+  /**
+   * Nucleus (top-p) cutoff.
+   * @default 0.5
+   */
+  topP?: number
+  /**
+   * Flat penalty applied once a token has appeared (`presence_penalty`).
+   * @default 0.4
+   */
+  presencePenalty?: number
+  /**
+   * Per-occurrence penalty scaled by token count (`count_penalty`).
+   * @default 0.4
+   */
+  countPenalty?: number
+  /**
+   * Multiplicative decay of accumulated counts each step (`penalty_decay`).
+   * @default 0.996
+   */
+  penaltyDecay?: number
+}
+
+/** Request to load (download + quantize + compile) a catalog model. */
+export interface RwkvLoadRequest {
+  /** Catalog id from `RWKV_MODELS`; resolves to a weights URL + quantization. */
+  modelId: RwkvModelId
+}
+
+/**
+ * Essentials of web-rwkv's `ModelInfo`, surfaced to the main thread.
+ *
+ * The raw `ModelInfo` is a wasm-owned handle that cannot cross the worker
+ * boundary, so the engine copies the scalar fields callers actually need.
+ */
+export interface RwkvModelInfo {
+  /** Transformer layer count (`num_layer`); also the quantized-layer count. */
+  numLayer: number
+  /** Vocabulary size (`num_vocab`); length of the logits/probs buffers. */
+  numVocab: number
+  /** Embedding width (`num_emb`). */
+  numEmb: number
+  /** RWKV architecture version of the loaded checkpoint. */
+  version: RwkvModel['version']
+}
+
+/** Terminal payload of a successful load. */
+export interface RwkvLoadResult {
+  /** Echoes the requested catalog id. */
+  modelId: RwkvModelId
+  /** Quantization actually applied (resolved from the catalog entry). */
+  quantization: RwkvQuantization
+  /** Loaded model metadata. */
+  info: RwkvModelInfo
+}
+
+/** Stage of a load, used to label progress for the UI. */
+export type RwkvLoadPhase = 'download-weights' | 'download-vocab' | 'compile'
+
+/** A single load-progress chunk (server-streamed during `load`). */
+export interface RwkvLoadProgress {
+  /** Which load stage this chunk reports. */
+  phase: RwkvLoadPhase
+  /** 0-100, or -1 when the total is unknown (indeterminate). */
+  percent: number
+  /** Bytes downloaded so far (download phases only). */
+  loaded?: number
+  /** Total bytes, when the server reported `content-length`. */
+  total?: number
+}
+
+/** Request to generate a completion from a fully-formatted prompt. */
+export interface RwkvGenerateRequest {
+  /**
+   * The exact prompt fed to the tokenizer. Chat-template formatting
+   * (`User: …\n\nAssistant:`) is the caller's responsibility, not the
+   * worker's, so the engine stays a pure text-completion boundary.
+   */
+  prompt: string
+  /**
+   * Hard cap on generated tokens.
+   * @default 256
+   */
+  maxTokens?: number
+  /** Decoded substrings that end generation when produced. */
+  stopSequences?: string[]
+  /** Sampling overrides; omitted fields use conversational defaults. */
+  sampling?: RwkvSamplingOptions
+  /**
+   * Clear the prefix-state cache before generating, starting a fresh context.
+   * Leave `false` to let web-rwkv reuse the shared prefix of the prior turn.
+   * @default false
+   */
+  fresh?: boolean
+}
+
+/** One streamed generation step. */
+export interface RwkvGenerateDelta {
+  /** The sampled token id. */
+  token: number
+  /** The incremental decoded text for this token (may be empty mid-codepoint). */
+  text: string
+}
+
+/** Why generation stopped. */
+export type RwkvFinishReason = 'stop' | 'length' | 'eos'
+
+/** Terminal payload of a generation. */
+export interface RwkvGenerateResult {
+  /** Full decoded text (with any matched stop sequence trimmed off the end). */
+  text: string
+  /** Number of tokens produced. */
+  tokens: number
+  /** Stop cause: a stop sequence, the token cap, or the end-of-text token. */
+  finishReason: RwkvFinishReason
+}

--- a/packages/stage-ui/src/workers/rwkv/weights.ts
+++ b/packages/stage-ui/src/workers/rwkv/weights.ts
@@ -1,0 +1,109 @@
+/**
+ * Weight/vocab fetching for the web-rwkv worker, backed by the Cache Storage API.
+ *
+ * RWKV f16 `safetensors` are large (≈0.4-5.9 GB), and web-rwkv quantizes them
+ * on-device — so quantization shrinks VRAM, never the download. Caching the raw
+ * responses keeps a model switch (or a reload after the worker is recycled)
+ * from re-downloading multiple gigabytes. Downloads are streamed so callers can
+ * render byte-level progress instead of a spinner that hangs for minutes.
+ */
+
+/** Byte-level download progress. */
+export interface FetchProgress {
+  /** Bytes received so far. */
+  loaded: number
+  /** Total bytes from `content-length`, or 0 when the server didn't report it. */
+  total: number
+}
+
+export interface FetchOptions {
+  /** Aborts the in-flight network read. */
+  signal?: AbortSignal
+  /** Called as bytes arrive (cache hits resolve without intermediate calls). */
+  onProgress?: (progress: FetchProgress) => void
+}
+
+/**
+ * Cache name. Bump the version suffix to invalidate every cached weight when
+ * the on-disk format or URL scheme changes.
+ */
+const WEIGHTS_CACHE = 'rwkv-weights-v1'
+
+/**
+ * Fetch a URL as an `ArrayBuffer`, persisting it in the Cache Storage API.
+ *
+ * Use when:
+ * - Downloading RWKV weights or the vocab JSON, where re-fetching multi-GB
+ *   files on every load is unacceptable.
+ *
+ * Expects:
+ * - A same-origin or CORS-readable `url`. In environments without `caches`
+ *   (e.g. a non-secure context or a unit test), it transparently degrades to a
+ *   plain streamed `fetch` with no persistence.
+ *
+ * Returns:
+ * - The full response body. On a cache hit the body still streams through
+ *   `onProgress` (instantly), so progress UIs behave the same either way.
+ */
+export async function fetchCached(url: string, options?: FetchOptions): Promise<ArrayBuffer> {
+  const cache = typeof caches !== 'undefined' ? await caches.open(WEIGHTS_CACHE) : undefined
+  const hit = cache ? await cache.match(url) : undefined
+
+  const response = hit ?? await fetch(url, { signal: options?.signal })
+  if (!response.ok)
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
+
+  const total = Number(response.headers.get('content-length') ?? 0)
+  const buffer = await readWithProgress(response, total, options)
+
+  // Best-effort persist on a miss; a full cache (quota) must not fail the load.
+  if (cache && !hit)
+    await cache.put(url, new Response(buffer)).catch(() => {})
+
+  return buffer
+}
+
+/**
+ * Fetch a URL as UTF-8 text (the World tokenizer vocab JSON), cached as above.
+ */
+export async function fetchCachedText(url: string, options?: FetchOptions): Promise<string> {
+  const buffer = await fetchCached(url, options)
+  return new TextDecoder().decode(buffer)
+}
+
+/**
+ * Drain a `Response` body into one `ArrayBuffer` while reporting byte progress.
+ *
+ * Falls back to `response.arrayBuffer()` when the body is not a readable stream
+ * (so no incremental progress, but still correct).
+ */
+async function readWithProgress(response: Response, total: number, options?: FetchOptions): Promise<ArrayBuffer> {
+  if (!response.body)
+    return response.arrayBuffer()
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let loaded = 0
+
+  for (;;) {
+    if (options?.signal?.aborted) {
+      await reader.cancel()
+      throw new DOMException('The operation was aborted', 'AbortError')
+    }
+    const { done, value } = await reader.read()
+    if (done)
+      break
+    chunks.push(value)
+    loaded += value.byteLength
+    options?.onProgress?.({ loaded, total })
+  }
+
+  // Concatenate into a single contiguous buffer for the wasm reader.
+  const out = new Uint8Array(loaded)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out.buffer
+}

--- a/packages/stage-ui/src/workers/rwkv/worker.ts
+++ b/packages/stage-ui/src/workers/rwkv/worker.ts
@@ -1,0 +1,53 @@
+/**
+ * web-rwkv worker entry point.
+ *
+ * Thin wiring only: resolve the catalog model, hand the engine's
+ * load/generate/unload to the transport binding, and let the transport route
+ * inbound messages. When PR #1917's `@moeru/eventa` contract lands, swap
+ * {@link createMessagePortTransport} for an eventa binding here — the engine
+ * and ops below stay exactly as they are.
+ *
+ * Call stack:
+ *
+ * (main thread) Worker.postMessage
+ *   -> {@link createMessagePortTransport}.serve
+ *     -> ops.load    -> {@link RwkvEngine.load}
+ *     -> ops.generate-> {@link RwkvEngine.generate}
+ *     -> ops.unload  -> {@link RwkvEngine.unload}
+ */
+
+import type { RwkvEngine } from './engine'
+import type { MessageEndpoint } from './transport'
+
+import { RWKV_MODELS, RWKV_VOCAB_URL } from './constants'
+import { createRwkvEngine } from './engine'
+import { createMessagePortTransport } from './transport'
+
+const engine: RwkvEngine = createRwkvEngine()
+
+// `globalThis` in a dedicated worker is the `postMessage`/`addEventListener`
+// endpoint; the cast narrows it to the minimal surface the transport uses.
+const transport = createMessagePortTransport(globalThis as unknown as MessageEndpoint)
+
+transport.serve({
+  async load(request, context) {
+    const model = RWKV_MODELS.find(entry => entry.id === request.modelId)
+    if (!model)
+      throw new Error(`Unknown RWKV model: ${request.modelId}`)
+
+    const info = await engine.load(
+      { modelUrl: model.modelUrl, vocabUrl: RWKV_VOCAB_URL, quantization: model.quantization },
+      { signal: context.signal, onProgress: context.emit },
+    )
+
+    return { modelId: model.id, quantization: model.quantization, info }
+  },
+
+  generate(request, context) {
+    return engine.generate(request, { signal: context.signal, onToken: context.emit })
+  },
+
+  unload() {
+    return engine.unload()
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,7 +1504,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.2.1)
@@ -1543,7 +1543,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -1579,10 +1579,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: ^0.1.7
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -1609,7 +1609,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -1642,7 +1642,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -1663,31 +1663,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: ^4.0.0
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: ^1.3.2
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: ^4.1.0
-        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: ^1.2.1
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: ^3.1.2
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -20015,9 +20015,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -20919,6 +20919,31 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -22927,10 +22952,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -23832,6 +23881,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -24497,6 +24547,12 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -24798,6 +24854,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -26940,7 +27005,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -26948,7 +27013,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -32864,7 +32929,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@6.24.1: {}
 
@@ -32976,11 +33042,6 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -33077,6 +33138,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -33108,6 +33177,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33219,6 +33301,17 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33451,11 +33544,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -33502,6 +33605,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -33533,6 +33651,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -33551,6 +33676,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -33565,6 +33704,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -33577,6 +33731,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -33831,6 +33995,54 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
+  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,7 +1504,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@24.12.2)
+        version: 2.0.0(@types/node@25.6.0)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.2.1)
@@ -1543,7 +1543,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.7
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -1579,10 +1579,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: ^0.1.7
-        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -1609,7 +1609,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -1642,7 +1642,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -1663,31 +1663,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: ^4.0.0
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: ^1.3.2
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: ^4.1.0
-        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: ^1.2.1
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: ^3.1.2
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -3212,6 +3212,9 @@ importers:
 
   packages/stage-ui:
     dependencies:
+      '@cryscan/web-rwkv-wasm':
+        specifier: ^0.10.20
+        version: 0.10.20
       '@date-fns/utc':
         specifier: ^2.1.1
         version: 2.1.1
@@ -5560,6 +5563,9 @@ packages:
 
   '@cryptography/aes@0.1.1':
     resolution: {integrity: sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==}
+
+  '@cryscan/web-rwkv-wasm@0.10.20':
+    resolution: {integrity: sha512-mpM+d4EE66tlhghZ+oO8edaZvpznPBbbEBOYOEbzXQhhNNeFiAVSHtz3LeKDORhcUA+vrSfLWddClLwRnPCSEw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -19816,6 +19822,8 @@ snapshots:
 
   '@cryptography/aes@0.1.1': {}
 
+  '@cryscan/web-rwkv-wasm@0.10.20': {}
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/color-helpers@6.0.2': {}
@@ -20007,9 +20015,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 25.6.0
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -20911,31 +20919,6 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.9.3)
-    optionalDependencies:
-      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/compiler-dom'
-      - eslint
-      - rollup
-      - supports-color
-      - typescript
-
-  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
-      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
-      '@intlify/shared': 11.3.2
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
-      fast-glob: 3.3.3
-      pathe: 2.0.3
-      picocolors: 1.1.1
-      unplugin: 2.3.11
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -22944,34 +22927,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      ofetch: 1.5.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
-    dependencies:
-      ofetch: 1.5.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      yauzl: 3.3.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -23873,7 +23832,6 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
-    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -24539,12 +24497,6 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.9.3)
-
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -24846,15 +24798,6 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
-
-  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      sirv: 3.0.2
-      vue: 3.5.32(typescript@5.9.3)
-    optionalDependencies:
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -26997,7 +26940,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -27005,7 +26948,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -32921,8 +32864,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2:
-    optional: true
+  undici-types@7.19.2: {}
 
   undici@6.24.1: {}
 
@@ -33034,6 +32976,11 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
+    dependencies:
+      '@unocss/preset-mini': 66.6.8
+      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -33130,14 +33077,6 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    optionalDependencies:
-      esbuild: 0.27.2
-      rolldown: 1.0.0-rc.16
-      rollup: 4.60.1
-      unplugin: 2.3.11
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -33169,19 +33108,6 @@ snapshots:
       esbuild: 0.27.2
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      ci-info: 4.4.0
-      git-url-parse: 16.1.0
-      simple-git: 3.36.0
-      unplugin: 2.3.11
-    optionalDependencies:
-      esbuild: 0.27.2
-      rollup: 4.60.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33293,17 +33219,6 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
-  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      unplugin: 3.0.0
-      yaml: 2.8.3
-    optionalDependencies:
-      esbuild: 0.27.2
-      rolldown: 1.0.0-rc.16
-      rollup: 4.60.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33536,21 +33451,11 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      birpc: 2.9.0
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
-  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -33597,21 +33502,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      ansis: 4.2.0
-      debug: 4.4.3(supports-color@10.2.2)
-      error-stack-parser-es: 1.0.5
-      ohash: 2.0.11
-      open: 10.2.0
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      unplugin-utils: 0.3.1
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -33643,13 +33533,6 @@ snapshots:
       - typescript
       - ws
 
-  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      supports-color: 10.2.2
-      undici: 8.1.0
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -33668,20 +33551,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
-    dependencies:
-      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
-      '@vue/devtools-kit': 8.1.1
-      '@vue/devtools-shared': 8.1.1
-      sirv: 3.0.2
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - supports-color
-      - vue
-
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -33696,21 +33565,6 @@ snapshots:
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
-      '@vue/compiler-dom': 3.5.32
-      kolorist: 1.8.0
-      magic-string: 0.30.21
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -33723,16 +33577,6 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      fast-glob: 3.3.3
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@5.9.3)
-      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -33987,54 +33831,6 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
-      vue: 3.5.32(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@rspack/core'
-      - '@vueuse/core'
-      - esbuild
-      - rolldown
-      - rollup
-      - typescript
-      - vite
-      - vue-tsc
-      - webpack
-
-  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
-    dependencies:
-      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
-      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
-      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
-      unplugin: 2.3.11
-      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION

## Description

Adds the contract-agnostic surface for an in-browser RWKV chat provider backed by @cryscan/web-rwkv-wasm:

- workers/rwkv/constants.ts: RWKV model catalog + pure helpers (rwkvModelsToModelInfo, getDefaultRwkvModel), WebGPU-gated, with unit tests.
- stores/providers.ts: rwkv-local chat provider metadata, defaultOptions, listModels, WebGPU availability gate, and config validation.
- i18n (en): provider title/description and model descriptions.

## Linked Issues

#919 

## Additional Context

The worker (workers/rwkv/worker.ts) and adapter
(libs/inference/adapters/rwkv.ts) are intentionally deferred: they speak the worker/main wire contract that PR #1917 is migrating from the hand-rolled postMessage protocol to a @moeru/eventa contract. createProvider and loadModel are documented seams that throw until that adapter lands on top of #1917, so no throwaway transport code is written now.
