### PR TITLE
refactor(server): use es-toolkit clamp for query bounds

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -52,6 +52,7 @@
     "cac": "catalog:",
     "drizzle-orm": "catalog:",
     "drizzle-valibot": "catalog:",
+    "es-toolkit": "catalog:",
     "hono": "catalog:",
     "hono-rate-limiter": "catalog:",
     "injeca": "catalog:",

--- a/apps/server/src/utils/http-query.ts
+++ b/apps/server/src/utils/http-query.ts
@@ -1,19 +1,10 @@
+import { clamp } from 'es-toolkit'
 import { fallback, integer, object, optional, pipe, string, transform } from 'valibot'
 
 interface QueryIntegerSchemaOptions {
   defaultValue: number
   minimum?: number
   maximum?: number
-}
-
-function clampQueryInteger(value: number, minimum?: number, maximum?: number): number {
-  if (minimum != null && value < minimum)
-    return minimum
-
-  if (maximum != null && value > maximum)
-    return maximum
-
-  return value
 }
 
 /**
@@ -27,7 +18,7 @@ export function createQueryIntegerSchema(options: QueryIntegerSchemaOptions) {
       transform(input => input.trim()),
       transform(input => Number.parseInt(input, 10)),
       integer(),
-      transform(value => clampQueryInteger(value, options.minimum, options.maximum)),
+      transform(value => clamp(value, options.minimum ?? Number.NEGATIVE_INFINITY, options.maximum ?? Number.POSITIVE_INFINITY)),
     ),
     options.defaultValue,
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -740,6 +740,9 @@ importers:
       drizzle-valibot:
         specifier: 'catalog:'
         version: 0.4.2(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.5.0)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9))(valibot@1.2.0(typescript@5.9.3))
+      es-toolkit:
+        specifier: 'catalog:'
+        version: 1.43.0
       hono:
         specifier: 'catalog:'
         version: 4.11.3


### PR DESCRIPTION
## Description

Replace the local `clampQueryInteger` helper in server query parsing with `es-toolkit`'s exported `clamp`, while preserving optional minimum-only and maximum-only bounds by using infinite fallback bounds.

Also declares `es-toolkit` as a direct `@proj-airi/server` dependency.

## Linked Issues

None.

## Additional Context

Validation run from the dedicated PR worktree:

- `pnpm install --ignore-scripts --frozen-lockfile`
- `pnpm -F @proj-airi/server-schema -F @proj-airi/server-sdk-shared build`
- `pnpm -F @proj-airi/server typecheck`
- `pnpm exec eslint apps/server/src/utils/http-query.ts`
- `git diff --check`