### PR TITLE
fix(stage-ui-live2d): normalize Live2D archive paths for import and display

### DIFF
--- a/packages/stage-ui-live2d/src/utils/live2d-archive-paths.test.ts
+++ b/packages/stage-ui-live2d/src/utils/live2d-archive-paths.test.ts
@@ -1,0 +1,342 @@
+import JSZip from 'jszip'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { encodeArchivePathForFileLoader, encodeModelSettingsJsonPaths, isIgnoredPath, sanitizeModelSettingsJson, stringifyModelSettingsJsonForFileLoader } from './live2d-archive-paths'
+
+describe('isIgnoredPath', () => {
+  it('flags __MACOSX directory entries', () => {
+    expect(isIgnoredPath('__MACOSX/model.model3.json')).toBe(true)
+    expect(isIgnoredPath('dir/__MACOSX/file.moc3')).toBe(true)
+    expect(isIgnoredPath('dir\\__MACOSX\\file.moc3')).toBe(true)
+  })
+
+  it('flags ._ Apple Double files', () => {
+    expect(isIgnoredPath('._model.model3.json')).toBe(true)
+    expect(isIgnoredPath('textures/._texture_00.png')).toBe(true)
+    expect(isIgnoredPath('textures\\._texture_00.png')).toBe(true)
+  })
+
+  it('flags .DS_Store', () => {
+    expect(isIgnoredPath('.DS_Store')).toBe(true)
+    expect(isIgnoredPath('subdir/.DS_Store')).toBe(true)
+  })
+
+  it('flags Thumbs.db', () => {
+    expect(isIgnoredPath('Thumbs.db')).toBe(true)
+    expect(isIgnoredPath('assets/Thumbs.db')).toBe(true)
+  })
+
+  it('allows normal model paths', () => {
+    expect(isIgnoredPath('model.model3.json')).toBe(false)
+    expect(isIgnoredPath('textures/texture_00.png')).toBe(false)
+    expect(isIgnoredPath('motions/idle.motion3.json')).toBe(false)
+    expect(isIgnoredPath('physics/physics3.json')).toBe(false)
+    expect(isIgnoredPath('model.moc3')).toBe(false)
+  })
+})
+
+describe('sanitizeModelSettingsJson', () => {
+  it('removes explicitly null Physics', () => {
+    const json: Record<string, unknown> = {
+      Version: 3,
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Physics: null,
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    expect((json.FileReferences as Record<string, unknown>)).not.toHaveProperty('Physics')
+  })
+
+  it('removes explicitly null Pose', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Pose: null,
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    expect((json.FileReferences as Record<string, unknown>)).not.toHaveProperty('Pose')
+  })
+
+  it('removes explicitly null DisplayInfo', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        DisplayInfo: null,
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    expect((json.FileReferences as Record<string, unknown>)).not.toHaveProperty('DisplayInfo')
+  })
+
+  it('keeps string Physics intact', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Physics: 'physics3.json',
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    expect((json.FileReferences as Record<string, unknown>).Physics).toBe('physics3.json')
+  })
+
+  it('filters motion entries with null File', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Motions: {
+          idle: [
+            { File: 'idle.motion3.json' },
+            { File: null },
+            { File: '' },
+          ],
+          tap: [
+            { File: null },
+          ],
+        },
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    const refs = json.FileReferences as Record<string, unknown>
+    const motions = refs.Motions as Record<string, unknown>
+    expect(motions.idle).toEqual([{ File: 'idle.motion3.json' }])
+    expect(motions).not.toHaveProperty('tap')
+  })
+
+  it('removes Motions entirely when all groups are empty after filtering', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Motions: {
+          idle: [{ File: null }],
+        },
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    expect((json.FileReferences as Record<string, unknown>)).not.toHaveProperty('Motions')
+  })
+
+  it('filters expression entries with null File', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Expressions: [
+          { File: 'happy.exp3.json', Name: 'happy' },
+          { File: null, Name: 'broken' },
+          { File: '', Name: 'empty' },
+        ],
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    const refs = json.FileReferences as Record<string, unknown>
+    expect(refs.Expressions).toEqual([{ File: 'happy.exp3.json', Name: 'happy' }])
+  })
+
+  it('removes Expressions entirely when all entries are invalid', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Expressions: [{ File: null }],
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    expect((json.FileReferences as Record<string, unknown>)).not.toHaveProperty('Expressions')
+  })
+
+  it('handles missing FileReferences gracefully', () => {
+    const json: Record<string, unknown> = { Version: 3 }
+    expect(() => sanitizeModelSettingsJson(json)).not.toThrow()
+  })
+
+  it('handles missing optional fields without error', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+      },
+    }
+    sanitizeModelSettingsJson(json)
+    const refs = json.FileReferences as Record<string, unknown>
+    expect(refs.Moc).toBe('model.moc3')
+  })
+})
+
+describe('encodeModelSettingsJsonPaths', () => {
+  it('encodes non-ASCII file references using the same form as FileLoader validation', () => {
+    const json: Record<string, unknown> = {
+      FileReferences: {
+        Moc: '八千代辉夜姬.moc3',
+        Textures: [
+          '八千代辉夜姬.8192/texture_00.png',
+          '八千代辉夜姬.8192/texture_01.png',
+        ],
+        Physics: '八千代辉夜姬.physics3.json',
+      },
+    }
+
+    encodeModelSettingsJsonPaths(json)
+
+    const refs = json.FileReferences as Record<string, unknown>
+    expect(refs.Moc).toBe(encodeURI('八千代辉夜姬.moc3'))
+    expect(refs.Textures).toEqual([
+      encodeURI('八千代辉夜姬.8192/texture_00.png'),
+      encodeURI('八千代辉夜姬.8192/texture_01.png'),
+    ])
+    expect(refs.Physics).toBe(encodeURI('八千代辉夜姬.physics3.json'))
+  })
+
+  it('keeps already encoded references stable', () => {
+    const encoded = encodeURI('八千代辉夜姬.moc3')
+
+    expect(encodeArchivePathForFileLoader(encoded)).toBe(encoded)
+  })
+
+  it('stringifies OPFS settings without double-encoding already normalized paths', () => {
+    const encodedUrl = encodeURI('【雪熊企划】八千代辉夜姬/八千代辉夜姬.model3.json')
+    const encodedMoc = encodeURI('八千代辉夜姬.moc3')
+    const encodedTexture = encodeURI('八千代辉夜姬.8192/texture_00.png')
+
+    const text = stringifyModelSettingsJsonForFileLoader({
+      url: encodedUrl,
+      Version: 3,
+      FileReferences: {
+        Moc: encodedMoc,
+        Textures: [encodedTexture],
+      },
+    })
+    const json = JSON.parse(text)
+
+    expect(json.url).toBe(encodedUrl)
+    expect(json.FileReferences.Moc).toBe(encodedMoc)
+    expect(json.FileReferences.Textures).toEqual([encodedTexture])
+    expect(text).not.toContain('%25E5')
+  })
+})
+
+describe('zipLoader integration: null Physics sanitization', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { Live2DCubismCore: {} })
+    vi.resetModules()
+  })
+
+  /**
+   * Regression: model3.json with "Physics": null (explicit null, not absent)
+   * caused the upstream replaceFiles() to pass null to url.resolve(), crashing
+   * the import chain. Now readText sanitizes null to absent before upstream sees it.
+   */
+  it('produces settings with physics === undefined when model3.json has Physics: null', async () => {
+    await import('./live2d-zip-loader')
+    const { ZipLoader } = await import('pixi-live2d-display/cubism4')
+
+    const zip = new JSZip()
+    zip.file('shisihangshi.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: {
+        Moc: 'shisihangshi.moc3',
+        Textures: ['texture_00.png'],
+        Physics: null,
+      },
+    }))
+
+    const settings = await ZipLoader.createSettings(zip)
+
+    expect(settings.physics).toBeUndefined()
+  })
+
+  /**
+   * Regression: macOS zips may contain __MACOSX/._model.model3.json alongside
+   * the real model.model3.json. The loader must ignore the junk entry.
+   */
+  it('ignores __MACOSX and ._ files when selecting settings file', async () => {
+    await import('./live2d-zip-loader')
+    const { ZipLoader } = await import('pixi-live2d-display/cubism4')
+
+    const zip = new JSZip()
+    // Junk first (would be selected first if not filtered)
+    zip.file('__MACOSX/._model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: { Moc: 'fake.moc3', Textures: ['fake.png'] },
+    }))
+    zip.file('model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: { Moc: 'real.moc3', Textures: ['real.png'] },
+    }))
+
+    const settings = await ZipLoader.createSettings(zip)
+
+    // Should pick the real settings file, not the macOS junk
+    expect(settings.moc).toBe('real.moc3')
+  })
+
+  /**
+   * Regression: FileLoader validates zip resources with encodeURI(webkitRelativePath).
+   * Settings paths must be encoded to the same form, otherwise models with Chinese
+   * file names parse successfully but fail during upload validation.
+   */
+  it('keeps non-ASCII model paths valid for FileLoader after unzip', async () => {
+    await import('./live2d-zip-loader')
+    const { ZipLoader } = await import('pixi-live2d-display/cubism4')
+
+    const zip = new JSZip()
+    zip.file('【雪熊企划】八千代辉夜姬/八千代辉夜姬.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: {
+        Moc: '八千代辉夜姬.moc3',
+        Textures: [
+          '八千代辉夜姬.8192/texture_00.png',
+          '八千代辉夜姬.8192/texture_01.png',
+        ],
+        Physics: '八千代辉夜姬.physics3.json',
+      },
+    }))
+    zip.file('【雪熊企划】八千代辉夜姬/八千代辉夜姬.moc3', new Uint8Array(10))
+    zip.file('【雪熊企划】八千代辉夜姬/八千代辉夜姬.physics3.json', '{}')
+    zip.file('【雪熊企划】八千代辉夜姬/八千代辉夜姬.8192/texture_00.png', new Uint8Array(10))
+    zip.file('【雪熊企划】八千代辉夜姬/八千代辉夜姬.8192/texture_01.png', new Uint8Array(10))
+
+    const settings = await ZipLoader.createSettings(zip)
+    const files = await ZipLoader.unzip(zip, settings)
+    const encodedPaths = files.map(file => encodeURI(file.webkitRelativePath))
+
+    expect(() => settings.validateFiles(encodedPaths)).not.toThrow()
+  })
+
+  /**
+   * Regression: OPFS saveMiddleware reconstructs a settings file between ZipLoader
+   * and FileLoader. It must persist the already-normalized settings without turning
+   * `%E5...` paths into `%25E5...`, or FileLoader cannot validate resources.
+   */
+  it('keeps OPFS-reconstructed non-ASCII settings valid for FileLoader', async () => {
+    const { Cubism4ModelSettings } = await import('pixi-live2d-display/cubism4')
+    const modelDir = '【雪熊企划】八千代辉夜姬'
+    const modelFile = '八千代辉夜姬.model3.json'
+    const mocFile = '八千代辉夜姬.moc3'
+    const textureFile = '八千代辉夜姬.8192/texture_00.png'
+    const settingsJson = JSON.parse(stringifyModelSettingsJsonForFileLoader({
+      url: encodeURI(`${modelDir}/${modelFile}`),
+      Version: 3,
+      FileReferences: {
+        Moc: encodeURI(mocFile),
+        Textures: [encodeURI(textureFile)],
+      },
+    }))
+
+    const settings = new Cubism4ModelSettings(settingsJson)
+    const encodedPaths = [
+      `${modelDir}/${mocFile}`,
+      `${modelDir}/${textureFile}`,
+    ].map(path => encodeURI(path))
+
+    expect(() => settings.validateFiles(encodedPaths)).not.toThrow()
+  })
+})

--- a/packages/stage-ui-live2d/src/utils/live2d-archive-paths.ts
+++ b/packages/stage-ui-live2d/src/utils/live2d-archive-paths.ts
@@ -1,0 +1,182 @@
+/**
+ * Checks whether a zip entry path should be ignored (macOS metadata / system junk).
+ *
+ * Use when scanning zip contents to avoid treating system files as model assets.
+ */
+export function isIgnoredPath(path: string): boolean {
+  return path.split(/[\\/]/).some(seg =>
+    seg === '__MACOSX'
+    || seg === '.DS_Store'
+    || seg === 'Thumbs.db'
+    || seg.startsWith('._'),
+  )
+}
+
+/**
+ * Normalizes archive paths to the encoded form expected by pixi-live2d-display's FileLoader.
+ *
+ * Before:
+ * - "八千代辉夜姬.8192/texture_00.png"
+ * - "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.moc3"
+ *
+ * After:
+ * - "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.8192/texture_00.png"
+ * - "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.moc3"
+ */
+export function encodeArchivePathForFileLoader(path: string): string {
+  try {
+    return encodeURI(decodeURI(path))
+  }
+  catch {
+    return encodeURI(path)
+  }
+}
+
+function encodeStringField(record: Record<string, unknown>, field: string): void {
+  if (typeof record[field] === 'string')
+    record[field] = encodeArchivePathForFileLoader(record[field])
+}
+
+function encodeStringArrayField(record: Record<string, unknown>, field: string): void {
+  if (!Array.isArray(record[field]))
+    return
+
+  record[field] = record[field].map(value =>
+    typeof value === 'string'
+      ? encodeArchivePathForFileLoader(value)
+      : value,
+  )
+}
+
+function encodeFileEntry(entry: unknown): unknown {
+  if (!entry || typeof entry !== 'object')
+    return entry
+
+  const fileEntry = entry as Record<string, unknown>
+  encodeStringField(fileEntry, 'File')
+  encodeStringField(fileEntry, 'Sound')
+  return fileEntry
+}
+
+/**
+ * Normalizes file references inside a parsed model settings JSON.
+ *
+ * Before:
+ * - `{ "FileReferences": { "Moc": "八千代辉夜姬.moc3" } }`
+ *
+ * After:
+ * - `{ "FileReferences": { "Moc": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.moc3" } }`
+ */
+export function encodeModelSettingsJsonPaths(json: Record<string, unknown>): void {
+  const refs = json.FileReferences as Record<string, unknown> | undefined
+  if (!refs)
+    return
+
+  encodeStringField(refs, 'Moc')
+  encodeStringField(refs, 'Physics')
+  encodeStringField(refs, 'Pose')
+  encodeStringField(refs, 'DisplayInfo')
+  encodeStringArrayField(refs, 'Textures')
+
+  if (refs.Motions && typeof refs.Motions === 'object') {
+    const motions = refs.Motions as Record<string, unknown>
+    for (const [group, list] of Object.entries(motions)) {
+      if (Array.isArray(list))
+        motions[group] = list.map(encodeFileEntry)
+    }
+  }
+
+  if (Array.isArray(refs.Expressions))
+    refs.Expressions = refs.Expressions.map(encodeFileEntry)
+}
+
+/**
+ * Normalizes the settings URL after pixi-live2d-display injects it into ModelSettings.
+ *
+ * Before:
+ * - `settings.url === "【雪熊企划】八千代辉夜姬/八千代辉夜姬.model3.json"`
+ *
+ * After:
+ * - `settings.url === "%E3%80%90%E9%9B%AA%E7%86%8A%E4%BC%81%E5%88%92%E3%80%91%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC/%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.model3.json"`
+ */
+export function encodeModelSettingsUrl(settings: { url: string, json: object }): void {
+  settings.url = encodeArchivePathForFileLoader(settings.url)
+  Object.assign(settings.json, { url: settings.url })
+}
+
+/**
+ * Normalizes a cloned settings JSON for FileLoader-compatible persistence.
+ *
+ * Before:
+ * - `{ "url": "八千代辉夜姬.model3.json", "FileReferences": { "Moc": "八千代辉夜姬.moc3" } }`
+ * - `{ "url": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.model3.json", "FileReferences": { "Moc": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.moc3" } }`
+ *
+ * After:
+ * - `{ "url": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.model3.json", "FileReferences": { "Moc": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.moc3" } }`
+ * - `{ "url": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.model3.json", "FileReferences": { "Moc": "%E5%85%AB%E5%8D%83%E4%BB%A3%E8%BE%89%E5%A4%9C%E5%A7%AC.moc3" } }`
+ */
+export function stringifyModelSettingsJsonForFileLoader(input: object): string {
+  const settings = JSON.parse(JSON.stringify(input)) as Record<string, unknown>
+
+  if (typeof settings.url === 'string')
+    settings.url = encodeArchivePathForFileLoader(settings.url)
+
+  encodeModelSettingsJsonPaths(settings)
+  return JSON.stringify(settings)
+}
+
+/**
+ * Sanitizes a parsed model3.json in place, fixing common data issues that would
+ * break the upstream pixi-live2d-display loader.
+ *
+ * - Removes `FileReferences.Physics`, `Pose`, `DisplayInfo` when explicitly `null`
+ * - Filters motion entries with null/empty/non-string `File`
+ * - Filters expression entries with null/empty/non-string `File`
+ */
+export function sanitizeModelSettingsJson(json: Record<string, unknown>): void {
+  const refs = json.FileReferences as Record<string, unknown> | undefined
+  if (!refs)
+    return
+
+  if (refs.Physics === null)
+    delete refs.Physics
+  if (refs.Pose === null)
+    delete refs.Pose
+  if (refs.DisplayInfo === null)
+    delete refs.DisplayInfo
+
+  if (refs.Motions) {
+    const motions = refs.Motions as Record<string, unknown>
+    let hasAny = false
+    for (const [group, list] of Object.entries(motions)) {
+      if (!Array.isArray(list))
+        continue
+      const filtered = list.filter(
+        (m: unknown) => m && typeof (m as Record<string, unknown>).File === 'string' && (m as Record<string, unknown>).File !== '',
+      )
+      if (filtered.length > 0) {
+        motions[group] = filtered
+        hasAny = true
+      }
+      else {
+        delete motions[group]
+      }
+    }
+    if (!hasAny)
+      delete refs.Motions
+  }
+
+  if (refs.Expressions) {
+    if (Array.isArray(refs.Expressions)) {
+      const filtered = refs.Expressions.filter(
+        (e: unknown) => e && typeof (e as Record<string, unknown>).File === 'string' && (e as Record<string, unknown>).File !== '',
+      )
+      if (filtered.length > 0) {
+        refs.Expressions = filtered
+      }
+      else {
+        delete refs.Expressions
+      }
+    }
+  }
+}

--- a/packages/stage-ui-live2d/src/utils/live2d-validator.test.ts
+++ b/packages/stage-ui-live2d/src/utils/live2d-validator.test.ts
@@ -1,0 +1,123 @@
+import JSZip from 'jszip'
+
+import { describe, expect, it } from 'vitest'
+
+import { validateLive2DZip } from './live2d-validator'
+
+function makeMockMoc3Content(): Uint8Array {
+  const buf = new Uint8Array(20)
+  buf[0] = 77 // M
+  buf[1] = 79 // O
+  buf[2] = 67 // C
+  buf[3] = 51 // 3
+  buf[4] = 1 // sub-version
+  return buf
+}
+
+async function zipToData(zip: JSZip): Promise<Uint8Array> {
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+describe('validateLive2DZip system file filtering', () => {
+  /**
+   * Regression: macOS zips contain __MACOSX/._ files that should not cause
+   * INVALID audit results. The validator must ignore these paths when scanning
+   * for entry points, checking basename collisions, and validating references.
+   */
+  it('ignores __MACOSX and ._ files when identifying entry point', async () => {
+    const zip = new JSZip()
+    zip.file('__MACOSX/._model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: { Moc: 'fake.moc3', Textures: ['fake.png'] },
+    }))
+    zip.file('model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: { Moc: 'model.moc3', Textures: ['tex.png'] },
+    }))
+    zip.file('model.moc3', makeMockMoc3Content())
+    zip.file('tex.png', new Uint8Array(10))
+
+    const data = await zipToData(zip)
+    const report = await validateLive2DZip(data as unknown as Blob)
+
+    expect(report.status).not.toBe('INVALID')
+    expect(report.entryPoint).toBe('model.model3.json')
+    expect(report.structureType).toBe('Standard (model3.json)')
+  })
+
+  it('does not flag basename collisions caused by macOS metadata', async () => {
+    const zip = new JSZip()
+    // Same basename in macOS junk dir should not cause collision error
+    zip.file('__MACOSX/tex.png', new Uint8Array(10))
+    zip.file('model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: { Moc: 'model.moc3', Textures: ['tex.png'] },
+    }))
+    zip.file('model.moc3', makeMockMoc3Content())
+    zip.file('tex.png', new Uint8Array(10))
+
+    const data = await zipToData(zip)
+    const report = await validateLive2DZip(data as unknown as Blob)
+
+    expect(report.errors).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('BASENAME COLLISION')]),
+    )
+  })
+
+  /**
+   * Regression: model3.json with "Physics": null should not cause
+   * a MISSING REFERENCE error in the validator (since sanitizeModelSettingsJson
+   * removes it before reference checking).
+   */
+  it('does not report missing reference for Physics: null', async () => {
+    const zip = new JSZip()
+    zip.file('model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: {
+        Moc: 'model.moc3',
+        Textures: ['tex.png'],
+        Physics: null,
+      },
+    }))
+    zip.file('model.moc3', makeMockMoc3Content())
+    zip.file('tex.png', new Uint8Array(10))
+
+    const data = await zipToData(zip)
+    const report = await validateLive2DZip(data as unknown as Blob)
+
+    expect(report.status).toBe('VALID')
+    expect(report.errors).toEqual([])
+  })
+
+  it('validates URI-encoded non-ASCII references against Unicode zip entries', async () => {
+    const zip = new JSZip()
+    const modelFile = '八千代辉夜姬.moc3'
+    const textureFile = '八千代辉夜姬.8192/texture_00.png'
+
+    // ROOT CAUSE:
+    //
+    // If model3.json references are already URI-encoded while ZIP entries use
+    // normal Unicode names, comparing the encoded reference directly against
+    // raw ZIP paths reports MISSING REFERENCE.
+    //
+    // "八千代辉夜姬.moc3" in the archive did not match "%E5...moc3" in settings.
+    //
+    // We fixed this by comparing normalized settings references against the
+    // encodeURI(webkitRelativePath) form used by pixi-live2d-display.
+    zip.file('model.model3.json', JSON.stringify({
+      Version: 3,
+      FileReferences: {
+        Moc: encodeURI(modelFile),
+        Textures: [encodeURI(textureFile)],
+      },
+    }))
+    zip.file(modelFile, makeMockMoc3Content())
+    zip.file(textureFile, new Uint8Array(10))
+
+    const data = await zipToData(zip)
+    const report = await validateLive2DZip(data as unknown as Blob)
+
+    expect(report.status).toBe('VALID')
+    expect(report.errors).toEqual([])
+  })
+})

--- a/packages/stage-ui-live2d/src/utils/live2d-validator.ts
+++ b/packages/stage-ui-live2d/src/utils/live2d-validator.ts
@@ -1,5 +1,7 @@
 import JSZip from 'jszip'
 
+import { encodeArchivePathForFileLoader, isIgnoredPath, sanitizeModelSettingsJson } from './live2d-archive-paths'
+
 export interface Live2DValidationReport {
   fileName: string
   totalFiles: number
@@ -16,9 +18,32 @@ export interface Live2DValidationReport {
   }
 }
 
+function fileReferenceFrom(value: unknown): string | undefined {
+  if (typeof value === 'string')
+    return value
+
+  if (!value || typeof value !== 'object')
+    return undefined
+
+  const file = (value as { File?: unknown }).File
+  return typeof file === 'string' ? file : undefined
+}
+
+function messageFromUnknown(error: unknown): string {
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === 'string')
+      return message
+  }
+
+  return String(error)
+}
+
 export async function validateLive2DZip(file: File | Blob): Promise<Live2DValidationReport> {
   const zip = await JSZip.loadAsync(file)
   const allPaths = Object.keys(zip.files)
+  const cleanPaths = allPaths.filter(p => !isIgnoredPath(p))
+  const encodedCleanPaths = new Map(cleanPaths.map(path => [encodeURI(path), path]))
 
   const report: Live2DValidationReport = {
     fileName: (file as File).name || 'live2d-model.zip',
@@ -32,14 +57,14 @@ export async function validateLive2DZip(file: File | Blob): Promise<Live2DValida
   }
 
   // 1. Entry Point Identification
-  const model3Files = allPaths.filter(p => p.endsWith('.model3.json'))
+  const model3Files = cleanPaths.filter(p => p.endsWith('.model3.json'))
   if (model3Files.length > 0) {
     report.entryPoint = model3Files[0]
     report.structureType = 'Standard (model3.json)'
     report.checks.push(`Entry point identified: ${report.entryPoint}`)
   }
   else {
-    const mocFiles = allPaths.filter(p => p.endsWith('.moc3'))
+    const mocFiles = cleanPaths.filter(p => p.endsWith('.moc3'))
     if (mocFiles.length === 1) {
       report.structureType = 'Heuristic (Loose Files)'
       report.checks.push(`Heuristic match found: Unique MOC file ${mocFiles[0]}`)
@@ -50,7 +75,7 @@ export async function validateLive2DZip(file: File | Blob): Promise<Live2DValida
   }
 
   // 2. MOC Header & Size Audit
-  const mocPath = allPaths.find(p => p.endsWith('.moc3'))
+  const mocPath = cleanPaths.find(p => p.endsWith('.moc3'))
   if (mocPath) {
     const buf = await zip.file(mocPath)!.async('uint8array')
     const header = String.fromCharCode(...buf.slice(0, 4))
@@ -76,7 +101,7 @@ export async function validateLive2DZip(file: File | Blob): Promise<Live2DValida
 
   // 3. Basename Collision Audit (AIRI ZipLoader weakness)
   const basenames = new Map<string, string[]>()
-  allPaths.forEach((p) => {
+  cleanPaths.forEach((p) => {
     if (p.endsWith('/'))
       return // Skip directories
     const base = p.split(/[\\/]/).pop()!
@@ -96,6 +121,7 @@ export async function validateLive2DZip(file: File | Blob): Promise<Live2DValida
     try {
       const content = await zip.file(report.entryPoint)!.async('text')
       const json = JSON.parse(content)
+      sanitizeModelSettingsJson(json)
       const baseDir = report.entryPoint.split(/[\\/]/).slice(0, -1).join('/')
 
       const resolve = (rel: string) => {
@@ -115,9 +141,10 @@ export async function validateLive2DZip(file: File | Blob): Promise<Live2DValida
 
       const checkRef = (rel: string, type: string) => {
         const full = resolve(rel)
-        if (!allPaths.includes(full)) {
+        const encodedFull = encodeArchivePathForFileLoader(full)
+        if (!encodedCleanPaths.has(encodedFull)) {
           // Check for case-insensitivity match to provide better error
-          const fuzzy = allPaths.find(p => p.toLowerCase() === full.toLowerCase())
+          const fuzzy = cleanPaths.find(p => encodeURI(p).toLowerCase() === encodedFull.toLowerCase())
           if (fuzzy) {
             report.errors.push(`CASE SENSITIVITY MISMATCH: "${rel}" expects "${full}" but ZIP contains "${fuzzy}". Browsers are case-sensitive.`)
           }
@@ -127,20 +154,32 @@ export async function validateLive2DZip(file: File | Blob): Promise<Live2DValida
         }
       }
 
-      const refs = json.FileReferences || {}
-      if (refs.Moc)
-        checkRef(refs.Moc, 'MOC')
+      const refs = json.FileReferences && typeof json.FileReferences === 'object'
+        ? json.FileReferences as Record<string, unknown>
+        : {}
+      const moc = fileReferenceFrom(refs.Moc)
+      if (moc)
+        checkRef(moc, 'MOC')
       if (Array.isArray(refs.Textures)) {
-        refs.Textures.forEach((t: string) => checkRef(t, 'Texture'))
+        refs.Textures.forEach((texture) => {
+          const textureFile = fileReferenceFrom(texture)
+          if (textureFile)
+            checkRef(textureFile, 'Texture')
+        })
       }
-      if (refs.Physics)
-        checkRef(refs.Physics, 'Physics')
+      const physics = fileReferenceFrom(refs.Physics)
+      if (physics)
+        checkRef(physics, 'Physics')
       if (Array.isArray(refs.Expressions)) {
-        refs.Expressions.forEach((e: any) => checkRef(typeof e === 'string' ? e : e.File, 'Expression'))
+        refs.Expressions.forEach((expression) => {
+          const expressionFile = fileReferenceFrom(expression)
+          if (expressionFile)
+            checkRef(expressionFile, 'Expression')
+        })
       }
     }
-    catch (e: any) {
-      report.errors.push(`JSON PARSE ERROR: Failed to parse ${report.entryPoint}: ${e.message}`)
+    catch (error: unknown) {
+      report.errors.push(`JSON PARSE ERROR: Failed to parse ${report.entryPoint}: ${messageFromUnknown(error)}`)
     }
   }
 

--- a/packages/stage-ui-live2d/src/utils/live2d-zip-loader.ts
+++ b/packages/stage-ui-live2d/src/utils/live2d-zip-loader.ts
@@ -4,17 +4,20 @@ import JSZip from 'jszip'
 
 import { Cubism4ModelSettings, ZipLoader } from 'pixi-live2d-display/cubism4'
 
+import { encodeModelSettingsJsonPaths, encodeModelSettingsUrl, isIgnoredPath, sanitizeModelSettingsJson } from './live2d-archive-paths'
+
 ZipLoader.zipReader = (data: Blob, _url: string) => JSZip.loadAsync(data)
 
 const defaultCreateSettings = ZipLoader.createSettings
 ZipLoader.createSettings = async (reader: JSZip) => {
-  const filePaths = Object.keys(reader.files)
+  const filePaths = Object.keys(reader.files).filter(f => !isIgnoredPath(f))
   const settings = await (async () => {
     if (!filePaths.some(file => isSettingsFile(file))) {
       return createFakeSettings(filePaths)
     }
     return defaultCreateSettings(reader)
   })()
+  encodeModelSettingsUrl(settings)
 
   // Extract CDI data from the zip if available
   try {
@@ -56,7 +59,7 @@ ZipLoader.createSettings = async (reader: JSZip) => {
 }
 
 export function isSettingsFile(file: string) {
-  return file.endsWith('.model3.json') || file.endsWith('.model.json')
+  return !isIgnoredPath(file) && (file.endsWith('.model3.json') || file.endsWith('.model.json'))
 }
 
 export function isMocFile(file: string) {
@@ -70,7 +73,8 @@ export function basename(path: string): string {
 
 // copy and modified from https://github.com/guansss/live2d-viewer-web/blob/f6060b2ce52c2e26b6b61fa903c837fe343f72d1/src/app/upload.ts#L81-L142
 function createFakeSettings(files: string[]): ModelSettings {
-  const mocFiles = files.filter(file => isMocFile(file))
+  const cleanFiles = files.filter(f => !isIgnoredPath(f))
+  const mocFiles = cleanFiles.filter(file => isMocFile(file))
 
   if (mocFiles.length !== 1) {
     const fileList = mocFiles.length ? `(${mocFiles.map(f => `"${f}"`).join(',')})` : ''
@@ -81,17 +85,17 @@ function createFakeSettings(files: string[]): ModelSettings {
   const mocFile = mocFiles[0]
   const modelName = basename(mocFile).replace(/\.moc3?/, '')
 
-  const textures = files.filter(f => f.endsWith('.png'))
+  const textures = cleanFiles.filter(f => f.endsWith('.png'))
 
   if (!textures.length) {
     throw new Error('Textures not found')
   }
 
-  const motions = files.filter(f => f.endsWith('.mtn') || f.endsWith('.motion3.json'))
-  const physics = files.find(f => f.includes('physics'))
-  const pose = files.find(f => f.includes('pose'))
+  const motions = cleanFiles.filter(f => f.endsWith('.mtn') || f.endsWith('.motion3.json'))
+  const physics = cleanFiles.find(f => f.includes('physics'))
+  const pose = cleanFiles.find(f => f.includes('pose'))
 
-  const settings = new Cubism4ModelSettings({
+  const json = {
     url: `${modelName}.model3.json`,
     Version: 3,
     FileReferences: {
@@ -105,7 +109,10 @@ function createFakeSettings(files: string[]): ModelSettings {
           }
         : undefined,
     },
-  })
+  }
+  encodeModelSettingsJsonPaths(json)
+
+  const settings = new Cubism4ModelSettings(json)
 
   settings.name = modelName
 
@@ -115,21 +122,30 @@ function createFakeSettings(files: string[]): ModelSettings {
   return settings
 }
 
-ZipLoader.readText = (jsZip: JSZip, path: string) => {
+ZipLoader.readText = async (jsZip: JSZip, path: string) => {
   const file = jsZip.file(path)
 
   if (!file) {
     throw new Error(`Cannot find file: ${path}`)
   }
 
-  return file.async('text')
+  const text: string = await file.async('text')
+
+  if (isSettingsFile(path)) {
+    const json = JSON.parse(text)
+    sanitizeModelSettingsJson(json)
+    encodeModelSettingsJsonPaths(json)
+    return JSON.stringify(json)
+  }
+
+  return text
 }
 
 ZipLoader.getFilePaths = (jsZip: JSZip) => {
   const paths: string[] = []
 
   jsZip.forEach((relativePath, file) => {
-    if (!file.dir) {
+    if (!file.dir && !isIgnoredPath(relativePath)) {
       paths.push(relativePath)
     }
   })

--- a/packages/stage-ui-live2d/src/utils/opfs-loader.ts
+++ b/packages/stage-ui-live2d/src/utils/opfs-loader.ts
@@ -1,9 +1,27 @@
 import type { Live2DFactoryContext, Middleware, ModelSettings } from 'pixi-live2d-display/cubism4'
 
+import { encodeArchivePathForFileLoader, stringifyModelSettingsJsonForFileLoader } from './live2d-archive-paths'
+
 interface OPFSContext extends Live2DFactoryContext {
   opfsKey?: string
   opfsUrl?: string
 }
+
+interface OPFSCacheMeta {
+  sourceUrl?: string
+  version?: number
+}
+
+interface Live2DFileListWithSettings extends Array<File> {
+  settings?: ModelSettings
+}
+
+/**
+ * Cache schema version for reconstructed Live2D zip contents.
+ *
+ * Increment when cached settings files need to be regenerated from the source zip.
+ */
+const live2DOpfsCacheVersion = 2
 
 declare global {
   interface FileSystemDirectoryHandle {
@@ -76,7 +94,7 @@ export class OPFSCache {
       const metaHandle = await dirHandle.getFileHandle('__meta.json', { create: false })
       const metaFile = await metaHandle.getFile()
       const metaText = await metaFile.text()
-      return JSON.parse(metaText) as { sourceUrl?: string }
+      return JSON.parse(metaText) as OPFSCacheMeta
     }
     catch {
       return null
@@ -91,6 +109,17 @@ export class OPFSCache {
       console.debug(`[OPFS] Cache hit for ${key}`)
 
       const meta = await OPFSCache.readMeta(dirHandle)
+      if (meta?.version !== live2DOpfsCacheVersion) {
+        // NOTICE: Rebuild caches created before path encoding was made idempotent.
+        // Older reconstructed model3.json files may contain double-encoded paths.
+        // Source/context: OPFSCache.saveMiddleware settings reconstruction.
+        // Removal condition: old OPFS caches no longer need migration support.
+        // eslint-disable-next-line no-console
+        console.debug(`[OPFS] Cache mismatch for ${key}, schema version changed`)
+        await root.removeEntry(dirHandle.name, { recursive: true })
+        return null
+      }
+
       if (meta?.sourceUrl && meta.sourceUrl !== sourceUrl) {
         // NOTICE: Skip cache when the requested URL changes while the key stays the same.
         // This avoids serving a stale model when ids are reused or props are out of sync.
@@ -129,7 +158,10 @@ export class OPFSCache {
 
       await Promise.all(writePromises)
       if (sourceUrl) {
-        await OPFSCache.writeFile(dirHandle, '__meta.json', JSON.stringify({ sourceUrl }))
+        await OPFSCache.writeFile(dirHandle, '__meta.json', JSON.stringify({
+          sourceUrl,
+          version: live2DOpfsCacheVersion,
+        }))
       }
       // eslint-disable-next-line no-console
       console.debug(`[OPFS] Saved to cache`)
@@ -199,7 +231,7 @@ export class OPFSCache {
       return next()
     }
 
-    const files = context.source as File[]
+    const files = context.source as Live2DFileListWithSettings
 
     if (files.length === 0 || !(files[0] instanceof File)) {
       return next()
@@ -208,63 +240,22 @@ export class OPFSCache {
     const settingsFile = files.find(f => f.name.endsWith('.model.json') || f.name.endsWith('.model3.json'))
     if (!settingsFile) {
       // reconstruct settings files from ModelSettings
-      const settings: ModelSettings = (files as any).settings
+      const settings = files.settings
       if (settings) {
         // eslint-disable-next-line no-console
         console.debug('[OPFS] Reconstructing settings file...')
-        const settingsText = encodeModelSettings(settings.json)
-        const settingsFilePath = settings.url || 'model.model3.json'
+        const settingsText = stringifyModelSettingsJsonForFileLoader(settings.json)
+        const settingsFilePath = encodeArchivePathForFileLoader(settings.url || 'model.model3.json')
         const settingsFile = new File([settingsText], settingsFilePath)
         Object.defineProperty(settingsFile, 'webkitRelativePath', {
-          value: encodeURI(settingsFilePath),
+          value: settingsFilePath,
         })
         files.push(settingsFile)
       }
-      delete (context.source as any).settings // force the loader to read re-created settings file
+      delete files.settings // force the loader to read re-created settings file
     }
     await OPFSCache.save(context.opfsKey, files, context.opfsUrl)
 
     return next()
   }
-}
-
-function encodeProperty(obj: any, path: string) {
-  let cursor = obj
-  const propPath = path.split('.')
-  // will lose reference when access to the last level
-  while (propPath.length > 1 && cursor != null && typeof cursor === 'object' && propPath[0] in cursor) {
-    cursor = cursor[propPath.shift()!]
-  }
-  if (cursor == null || cursor[propPath[0]] == null)
-    return
-  if (typeof cursor[propPath[0]] === 'string')
-    cursor[propPath[0]] = encodeURI(cursor[propPath[0]])
-  if (Array.isArray(cursor[propPath[0]]) && typeof cursor[propPath[0]][0] === 'string') {
-    cursor[propPath[0]] = cursor[propPath[0]].map((s: string) => encodeURI(s))
-  }
-}
-// TODO: find all file paths and encode them by recursively visiting the settings
-function encodeModelSettings(input: any): string {
-  const settings = JSON.parse(JSON.stringify(input))
-  const propertyToEncode = [
-    'FileReferences.DisplayInfo',
-    'FileReferences.Moc',
-    'FileReferences.Textures',
-    'FileReferences.Physics',
-    'url',
-  ]
-  propertyToEncode.forEach(k => encodeProperty(settings, k))
-  settings?.FileReferences?.Expressions?.map((exp: { Name: string, File: string }) => {
-    exp.File = encodeURI(exp.File)
-    return exp
-  })
-  Object.keys(settings?.FileReferences?.Motions ?? {}).forEach((k) => {
-    if (!Array.isArray(settings?.FileReferences?.Motions[k]))
-      return // not sure whether 'Motions' is of type Record<string,[]>, assume it is for now.
-    settings?.FileReferences?.Motions[k].map((exp: { File: string }) => {
-      exp.File = encodeURI(exp.File)
-      return exp
-    })
-  })
-  return JSON.stringify(settings)
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'packages/server-runtime',
       'packages/server-sdk',
       'packages/stage-shared',
+      'packages/stage-ui-live2d',
     ],
   },
 })


### PR DESCRIPTION
## Summary

- Ignore macOS/Windows metadata files when validating and loading Live2D zip archives.
- Sanitize malformed `model3.json` optional references such as `Physics: null`.
- Normalize non-ASCII Live2D resource paths to match `pixi-live2d-display` FileLoader validation.
- Prevent OPFS-reconstructed settings files from double-encoding already-normalized paths.
- Add OPFS cache versioning so stale cached Live2D settings are rebuilt.
- Register `packages/stage-ui-live2d` in the root Vitest project list.

## Testing

- `pnpm exec vitest run packages/stage-ui-live2d/src/utils/live2d-archive-paths.test.ts packages/stage-ui-live2d/src/utils/live2d-validator.test.ts`
- `pnpm -F @proj-airi/stage-ui-live2d typecheck`
- `pnpm exec moeru-lint <touched files>`
- `git diff --cached --check`