### PR TITLE
feat(server-dashboard): add admin UI for AIRI operations

### DIFF
--- a/.github/workflows/release-docker-assets.yml
+++ b/.github/workflows/release-docker-assets.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths:
       - 'apps/ui-server-auth/**'
+      - 'apps/ui-admin/**'
   workflow_dispatch:
 
 jobs:
@@ -20,8 +21,14 @@ jobs:
         include:
           - assets_name: ui-server-auth
             build_directory: ./apps/server/public/ui-server-auth
+            dockerfile: ./apps/ui-server-auth/Dockerfile
             build_command: |
               pnpm -F @proj-airi/ui-server-auth run build
+          - assets_name: ui-admin
+            build_directory: ./apps/server/public/ui-admin
+            dockerfile: ./apps/ui-admin/Dockerfile
+            build_command: |
+              pnpm -F @proj-airi/ui-admin run build
     steps:
       # Why?
       #
@@ -68,8 +75,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
-          context: ./apps/server/public/ui-server-auth
-          file: ./apps/ui-server-auth/Dockerfile
+          context: ${{ matrix.build_directory }}
+          file: ${{ matrix.dockerfile }}
           build-args: |
             VITE_ENABLE_POSTHOG=true
           platforms: linux/amd64,linux/arm64,linux/arm64/v8

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -9,6 +9,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.json ./
 COPY patches/ ./patches/
 COPY apps/server apps/server
 COPY --from=ghcr.io/moeru-ai/airi/ui-server-auth:latest /app/airi/projects/ui/ui-server-auth apps/server/public/ui-server-auth
+COPY --from=ghcr.io/moeru-ai/airi/ui-admin:latest /app/airi/projects/ui/ui-admin apps/server/public/ui-admin
 COPY packages/server-schema packages/server-schema
 COPY packages/server-sdk-shared packages/server-sdk-shared
 

--- a/apps/server/production/railway/Dockerfile
+++ b/apps/server/production/railway/Dockerfile
@@ -7,6 +7,7 @@ RUN corepack enable
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.json ./
 COPY patches/ ./patches/
 COPY --from=ghcr.io/moeru-ai/airi/ui-server-auth:latest /app/airi/projects/ui/ui-server-auth apps/server/public/ui-server-auth
+COPY --from=ghcr.io/moeru-ai/airi/ui-admin:latest /app/airi/projects/ui/ui-admin apps/server/public/ui-admin
 COPY apps/server apps/server
 COPY packages/server-schema packages/server-schema
 COPY packages/server-sdk-shared packages/server-sdk-shared

--- a/apps/server/railway.toml
+++ b/apps/server/railway.toml
@@ -3,6 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "/apps/server/production/railway/Dockerfile"
 watchPatterns = [
   "apps/server/**",
+  "apps/ui-admin/**",
   "packages/**",
   "pnpm-lock.yaml"
 ]

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -51,6 +51,8 @@ import { registerActiveSessionsGauge } from './otel/gauges/active-sessions'
 import { registerDistinctActiveUsersGauge } from './otel/gauges/distinct-active-users'
 import { registerRollingActiveUsersGauge } from './otel/gauges/rolling-active-users'
 import { registerTotalUsersGauge } from './otel/gauges/total-users'
+import { createAdminRoutes } from './routes/admin'
+import { createAdminUiRoutes } from './routes/admin-ui'
 import { createAdminRouterConfigRoutes } from './routes/admin/config/router'
 import { createAdminFluxGrantsRoutes } from './routes/admin/flux-grants'
 import { createAdminUsersRoutes } from './routes/admin/users'
@@ -326,6 +328,12 @@ export async function buildApp(deps: AppDeps) {
     }))
 
     /**
+     * Admin dashboard SPA. Auth is enforced by `/api/admin/*`; the bundle
+     * itself is public so unauthenticated users can be redirected cleanly.
+     */
+    .route('/', createAdminUiRoutes(deps.env))
+
+    /**
      * Character routes are handled by the character service.
      */
     .route('/api/v1/characters', createCharacterRoutes(deps.characterService))
@@ -380,6 +388,16 @@ export async function buildApp(deps: AppDeps) {
      * `routes/admin/config/router/index.ts` for the body shape.
      */
     .route('/api/admin/config/router', createAdminRouterConfigRoutes(deps.adminRouterConfigService))
+
+    /**
+     * Admin dashboard support APIs: user search, balance adjustments, metrics,
+     * and editable LLM router config.
+     */
+    .route('/api/admin', createAdminRoutes({
+      db: deps.db,
+      billingService: deps.billingService,
+      configKV: deps.configKV,
+    }))
 
     /**
      * Catch-all 404 in JSON. Replaces hono's default `text/html` "404 Not

--- a/apps/server/src/middlewares/auth.ts
+++ b/apps/server/src/middlewares/auth.ts
@@ -27,6 +27,8 @@ export function sessionMiddleware(auth: AuthInstance, env: Env): MiddlewareHandl
     // starts with `/api` and won't be matched by the `/auth/` startsWith.
     if (
       c.req.path.startsWith('/auth/')
+      || c.req.path.startsWith('/admin/')
+      || c.req.path === '/admin'
       || c.req.path.startsWith('/api/auth/')
       || c.req.path === '/.well-known/oauth-authorization-server/api/auth'
     ) {

--- a/apps/server/src/routes/admin-ui.ts
+++ b/apps/server/src/routes/admin-ui.ts
@@ -11,14 +11,22 @@ const RE_SERVER_ADMIN_UI_BASE_PATH = /^\/admin/
 export function createAdminUiRoutes(env: Env) {
   return new Hono<HonoEnv>()
     .get(SERVER_ADMIN_UI_BASE_PATH, c => c.redirect(`${SERVER_ADMIN_UI_BASE_PATH}/`))
-    .use(`${SERVER_ADMIN_UI_BASE_PATH}/*`, serveStatic({
-      root: getServerAdminUiDistDir(),
-      rewriteRequestPath: (path: string) => path.replace(RE_SERVER_ADMIN_UI_BASE_PATH, ''),
-    }))
-    .on('GET', `${SERVER_ADMIN_UI_BASE_PATH}/*`, (c) => {
+    .get(`${SERVER_ADMIN_UI_BASE_PATH}/*`, async (c, next) => {
+      if (!shouldRenderAdminUiHtml(new URL(c.req.url).pathname))
+        return next()
+
       return c.html(renderServerAdminUiHtml({
         apiServerUrl: env.API_SERVER_URL,
         currentUrl: c.req.url,
       }))
     })
+    .use(`${SERVER_ADMIN_UI_BASE_PATH}/*`, serveStatic({
+      root: getServerAdminUiDistDir(),
+      rewriteRequestPath: (path: string) => path.replace(RE_SERVER_ADMIN_UI_BASE_PATH, ''),
+    }))
+}
+
+function shouldRenderAdminUiHtml(pathname: string): boolean {
+  const segment = pathname.split('/').pop() ?? ''
+  return segment === '' || segment === 'index.html' || !segment.includes('.')
 }

--- a/apps/server/src/routes/admin-ui.ts
+++ b/apps/server/src/routes/admin-ui.ts
@@ -1,0 +1,24 @@
+import type { Env } from '../libs/env'
+import type { HonoEnv } from '../types/hono'
+
+import { serveStatic } from '@hono/node-server/serve-static'
+import { Hono } from 'hono'
+
+import { getServerAdminUiDistDir, renderServerAdminUiHtml, SERVER_ADMIN_UI_BASE_PATH } from '../utils/server-admin-ui'
+
+const RE_SERVER_ADMIN_UI_BASE_PATH = /^\/admin/
+
+export function createAdminUiRoutes(env: Env) {
+  return new Hono<HonoEnv>()
+    .get(SERVER_ADMIN_UI_BASE_PATH, c => c.redirect(`${SERVER_ADMIN_UI_BASE_PATH}/`))
+    .use(`${SERVER_ADMIN_UI_BASE_PATH}/*`, serveStatic({
+      root: getServerAdminUiDistDir(),
+      rewriteRequestPath: (path: string) => path.replace(RE_SERVER_ADMIN_UI_BASE_PATH, ''),
+    }))
+    .on('GET', `${SERVER_ADMIN_UI_BASE_PATH}/*`, (c) => {
+      return c.html(renderServerAdminUiHtml({
+        apiServerUrl: env.API_SERVER_URL,
+        currentUrl: c.req.url,
+      }))
+    })
+}

--- a/apps/server/src/routes/admin/index.ts
+++ b/apps/server/src/routes/admin/index.ts
@@ -1,0 +1,387 @@
+import type { Context } from 'hono'
+
+import type { Database } from '../../libs/db'
+import type { ConfigKVService } from '../../services/adapters/config-kv'
+import type { BillingService } from '../../services/domain/billing/billing-service'
+import type { HonoEnv } from '../../types/hono'
+
+import { and, asc, count, desc, eq, gt, ilike, isNull, or, sql } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { any, array, integer, maxLength, maxValue, minValue, nonEmpty, number, object, optional, pipe, record, safeParse, string } from 'valibot'
+
+import { adminGuard } from '../../middlewares/admin-guard'
+import { authGuard } from '../../middlewares/auth'
+import { session as sessionTable, user as userTable } from '../../schemas/accounts'
+import { userFlux } from '../../schemas/flux'
+import { fluxTransaction } from '../../schemas/flux-transaction'
+import { llmRequestLog } from '../../schemas/llm-request-log'
+import { createBadRequestError, createNotFoundError } from '../../utils/error'
+import { createQueryIntegerSchema } from '../../utils/http-query'
+
+const MAX_FLUX_ADJUSTMENT = 1_000_000_000
+
+const ListUsersQuerySchema = object({
+  limit: createQueryIntegerSchema({
+    defaultValue: 20,
+    minimum: 1,
+    maximum: 100,
+  }),
+  offset: createQueryIntegerSchema({
+    defaultValue: 0,
+    minimum: 0,
+  }),
+  query: optional(pipe(string(), maxLength(200)), ''),
+  status: optional(pipe(string(), maxLength(20)), 'all'),
+  sortKey: optional(pipe(string(), maxLength(40)), 'createdAt'),
+  sortDirection: optional(pipe(string(), maxLength(10)), 'desc'),
+})
+
+const LlmRouterEntrySchema = record(string(), any())
+
+const UpdateLlmRouterBodySchema = object({
+  entries: array(LlmRouterEntrySchema),
+})
+
+const GrantUserFluxBodySchema = object({
+  amount: pipe(number(), integer('amount must be an integer'), minValue(1, 'amount must be at least 1')),
+  description: pipe(string(), nonEmpty('description is required'), maxLength(500)),
+  idempotencyKey: optional(pipe(string(), maxLength(100))),
+})
+
+const SetUserFluxBodySchema = object({
+  balance: pipe(
+    number(),
+    integer('balance must be an integer'),
+    minValue(0, 'balance must be at least 0'),
+    maxValue(MAX_FLUX_ADJUSTMENT, `balance must be at most ${MAX_FLUX_ADJUSTMENT}`),
+  ),
+  description: optional(pipe(string(), maxLength(500)), 'Admin balance adjustment'),
+})
+
+export interface AdminRoutesDeps {
+  db: Database
+  billingService: BillingService
+  configKV: ConfigKVService
+}
+
+function serializeUser(row: {
+  id: string
+  name: string
+  email: string
+  emailVerified: boolean
+  image: string | null
+  createdAt: Date
+  updatedAt: Date
+  flux: number | null
+  stripeCustomerId: string | null
+}) {
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    emailVerified: row.emailVerified,
+    image: row.image,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    flux: row.flux ?? 0,
+    stripeCustomerId: row.stripeCustomerId,
+  }
+}
+
+function userSortExpression(sortKey: string) {
+  switch (sortKey) {
+    case 'name':
+      return userTable.name
+    case 'email':
+      return userTable.email
+    case 'status':
+      return userTable.emailVerified
+    case 'flux':
+      return sql<number>`coalesce(${userFlux.flux}, 0)`
+    case 'createdAt':
+      return userTable.createdAt
+    default:
+      throw createBadRequestError('Invalid sort key', 'INVALID_SORT_KEY', { sortKey })
+  }
+}
+
+function userSortDirection(sortDirection: string) {
+  switch (sortDirection) {
+    case 'asc':
+      return asc
+    case 'desc':
+      return desc
+    default:
+      throw createBadRequestError('Invalid sort direction', 'INVALID_SORT_DIRECTION', { sortDirection })
+  }
+}
+
+function userStatusWhere(status: string) {
+  switch (status) {
+    case 'all':
+      return undefined
+    case 'verified':
+      return eq(userTable.emailVerified, true)
+    case 'unverified':
+      return eq(userTable.emailVerified, false)
+    default:
+      throw createBadRequestError('Invalid status filter', 'INVALID_STATUS_FILTER', { status })
+  }
+}
+
+async function readJson(c: Context<HonoEnv>): Promise<unknown> {
+  const raw = await c.req.json().catch(() => null)
+  if (raw == null)
+    throw createBadRequestError('Request body must be JSON', 'INVALID_BODY')
+  return raw
+}
+
+async function ensureUserExists(db: Database, userId: string) {
+  const [target] = await db
+    .select({ id: userTable.id })
+    .from(userTable)
+    .where(eq(userTable.id, userId))
+    .limit(1)
+
+  if (!target)
+    throw createNotFoundError('User not found', { userId })
+}
+
+export function createAdminRoutes(deps: AdminRoutesDeps) {
+  return new Hono<HonoEnv>()
+    .use('*', authGuard)
+    .use('*', adminGuard)
+
+    .get('/me', async (c) => {
+      const user = c.get('user')!
+      return c.json({
+        role: 'admin',
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          emailVerified: user.emailVerified,
+          image: user.image,
+        },
+      })
+    })
+
+    .get('/metrics', async (c) => {
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+
+      const [
+        totalUsers,
+        verifiedUsers,
+        activeSessions,
+        currentFlux,
+        issuedFlux,
+        llmRequests24h,
+        llmFlux24h,
+        adminUsers,
+      ] = await Promise.all([
+        deps.db.select({ count: count() }).from(userTable),
+        deps.db.select({ count: count() }).from(userTable).where(eq(userTable.emailVerified, true)),
+        deps.db.select({ count: count() }).from(sessionTable).where(gt(sessionTable.expiresAt, new Date())),
+        deps.db.select({ total: sql<number>`coalesce(sum(${userFlux.flux}), 0)::int` }).from(userFlux).where(isNull(userFlux.deletedAt)),
+        deps.db.select({ total: sql<number>`coalesce(sum(${fluxTransaction.amount}) filter (where ${fluxTransaction.type} in ('credit', 'initial', 'promo')), 0)::int` }).from(fluxTransaction),
+        deps.db.select({ count: count() }).from(llmRequestLog).where(gt(llmRequestLog.createdAt, yesterday)),
+        deps.db.select({ total: sql<number>`coalesce(sum(${llmRequestLog.fluxConsumed}), 0)::int` }).from(llmRequestLog).where(gt(llmRequestLog.createdAt, yesterday)),
+        deps.db
+          .select({ count: count() })
+          .from(userTable)
+          .where(sql<boolean>`'admin' = any(regexp_split_to_array(coalesce(${userTable.role}, ''), '\\s*,\\s*'))`),
+      ])
+
+      return c.json({
+        totalUsers: Number(totalUsers[0]?.count ?? 0),
+        verifiedUsers: Number(verifiedUsers[0]?.count ?? 0),
+        activeSessions: Number(activeSessions[0]?.count ?? 0),
+        currentFlux: Number(currentFlux[0]?.total ?? 0),
+        issuedFlux: Number(issuedFlux[0]?.total ?? 0),
+        llmRequests24h: Number(llmRequests24h[0]?.count ?? 0),
+        llmFlux24h: Number(llmFlux24h[0]?.total ?? 0),
+        adminSeats: Number(adminUsers[0]?.count ?? 0),
+        grafanaEmbedUrl: null,
+      })
+    })
+
+    .get('/users', async (c) => {
+      const query = safeParse(ListUsersQuerySchema, {
+        limit: c.req.query('limit'),
+        offset: c.req.query('offset'),
+        query: c.req.query('query'),
+        sortDirection: c.req.query('sortDirection'),
+        sortKey: c.req.query('sortKey'),
+        status: c.req.query('status'),
+      })
+
+      if (!query.success) {
+        throw createBadRequestError('Invalid query', 'INVALID_QUERY', query.issues)
+      }
+
+      const search = query.output.query.trim()
+      const searchWhere = search
+        ? or(
+            eq(userTable.id, search),
+            ilike(userTable.email, `%${search}%`),
+            ilike(userTable.name, `%${search}%`),
+          )
+        : undefined
+      const statusWhere = userStatusWhere(query.output.status)
+      const where = searchWhere && statusWhere
+        ? and(searchWhere, statusWhere)
+        : searchWhere ?? statusWhere
+      const sort = userSortDirection(query.output.sortDirection)
+      const sortExpression = userSortExpression(query.output.sortKey)
+
+      const [rows, totalRows] = await Promise.all([
+        deps.db
+          .select({
+            id: userTable.id,
+            name: userTable.name,
+            email: userTable.email,
+            emailVerified: userTable.emailVerified,
+            image: userTable.image,
+            createdAt: userTable.createdAt,
+            updatedAt: userTable.updatedAt,
+            flux: userFlux.flux,
+            stripeCustomerId: userFlux.stripeCustomerId,
+          })
+          .from(userTable)
+          .leftJoin(userFlux, and(
+            eq(userTable.id, userFlux.userId),
+            isNull(userFlux.deletedAt),
+          ))
+          .where(where)
+          .orderBy(sort(sortExpression), desc(userTable.createdAt))
+          .limit(query.output.limit + 1)
+          .offset(query.output.offset),
+        deps.db
+          .select({ count: count() })
+          .from(userTable)
+          .where(where),
+      ])
+
+      const hasMore = rows.length > query.output.limit
+      if (hasMore)
+        rows.pop()
+
+      return c.json({
+        users: rows.map(serializeUser),
+        hasMore,
+        nextOffset: hasMore ? query.output.offset + query.output.limit : null,
+        total: Number(totalRows[0]?.count ?? 0),
+      })
+    })
+
+    .get('/users/:id', async (c) => {
+      const id = c.req.param('id')
+
+      const [row] = await deps.db
+        .select({
+          id: userTable.id,
+          name: userTable.name,
+          email: userTable.email,
+          emailVerified: userTable.emailVerified,
+          image: userTable.image,
+          createdAt: userTable.createdAt,
+          updatedAt: userTable.updatedAt,
+          flux: userFlux.flux,
+          stripeCustomerId: userFlux.stripeCustomerId,
+        })
+        .from(userTable)
+        .leftJoin(userFlux, and(
+          eq(userTable.id, userFlux.userId),
+          isNull(userFlux.deletedAt),
+        ))
+        .where(eq(userTable.id, id))
+        .limit(1)
+
+      if (!row)
+        throw createNotFoundError('User not found', { id })
+
+      const transactions = await deps.db.query.fluxTransaction.findMany({
+        where: eq(fluxTransaction.userId, id),
+        orderBy: [desc(fluxTransaction.createdAt)],
+        limit: 20,
+      })
+
+      return c.json({
+        user: serializeUser(row),
+        recentFluxTransactions: transactions.map(tx => ({
+          id: tx.id,
+          type: tx.type,
+          amount: tx.amount,
+          balanceBefore: tx.balanceBefore,
+          balanceAfter: tx.balanceAfter,
+          description: tx.description,
+          metadata: tx.metadata,
+          createdAt: tx.createdAt.toISOString(),
+        })),
+      })
+    })
+
+    .post('/users/:id/flux/grant', async (c) => {
+      const actor = c.get('user')!
+      const userId = c.req.param('id')
+      await ensureUserExists(deps.db, userId)
+
+      const parsed = safeParse(GrantUserFluxBodySchema, await readJson(c))
+      if (!parsed.success) {
+        throw createBadRequestError('Invalid request body', 'INVALID_BODY', parsed.issues)
+      }
+
+      const result = await deps.billingService.creditFlux({
+        userId,
+        amount: parsed.output.amount,
+        requestId: parsed.output.idempotencyKey,
+        description: parsed.output.description,
+        source: 'admin.user_grant',
+        type: 'promo',
+        auditMetadata: {
+          source: 'admin.user_grant',
+          issuedByUserId: actor.id,
+        },
+      })
+
+      return c.json(result)
+    })
+
+    .patch('/users/:id/flux', async (c) => {
+      const actor = c.get('user')!
+      const userId = c.req.param('id')
+      await ensureUserExists(deps.db, userId)
+
+      const parsed = safeParse(SetUserFluxBodySchema, await readJson(c))
+      if (!parsed.success) {
+        throw createBadRequestError('Invalid request body', 'INVALID_BODY', parsed.issues)
+      }
+
+      const result = await deps.billingService.setFlux({
+        userId,
+        balance: parsed.output.balance,
+        description: parsed.output.description,
+        issuedByUserId: actor.id,
+      })
+
+      return c.json({
+        ...result,
+        changed: result.balanceBefore !== result.balanceAfter,
+      })
+    })
+
+    .get('/llm-router', async (c) => {
+      const entries = await deps.configKV.get('LLM_ROUTER')
+      return c.json({ entries })
+    })
+
+    .put('/llm-router', async (c) => {
+      const parsed = safeParse(UpdateLlmRouterBodySchema, await readJson(c))
+      if (!parsed.success) {
+        throw createBadRequestError('Invalid request body', 'INVALID_BODY', parsed.issues)
+      }
+
+      await deps.configKV.set('LLM_ROUTER', parsed.output.entries)
+      return c.json({ entries: parsed.output.entries })
+    })
+}

--- a/apps/server/src/routes/admin/index.ts
+++ b/apps/server/src/routes/admin/index.ts
@@ -7,7 +7,7 @@ import type { HonoEnv } from '../../types/hono'
 
 import { and, asc, count, desc, eq, gt, ilike, isNull, or, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { any, array, integer, maxLength, maxValue, minValue, nonEmpty, number, object, optional, pipe, record, safeParse, string } from 'valibot'
+import { integer, maxLength, maxValue, minValue, nonEmpty, number, object, optional, pipe, safeParse, string } from 'valibot'
 
 import { adminGuard } from '../../middlewares/admin-guard'
 import { authGuard } from '../../middlewares/auth'
@@ -34,12 +34,6 @@ const ListUsersQuerySchema = object({
   status: optional(pipe(string(), maxLength(20)), 'all'),
   sortKey: optional(pipe(string(), maxLength(40)), 'createdAt'),
   sortDirection: optional(pipe(string(), maxLength(10)), 'desc'),
-})
-
-const LlmRouterEntrySchema = record(string(), any())
-
-const UpdateLlmRouterBodySchema = object({
-  entries: array(LlmRouterEntrySchema),
 })
 
 const GrantUserFluxBodySchema = object({
@@ -368,20 +362,5 @@ export function createAdminRoutes(deps: AdminRoutesDeps) {
         ...result,
         changed: result.balanceBefore !== result.balanceAfter,
       })
-    })
-
-    .get('/llm-router', async (c) => {
-      const entries = await deps.configKV.get('LLM_ROUTER')
-      return c.json({ entries })
-    })
-
-    .put('/llm-router', async (c) => {
-      const parsed = safeParse(UpdateLlmRouterBodySchema, await readJson(c))
-      if (!parsed.success) {
-        throw createBadRequestError('Invalid request body', 'INVALID_BODY', parsed.issues)
-      }
-
-      await deps.configKV.set('LLM_ROUTER', parsed.output.entries)
-      return c.json({ entries: parsed.output.entries })
     })
 }

--- a/apps/server/src/services/adapters/config-kv.ts
+++ b/apps/server/src/services/adapters/config-kv.ts
@@ -132,6 +132,10 @@ const ConfigEntrySchemas = {
   // The two key spaces do not overlap. Consumed by the client to preselect a
   // voice matching UI locale per active model.
   DEFAULT_TTS_VOICES: optional(record(string(), record(string(), string())), {}),
+  // Admin-managed routing hints for legacy upstream router surfaces.
+  // Kept intentionally loose because router backends may need provider-specific
+  // fields. The admin UI edits it as a list of JSON objects.
+  LLM_ROUTER: optional(array(record(string(), any())), []),
   // Server-side alias resolution for `model: 'auto'` in /chat/completions and
   // /audio/speech. The modelName written here must exist as a key in
   // LLM_ROUTER_CONFIG.{llm,tts}.models — the router itself doesn't understand

--- a/apps/server/src/services/adapters/config-kv.ts
+++ b/apps/server/src/services/adapters/config-kv.ts
@@ -132,10 +132,6 @@ const ConfigEntrySchemas = {
   // The two key spaces do not overlap. Consumed by the client to preselect a
   // voice matching UI locale per active model.
   DEFAULT_TTS_VOICES: optional(record(string(), record(string(), string())), {}),
-  // Admin-managed routing hints for legacy upstream router surfaces.
-  // Kept intentionally loose because router backends may need provider-specific
-  // fields. The admin UI edits it as a list of JSON objects.
-  LLM_ROUTER: optional(array(record(string(), any())), []),
   // Server-side alias resolution for `model: 'auto'` in /chat/completions and
   // /audio/speech. The modelName written here must exist as a key in
   // LLM_ROUTER_CONFIG.{llm,tts}.models — the router itself doesn't understand

--- a/apps/server/src/utils/server-admin-ui.ts
+++ b/apps/server/src/utils/server-admin-ui.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export const SERVER_ADMIN_UI_BASE_PATH = '/admin'
+
+const SERVER_ADMIN_UI_DIST_DIR = fileURLToPath(new URL('../../public/ui-admin', import.meta.url))
+const SERVER_ADMIN_UI_INDEX_HTML_PATH = fileURLToPath(new URL('../../public/ui-admin/index.html', import.meta.url))
+const RE_HTML_LT = /</g
+const RE_HTML_GT = />/g
+const RE_HTML_AMP = /&/g
+const RE_UNICODE_LINE_SEPARATOR = /\u2028/g
+const RE_UNICODE_PARAGRAPH_SEPARATOR = /\u2029/g
+
+let cachedIndexHtml: string | null = null
+
+export interface ServerAdminUiContext {
+  apiServerUrl: string
+  currentUrl: string
+}
+
+export function getServerAdminUiDistDir(): string {
+  return SERVER_ADMIN_UI_DIST_DIR
+}
+
+export function renderServerAdminUiHtml(context: ServerAdminUiContext): string {
+  const indexHtml = getServerAdminUiIndexHtml()
+
+  if (!indexHtml.includes('__AIRI_SERVER_ADMIN_CONTEXT__'))
+    throw new Error('ui-admin index.html is missing __AIRI_SERVER_ADMIN_CONTEXT__ placeholder')
+
+  return indexHtml.replace('__AIRI_SERVER_ADMIN_CONTEXT__', serializeInlineJson(context))
+}
+
+function getServerAdminUiIndexHtml(): string {
+  if (cachedIndexHtml !== null)
+    return cachedIndexHtml
+
+  cachedIndexHtml = readFileSync(SERVER_ADMIN_UI_INDEX_HTML_PATH, 'utf8')
+  return cachedIndexHtml
+}
+
+function serializeInlineJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(RE_HTML_LT, '\\u003c')
+    .replace(RE_HTML_GT, '\\u003e')
+    .replace(RE_HTML_AMP, '\\u0026')
+    .replace(RE_UNICODE_LINE_SEPARATOR, '\\u2028')
+    .replace(RE_UNICODE_PARAGRAPH_SEPARATOR, '\\u2029')
+}

--- a/apps/ui-admin/Dockerfile
+++ b/apps/ui-admin/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+WORKDIR /app/airi/projects/ui/ui-admin
+COPY . /app/airi/projects/ui/ui-admin

--- a/apps/ui-admin/index.html
+++ b/apps/ui-admin/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>AIRI Admin</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#f8fafc" />
+  </head>
+  <body class="font-sans">
+    <div id="app"></div>
+    <script id="airi-server-admin-context" type="application/json">__AIRI_SERVER_ADMIN_CONTEXT__</script>
+    <script type="module" src="/src/main.ts"></script>
+    <noscript>This dashboard requires JavaScript.</noscript>
+  </body>
+</html>

--- a/apps/ui-admin/package.json
+++ b/apps/ui-admin/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@proj-airi/ui-admin",
+  "type": "module",
+  "private": true,
+  "description": "Admin dashboard for Project AIRI",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --host",
+    "preview": "vite preview",
+    "typecheck": "vue-tsc --noEmit"
+  },
+  "dependencies": {
+    "@proj-airi/font-chillroundm": "workspace:^",
+    "@proj-airi/stage-shared": "workspace:^",
+    "@proj-airi/ui": "workspace:^",
+    "@vueuse/core": "^14.2.1",
+    "nprogress": "^0.2.0",
+    "pinia": "^3.0.4",
+    "vue": "catalog:",
+    "vue-router": "^5.0.4",
+    "vue-sonner": "^2.0.9"
+  },
+  "devDependencies": {
+    "@iconify-json/lucide": "^1.2.102",
+    "@types/nprogress": "^0.2.3",
+    "@unocss/reset": "^66.6.8",
+    "@vitejs/plugin-vue": "^6.0.6",
+    "@vue-macros/volar": "^3.1.2",
+    "unocss": "^66.6.8",
+    "vite": "catalog:",
+    "vue-macros": "^3.1.2",
+    "vue-tsc": "^3.2.6"
+  }
+}

--- a/apps/ui-admin/src/App.vue
+++ b/apps/ui-admin/src/App.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import type { AdminMe } from './modules/api'
+
+import { errorMessageFromUnknown } from '@proj-airi/stage-shared'
+import { computed, onMounted, shallowRef } from 'vue'
+import { RouterLink, RouterView, useRoute } from 'vue-router'
+import { Toaster } from 'vue-sonner'
+
+import { adminApi, AdminApiError, signInUrl } from './modules/api'
+
+const route = useRoute()
+
+const loading = shallowRef(true)
+const me = shallowRef<AdminMe | null>(null)
+const accessError = shallowRef<string | null>(null)
+
+const navItems = [
+  { to: '/', icon: 'i-lucide-layout-dashboard', label: 'Overview' },
+  { to: '/users', icon: 'i-lucide-users', label: 'Users' },
+  { to: '/flux', icon: 'i-lucide-coins', label: 'Flux' },
+  { to: '/llm-router', icon: 'i-lucide-route', label: 'LLM Router' },
+]
+
+const currentTitle = computed(() => navItems.find(item => item.to === route.path)?.label ?? 'Overview')
+const initials = computed(() => {
+  const source = me.value?.user.name || me.value?.user.email || 'A'
+  return source.slice(0, 1).toUpperCase()
+})
+
+onMounted(async () => {
+  try {
+    me.value = await adminApi.me()
+  }
+  catch (error) {
+    if (error instanceof AdminApiError && error.status === 401) {
+      window.location.href = signInUrl()
+      return
+    }
+
+    accessError.value = errorMessageFromUnknown(error, 'Admin access required')
+  }
+  finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="min-h-screen bg-[#f7f8fa] text-[#171717]">
+    <div v-if="loading" class="grid min-h-screen place-items-center">
+      <div class="flex items-center gap-3 text-sm text-neutral-500">
+        <span class="i-lucide-loader-2 animate-spin text-lg" />
+        Loading admin session
+      </div>
+    </div>
+
+    <div v-else-if="accessError" class="grid min-h-screen place-items-center px-6">
+      <section class="max-w-md w-full border border-neutral-200 rounded-lg bg-white p-6 shadow-sm">
+        <div class="mb-4 h-10 w-10 flex items-center justify-center rounded-lg bg-red-50 text-red-600">
+          <span class="i-lucide-shield-alert text-xl" />
+        </div>
+        <h1 class="text-xl font-semibold">
+          Admin access required
+        </h1>
+        <p class="mt-2 text-sm text-neutral-500">
+          {{ accessError }}
+        </p>
+        <a class="mt-5 h-9 inline-flex items-center gap-2 rounded-md bg-emerald-600 px-3 text-sm text-white" :href="signInUrl()">
+          <span class="i-lucide-log-in" />
+          Sign in
+        </a>
+      </section>
+    </div>
+
+    <div v-else class="admin-shell">
+      <aside class="admin-sidebar">
+        <div class="flex items-center gap-2 px-2 py-1.5">
+          <div class="h-7 w-7 flex items-center justify-center rounded-md bg-neutral-950 text-white">
+            <span class="i-lucide-sparkles text-sm" />
+          </div>
+          <div class="min-w-0">
+            <div class="truncate text-sm font-semibold">
+              AIRI Admin
+            </div>
+            <div class="truncate text-xs text-neutral-500">
+              Operations
+            </div>
+          </div>
+        </div>
+
+        <button class="quick-action" type="button" @click="$router.push('/flux')">
+          <span class="i-lucide-plus-circle" />
+          Quick Grant
+        </button>
+
+        <nav class="mt-3 space-y-1">
+          <RouterLink
+            v-for="item in navItems"
+            :key="item.to"
+            :to="item.to"
+            class="nav-item"
+            :class="{ 'nav-item-active': route.path === item.to }"
+          >
+            <span :class="item.icon" />
+            {{ item.label }}
+          </RouterLink>
+        </nav>
+
+        <div class="mt-auto">
+          <div class="mt-4 flex items-center gap-3 rounded-lg px-2 py-2">
+            <div class="h-9 w-9 flex shrink-0 items-center justify-center rounded-full bg-neutral-900 text-sm text-white">
+              {{ initials }}
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="truncate text-sm font-medium">
+                {{ me?.user.name }}
+              </div>
+              <div class="truncate text-xs text-neutral-500">
+                {{ me?.user.email }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <main class="admin-main">
+        <header class="admin-topbar">
+          <div class="flex items-center gap-3">
+            <span class="i-lucide-panel-left text-neutral-500" />
+            <div class="h-5 w-px bg-neutral-200" />
+            <h1 class="text-sm font-semibold">
+              {{ currentTitle }}
+            </h1>
+          </div>
+        </header>
+        <div class="admin-content">
+          <RouterView />
+        </div>
+      </main>
+    </div>
+
+    <Toaster rich-colors position="top-right" />
+  </div>
+</template>

--- a/apps/ui-admin/src/components/admin-list/AdminListPanel.vue
+++ b/apps/ui-admin/src/components/admin-list/AdminListPanel.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { computed, shallowRef, watch } from 'vue'
+
+export interface AdminListColumn {
+  key: string
+  label: string
+  sortable?: boolean
+}
+
+export interface AdminListFilter {
+  key: string
+  label: string
+  value: string
+  options: Array<{
+    label: string
+    value: string
+  }>
+}
+
+const props = withDefaults(defineProps<{
+  columns: AdminListColumn[]
+  currentPage: number
+  emptyLabel: string
+  filters?: AdminListFilter[]
+  initialLoading: boolean
+  loading: boolean
+  loadingPage?: number | null
+  pageEnd: number
+  pageStart: number
+  search: string
+  searchPlaceholder: string
+  sortDirection: 'asc' | 'desc'
+  sortKey: string
+  tableClass?: string
+  title: string
+  totalItems: number
+  totalPages: number
+  description?: string
+}>(), {
+  description: '',
+  filters: () => [],
+  loadingPage: null,
+  tableClass: '',
+})
+
+const emit = defineEmits<{
+  filter: [key: string, value: string]
+  page: [page: number]
+  search: [value: string]
+  sort: [key: string]
+}>()
+
+const searchDraft = shallowRef(props.search)
+const pageDraft = shallowRef(String(props.currentPage))
+
+const hasPreviousPage = computed(() => props.currentPage > 1)
+const hasNextPage = computed(() => props.currentPage < props.totalPages)
+
+watch(() => props.search, (value) => {
+  searchDraft.value = value
+})
+
+watch(() => props.currentPage, (page) => {
+  pageDraft.value = String(page)
+})
+
+function submitSearch() {
+  emit('search', searchDraft.value)
+}
+
+function submitPage() {
+  const parsed = Number(pageDraft.value)
+  if (!Number.isFinite(parsed))
+    return
+  emit('page', Math.min(Math.max(1, Math.trunc(parsed)), props.totalPages))
+}
+</script>
+
+<template>
+  <section class="panel overflow-hidden">
+    <div class="flex flex-col gap-3 border-b border-neutral-200 px-5 py-4 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h2 class="text-sm font-semibold">
+          {{ title }}
+        </h2>
+        <p v-if="description" class="mt-1 text-sm text-neutral-500">
+          {{ description }}
+        </p>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-end gap-2">
+        <slot name="actions" />
+        <form class="min-w-0 flex gap-2" @submit.prevent="submitSearch">
+          <input v-model="searchDraft" class="field w-72" :placeholder="searchPlaceholder" type="search">
+          <button class="btn btn-secondary" type="submit">
+            <span class="i-lucide-search" />
+            Search
+          </button>
+        </form>
+        <label v-for="filter in filters" :key="filter.key" class="flex items-center gap-2 text-sm text-neutral-500">
+          {{ filter.label }}
+          <select class="field w-36" :value="filter.value" @change="emit('filter', filter.key, ($event.target as HTMLSelectElement).value)">
+            <option v-for="option in filter.options" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
+        </label>
+      </div>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="table" :class="tableClass">
+        <slot name="colgroup" />
+        <thead>
+          <tr>
+            <th v-for="column in columns" :key="column.key">
+              <button
+                v-if="column.sortable"
+                class="inline-flex items-center gap-1 text-left font-semibold"
+                type="button"
+                @click="emit('sort', column.key)"
+              >
+                {{ column.label }}
+                <span v-if="sortKey === column.key" :class="sortDirection === 'asc' ? 'i-lucide-arrow-up' : 'i-lucide-arrow-down'" />
+                <span v-else class="i-lucide-arrow-up-down text-neutral-400" />
+              </button>
+              <span v-else>{{ column.label }}</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-if="initialLoading">
+            <tr v-for="index in 6" :key="index">
+              <td v-for="column in columns" :key="column.key">
+                <div class="h-4 w-24 animate-pulse rounded bg-neutral-200" />
+              </td>
+            </tr>
+          </template>
+          <slot v-else name="rows" />
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="totalItems === 0 && !loading" class="empty-state">
+      <span class="i-lucide-list-filter text-2xl" />
+      {{ emptyLabel }}
+    </div>
+
+    <div v-if="loading && !initialLoading" class="border-t border-neutral-100 px-5 py-3 text-sm text-neutral-500">
+      <span class="inline-flex items-center gap-2">
+        <span class="i-lucide-loader-2 animate-spin" />
+        Loading page {{ loadingPage ?? currentPage }}
+      </span>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
+      <div class="text-sm text-neutral-500">
+        Page {{ currentPage }} of {{ totalPages }} · {{ pageStart }}-{{ pageEnd }} of {{ totalItems.toLocaleString() }} items
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <form class="flex items-center gap-2" @submit.prevent="submitPage">
+          <span class="text-sm text-neutral-500">Go to</span>
+          <input
+            v-model="pageDraft"
+            class="field w-20 text-center"
+            inputmode="numeric"
+            min="1"
+            :max="totalPages"
+            type="number"
+          >
+          <button class="btn btn-secondary" :disabled="loading" type="submit">
+            <span v-if="loading" class="i-lucide-loader-2 animate-spin" />
+            Go
+          </button>
+        </form>
+        <button class="btn btn-secondary" :disabled="loading || !hasPreviousPage" type="button" @click="emit('page', currentPage - 1)">
+          <span :class="loading && loadingPage === currentPage - 1 ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-chevron-left'" />
+          Previous
+        </button>
+        <button class="btn btn-secondary" :disabled="loading || !hasNextPage" type="button" @click="emit('page', currentPage + 1)">
+          Next
+          <span :class="loading && loadingPage === currentPage + 1 ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-chevron-right'" />
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/ui-admin/src/main.ts
+++ b/apps/ui-admin/src/main.ts
@@ -1,0 +1,43 @@
+import NProgress from 'nprogress'
+
+import { createPinia } from 'pinia'
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import { Toaster } from 'vue-sonner'
+
+import App from './App.vue'
+import FluxPage from './pages/FluxPage.vue'
+import LlmRouterPage from './pages/LlmRouterPage.vue'
+import OverviewPage from './pages/OverviewPage.vue'
+import UsersPage from './pages/UsersPage.vue'
+
+import '@proj-airi/font-chillroundm/index.css'
+import '@unocss/reset/tailwind.css'
+import 'vue-sonner/style.css'
+import './styles/main.css'
+import 'uno.css'
+
+const router = createRouter({
+  history: createWebHistory('/admin/'),
+  routes: [
+    { path: '/', component: OverviewPage },
+    { path: '/users', component: UsersPage },
+    { path: '/flux', component: FluxPage },
+    { path: '/llm-router', component: LlmRouterPage },
+  ],
+})
+
+router.beforeEach((to, from) => {
+  if (to.path !== from.path)
+    NProgress.start()
+})
+
+router.afterEach(() => {
+  NProgress.done()
+})
+
+createApp(App)
+  .use(createPinia())
+  .use(router)
+  .component('Toaster', Toaster)
+  .mount('#app')

--- a/apps/ui-admin/src/modules/api.ts
+++ b/apps/ui-admin/src/modules/api.ts
@@ -1,0 +1,160 @@
+import { defaultApiServerUrl, getServerAdminBootstrapContext } from './server-admin-context'
+
+export interface AdminUser {
+  id: string
+  name: string
+  email: string
+  emailVerified: boolean
+  image: string | null
+  createdAt: string
+  updatedAt: string
+  flux: number
+  stripeCustomerId: string | null
+}
+
+export interface AdminMe {
+  role: 'admin'
+  user: Pick<AdminUser, 'id' | 'name' | 'email' | 'emailVerified' | 'image'>
+}
+
+export interface AdminMetrics {
+  totalUsers: number
+  verifiedUsers: number
+  activeSessions: number
+  currentFlux: number
+  issuedFlux: number
+  llmRequests24h: number
+  llmFlux24h: number
+  adminSeats: number
+  grafanaEmbedUrl: string | null
+}
+
+export interface FluxTransaction {
+  id: string
+  type: string
+  amount: number
+  balanceBefore: number
+  balanceAfter: number
+  description: string
+  metadata: unknown
+  createdAt: string
+}
+
+export interface AdminUsersPage {
+  users: AdminUser[]
+  hasMore: boolean
+  nextOffset: number | null
+  total: number
+}
+
+export type LlmRouterEntry = Record<string, unknown>
+
+export class AdminApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly payload: unknown,
+  ) {
+    super(message)
+    this.name = 'AdminApiError'
+  }
+}
+
+export function apiServerUrl(): string {
+  return getServerAdminBootstrapContext()?.apiServerUrl ?? defaultApiServerUrl()
+}
+
+export function signInUrl(): string {
+  const url = new URL('/auth/sign-in', apiServerUrl())
+  url.searchParams.set('redirect', `${window.location.pathname}${window.location.search}`)
+  return url.toString()
+}
+
+async function adminFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const endpoint = new URL(`/api/admin${path}`, apiServerUrl())
+  const headers = new Headers(init.headers)
+
+  if (init.body && !headers.has('Content-Type'))
+    headers.set('Content-Type', 'application/json')
+
+  const response = await fetch(endpoint.toString(), {
+    ...init,
+    headers,
+    credentials: 'include',
+  })
+
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  }
+  catch {
+    payload = null
+  }
+
+  if (!response.ok) {
+    const message = extractErrorMessage(payload) ?? `Admin API request failed (${response.status})`
+    throw new AdminApiError(message, response.status, payload)
+  }
+
+  return payload as T
+}
+
+function extractErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object')
+    return null
+  const maybe = payload as { message?: unknown, error?: unknown }
+  if (typeof maybe.message === 'string')
+    return maybe.message
+  if (typeof maybe.error === 'string')
+    return maybe.error
+  return null
+}
+
+export const adminApi = {
+  me: () => adminFetch<AdminMe>('/me'),
+  metrics: () => adminFetch<AdminMetrics>('/metrics'),
+  users: (params: { query?: string, limit?: number, offset?: number, sortDirection?: string, sortKey?: string, status?: string }) => {
+    const query = new URLSearchParams()
+    if (params.query)
+      query.set('query', params.query)
+    if (params.limit != null)
+      query.set('limit', String(params.limit))
+    if (params.offset != null)
+      query.set('offset', String(params.offset))
+    if (params.sortDirection)
+      query.set('sortDirection', params.sortDirection)
+    if (params.sortKey)
+      query.set('sortKey', params.sortKey)
+    if (params.status)
+      query.set('status', params.status)
+    const suffix = query.toString() ? `?${query.toString()}` : ''
+    return adminFetch<AdminUsersPage>(`/users${suffix}`)
+  },
+  user: (id: string) => adminFetch<{ user: AdminUser, recentFluxTransactions: FluxTransaction[] }>(`/users/${encodeURIComponent(id)}`),
+  grantUserFlux: (id: string, body: { amount: number, description: string, idempotencyKey?: string }) =>
+    adminFetch<{ balanceBefore: number, balanceAfter: number, fluxTransactionId: string, idempotent: boolean }>(`/users/${encodeURIComponent(id)}/flux/grant`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  setUserFlux: (id: string, body: { balance: number, description: string }) =>
+    adminFetch<{ balanceBefore: number, balanceAfter: number, fluxTransactionId: string | null, changed: boolean }>(`/users/${encodeURIComponent(id)}/flux`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+  fluxGrantPreview: (body: { amount: number, description: string, emails: string[], idempotencyKey?: string }) =>
+    adminFetch<unknown>('/flux-grants?dryRun=true', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  fluxGrant: (body: { amount: number, description: string, emails: string[], idempotencyKey?: string }) =>
+    adminFetch<unknown>('/flux-grants', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  llmRouter: () => adminFetch<{ entries: LlmRouterEntry[] }>('/llm-router'),
+  saveLlmRouter: (entries: LlmRouterEntry[]) =>
+    adminFetch<{ entries: LlmRouterEntry[] }>('/llm-router', {
+      method: 'PUT',
+      body: JSON.stringify({ entries }),
+    }),
+}

--- a/apps/ui-admin/src/modules/api.ts
+++ b/apps/ui-admin/src/modules/api.ts
@@ -47,7 +47,22 @@ export interface AdminUsersPage {
   total: number
 }
 
-export type LlmRouterEntry = Record<string, unknown>
+export interface AdminRouterConfigRequest {
+  mode?: 'merge' | 'reset'
+  dryRun?: boolean
+  slices?: Array<Record<string, unknown>>
+  defaults?: {
+    chatModel?: string
+    ttsModel?: string
+    ttsVoices?: Record<string, Record<string, string>>
+  }
+}
+
+export interface AdminRouterConfigResult {
+  applied: Array<Record<string, unknown>>
+  invalidatedKeys: string[]
+  preview: Record<string, unknown>
+}
 
 export class AdminApiError extends Error {
   constructor(
@@ -151,10 +166,9 @@ export const adminApi = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
-  llmRouter: () => adminFetch<{ entries: LlmRouterEntry[] }>('/llm-router'),
-  saveLlmRouter: (entries: LlmRouterEntry[]) =>
-    adminFetch<{ entries: LlmRouterEntry[] }>('/llm-router', {
-      method: 'PUT',
-      body: JSON.stringify({ entries }),
+  applyRouterConfig: (body: AdminRouterConfigRequest, dryRun: boolean) =>
+    adminFetch<AdminRouterConfigResult>('/config/router', {
+      method: 'POST',
+      body: JSON.stringify({ ...body, dryRun }),
     }),
 }

--- a/apps/ui-admin/src/modules/server-admin-context.ts
+++ b/apps/ui-admin/src/modules/server-admin-context.ts
@@ -1,0 +1,36 @@
+export interface ServerAdminBootstrapContext {
+  apiServerUrl: string
+  currentUrl: string
+}
+
+const SCRIPT_ID = 'airi-server-admin-context'
+
+let cachedContext: ServerAdminBootstrapContext | null | undefined
+
+export function getServerAdminBootstrapContext(): ServerAdminBootstrapContext | null {
+  if (cachedContext !== undefined)
+    return cachedContext
+
+  const element = document.getElementById(SCRIPT_ID)
+  if (!element) {
+    cachedContext = null
+    return cachedContext
+  }
+
+  try {
+    const parsed = JSON.parse(element.textContent ?? '') as Partial<ServerAdminBootstrapContext>
+    cachedContext = {
+      apiServerUrl: parsed.apiServerUrl ?? defaultApiServerUrl(),
+      currentUrl: parsed.currentUrl ?? window.location.href,
+    }
+    return cachedContext
+  }
+  catch {
+    cachedContext = null
+    return cachedContext
+  }
+}
+
+export function defaultApiServerUrl(): string {
+  return import.meta.env.VITE_SERVER_URL || window.location.origin
+}

--- a/apps/ui-admin/src/pages/FluxPage.vue
+++ b/apps/ui-admin/src/pages/FluxPage.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { errorMessageFromUnknown } from '@proj-airi/stage-shared'
+import { computed, reactive, shallowRef } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { adminApi } from '../modules/api'
+
+const form = reactive({
+  amount: 100,
+  description: 'Admin promo Flux grant',
+  idempotencyKey: '',
+  emails: '',
+})
+
+const loading = shallowRef(false)
+const preview = shallowRef<unknown>(null)
+const result = shallowRef<unknown>(null)
+
+const emails = computed(() =>
+  form.emails
+    .split(/[\n,;]/)
+    .map(item => item.trim())
+    .filter(Boolean),
+)
+
+const totalFlux = computed(() => emails.value.length * Number(form.amount || 0))
+
+async function dryRun() {
+  await submit(true)
+}
+
+async function grant() {
+  await submit(false)
+}
+
+async function submit(isDryRun: boolean) {
+  loading.value = true
+  result.value = null
+  try {
+    const body = {
+      amount: Number(form.amount),
+      description: form.description,
+      emails: emails.value,
+      ...(form.idempotencyKey.trim() ? { idempotencyKey: form.idempotencyKey.trim() } : {}),
+    }
+    if (isDryRun) {
+      preview.value = await adminApi.fluxGrantPreview(body)
+      toast.success('Preview generated')
+      return
+    }
+
+    result.value = await adminApi.fluxGrant(body)
+    toast.success('Flux grant issued')
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Flux grant failed'))
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+</script>
+
+<template>
+  <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+    <section class="panel p-5">
+      <div class="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h2 class="text-sm font-semibold">
+            Bulk Flux Grant
+          </h2>
+          <p class="mt-1 text-sm text-neutral-500">
+            Issues promo Flux to existing users by email. Preview first for recipient validation.
+          </p>
+        </div>
+        <span class="badge badge-green">
+          <span class="i-lucide-shield-check" />
+          Admin guarded
+        </span>
+      </div>
+
+      <form class="space-y-4" @submit.prevent="dryRun">
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="block">
+            <span class="mb-1 block text-xs text-neutral-500 font-semibold uppercase">Amount per user</span>
+            <input v-model.number="form.amount" class="field" min="1" type="number">
+          </label>
+          <label class="block">
+            <span class="mb-1 block text-xs text-neutral-500 font-semibold uppercase">Idempotency key</span>
+            <input v-model="form.idempotencyKey" class="field" placeholder="Optional safe retry key" type="text">
+          </label>
+        </div>
+
+        <label class="block">
+          <span class="mb-1 block text-xs text-neutral-500 font-semibold uppercase">Description</span>
+          <input v-model="form.description" class="field" type="text">
+        </label>
+
+        <label class="block">
+          <span class="mb-1 block text-xs text-neutral-500 font-semibold uppercase">Emails</span>
+          <textarea v-model="form.emails" class="textarea min-h-[260px]" placeholder="alice@example.com&#10;bob@example.com" />
+        </label>
+
+        <div class="flex flex-col gap-3 border-t border-neutral-200 pt-4 md:flex-row md:items-center md:justify-between">
+          <div class="text-sm text-neutral-500">
+            {{ emails.length }} recipients · {{ formatNumber(totalFlux) }} total Flux
+          </div>
+          <div class="flex gap-2">
+            <button class="btn btn-secondary" :disabled="loading || emails.length === 0" type="submit">
+              <span class="i-lucide-eye" />
+              Preview
+            </button>
+            <button class="btn btn-primary" :disabled="loading || emails.length === 0" type="button" @click="grant">
+              <span class="i-lucide-send" />
+              Grant Flux
+            </button>
+          </div>
+        </div>
+      </form>
+    </section>
+
+    <aside class="space-y-4">
+      <section class="metric-card">
+        <div class="text-sm text-neutral-500">
+          Recipients
+        </div>
+        <div class="mt-3 text-3xl font-semibold">
+          {{ formatNumber(emails.length) }}
+        </div>
+        <div class="mt-5 text-sm text-neutral-600">
+          Synchronous grants are capped by the server.
+        </div>
+      </section>
+
+      <section class="panel overflow-hidden">
+        <div class="border-b border-neutral-200 px-4 py-3 text-sm font-semibold">
+          Preview
+        </div>
+        <pre v-if="preview" class="max-h-[280px] overflow-auto p-4 text-xs leading-5">{{ formatJson(preview) }}</pre>
+        <div v-else class="empty-state min-h-40">
+          <span class="i-lucide-clipboard-list text-2xl" />
+          No preview yet
+        </div>
+      </section>
+
+      <section class="panel overflow-hidden">
+        <div class="border-b border-neutral-200 px-4 py-3 text-sm font-semibold">
+          Last Result
+        </div>
+        <pre v-if="result" class="max-h-[280px] overflow-auto p-4 text-xs leading-5">{{ formatJson(result) }}</pre>
+        <div v-else class="empty-state min-h-40">
+          <span class="i-lucide-history text-2xl" />
+          No grant result
+        </div>
+      </section>
+    </aside>
+  </div>
+</template>

--- a/apps/ui-admin/src/pages/LlmRouterPage.vue
+++ b/apps/ui-admin/src/pages/LlmRouterPage.vue
@@ -1,556 +1,150 @@
 <script setup lang="ts">
-import type { LlmRouterEntry } from '../modules/api'
+import type { AdminRouterConfigRequest, AdminRouterConfigResult } from '../modules/api'
 
 import { errorMessageFromUnknown } from '@proj-airi/stage-shared'
-import { computed, onMounted, shallowRef } from 'vue'
+import { computed, shallowRef } from 'vue'
 import { toast } from 'vue-sonner'
-
-import AdminListPanel from '../components/admin-list/AdminListPanel.vue'
 
 import { adminApi } from '../modules/api'
 
-const entries = shallowRef<LlmRouterEntry[]>([])
-const selectedIndex = shallowRef(0)
-const currentPage = shallowRef(1)
-const savedSnapshot = shallowRef('[]')
-const loading = shallowRef(true)
-const search = shallowRef('')
-const saving = shallowRef(false)
-const sortDirection = shallowRef<'asc' | 'desc'>('asc')
-const sortKey = shallowRef('name')
-const statusFilter = shallowRef('all')
-
-const knownRouteFields = new Set(['id', 'name', 'model', 'baseUrl', 'enabled', 'weight', 'apiKeyEnv'])
-const pageSize = 12
-const columns = [
-  { key: 'name', label: 'Name', sortable: true },
-  { key: 'model', label: 'Model', sortable: true },
-  { key: 'baseUrl', label: 'Base URL', sortable: true },
-  { key: 'weight', label: 'Weight', sortable: true },
-  { key: 'status', label: 'Status', sortable: true },
-  { key: 'actions', label: '' },
-]
-
-const selectedEntry = computed(() => entries.value[selectedIndex.value] ?? null)
-const savedEntries = computed(() => parseSavedEntries(savedSnapshot.value))
-const deletedEntries = computed(() => savedEntries.value.filter(savedEntry => !entries.value.some(entry => routeKey(entry) === routeKey(savedEntry))))
-const statusFilters = computed(() => [
-  {
-    key: 'status',
-    label: 'Status',
-    value: statusFilter.value,
-    options: [
-      { label: 'All', value: 'all' },
-      { label: 'Enabled', value: 'enabled' },
-      { label: 'Disabled', value: 'disabled' },
-      { label: 'Changed', value: 'changed' },
-    ],
-  },
-])
-const filteredEntries = computed(() => {
-  const term = search.value.trim().toLowerCase()
-  return entries.value.filter((entry) => {
-    if (statusFilter.value === 'enabled' && entry.enabled === false)
-      return false
-    if (statusFilter.value === 'disabled' && entry.enabled !== false)
-      return false
-    if (statusFilter.value === 'changed' && !isRouteDirty(entry))
-      return false
-    if (!term)
-      return true
-    return [
-      valueFor(entry, 'id'),
-      valueFor(entry, 'name'),
-      valueFor(entry, 'model'),
-      valueFor(entry, 'baseUrl'),
-    ].some(value => value.toLowerCase().includes(term))
-  })
-})
-const sortedEntries = computed(() => {
-  const direction = sortDirection.value === 'asc' ? 1 : -1
-  return [...filteredEntries.value].sort((left, right) => compareRouteValue(left, right, sortKey.value) * direction)
-})
-const totalPages = computed(() => Math.max(1, Math.ceil(sortedEntries.value.length / pageSize)))
-const pageStart = computed(() => sortedEntries.value.length === 0 ? 0 : (currentPage.value - 1) * pageSize + 1)
-const pageEnd = computed(() => Math.min(currentPage.value * pageSize, sortedEntries.value.length))
-const paginatedEntries = computed(() => sortedEntries.value.slice((currentPage.value - 1) * pageSize, currentPage.value * pageSize))
-const listDirty = computed(() => JSON.stringify(entries.value) !== savedSnapshot.value)
-const saveStatusLabel = computed(() => {
-  if (saving.value)
-    return 'Saving'
-  if (listDirty.value)
-    return 'Unsaved changes'
-  return 'Saved'
-})
-const selectedDirtyFields = computed(() => {
-  const entry = selectedEntry.value
-  if (!entry)
-    return new Set<string>()
-  return dirtyFieldsFor(entry)
-})
-const selectedAdditionalFields = computed(() => {
-  const entry = selectedEntry.value
-  if (!entry)
-    return []
-  return Object.entries(entry)
-    .filter(([key]) => !knownRouteFields.has(key))
-    .map(([key, value]) => ({
-      key,
-      value: formatFieldValue(value),
-    }))
-})
-
-function parseSavedEntries(value: string): LlmRouterEntry[] {
-  try {
-    const parsed = JSON.parse(value) as unknown
-    return Array.isArray(parsed) ? parsed as LlmRouterEntry[] : []
-  }
-  catch {
-    return []
-  }
-}
-
-onMounted(async () => {
-  try {
-    const result = await adminApi.llmRouter()
-    entries.value = result.entries
-    savedSnapshot.value = JSON.stringify(result.entries)
-    selectEntry(0)
-  }
-  catch (error) {
-    toast.error(errorMessageFromUnknown(error, 'Failed to load LLM_ROUTER'))
-  }
-  finally {
-    loading.value = false
-  }
-})
-
-function selectEntry(index: number) {
-  selectedIndex.value = index
-}
-
-function selectRoute(entry: LlmRouterEntry) {
-  const index = entries.value.indexOf(entry)
-  if (index >= 0)
-    selectEntry(index)
-}
-
-function addEntry() {
-  entries.value = [
-    ...entries.value,
+const DEFAULT_REQUEST_BODY = `{
+  "mode": "merge",
+  "slices": [
     {
-      id: `route-${Date.now()}`,
-      name: 'New Route',
-      model: 'auto',
-      baseUrl: '',
-      enabled: true,
-      weight: 1,
-      apiKeyEnv: '',
-    },
-  ]
-  selectEntry(entries.value.length - 1)
-}
-
-function removeEntry(index: number) {
-  const target = paginatedEntries.value[index]
-  entries.value = entries.value.filter(entry => entry !== target)
-  selectEntry(Math.max(0, Math.min(selectedIndex.value, entries.value.length - 1)))
-}
-
-function updateSelectedEntry(patch: LlmRouterEntry) {
-  const entry = selectedEntry.value
-  if (!entry)
-    return
-
-  const next = [...entries.value]
-  next[selectedIndex.value] = {
-    ...entry,
-    ...patch,
+      "kind": "openrouter",
+      "modelName": "chat-default",
+      "overrideModel": "openai/gpt-4o-mini",
+      "plaintextKey": "",
+      "baseURL": "https://openrouter.ai/api/v1"
+    }
+  ],
+  "defaults": {
+    "chatModel": "chat-default"
   }
-  entries.value = next
-}
+}`
 
-async function saveAll() {
-  saving.value = true
+const requestBody = shallowRef(DEFAULT_REQUEST_BODY)
+const previewResult = shallowRef<AdminRouterConfigResult | null>(null)
+const applyResult = shallowRef<AdminRouterConfigResult | null>(null)
+const busy = shallowRef<'preview' | 'apply' | null>(null)
+
+const parseError = computed(() => {
   try {
-    const result = await adminApi.saveLlmRouter(entries.value)
-    entries.value = result.entries
-    savedSnapshot.value = JSON.stringify(result.entries)
-    selectEntry(Math.min(selectedIndex.value, entries.value.length - 1))
-    toast.success('LLM_ROUTER saved')
+    parseRequestBody()
+    return null
   }
   catch (error) {
-    toast.error(errorMessageFromUnknown(error, 'Failed to save LLM_ROUTER'))
+    return errorMessageFromUnknown(error, 'Invalid JSON')
+  }
+})
+
+async function previewConfig() {
+  await submit(true)
+}
+
+async function applyConfig() {
+  await submit(false)
+}
+
+async function submit(dryRun: boolean) {
+  busy.value = dryRun ? 'preview' : 'apply'
+  try {
+    const result = await adminApi.applyRouterConfig(parseRequestBody(), dryRun)
+    if (dryRun) {
+      previewResult.value = result
+      toast.success('Router config preview generated')
+      return
+    }
+
+    applyResult.value = result
+    previewResult.value = result
+    toast.success('Router config applied')
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, dryRun ? 'Failed to preview router config' : 'Failed to apply router config'))
   }
   finally {
-    saving.value = false
+    busy.value = null
   }
 }
 
-function labelFor(entry: LlmRouterEntry, index: number): string {
-  return String(entry.name ?? entry.id ?? entry.model ?? `Route ${index + 1}`)
+function parseRequestBody(): AdminRouterConfigRequest {
+  const parsed = JSON.parse(requestBody.value) as unknown
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed))
+    throw new Error('Request body must be a JSON object')
+
+  return parsed as AdminRouterConfigRequest
 }
 
-function routeKey(entry: LlmRouterEntry): string {
-  return String(entry.id ?? entry.name ?? entry.model ?? JSON.stringify(entry))
-}
-
-function savedEntryFor(entry: LlmRouterEntry): LlmRouterEntry | null {
-  return savedEntries.value.find(savedEntry => routeKey(savedEntry) === routeKey(entry)) ?? null
-}
-
-function dirtyFieldsFor(entry: LlmRouterEntry): Set<string> {
-  const savedEntry = savedEntryFor(entry)
-  const fields = new Set<string>()
-  if (!savedEntry) {
-    for (const key of Object.keys(entry))
-      fields.add(key)
-    return fields
-  }
-
-  const keys = new Set([...Object.keys(entry), ...Object.keys(savedEntry)])
-  for (const key of keys) {
-    if (JSON.stringify(entry[key]) !== JSON.stringify(savedEntry[key]))
-      fields.add(key)
-  }
-  return fields
-}
-
-function routeChangeLabel(entry: LlmRouterEntry): string {
-  if (!savedEntryFor(entry))
-    return 'New'
-  if (dirtyFieldsFor(entry).size > 0)
-    return 'Modified'
-  return ''
-}
-
-function isRouteDirty(entry: LlmRouterEntry): boolean {
-  return routeChangeLabel(entry) !== ''
-}
-
-function isFieldDirty(key: string): boolean {
-  return selectedDirtyFields.value.has(key)
-}
-
-function compareRouteValue(left: LlmRouterEntry, right: LlmRouterEntry, key: string): number {
-  if (key === 'weight')
-    return Number(left.weight ?? 0) - Number(right.weight ?? 0)
-  if (key === 'status')
-    return Number(left.enabled !== false) - Number(right.enabled !== false)
-  return valueFor(left, key).localeCompare(valueFor(right, key))
-}
-
-function valueFor(entry: LlmRouterEntry, key: string): string {
-  const value = entry[key]
-  if (value == null)
-    return '-'
-  return formatFieldValue(value)
-}
-
-function formatFieldValue(value: unknown): string {
-  if (value == null)
-    return '-'
-  if (typeof value === 'object')
-    return JSON.stringify(value)
-  return String(value)
-}
-
-function stringField(key: string): string {
-  const value = selectedEntry.value?.[key]
-  return typeof value === 'string' ? value : value == null ? '' : String(value)
-}
-
-function numberField(key: string): number {
-  const value = selectedEntry.value?.[key]
-  if (typeof value === 'number')
-    return value
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : 0
-}
-
-function booleanField(key: string, defaultValue: boolean): boolean {
-  const value = selectedEntry.value?.[key]
-  return typeof value === 'boolean' ? value : defaultValue
-}
-
-function updateStringField(key: string, value: string) {
-  updateSelectedEntry({ [key]: value })
-}
-
-function updateNumberField(key: string, value: number) {
-  updateSelectedEntry({ [key]: Number.isFinite(value) ? value : 0 })
-}
-
-function updateBooleanField(key: string, value: boolean) {
-  updateSelectedEntry({ [key]: value })
-}
-
-function setFilter(key: string, value: string) {
-  if (key !== 'status')
-    return
-  statusFilter.value = value
-  currentPage.value = 1
-}
-
-function setPage(page: number) {
-  currentPage.value = Math.min(Math.max(1, page), totalPages.value)
-}
-
-function setSearch(value: string) {
-  search.value = value
-  currentPage.value = 1
-}
-
-function setSort(key: string) {
-  if (sortKey.value === key) {
-    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
-  }
-  else {
-    sortKey.value = key
-    sortDirection.value = 'asc'
-  }
-  currentPage.value = 1
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2)
 }
 </script>
 
 <template>
   <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
-    <AdminListPanel
-      :columns="columns"
-      :current-page="currentPage"
-      description="Admin-managed routing entries stored in configKV."
-      empty-label="No router entries"
-      :filters="statusFilters"
-      :initial-loading="loading"
-      :loading="loading"
-      :page-end="pageEnd"
-      :page-start="pageStart"
-      :search="search"
-      search-placeholder="Search route, model, or URL"
-      :sort-direction="sortDirection"
-      :sort-key="sortKey"
-      table-class="min-w-[860px] table-fixed"
-      title="LLM_ROUTER"
-      :total-items="sortedEntries.length"
-      :total-pages="totalPages"
-      @filter="setFilter"
-      @page="setPage"
-      @search="setSearch"
-      @sort="setSort"
-    >
-      <template #actions>
-        <div class="flex flex-col items-end gap-2">
-          <div class="flex items-center gap-2">
-            <span
-              class="badge whitespace-nowrap"
-              :class="listDirty ? 'badge-amber' : 'badge-green'"
-            >
-              <span :class="listDirty ? 'i-lucide-dot' : 'i-lucide-check-circle-2'" />
-              {{ saveStatusLabel }}
-            </span>
-            <span v-if="listDirty" class="max-w-[260px] text-right text-xs text-neutral-500">
-              {{ entries.filter(isRouteDirty).length }} changed<span v-if="deletedEntries.length"> · {{ deletedEntries.length }} deleted</span>
-            </span>
-          </div>
-          <div class="flex flex-nowrap items-center gap-2">
-            <button class="btn btn-secondary min-w-[104px] whitespace-nowrap" type="button" @click="addEntry">
-              <span class="i-lucide-plus" />
-              Add Route
-            </button>
-            <button class="btn btn-primary min-w-[104px] whitespace-nowrap" :disabled="saving" type="button" @click="saveAll">
-              <span class="i-lucide-save" />
-              Save List
-            </button>
-          </div>
+    <section class="panel overflow-hidden">
+      <div class="flex flex-col gap-3 border-b border-neutral-200 px-5 py-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-sm font-semibold">
+            Router Config Request
+          </h2>
+          <p class="mt-1 text-sm text-neutral-500">
+            Writes the active LLM_ROUTER_CONFIG, UNSPEECH_UPSTREAM, and default model aliases.
+          </p>
         </div>
-      </template>
-
-      <template #colgroup>
-        <colgroup>
-          <col class="w-[240px]">
-          <col class="w-[180px]">
-          <col class="w-[220px]">
-          <col class="w-[72px]">
-          <col class="w-[112px]">
-          <col class="w-[56px]">
-        </colgroup>
-      </template>
-
-      <template #rows>
-        <tr
-          v-for="(entry, index) in paginatedEntries"
-          :key="String(entry.id ?? index)"
-          class="cursor-pointer transition-colors hover:bg-neutral-50"
-          :class="{ 'bg-emerald-50/50': selectedEntry === entry }"
-          tabindex="0"
-          @click="selectRoute(entry)"
-          @keydown.enter.prevent="selectRoute(entry)"
-          @keydown.space.prevent="selectRoute(entry)"
-        >
-          <td>
-            <div class="truncate text-left text-neutral-900 font-medium">
-              {{ labelFor(entry, index) }}
-            </div>
-            <div class="mt-1 truncate text-xs text-neutral-500">
-              {{ valueFor(entry, 'id') }}
-            </div>
-            <div v-if="routeChangeLabel(entry)" class="mt-2">
-              <span class="badge badge-amber whitespace-nowrap">
-                {{ routeChangeLabel(entry) }}
-              </span>
-            </div>
-          </td>
-          <td class="truncate">
-            {{ valueFor(entry, 'model') }}
-          </td>
-          <td class="truncate">
-            {{ valueFor(entry, 'baseUrl') }}
-          </td>
-          <td class="whitespace-nowrap">
-            {{ valueFor(entry, 'weight') }}
-          </td>
-          <td>
-            <span class="badge whitespace-nowrap" :class="entry.enabled === false ? 'badge-amber' : 'badge-green'">
-              <span :class="entry.enabled === false ? 'i-lucide-pause-circle' : 'i-lucide-check-circle-2'" />
-              {{ entry.enabled === false ? 'Disabled' : 'Enabled' }}
-            </span>
-          </td>
-          <td class="text-right">
-            <button class="btn btn-danger w-9 px-0" type="button" @click.stop="removeEntry(index)">
-              <span class="i-lucide-trash-2" />
-            </button>
-          </td>
-        </tr>
-      </template>
-    </AdminListPanel>
-
-    <aside class="panel overflow-hidden">
-      <div class="border-b border-neutral-200 px-5 py-4">
-        <div class="flex items-start justify-between gap-3">
-          <div>
-            <h2 class="text-sm font-semibold">
-              Route Settings
-            </h2>
-            <p class="mt-1 text-sm text-neutral-500">
-              Edit common router fields. Save List writes the full list to configKV.
-            </p>
-          </div>
-          <span v-if="selectedEntry && isRouteDirty(selectedEntry)" class="badge badge-amber">
-            <span class="i-lucide-pencil" />
-            {{ routeChangeLabel(selectedEntry) || 'Unsaved' }}
-          </span>
-        </div>
+        <span class="badge" :class="parseError ? 'badge-amber' : 'badge-green'">
+          <span :class="parseError ? 'i-lucide-alert-circle' : 'i-lucide-check-circle-2'" />
+          {{ parseError ? 'Invalid JSON' : 'Ready' }}
+        </span>
       </div>
-      <div v-if="selectedEntry" class="p-5 space-y-4">
-        <div class="grid gap-3">
-          <label class="grid gap-1.5">
-            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-              Name
-              <span v-if="isFieldDirty('name')" class="badge badge-amber">Unsaved</span>
-            </span>
-            <input class="field" :value="stringField('name')" type="text" @input="updateStringField('name', ($event.target as HTMLInputElement).value)">
-          </label>
 
-          <label class="grid gap-1.5">
-            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-              Route ID
-              <span v-if="isFieldDirty('id')" class="badge badge-amber">Unsaved</span>
-            </span>
-            <input class="field text-xs font-mono" :value="stringField('id')" type="text" @input="updateStringField('id', ($event.target as HTMLInputElement).value)">
-          </label>
+      <div class="p-5 space-y-4">
+        <textarea
+          v-model="requestBody"
+          class="textarea min-h-[520px] text-xs leading-5 font-mono"
+          spellcheck="false"
+        />
 
-          <label class="grid gap-1.5">
-            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-              Model
-              <span v-if="isFieldDirty('model')" class="badge badge-amber">Unsaved</span>
-            </span>
-            <input class="field text-xs font-mono" :value="stringField('model')" type="text" placeholder="openai/gpt-5-mini" @input="updateStringField('model', ($event.target as HTMLInputElement).value)">
-          </label>
-
-          <label class="grid gap-1.5">
-            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-              Base URL
-              <span v-if="isFieldDirty('baseUrl')" class="badge badge-amber">Unsaved</span>
-            </span>
-            <input class="field text-xs font-mono" :value="stringField('baseUrl')" type="url" placeholder="https://openrouter.ai/api/v1" @input="updateStringField('baseUrl', ($event.target as HTMLInputElement).value)">
-          </label>
-
-          <div class="grid grid-cols-2 gap-3">
-            <label class="grid gap-1.5">
-              <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-                Weight
-                <span v-if="isFieldDirty('weight')" class="badge badge-amber">Unsaved</span>
-              </span>
-              <input class="field" min="0" step="0.01" :value="numberField('weight')" type="number" @input="updateNumberField('weight', ($event.target as HTMLInputElement).valueAsNumber)">
-            </label>
-
-            <label class="grid gap-1.5">
-              <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-                Status
-                <span v-if="isFieldDirty('enabled')" class="badge badge-amber">Unsaved</span>
-              </span>
-              <select class="field" :value="String(booleanField('enabled', true))" @change="updateBooleanField('enabled', ($event.target as HTMLSelectElement).value === 'true')">
-                <option value="true">
-                  Enabled
-                </option>
-                <option value="false">
-                  Disabled
-                </option>
-              </select>
-            </label>
-          </div>
-
-          <label class="grid gap-1.5">
-            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
-              API Key Env
-              <span v-if="isFieldDirty('apiKeyEnv')" class="badge badge-amber">Unsaved</span>
-            </span>
-            <input class="field text-xs font-mono" :value="stringField('apiKeyEnv')" type="text" placeholder="BACKEND_LLM_API_KEY" @input="updateStringField('apiKeyEnv', ($event.target as HTMLInputElement).value)">
-          </label>
+        <div v-if="parseError" class="border border-amber-200 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {{ parseError }}
         </div>
 
-        <div v-if="selectedAdditionalFields.length > 0" class="border border-neutral-200 rounded-lg">
-          <div class="border-b border-neutral-200 px-3 py-2 text-xs text-neutral-500 font-semibold uppercase">
-            Additional Fields
-          </div>
-          <div v-for="field in selectedAdditionalFields" :key="field.key" class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-neutral-100 px-3 py-2 text-xs last:border-b-0">
-            <div class="min-w-0 flex items-center gap-2 text-neutral-500 font-mono">
-              <span class="truncate">{{ field.key }}</span>
-              <span v-if="isFieldDirty(field.key)" class="badge badge-amber">Unsaved</span>
-            </div>
-            <div class="truncate text-neutral-800 font-mono">
-              {{ field.value }}
-            </div>
-          </div>
-        </div>
-
-        <div v-if="deletedEntries.length > 0" class="border border-amber-200 rounded-lg">
-          <div class="border-b border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 font-semibold uppercase">
-            Deleted Routes
-          </div>
-          <div v-for="entry in deletedEntries" :key="routeKey(entry)" class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-amber-100 px-3 py-2 text-xs last:border-b-0">
-            <div class="truncate text-amber-700 font-mono">
-              {{ valueFor(entry, 'id') }}
-            </div>
-            <div class="truncate text-amber-900 font-medium">
-              {{ labelFor(entry, 0) }}
-            </div>
-          </div>
-        </div>
-
-        <div v-if="listDirty" class="border border-emerald-200 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
-          Route list changed. Save List writes it to configKV.
-        </div>
-        <div class="flex justify-end gap-2">
-          <button class="btn btn-secondary" type="button" @click="selectEntry(selectedIndex)">
-            <span class="i-lucide-rotate-ccw" />
-            Reset Route
+        <div class="flex flex-wrap justify-end gap-2">
+          <button class="btn btn-secondary" :disabled="busy != null || parseError != null" type="button" @click="previewConfig">
+            <span :class="busy === 'preview' ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-eye'" />
+            Preview
+          </button>
+          <button class="btn btn-primary" :disabled="busy != null || parseError != null" type="button" @click="applyConfig">
+            <span :class="busy === 'apply' ? 'i-lucide-loader-2 animate-spin' : 'i-lucide-save'" />
+            Apply
           </button>
         </div>
       </div>
-      <div v-else class="empty-state">
-        Select or add an entry
-      </div>
+    </section>
+
+    <aside class="space-y-4">
+      <section class="panel overflow-hidden">
+        <div class="border-b border-neutral-200 px-4 py-3 text-sm font-semibold">
+          Preview
+        </div>
+        <pre v-if="previewResult" class="max-h-[420px] overflow-auto p-4 text-xs leading-5">{{ formatJson(previewResult) }}</pre>
+        <div v-else class="empty-state min-h-40">
+          <span class="i-lucide-clipboard-list text-2xl" />
+          No preview yet
+        </div>
+      </section>
+
+      <section class="panel overflow-hidden">
+        <div class="border-b border-neutral-200 px-4 py-3 text-sm font-semibold">
+          Last Apply
+        </div>
+        <pre v-if="applyResult" class="max-h-[420px] overflow-auto p-4 text-xs leading-5">{{ formatJson(applyResult) }}</pre>
+        <div v-else class="empty-state min-h-40">
+          <span class="i-lucide-history text-2xl" />
+          No applied changes
+        </div>
+      </section>
     </aside>
   </div>
 </template>

--- a/apps/ui-admin/src/pages/LlmRouterPage.vue
+++ b/apps/ui-admin/src/pages/LlmRouterPage.vue
@@ -1,0 +1,556 @@
+<script setup lang="ts">
+import type { LlmRouterEntry } from '../modules/api'
+
+import { errorMessageFromUnknown } from '@proj-airi/stage-shared'
+import { computed, onMounted, shallowRef } from 'vue'
+import { toast } from 'vue-sonner'
+
+import AdminListPanel from '../components/admin-list/AdminListPanel.vue'
+
+import { adminApi } from '../modules/api'
+
+const entries = shallowRef<LlmRouterEntry[]>([])
+const selectedIndex = shallowRef(0)
+const currentPage = shallowRef(1)
+const savedSnapshot = shallowRef('[]')
+const loading = shallowRef(true)
+const search = shallowRef('')
+const saving = shallowRef(false)
+const sortDirection = shallowRef<'asc' | 'desc'>('asc')
+const sortKey = shallowRef('name')
+const statusFilter = shallowRef('all')
+
+const knownRouteFields = new Set(['id', 'name', 'model', 'baseUrl', 'enabled', 'weight', 'apiKeyEnv'])
+const pageSize = 12
+const columns = [
+  { key: 'name', label: 'Name', sortable: true },
+  { key: 'model', label: 'Model', sortable: true },
+  { key: 'baseUrl', label: 'Base URL', sortable: true },
+  { key: 'weight', label: 'Weight', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'actions', label: '' },
+]
+
+const selectedEntry = computed(() => entries.value[selectedIndex.value] ?? null)
+const savedEntries = computed(() => parseSavedEntries(savedSnapshot.value))
+const deletedEntries = computed(() => savedEntries.value.filter(savedEntry => !entries.value.some(entry => routeKey(entry) === routeKey(savedEntry))))
+const statusFilters = computed(() => [
+  {
+    key: 'status',
+    label: 'Status',
+    value: statusFilter.value,
+    options: [
+      { label: 'All', value: 'all' },
+      { label: 'Enabled', value: 'enabled' },
+      { label: 'Disabled', value: 'disabled' },
+      { label: 'Changed', value: 'changed' },
+    ],
+  },
+])
+const filteredEntries = computed(() => {
+  const term = search.value.trim().toLowerCase()
+  return entries.value.filter((entry) => {
+    if (statusFilter.value === 'enabled' && entry.enabled === false)
+      return false
+    if (statusFilter.value === 'disabled' && entry.enabled !== false)
+      return false
+    if (statusFilter.value === 'changed' && !isRouteDirty(entry))
+      return false
+    if (!term)
+      return true
+    return [
+      valueFor(entry, 'id'),
+      valueFor(entry, 'name'),
+      valueFor(entry, 'model'),
+      valueFor(entry, 'baseUrl'),
+    ].some(value => value.toLowerCase().includes(term))
+  })
+})
+const sortedEntries = computed(() => {
+  const direction = sortDirection.value === 'asc' ? 1 : -1
+  return [...filteredEntries.value].sort((left, right) => compareRouteValue(left, right, sortKey.value) * direction)
+})
+const totalPages = computed(() => Math.max(1, Math.ceil(sortedEntries.value.length / pageSize)))
+const pageStart = computed(() => sortedEntries.value.length === 0 ? 0 : (currentPage.value - 1) * pageSize + 1)
+const pageEnd = computed(() => Math.min(currentPage.value * pageSize, sortedEntries.value.length))
+const paginatedEntries = computed(() => sortedEntries.value.slice((currentPage.value - 1) * pageSize, currentPage.value * pageSize))
+const listDirty = computed(() => JSON.stringify(entries.value) !== savedSnapshot.value)
+const saveStatusLabel = computed(() => {
+  if (saving.value)
+    return 'Saving'
+  if (listDirty.value)
+    return 'Unsaved changes'
+  return 'Saved'
+})
+const selectedDirtyFields = computed(() => {
+  const entry = selectedEntry.value
+  if (!entry)
+    return new Set<string>()
+  return dirtyFieldsFor(entry)
+})
+const selectedAdditionalFields = computed(() => {
+  const entry = selectedEntry.value
+  if (!entry)
+    return []
+  return Object.entries(entry)
+    .filter(([key]) => !knownRouteFields.has(key))
+    .map(([key, value]) => ({
+      key,
+      value: formatFieldValue(value),
+    }))
+})
+
+function parseSavedEntries(value: string): LlmRouterEntry[] {
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return Array.isArray(parsed) ? parsed as LlmRouterEntry[] : []
+  }
+  catch {
+    return []
+  }
+}
+
+onMounted(async () => {
+  try {
+    const result = await adminApi.llmRouter()
+    entries.value = result.entries
+    savedSnapshot.value = JSON.stringify(result.entries)
+    selectEntry(0)
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to load LLM_ROUTER'))
+  }
+  finally {
+    loading.value = false
+  }
+})
+
+function selectEntry(index: number) {
+  selectedIndex.value = index
+}
+
+function selectRoute(entry: LlmRouterEntry) {
+  const index = entries.value.indexOf(entry)
+  if (index >= 0)
+    selectEntry(index)
+}
+
+function addEntry() {
+  entries.value = [
+    ...entries.value,
+    {
+      id: `route-${Date.now()}`,
+      name: 'New Route',
+      model: 'auto',
+      baseUrl: '',
+      enabled: true,
+      weight: 1,
+      apiKeyEnv: '',
+    },
+  ]
+  selectEntry(entries.value.length - 1)
+}
+
+function removeEntry(index: number) {
+  const target = paginatedEntries.value[index]
+  entries.value = entries.value.filter(entry => entry !== target)
+  selectEntry(Math.max(0, Math.min(selectedIndex.value, entries.value.length - 1)))
+}
+
+function updateSelectedEntry(patch: LlmRouterEntry) {
+  const entry = selectedEntry.value
+  if (!entry)
+    return
+
+  const next = [...entries.value]
+  next[selectedIndex.value] = {
+    ...entry,
+    ...patch,
+  }
+  entries.value = next
+}
+
+async function saveAll() {
+  saving.value = true
+  try {
+    const result = await adminApi.saveLlmRouter(entries.value)
+    entries.value = result.entries
+    savedSnapshot.value = JSON.stringify(result.entries)
+    selectEntry(Math.min(selectedIndex.value, entries.value.length - 1))
+    toast.success('LLM_ROUTER saved')
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to save LLM_ROUTER'))
+  }
+  finally {
+    saving.value = false
+  }
+}
+
+function labelFor(entry: LlmRouterEntry, index: number): string {
+  return String(entry.name ?? entry.id ?? entry.model ?? `Route ${index + 1}`)
+}
+
+function routeKey(entry: LlmRouterEntry): string {
+  return String(entry.id ?? entry.name ?? entry.model ?? JSON.stringify(entry))
+}
+
+function savedEntryFor(entry: LlmRouterEntry): LlmRouterEntry | null {
+  return savedEntries.value.find(savedEntry => routeKey(savedEntry) === routeKey(entry)) ?? null
+}
+
+function dirtyFieldsFor(entry: LlmRouterEntry): Set<string> {
+  const savedEntry = savedEntryFor(entry)
+  const fields = new Set<string>()
+  if (!savedEntry) {
+    for (const key of Object.keys(entry))
+      fields.add(key)
+    return fields
+  }
+
+  const keys = new Set([...Object.keys(entry), ...Object.keys(savedEntry)])
+  for (const key of keys) {
+    if (JSON.stringify(entry[key]) !== JSON.stringify(savedEntry[key]))
+      fields.add(key)
+  }
+  return fields
+}
+
+function routeChangeLabel(entry: LlmRouterEntry): string {
+  if (!savedEntryFor(entry))
+    return 'New'
+  if (dirtyFieldsFor(entry).size > 0)
+    return 'Modified'
+  return ''
+}
+
+function isRouteDirty(entry: LlmRouterEntry): boolean {
+  return routeChangeLabel(entry) !== ''
+}
+
+function isFieldDirty(key: string): boolean {
+  return selectedDirtyFields.value.has(key)
+}
+
+function compareRouteValue(left: LlmRouterEntry, right: LlmRouterEntry, key: string): number {
+  if (key === 'weight')
+    return Number(left.weight ?? 0) - Number(right.weight ?? 0)
+  if (key === 'status')
+    return Number(left.enabled !== false) - Number(right.enabled !== false)
+  return valueFor(left, key).localeCompare(valueFor(right, key))
+}
+
+function valueFor(entry: LlmRouterEntry, key: string): string {
+  const value = entry[key]
+  if (value == null)
+    return '-'
+  return formatFieldValue(value)
+}
+
+function formatFieldValue(value: unknown): string {
+  if (value == null)
+    return '-'
+  if (typeof value === 'object')
+    return JSON.stringify(value)
+  return String(value)
+}
+
+function stringField(key: string): string {
+  const value = selectedEntry.value?.[key]
+  return typeof value === 'string' ? value : value == null ? '' : String(value)
+}
+
+function numberField(key: string): number {
+  const value = selectedEntry.value?.[key]
+  if (typeof value === 'number')
+    return value
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function booleanField(key: string, defaultValue: boolean): boolean {
+  const value = selectedEntry.value?.[key]
+  return typeof value === 'boolean' ? value : defaultValue
+}
+
+function updateStringField(key: string, value: string) {
+  updateSelectedEntry({ [key]: value })
+}
+
+function updateNumberField(key: string, value: number) {
+  updateSelectedEntry({ [key]: Number.isFinite(value) ? value : 0 })
+}
+
+function updateBooleanField(key: string, value: boolean) {
+  updateSelectedEntry({ [key]: value })
+}
+
+function setFilter(key: string, value: string) {
+  if (key !== 'status')
+    return
+  statusFilter.value = value
+  currentPage.value = 1
+}
+
+function setPage(page: number) {
+  currentPage.value = Math.min(Math.max(1, page), totalPages.value)
+}
+
+function setSearch(value: string) {
+  search.value = value
+  currentPage.value = 1
+}
+
+function setSort(key: string) {
+  if (sortKey.value === key) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  }
+  else {
+    sortKey.value = key
+    sortDirection.value = 'asc'
+  }
+  currentPage.value = 1
+}
+</script>
+
+<template>
+  <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
+    <AdminListPanel
+      :columns="columns"
+      :current-page="currentPage"
+      description="Admin-managed routing entries stored in configKV."
+      empty-label="No router entries"
+      :filters="statusFilters"
+      :initial-loading="loading"
+      :loading="loading"
+      :page-end="pageEnd"
+      :page-start="pageStart"
+      :search="search"
+      search-placeholder="Search route, model, or URL"
+      :sort-direction="sortDirection"
+      :sort-key="sortKey"
+      table-class="min-w-[860px] table-fixed"
+      title="LLM_ROUTER"
+      :total-items="sortedEntries.length"
+      :total-pages="totalPages"
+      @filter="setFilter"
+      @page="setPage"
+      @search="setSearch"
+      @sort="setSort"
+    >
+      <template #actions>
+        <div class="flex flex-col items-end gap-2">
+          <div class="flex items-center gap-2">
+            <span
+              class="badge whitespace-nowrap"
+              :class="listDirty ? 'badge-amber' : 'badge-green'"
+            >
+              <span :class="listDirty ? 'i-lucide-dot' : 'i-lucide-check-circle-2'" />
+              {{ saveStatusLabel }}
+            </span>
+            <span v-if="listDirty" class="max-w-[260px] text-right text-xs text-neutral-500">
+              {{ entries.filter(isRouteDirty).length }} changed<span v-if="deletedEntries.length"> · {{ deletedEntries.length }} deleted</span>
+            </span>
+          </div>
+          <div class="flex flex-nowrap items-center gap-2">
+            <button class="btn btn-secondary min-w-[104px] whitespace-nowrap" type="button" @click="addEntry">
+              <span class="i-lucide-plus" />
+              Add Route
+            </button>
+            <button class="btn btn-primary min-w-[104px] whitespace-nowrap" :disabled="saving" type="button" @click="saveAll">
+              <span class="i-lucide-save" />
+              Save List
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <template #colgroup>
+        <colgroup>
+          <col class="w-[240px]">
+          <col class="w-[180px]">
+          <col class="w-[220px]">
+          <col class="w-[72px]">
+          <col class="w-[112px]">
+          <col class="w-[56px]">
+        </colgroup>
+      </template>
+
+      <template #rows>
+        <tr
+          v-for="(entry, index) in paginatedEntries"
+          :key="String(entry.id ?? index)"
+          class="cursor-pointer transition-colors hover:bg-neutral-50"
+          :class="{ 'bg-emerald-50/50': selectedEntry === entry }"
+          tabindex="0"
+          @click="selectRoute(entry)"
+          @keydown.enter.prevent="selectRoute(entry)"
+          @keydown.space.prevent="selectRoute(entry)"
+        >
+          <td>
+            <div class="truncate text-left text-neutral-900 font-medium">
+              {{ labelFor(entry, index) }}
+            </div>
+            <div class="mt-1 truncate text-xs text-neutral-500">
+              {{ valueFor(entry, 'id') }}
+            </div>
+            <div v-if="routeChangeLabel(entry)" class="mt-2">
+              <span class="badge badge-amber whitespace-nowrap">
+                {{ routeChangeLabel(entry) }}
+              </span>
+            </div>
+          </td>
+          <td class="truncate">
+            {{ valueFor(entry, 'model') }}
+          </td>
+          <td class="truncate">
+            {{ valueFor(entry, 'baseUrl') }}
+          </td>
+          <td class="whitespace-nowrap">
+            {{ valueFor(entry, 'weight') }}
+          </td>
+          <td>
+            <span class="badge whitespace-nowrap" :class="entry.enabled === false ? 'badge-amber' : 'badge-green'">
+              <span :class="entry.enabled === false ? 'i-lucide-pause-circle' : 'i-lucide-check-circle-2'" />
+              {{ entry.enabled === false ? 'Disabled' : 'Enabled' }}
+            </span>
+          </td>
+          <td class="text-right">
+            <button class="btn btn-danger w-9 px-0" type="button" @click.stop="removeEntry(index)">
+              <span class="i-lucide-trash-2" />
+            </button>
+          </td>
+        </tr>
+      </template>
+    </AdminListPanel>
+
+    <aside class="panel overflow-hidden">
+      <div class="border-b border-neutral-200 px-5 py-4">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-sm font-semibold">
+              Route Settings
+            </h2>
+            <p class="mt-1 text-sm text-neutral-500">
+              Edit common router fields. Save List writes the full list to configKV.
+            </p>
+          </div>
+          <span v-if="selectedEntry && isRouteDirty(selectedEntry)" class="badge badge-amber">
+            <span class="i-lucide-pencil" />
+            {{ routeChangeLabel(selectedEntry) || 'Unsaved' }}
+          </span>
+        </div>
+      </div>
+      <div v-if="selectedEntry" class="p-5 space-y-4">
+        <div class="grid gap-3">
+          <label class="grid gap-1.5">
+            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+              Name
+              <span v-if="isFieldDirty('name')" class="badge badge-amber">Unsaved</span>
+            </span>
+            <input class="field" :value="stringField('name')" type="text" @input="updateStringField('name', ($event.target as HTMLInputElement).value)">
+          </label>
+
+          <label class="grid gap-1.5">
+            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+              Route ID
+              <span v-if="isFieldDirty('id')" class="badge badge-amber">Unsaved</span>
+            </span>
+            <input class="field text-xs font-mono" :value="stringField('id')" type="text" @input="updateStringField('id', ($event.target as HTMLInputElement).value)">
+          </label>
+
+          <label class="grid gap-1.5">
+            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+              Model
+              <span v-if="isFieldDirty('model')" class="badge badge-amber">Unsaved</span>
+            </span>
+            <input class="field text-xs font-mono" :value="stringField('model')" type="text" placeholder="openai/gpt-5-mini" @input="updateStringField('model', ($event.target as HTMLInputElement).value)">
+          </label>
+
+          <label class="grid gap-1.5">
+            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+              Base URL
+              <span v-if="isFieldDirty('baseUrl')" class="badge badge-amber">Unsaved</span>
+            </span>
+            <input class="field text-xs font-mono" :value="stringField('baseUrl')" type="url" placeholder="https://openrouter.ai/api/v1" @input="updateStringField('baseUrl', ($event.target as HTMLInputElement).value)">
+          </label>
+
+          <div class="grid grid-cols-2 gap-3">
+            <label class="grid gap-1.5">
+              <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+                Weight
+                <span v-if="isFieldDirty('weight')" class="badge badge-amber">Unsaved</span>
+              </span>
+              <input class="field" min="0" step="0.01" :value="numberField('weight')" type="number" @input="updateNumberField('weight', ($event.target as HTMLInputElement).valueAsNumber)">
+            </label>
+
+            <label class="grid gap-1.5">
+              <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+                Status
+                <span v-if="isFieldDirty('enabled')" class="badge badge-amber">Unsaved</span>
+              </span>
+              <select class="field" :value="String(booleanField('enabled', true))" @change="updateBooleanField('enabled', ($event.target as HTMLSelectElement).value === 'true')">
+                <option value="true">
+                  Enabled
+                </option>
+                <option value="false">
+                  Disabled
+                </option>
+              </select>
+            </label>
+          </div>
+
+          <label class="grid gap-1.5">
+            <span class="flex items-center gap-2 text-xs text-neutral-500 font-semibold uppercase">
+              API Key Env
+              <span v-if="isFieldDirty('apiKeyEnv')" class="badge badge-amber">Unsaved</span>
+            </span>
+            <input class="field text-xs font-mono" :value="stringField('apiKeyEnv')" type="text" placeholder="BACKEND_LLM_API_KEY" @input="updateStringField('apiKeyEnv', ($event.target as HTMLInputElement).value)">
+          </label>
+        </div>
+
+        <div v-if="selectedAdditionalFields.length > 0" class="border border-neutral-200 rounded-lg">
+          <div class="border-b border-neutral-200 px-3 py-2 text-xs text-neutral-500 font-semibold uppercase">
+            Additional Fields
+          </div>
+          <div v-for="field in selectedAdditionalFields" :key="field.key" class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-neutral-100 px-3 py-2 text-xs last:border-b-0">
+            <div class="min-w-0 flex items-center gap-2 text-neutral-500 font-mono">
+              <span class="truncate">{{ field.key }}</span>
+              <span v-if="isFieldDirty(field.key)" class="badge badge-amber">Unsaved</span>
+            </div>
+            <div class="truncate text-neutral-800 font-mono">
+              {{ field.value }}
+            </div>
+          </div>
+        </div>
+
+        <div v-if="deletedEntries.length > 0" class="border border-amber-200 rounded-lg">
+          <div class="border-b border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 font-semibold uppercase">
+            Deleted Routes
+          </div>
+          <div v-for="entry in deletedEntries" :key="routeKey(entry)" class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-amber-100 px-3 py-2 text-xs last:border-b-0">
+            <div class="truncate text-amber-700 font-mono">
+              {{ valueFor(entry, 'id') }}
+            </div>
+            <div class="truncate text-amber-900 font-medium">
+              {{ labelFor(entry, 0) }}
+            </div>
+          </div>
+        </div>
+
+        <div v-if="listDirty" class="border border-emerald-200 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+          Route list changed. Save List writes it to configKV.
+        </div>
+        <div class="flex justify-end gap-2">
+          <button class="btn btn-secondary" type="button" @click="selectEntry(selectedIndex)">
+            <span class="i-lucide-rotate-ccw" />
+            Reset Route
+          </button>
+        </div>
+      </div>
+      <div v-else class="empty-state">
+        Select or add an entry
+      </div>
+    </aside>
+  </div>
+</template>

--- a/apps/ui-admin/src/pages/OverviewPage.vue
+++ b/apps/ui-admin/src/pages/OverviewPage.vue
@@ -135,7 +135,7 @@ function formatNumber(value: number | null | undefined): string {
               Router Config
             </div>
             <RouterLink class="mt-2 inline-flex items-center gap-2 text-sm text-emerald-700 font-semibold" to="/llm-router">
-              Open LLM_ROUTER
+              Open Router Config
               <span class="i-lucide-arrow-right" />
             </RouterLink>
           </div>

--- a/apps/ui-admin/src/pages/OverviewPage.vue
+++ b/apps/ui-admin/src/pages/OverviewPage.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import type { AdminMetrics } from '../modules/api'
+
+import { errorMessageFromUnknown } from '@proj-airi/stage-shared'
+import { computed, onMounted, shallowRef } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { adminApi } from '../modules/api'
+
+const loading = shallowRef(true)
+const metrics = shallowRef<AdminMetrics | null>(null)
+
+const cards = computed(() => {
+  const data = metrics.value
+  return [
+    {
+      label: 'Total Users',
+      value: formatNumber(data?.totalUsers),
+      trend: `${formatNumber(data?.verifiedUsers)} verified`,
+      icon: 'i-lucide-users',
+    },
+    {
+      label: 'Active Sessions',
+      value: formatNumber(data?.activeSessions),
+      trend: 'Better Auth session rows',
+      icon: 'i-lucide-activity',
+    },
+    {
+      label: 'Current Flux',
+      value: formatNumber(data?.currentFlux),
+      trend: `${formatNumber(data?.issuedFlux)} issued lifetime`,
+      icon: 'i-lucide-coins',
+    },
+    {
+      label: 'LLM 24h',
+      value: formatNumber(data?.llmRequests24h),
+      trend: `${formatNumber(data?.llmFlux24h)} Flux consumed`,
+      icon: 'i-lucide-bot',
+    },
+  ]
+})
+
+onMounted(async () => {
+  try {
+    metrics.value = await adminApi.metrics()
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to load metrics'))
+  }
+  finally {
+    loading.value = false
+  }
+})
+
+function formatNumber(value: number | null | undefined): string {
+  if (value == null)
+    return loading.value ? '...' : '0'
+  return new Intl.NumberFormat().format(value)
+}
+</script>
+
+<template>
+  <div class="space-y-5">
+    <section class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <article v-for="card in cards" :key="card.label" class="metric-card">
+        <div class="flex items-start justify-between">
+          <div class="text-sm text-neutral-500">
+            {{ card.label }}
+          </div>
+          <div class="h-8 w-8 flex items-center justify-center border border-neutral-200 rounded-md bg-white text-neutral-600">
+            <span :class="card.icon" />
+          </div>
+        </div>
+        <div class="mt-3 text-3xl font-semibold tracking-tight">
+          {{ card.value }}
+        </div>
+        <div class="mt-5 flex items-center gap-2 text-sm text-neutral-600">
+          <span class="i-lucide-trending-up text-emerald-600" />
+          {{ card.trend }}
+        </div>
+      </article>
+    </section>
+
+    <section class="panel overflow-hidden">
+      <div class="flex flex-col gap-3 border-b border-neutral-200 px-5 py-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-sm font-semibold">
+            Operational Overview
+          </h2>
+          <p class="mt-1 text-sm text-neutral-500">
+            Reserved surface for Grafana panels and live gateway indicators.
+          </p>
+        </div>
+        <button class="btn btn-secondary" type="button">
+          <span class="i-lucide-panel-top" />
+          Grafana Embed
+        </button>
+      </div>
+
+      <div class="grid gap-4 p-5 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div v-if="metrics?.grafanaEmbedUrl" class="min-h-[340px] overflow-hidden border border-neutral-200 rounded-lg">
+          <iframe class="h-full min-h-[340px] w-full" :src="metrics.grafanaEmbedUrl" />
+        </div>
+        <div v-else class="relative min-h-[340px] overflow-hidden border border-neutral-200 rounded-lg from-white to-emerald-50/60 bg-gradient-to-b px-5 py-5">
+          <div class="absolute inset-x-5 bottom-10 top-8 flex items-end gap-2">
+            <div v-for="height in [32, 46, 38, 72, 54, 88, 50, 64, 80, 44, 70, 92, 60, 74, 56, 84, 68, 96]" :key="height" class="flex-1 rounded-t bg-emerald-500/35" :style="{ height: `${height}%` }" />
+          </div>
+          <div class="relative z-1 flex items-center justify-between">
+            <div>
+              <div class="text-sm font-semibold">
+                Grafana placeholder
+              </div>
+              <div class="mt-1 text-sm text-neutral-500">
+                Add an embed URL later without changing the page shell.
+              </div>
+            </div>
+            <span class="badge badge-green">
+              <span class="i-lucide-circle" />
+              Ready
+            </span>
+          </div>
+        </div>
+
+        <div class="space-y-3">
+          <div class="border border-neutral-200 rounded-lg bg-white p-4">
+            <div class="text-xs text-neutral-500 font-semibold uppercase">
+              Admin Seats
+            </div>
+            <div class="mt-2 text-2xl font-semibold">
+              {{ formatNumber(metrics?.adminSeats) }}
+            </div>
+          </div>
+          <div class="border border-neutral-200 rounded-lg bg-white p-4">
+            <div class="text-xs text-neutral-500 font-semibold uppercase">
+              Router Config
+            </div>
+            <RouterLink class="mt-2 inline-flex items-center gap-2 text-sm text-emerald-700 font-semibold" to="/llm-router">
+              Open LLM_ROUTER
+              <span class="i-lucide-arrow-right" />
+            </RouterLink>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/apps/ui-admin/src/pages/UsersPage.vue
+++ b/apps/ui-admin/src/pages/UsersPage.vue
@@ -1,0 +1,332 @@
+<script setup lang="ts">
+import type { AdminUser, FluxTransaction } from '../modules/api'
+
+import { errorMessageFromUnknown } from '@proj-airi/stage-shared'
+import { computed, onMounted, reactive, shallowRef } from 'vue'
+import { toast } from 'vue-sonner'
+
+import AdminListPanel from '../components/admin-list/AdminListPanel.vue'
+
+import { adminApi } from '../modules/api'
+
+const users = shallowRef<AdminUser[]>([])
+const selected = shallowRef<AdminUser | null>(null)
+const transactions = shallowRef<FluxTransaction[]>([])
+const loading = shallowRef(false)
+const loadingPage = shallowRef<number | null>(null)
+const detailLoading = shallowRef(false)
+const currentPage = shallowRef(1)
+const sortDirection = shallowRef<'asc' | 'desc'>('desc')
+const sortKey = shallowRef('createdAt')
+const statusFilter = shallowRef('all')
+const totalUsers = shallowRef(0)
+const pageSize = 20
+
+const search = shallowRef('')
+const columns = [
+  { key: 'user', label: 'User', sortable: true },
+  { key: 'status', label: 'Status', sortable: true },
+  { key: 'flux', label: 'Flux', sortable: true },
+  { key: 'createdAt', label: 'Created', sortable: true },
+]
+const statusFilters = computed(() => [
+  {
+    key: 'status',
+    label: 'Status',
+    value: statusFilter.value,
+    options: [
+      { label: 'All', value: 'all' },
+      { label: 'Verified', value: 'verified' },
+      { label: 'Unverified', value: 'unverified' },
+    ],
+  },
+])
+const fluxForm = reactive({
+  grantAmount: 100,
+  grantDescription: 'Admin Flux grant',
+  targetBalance: 0,
+  balanceDescription: 'Admin balance adjustment',
+})
+
+const selectedStatus = computed(() => selected.value?.emailVerified ? 'Verified' : 'Unverified')
+const totalPages = computed(() => Math.max(1, Math.ceil(totalUsers.value / pageSize)))
+const pageStart = computed(() => totalUsers.value === 0 ? 0 : (currentPage.value - 1) * pageSize + 1)
+const pageEnd = computed(() => Math.min(currentPage.value * pageSize, totalUsers.value))
+const isInitialLoading = computed(() => loading.value && users.value.length === 0)
+
+onMounted(() => {
+  void loadUsers(1)
+})
+
+async function loadUsers(page: number) {
+  const nextPage = clampPage(page)
+  loading.value = true
+  loadingPage.value = nextPage
+  try {
+    const result = await adminApi.users({
+      query: search.value.trim() || undefined,
+      limit: pageSize,
+      offset: (nextPage - 1) * pageSize,
+      sortDirection: sortDirection.value,
+      sortKey: sortKey.value === 'user' ? 'name' : sortKey.value,
+      status: statusFilter.value,
+    })
+    users.value = result.users
+    totalUsers.value = result.total
+    currentPage.value = nextPage
+    if (result.users[0] && !result.users.some(user => user.id === selected.value?.id))
+      await selectUser(result.users[0])
+    if (result.users.length === 0) {
+      selected.value = null
+      transactions.value = []
+    }
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to load users'))
+  }
+  finally {
+    loading.value = false
+    loadingPage.value = null
+  }
+}
+
+function clampPage(page: number): number {
+  if (!Number.isFinite(page))
+    return currentPage.value
+  return Math.min(Math.max(1, Math.trunc(page)), totalPages.value)
+}
+
+function setFilter(key: string, value: string) {
+  if (key !== 'status')
+    return
+  statusFilter.value = value
+  void loadUsers(1)
+}
+
+function setPage(page: number) {
+  void loadUsers(page)
+}
+
+function setSearch(value: string) {
+  search.value = value
+  void loadUsers(1)
+}
+
+function setSort(key: string) {
+  if (sortKey.value === key) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  }
+  else {
+    sortKey.value = key
+    sortDirection.value = key === 'createdAt' ? 'desc' : 'asc'
+  }
+  void loadUsers(1)
+}
+
+async function selectUser(user: AdminUser) {
+  detailLoading.value = true
+  try {
+    const result = await adminApi.user(user.id)
+    selected.value = result.user
+    transactions.value = result.recentFluxTransactions
+    fluxForm.targetBalance = result.user.flux
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to load user'))
+  }
+  finally {
+    detailLoading.value = false
+  }
+}
+
+async function grantFlux() {
+  if (!selected.value)
+    return
+  try {
+    const result = await adminApi.grantUserFlux(selected.value.id, {
+      amount: Number(fluxForm.grantAmount),
+      description: fluxForm.grantDescription,
+    })
+    toast.success(`Balance updated to ${formatNumber(result.balanceAfter)}`)
+    await selectUser(selected.value)
+    await loadUsers(currentPage.value)
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to grant Flux'))
+  }
+}
+
+async function setBalance() {
+  if (!selected.value)
+    return
+  try {
+    const result = await adminApi.setUserFlux(selected.value.id, {
+      balance: Number(fluxForm.targetBalance),
+      description: fluxForm.balanceDescription,
+    })
+    toast.success(result.changed ? `Balance set to ${formatNumber(result.balanceAfter)}` : 'Balance unchanged')
+    await selectUser(selected.value)
+    await loadUsers(currentPage.value)
+  }
+  catch (error) {
+    toast.error(errorMessageFromUnknown(error, 'Failed to set balance'))
+  }
+}
+
+function formatNumber(value: number | null | undefined): string {
+  return new Intl.NumberFormat().format(value ?? 0)
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value))
+}
+</script>
+
+<template>
+  <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_380px]">
+    <AdminListPanel
+      :columns="columns"
+      :current-page="currentPage"
+      description="Search accounts, inspect balances, and apply Flux changes."
+      empty-label="No users matched this query"
+      :filters="statusFilters"
+      :initial-loading="isInitialLoading"
+      :loading="loading"
+      :loading-page="loadingPage"
+      :page-end="pageEnd"
+      :page-start="pageStart"
+      :search="search"
+      search-placeholder="Search email, name, or user ID"
+      :sort-direction="sortDirection"
+      :sort-key="sortKey"
+      title="Users"
+      :total-items="totalUsers"
+      :total-pages="totalPages"
+      @filter="setFilter"
+      @page="setPage"
+      @search="setSearch"
+      @sort="setSort"
+    >
+      <template #rows>
+        <tr
+          v-for="user in users"
+          :key="user.id"
+          class="cursor-pointer transition-colors hover:bg-neutral-50"
+          :class="{ 'bg-emerald-50/50': selected?.id === user.id }"
+          tabindex="0"
+          @click="selectUser(user)"
+          @keydown.enter.prevent="selectUser(user)"
+          @keydown.space.prevent="selectUser(user)"
+        >
+          <td>
+            <div class="font-medium">
+              {{ user.name }}
+            </div>
+            <div class="mt-1 text-xs text-neutral-500">
+              {{ user.email }}
+            </div>
+          </td>
+          <td>
+            <span class="badge" :class="user.emailVerified ? 'badge-green' : 'badge-amber'">
+              <span :class="user.emailVerified ? 'i-lucide-check-circle-2' : 'i-lucide-clock-3'" />
+              {{ user.emailVerified ? 'Verified' : 'Unverified' }}
+            </span>
+          </td>
+          <td class="font-semibold">
+            {{ formatNumber(user.flux) }}
+          </td>
+          <td>{{ formatDate(user.createdAt) }}</td>
+        </tr>
+      </template>
+    </AdminListPanel>
+
+    <aside class="space-y-4">
+      <section class="panel p-5">
+        <div v-if="!selected" class="empty-state">
+          <span class="i-lucide-mouse-pointer-click text-2xl" />
+          Select a user
+        </div>
+        <div v-else class="space-y-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <h2 class="truncate text-base font-semibold">
+                {{ selected.name }}
+              </h2>
+              <p class="mt-1 truncate text-sm text-neutral-500">
+                {{ selected.email }}
+              </p>
+            </div>
+            <span class="badge" :class="selected.emailVerified ? 'badge-green' : 'badge-amber'">
+              {{ selectedStatus }}
+            </span>
+          </div>
+
+          <div class="grid grid-cols-2 gap-3">
+            <div class="border border-neutral-200 rounded-lg p-3">
+              <div class="text-xs text-neutral-500">
+                Flux Balance
+              </div>
+              <div class="mt-1 text-xl font-semibold">
+                {{ formatNumber(selected.flux) }}
+              </div>
+            </div>
+            <div class="border border-neutral-200 rounded-lg p-3">
+              <div class="text-xs text-neutral-500">
+                Joined
+              </div>
+              <div class="mt-1 text-sm font-semibold">
+                {{ formatDate(selected.createdAt) }}
+              </div>
+            </div>
+          </div>
+
+          <div class="border border-neutral-200 rounded-lg p-3">
+            <label class="text-xs text-neutral-500 font-semibold uppercase">Grant Flux</label>
+            <div class="grid grid-cols-[110px_minmax(0,1fr)] mt-3 gap-2">
+              <input v-model.number="fluxForm.grantAmount" class="field" min="1" type="number">
+              <input v-model="fluxForm.grantDescription" class="field" type="text">
+            </div>
+            <button class="btn btn-primary mt-3 w-full" :disabled="detailLoading" type="button" @click="grantFlux">
+              <span class="i-lucide-plus-circle" />
+              Grant Flux
+            </button>
+          </div>
+
+          <div class="border border-neutral-200 rounded-lg p-3">
+            <label class="text-xs text-neutral-500 font-semibold uppercase">Set Balance</label>
+            <div class="grid grid-cols-[110px_minmax(0,1fr)] mt-3 gap-2">
+              <input v-model.number="fluxForm.targetBalance" class="field" min="0" type="number">
+              <input v-model="fluxForm.balanceDescription" class="field" type="text">
+            </div>
+            <button class="btn btn-secondary mt-3 w-full" :disabled="detailLoading" type="button" @click="setBalance">
+              <span class="i-lucide-pencil" />
+              Set Balance
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section v-if="selected" class="panel overflow-hidden">
+        <div class="border-b border-neutral-200 px-4 py-3 text-sm font-semibold">
+          Recent Flux Ledger
+        </div>
+        <div v-if="transactions.length === 0" class="empty-state min-h-32">
+          No Flux transactions
+        </div>
+        <div v-else class="max-h-[360px] overflow-auto">
+          <div v-for="tx in transactions" :key="tx.id" class="border-b border-neutral-100 px-4 py-3 last:border-b-0">
+            <div class="flex items-center justify-between gap-3">
+              <span class="text-sm font-medium">{{ tx.description }}</span>
+              <span class="text-sm font-semibold" :class="tx.type === 'debit' ? 'text-red-600' : 'text-emerald-700'">
+                {{ tx.type === 'debit' ? '-' : '+' }}{{ formatNumber(tx.amount) }}
+              </span>
+            </div>
+            <div class="mt-1 text-xs text-neutral-500">
+              {{ tx.type }} · {{ formatDate(tx.createdAt) }} · {{ formatNumber(tx.balanceBefore) }} -> {{ formatNumber(tx.balanceAfter) }}
+            </div>
+          </div>
+        </div>
+      </section>
+    </aside>
+  </div>
+</template>

--- a/apps/ui-admin/src/styles/main.css
+++ b/apps/ui-admin/src/styles/main.css
@@ -1,0 +1,262 @@
+@import '@proj-airi/ui/main.css';
+
+:root {
+  --admin-accent: #059669;
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background: #f7f8fa;
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: var(--admin-accent);
+  height: 2px;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 50;
+}
+
+.admin-shell {
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.admin-sidebar {
+  background: #f4f5f7;
+  border-right: 1px solid #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px 14px;
+}
+
+.admin-main {
+  min-width: 0;
+}
+
+.admin-topbar {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  height: 56px;
+  justify-content: space-between;
+  padding: 0 28px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.admin-content {
+  padding: 22px;
+}
+
+.quick-action {
+  align-items: center;
+  background: #059669;
+  border: 0;
+  border-radius: 7px;
+  color: white;
+  display: flex;
+  font-size: 13px;
+  font-weight: 600;
+  gap: 8px;
+  height: 34px;
+  justify-content: flex-start;
+  margin-top: 12px;
+  padding: 0 10px;
+}
+
+.nav-item {
+  align-items: center;
+  border-radius: 7px;
+  color: #27272a;
+  display: flex;
+  font-size: 13px;
+  gap: 9px;
+  height: 34px;
+  padding: 0 9px;
+  text-decoration: none;
+}
+
+.nav-item:hover {
+  background: #e9ecef;
+}
+
+.nav-item-active {
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  font-weight: 600;
+}
+
+.panel {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.metric-card {
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbfa 100%);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  min-height: 132px;
+  padding: 20px;
+}
+
+.field {
+  background: #fff;
+  border: 1px solid #dfe3e8;
+  border-radius: 7px;
+  color: #171717;
+  min-height: 36px;
+  outline: none;
+  padding: 0 10px;
+  width: 100%;
+}
+
+.field:focus,
+.textarea:focus {
+  border-color: #10b981;
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.14);
+}
+
+.textarea {
+  background: #fff;
+  border: 1px solid #dfe3e8;
+  border-radius: 7px;
+  color: #171717;
+  min-height: 112px;
+  outline: none;
+  padding: 10px;
+  resize: vertical;
+  width: 100%;
+}
+
+.btn {
+  align-items: center;
+  border: 1px solid #dfe3e8;
+  border-radius: 7px;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 600;
+  gap: 8px;
+  height: 36px;
+  justify-content: center;
+  padding: 0 12px;
+}
+
+.btn-primary {
+  background: #059669;
+  border-color: #059669;
+  color: white;
+}
+
+.btn-secondary {
+  background: white;
+  color: #27272a;
+}
+
+.btn-danger {
+  background: #fff;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid #edf0f2;
+  padding: 12px 14px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.table th {
+  background: #f8fafc;
+  color: #52525b;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.table td {
+  color: #27272a;
+  font-size: 13px;
+}
+
+.badge {
+  align-items: center;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 6px;
+  height: 24px;
+  padding: 0 8px;
+}
+
+.badge-green {
+  background: #ecfdf5;
+  border-color: #bbf7d0;
+  color: #047857;
+}
+
+.badge-amber {
+  background: #fffbeb;
+  border-color: #fde68a;
+  color: #b45309;
+}
+
+.empty-state {
+  align-items: center;
+  color: #71717a;
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  gap: 10px;
+  justify-content: center;
+  min-height: 180px;
+}
+
+@media (max-width: 900px) {
+  .admin-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    border-bottom: 1px solid #e5e7eb;
+    border-right: 0;
+    min-height: auto;
+  }
+
+  .admin-content {
+    padding: 16px;
+  }
+}

--- a/apps/ui-admin/tsconfig.json
+++ b/apps/ui-admin/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": [
+      "DOM",
+      "ESNext",
+      "DOM.Iterable",
+      "DOM.AsyncIterable"
+    ],
+    "useDefineForClassFields": true,
+    "paths": {
+      "@proj-airi/stage-shared/*": [
+        "../../packages/stage-shared/src/*"
+      ]
+    },
+    "resolveJsonModule": true,
+    "types": [
+      "vite/client",
+      "vue-macros/macros-global"
+    ],
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "vueCompilerOptions": {
+    "plugins": [
+      "@vue-macros/volar/define-models",
+      "@vue-macros/volar/define-slots"
+    ]
+  }
+}

--- a/apps/ui-admin/uno.config.ts
+++ b/apps/ui-admin/uno.config.ts
@@ -1,0 +1,20 @@
+import { mergeConfigs, presetWebFonts } from 'unocss'
+
+import { presetWebFontsFonts, sharedUnoConfig } from '../../uno.config'
+
+export default mergeConfigs([
+  sharedUnoConfig(),
+  {
+    presets: [
+      presetWebFonts({
+        fonts: {
+          ...presetWebFontsFonts('fontsource'),
+        },
+        timeouts: {
+          warning: 5000,
+          failure: 10000,
+        },
+      }),
+    ],
+  },
+])

--- a/apps/ui-admin/vite.config.ts
+++ b/apps/ui-admin/vite.config.ts
@@ -1,0 +1,38 @@
+import { join, resolve } from 'node:path'
+
+import Vue from '@vitejs/plugin-vue'
+import Unocss from 'unocss/vite'
+import VueMacros from 'vue-macros/vite'
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  base: '/admin/',
+  resolve: {
+    alias: {
+      '@proj-airi/stage-shared': resolve(join(import.meta.dirname, '..', '..', 'packages', 'stage-shared', 'src')),
+    },
+  },
+  server: {
+    fs: {
+      strict: false,
+    },
+  },
+  build: {
+    emptyOutDir: true,
+    outDir: resolve(join(import.meta.dirname, '..', 'server', 'public', 'ui-admin')),
+    sourcemap: true,
+  },
+  plugins: [
+    VueMacros({
+      plugins: {
+        vue: Vue({
+          include: [/\.vue$/, /\.md$/],
+        }),
+        vueJsx: false,
+      },
+      betterDefine: false,
+    }),
+    Unocss(),
+  ],
+})

--- a/apps/ui-server-auth/src/modules/sign-in.ts
+++ b/apps/ui-server-auth/src/modules/sign-in.ts
@@ -18,8 +18,10 @@ export function createServerSignInContext(currentUrl: string, apiServerUrl: stri
   const url = new URL(currentUrl)
   const oidcParams = new URLSearchParams(url.searchParams)
   const requestedProvider = oidcParams.get('provider')
+  const redirect = oidcParams.get('redirect')
 
   oidcParams.delete('provider')
+  oidcParams.delete('redirect')
   oidcParams.delete('prompt')
 
   // NOTICE:
@@ -36,7 +38,7 @@ export function createServerSignInContext(currentUrl: string, apiServerUrl: stri
   // verification redirects can never land on /auth/sign-in carrying a `token`.
   if (!oidcParams.has('client_id') || !oidcParams.has('response_type')) {
     return {
-      callbackURL: '/',
+      callbackURL: normalizeStandaloneRedirect(url, redirect) ?? '/',
       requestedProvider,
     }
   }
@@ -48,6 +50,16 @@ export function createServerSignInContext(currentUrl: string, apiServerUrl: stri
     callbackURL: authorizeUrl.toString(),
     requestedProvider,
   }
+}
+
+function normalizeStandaloneRedirect(currentUrl: URL, redirect: string | null): string | null {
+  if (!redirect || !redirect.startsWith('/') || redirect.startsWith('//'))
+    return null
+
+  if (redirect.startsWith('/admin') || redirect.startsWith('/auth'))
+    return `${currentUrl.origin}${redirect}`
+
+  return `${currentUrl.origin}/auth${redirect}`
 }
 
 export async function requestSocialSignInRedirect(params: SocialSignInRedirectParams): Promise<string> {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:web": "pnpm -rF @proj-airi/stage-web run dev",
     "dev:web:https": "pnpm -rF @proj-airi/stage-web run dev:https",
     "dev:server-auth": "pnpm -rF @proj-airi/ui-server-auth run dev",
+    "dev:admin": "pnpm -rF @proj-airi/ui-admin run dev",
     "dev:pocket:ios": "pnpm -rF @proj-airi/stage-pocket run dev:ios",
     "dev:pocket:android": "pnpm -rF @proj-airi/stage-pocket run dev:android",
     "dev:server": "pnpm -rF @proj-airi/server-runtime run dev",

--- a/packages/electron-screen-capture/package.json
+++ b/packages/electron-screen-capture/package.json
@@ -51,6 +51,7 @@
   },
   "inlinedDependencies": {
     "@electron-toolkit/preload": "3.0.2",
+    "@moeru/eventa": "1.0.0-beta.8",
     "async-mutex": "0.5.0",
     "nanoid": [
       "5.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2345,7 +2345,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: 'catalog:'
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: 'catalog:'
         version: 4.0.0(electron@41.2.1)
@@ -2384,7 +2384,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: 'catalog:'
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -2420,10 +2420,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: 'catalog:'
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -2450,7 +2450,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: 'catalog:'
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -2483,7 +2483,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: 'catalog:'
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -2504,31 +2504,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: 'catalog:'
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: 'catalog:'
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: 'catalog:'
-        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: 'catalog:'
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: 'catalog:'
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: 'catalog:'
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: 'catalog:'
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.6(typescript@5.9.3)
@@ -2922,6 +2922,64 @@ importers:
         version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: 'catalog:'
+        version: 3.2.6(typescript@5.9.3)
+
+  apps/ui-admin:
+    dependencies:
+      '@proj-airi/font-chillroundm':
+        specifier: workspace:^
+        version: link:../../packages/font-chillroundm
+      '@proj-airi/stage-shared':
+        specifier: workspace:^
+        version: link:../../packages/stage-shared
+      '@proj-airi/ui':
+        specifier: workspace:^
+        version: link:../../packages/ui
+      '@vueuse/core':
+        specifier: ^14.2.1
+        version: 14.2.1(vue@3.5.32(typescript@5.9.3))
+      nprogress:
+        specifier: ^0.2.0
+        version: 0.2.0
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.32(typescript@5.9.3)
+      vue-router:
+        specifier: ^5.0.4
+        version: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      vue-sonner:
+        specifier: ^2.0.9
+        version: 2.0.9(vue@3.5.32(typescript@5.9.3))
+    devDependencies:
+      '@iconify-json/lucide':
+        specifier: ^1.2.102
+        version: 1.2.102
+      '@types/nprogress':
+        specifier: ^0.2.3
+        version: 0.2.3
+      '@unocss/reset':
+        specifier: ^66.6.8
+        version: 66.6.8
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.6
+        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar':
+        specifier: ^3.1.2
+        version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unocss:
+        specifier: ^66.6.8
+        version: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue-macros:
+        specifier: ^3.1.2
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      vue-tsc:
+        specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
 
   apps/ui-server-auth:
@@ -20851,9 +20909,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -21755,6 +21813,31 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -23773,10 +23856,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -25343,6 +25450,12 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -25423,9 +25536,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:
@@ -25644,6 +25757,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -27786,7 +27908,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -27794,7 +27916,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33822,11 +33944,6 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -33923,6 +34040,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -33954,6 +34079,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -34065,6 +34203,17 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 4.60.1
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -34297,11 +34446,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -34348,6 +34507,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -34379,6 +34553,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -34397,6 +34578,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -34411,6 +34606,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -34423,6 +34633,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -34677,6 +34897,54 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
+  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

Add the first server admin UI for AIRI operations.

This PR introduces a new `@proj-airi/ui-admin` app served from `/admin`, backed by admin-only server APIs under `/api/admin`. The UI gives operators a protected dashboard for checking operational metrics, browsing users, inspecting recent Flux transactions, granting or setting user Flux balances, issuing bulk promo Flux grants, and applying router config changes through the existing admin router config endpoint.

On the server side, this adds admin route wiring for the UI shell and supporting APIs, including authenticated/admin-guarded metrics, user search/detail, per-user Flux adjustments, bulk Flux grant access through the admin service routes, and router config application through `/api/admin/config/router`. The `/admin` UI shell injects server context before serving the SPA so the frontend can resolve the API server URL correctly.

The admin UI is also packaged as an external Docker artifact, matching the existing `ui-server-auth` pattern. Server Docker images now copy both `ui-server-auth` and `ui-admin` artifacts during image builds.

Notable changes:

- Add `apps/ui-admin` with Vue, Vue Router, UnoCSS, and admin API client modules.
- Add admin shell navigation for Overview, Users, Flux, and LLM Router.
- Add overview metrics for users, sessions, Flux, LLM usage, and admin seats.
- Add searchable/sortable/paginated user management with user detail and recent Flux transaction inspection.
- Add per-user Flux grant and balance set actions.
- Add bulk Flux grant UI with dry-run preview and grant result display.
- Add router config editor that calls `/api/admin/config/router` instead of the obsolete `LLM_ROUTER` key.
- Add `/admin` static/UI route handling with server-side bootstrap context injection.
- Add `ui-admin` artifact publishing to the Docker assets workflow.
- Copy `ghcr.io/moeru-ai/airi/ui-admin:latest` into server and Railway Docker images.

## Linked Issues

N/A

## Additional Context

Review focus:

- Admin API permissions and `authGuard`/`adminGuard` coverage.
- Flux adjustment behavior and audit metadata.
- Router config request shape and dry-run/apply flow.
- `/admin` SPA route handling vs static asset serving.
- Docker artifact publishing and `COPY --from` paths.

Validation run:

- `pnpm -F @proj-airi/ui-admin build`
- `pnpm -F @proj-airi/server typecheck`
- `pnpm -F @proj-airi/ui-admin typecheck`
- `pnpm typecheck`
- `docker build -f apps/ui-admin/Dockerfile -t ghcr.io/moeru-ai/airi/ui-admin:latest apps/server/public/ui-admin`
- `docker build -f apps/server/Dockerfile -t airi-server-admin-ui-test .`
