### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-isDHhyxB6xm48p1K9y3Avn22xGp7Fe7y67Mc7lwdc3Q=
+sha256-yLxJY/vGscG3ljgr+wDI0dKrjH5tjfs/8/hsG1cAyTo=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.