### PR TITLE
chore(nix): update assets hash

### DIFF
--- a/nix/assets-hash.txt
+++ b/nix/assets-hash.txt
@@ -1,1 +1,1 @@
-sha256-isDHhyxB6xm48p1K9y3Avn22xGp7Fe7y67Mc7lwdc3Q=
+sha256-69tCpJaxRUnyR9CrHlmWJWEWLDpYzyzska7ui9++QoY=


### PR DESCRIPTION
Auto-generated by CI to keep Nix asset hash up-to-date.