### PR TITLE
fix(stage-tamagotchi): avoid controls panel auto-close on expand

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/auto-collapse.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/auto-collapse.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasMouseMovedSinceExpand, shouldCollapseControlsIsland } from './auto-collapse'
+
+describe('controls island auto collapse helpers', () => {
+  it('does not arm auto collapse until the pointer actually moves', () => {
+    expect(hasMouseMovedSinceExpand({ currentX: 100, currentY: 200, initialX: 100, initialY: 200 })).toBe(false)
+    expect(hasMouseMovedSinceExpand({ currentX: 101, currentY: 200, initialX: 100, initialY: 200 })).toBe(true)
+    expect(hasMouseMovedSinceExpand({ currentX: 100, currentY: 201, initialX: 100, initialY: 200 })).toBe(true)
+  })
+
+  it('only collapses when expanded, armed, outside, and not blocked', () => {
+    expect(shouldCollapseControlsIsland({ expanded: true, autoCollapseArmed: true, isOutside: true, isBlocked: false })).toBe(true)
+    expect(shouldCollapseControlsIsland({ expanded: true, autoCollapseArmed: false, isOutside: true, isBlocked: false })).toBe(false)
+    expect(shouldCollapseControlsIsland({ expanded: true, autoCollapseArmed: true, isOutside: false, isBlocked: false })).toBe(false)
+    expect(shouldCollapseControlsIsland({ expanded: true, autoCollapseArmed: true, isOutside: true, isBlocked: true })).toBe(false)
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/auto-collapse.ts
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/auto-collapse.ts
@@ -1,0 +1,27 @@
+export function hasMouseMovedSinceExpand({
+  currentX,
+  currentY,
+  initialX,
+  initialY,
+}: {
+  currentX: number
+  currentY: number
+  initialX: number
+  initialY: number
+}) {
+  return currentX !== initialX || currentY !== initialY
+}
+
+export function shouldCollapseControlsIsland({
+  expanded,
+  isBlocked,
+  isOutside,
+  autoCollapseArmed,
+}: {
+  expanded: boolean
+  isBlocked: boolean
+  isOutside: boolean
+  autoCollapseArmed: boolean
+}) {
+  return expanded && autoCollapseArmed && isOutside && !isBlocked
+}

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -16,6 +16,8 @@ import ControlsIslandHearingConfig from './controls-island-hearing-config.vue'
 import ControlsIslandProfilePicker from './controls-island-profile-picker.vue'
 import IndicatorMicVolume from './indicator-mic-volume.vue'
 
+import { hasMouseMovedSinceExpand, shouldCollapseControlsIsland } from './auto-collapse'
+
 import {
   electron,
   electronAppQuit,
@@ -61,23 +63,56 @@ defineExpose({
   set hearingDialogOpen(v: boolean) { setOverlay('hearing', v) },
 })
 
-const { isOutside } = useElectronMouseInElement(islandRef)
+const { isOutside, x: mouseX, y: mouseY } = useElectronMouseInElement(islandRef)
+const autoCollapseArmed = ref(false)
+const pointerPositionOnExpand = reactive({ x: 0, y: 0 })
 const isOutsideAfter2seconds = refDebounced(isOutside, 1500)
 
 watch(isOutsideAfter2seconds, (outside) => {
-  if (outside && expanded.value && !isBlocked.value) {
+  if (shouldCollapseControlsIsland({
+    expanded: expanded.value,
+    autoCollapseArmed: autoCollapseArmed.value,
+    isOutside: outside,
+    isBlocked: isBlocked.value,
+  })) {
     expanded.value = false
   }
 })
 
-watch(expanded, (isExpanded) => {
-  if (!isExpanded) {
-    blockingOverlays.clear()
+watch([mouseX, mouseY], ([currentX, currentY]) => {
+  if (!expanded.value || autoCollapseArmed.value) {
+    return
+  }
+
+  if (hasMouseMovedSinceExpand({
+    currentX,
+    currentY,
+    initialX: pointerPositionOnExpand.x,
+    initialY: pointerPositionOnExpand.y,
+  })) {
+    autoCollapseArmed.value = true
   }
 })
 
+watch(expanded, (isExpanded) => {
+  if (isExpanded) {
+    autoCollapseArmed.value = false
+    pointerPositionOnExpand.x = mouseX.value
+    pointerPositionOnExpand.y = mouseY.value
+    return
+  }
+
+  autoCollapseArmed.value = false
+  blockingOverlays.clear()
+})
+
 useIntervalFn(() => {
-  if (expanded.value && isOutside.value && !isBlocked.value) {
+  if (shouldCollapseControlsIsland({
+    expanded: expanded.value,
+    autoCollapseArmed: autoCollapseArmed.value,
+    isOutside: isOutside.value,
+    isBlocked: isBlocked.value,
+  })) {
     expanded.value = false
   }
 }, 1500)

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -16,8 +16,6 @@ import ControlsIslandHearingConfig from './controls-island-hearing-config.vue'
 import ControlsIslandProfilePicker from './controls-island-profile-picker.vue'
 import IndicatorMicVolume from './indicator-mic-volume.vue'
 
-import { hasMouseMovedSinceExpand, shouldCollapseControlsIsland } from './auto-collapse'
-
 import {
   electron,
   electronAppQuit,
@@ -26,6 +24,7 @@ import {
   electronStartDraggingWindow,
   electronWindowSetAlwaysOnTop,
 } from '../../../../shared/eventa'
+import { hasMouseMovedSinceExpand, shouldCollapseControlsIsland } from './auto-collapse'
 
 const { isDark, toggleDark } = useTheme()
 const { t } = useI18n()

--- a/packages/stage-pages/src/pages/settings/providers/index.vue
+++ b/packages/stage-pages/src/pages/settings/providers/index.vue
@@ -52,7 +52,7 @@ const {
   allAudioTranscriptionProvidersMetadata,
 } = storeToRefs(providersStore)
 
-const allArtistryProvidersMetadata = computed<ProviderSourceCard[]>(() => {
+const allArtistryProvidersMetadata = computed<ProviderSourceCard[]>((): ProviderSourceCard[] => {
   return [
     {
       id: 'comfyui',
@@ -103,7 +103,7 @@ const allArtistryProvidersMetadata = computed<ProviderSourceCard[]>(() => {
             deployment: 'cloud',
             iconImage: undefined,
           },
-        ]),
+        ] as ProviderSourceCard[]),
   ]
 })
 


### PR DESCRIPTION
## Summary
- Fixes #1939 by preventing the expanded controls island from auto-collapsing immediately after expansion when the pointer has not actually moved.
- Keeps the existing outside-based auto-collapse behavior once the pointer has moved away from the expansion point.
- Adds a focused unit test for the new auto-collapse arming semantics.

## Testing
- [x] `cd apps/stage-tamagotchi && bun x vitest run src/renderer/components/stage-islands/controls-island/auto-collapse.test.ts --config vitest.config.ts`
- [x] `git diff --check`
