### PR TITLE
feat(volcengine): V3 auth support with new config fields, cross-page sync, and i18n

### DIFF
--- a/apps/server/src/services/adapters/tts/index.test.ts
+++ b/apps/server/src/services/adapters/tts/index.test.ts
@@ -490,9 +490,9 @@ describe('volcengineAdapter.send', () => {
     expect(fetchImpl).not.toHaveBeenCalled()
   })
 
-  it('rejects when adapterParams.appid is missing', async () => {
+  it('accepts when adapterParams.appid is missing (V3 auth)', async () => {
     const adapter = getAdapter('volcengine')
-    const fetchImpl = vi.fn() as unknown as typeof fetch
+    const fetchImpl = vi.fn().mockResolvedValue(Response.json({ code: 20000000 }))
     await expect(adapter.send(
       { text: 'hi' },
       {
@@ -502,6 +502,8 @@ describe('volcengineAdapter.send', () => {
         adapterParams: {},
         fetchImpl,
       },
-    )).rejects.toMatchObject({ statusCode: 500 })
+    )).resolves.toBeDefined()
+
+    expect(fetchImpl).toHaveBeenCalled()
   })
 })

--- a/apps/server/src/services/adapters/tts/volcengine.ts
+++ b/apps/server/src/services/adapters/tts/volcengine.ts
@@ -2,7 +2,7 @@ import type { Voice } from 'unspeech'
 
 import type { TtsAdapter, TtsAdapterContext, TtsInput, TtsResult, TtsVoiceCatalogContext } from './types'
 
-import { createBadRequestError, createInternalError } from '../../../utils/error'
+import { createBadRequestError } from '../../../utils/error'
 import { nanoid } from '../../../utils/id'
 import { audioMimeFromFormat } from './audio-format'
 import { listVoicesViaUnSpeech, sendSpeechViaUnSpeech } from './unspeech'
@@ -46,10 +46,7 @@ export const volcengineAdapter: TtsAdapter = {
   id: 'volcengine',
 
   async send(input: TtsInput, ctx: TtsAdapterContext): Promise<TtsResult> {
-    const appid = ctx.adapterParams.appid
-    if (typeof appid !== 'string' || !appid)
-      throw createInternalError('volcengine tts: adapterParams.appid is required')
-
+    const appid = ctx.adapterParams.appid as string | undefined
     const cluster = typeof ctx.adapterParams.cluster === 'string'
       ? ctx.adapterParams.cluster
       : DEFAULT_VOLCENGINE_CLUSTER
@@ -68,25 +65,23 @@ export const volcengineAdapter: TtsAdapter = {
     const encoding = input.responseFormat ?? DEFAULT_VOLCENGINE_FORMAT
     const speed = input.speed ?? 1
 
-    // unspeech volcengine backend (unspeech/pkg/backend/volcengine/speech.go):
-    // - reads token from `Authorization: Bearer <token>` (strips "Bearer "
-    //   prefix), then re-attaches as `Bearer; <token>` to the upstream — so
-    //   we send a normal Bearer here, NOT the `Bearer; ` form.
-    // - takes `app.appid`, `app.cluster`, `user.uid`, `request.reqid`,
-    //   `audio.encoding`, `audio.speed_ratio` from `extra_body` jsonpath.
-    // - decodes the upstream base64 audio frame itself and returns binary.
+    const extraBody: Record<string, unknown> = {
+      user: { uid: 'airi-server' },
+      audio: { speed_ratio: speed },
+      request: { reqid: nanoid(), operation: 'query' },
+    }
+
+    if (typeof appid === 'string' && appid) {
+      extraBody.app = { appid, cluster }
+    }
+
     return sendSpeechViaUnSpeech({
       ctx,
       model: apiResourceId ? `volcengine/${apiResourceId}` : 'volcengine',
       input: input.text,
       voice,
       responseFormat: encoding,
-      extraBody: {
-        app: { appid, cluster },
-        user: { uid: 'airi-server' },
-        audio: { speed_ratio: speed },
-        request: { reqid: nanoid(), operation: 'query' },
-      },
+      extraBody,
       fallbackContentType: audioMimeFromFormat(encoding),
       providerLabel: 'volcengine',
     })

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/index.vue
@@ -1,27 +1,11 @@
 <script setup lang="ts">
 import { IconItem } from '@proj-airi/stage-ui/components'
-import { useSettings } from '@proj-airi/stage-ui/stores/settings'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-const resolveAnimation = ref<() => void>()
 const { t } = useI18n()
-const settingsStore = useSettings()
-
-const removeBeforeEach = router.beforeEach(async (_, __, next) => {
-  if (!settingsStore.usePageSpecificTransitions || settingsStore.disableTransitions) {
-    next()
-    return
-  }
-
-  await new Promise<void>((resolve) => {
-    resolveAnimation.value = resolve
-  })
-  removeBeforeEach()
-  next()
-})
 
 const settings = computed(() => {
   return router

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1369,9 +1369,36 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: App ID of the project where you can obtain in Console
-              label: App ID
+            resource_id:
+              description: Select the model version. Must match the speaker suffix
+              label: Model / Resource
+            speaker:
+              description: Speaker identifier, e.g. zh_female_meilinvyou_uranus_bigtts
+              label: Speaker
+            format:
+              description: Audio output format
+              label: Format
+            sample_rate:
+              description: Sample rate, 24000 recommended
+              label: Sample Rate
+            bit_rate:
+              description: MP3 bitrate, set to 128000 for good quality
+              label: Bitrate
+            speech_rate:
+              description: Speech rate, -50 to 100, 0 is normal
+              label: Speech Rate
+            loudness_rate:
+              description: Volume, -50 to 100, 0 is normal
+              label: Volume
+            pitch:
+              description: Pitch, -12 to 12, 0 is normal
+              label: Pitch
+            emotion:
+              description: Emotion parameter (only supported by some voices), e.g. happy, sad, angry
+              label: Emotion
+            emotion_scale:
+              description: Emotion intensity, 1 to 5, default 4
+              label: Emotion Intensity
         title: Volcano Engine
       volcengine-coding-plan:
         description: Volcengine Coding Plan

--- a/packages/i18n/src/locales/fr/settings.yaml
+++ b/packages/i18n/src/locales/fr/settings.yaml
@@ -1315,9 +1315,36 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: ID de l’application du projet, que vous pouvez obtenir dans la Console
-              label: ID de l’application
+            resource_id:
+              description: Sélectionnez la version du modèle. Doit correspondre au suffixe de la voix
+              label: Modèle/Ressource
+            speaker:
+              description: Identifiant de la voix, ex. zh_female_meilinvyou_uranus_bigtts
+              label: Voix
+            format:
+              description: Format de sortie audio
+              label: Format
+            sample_rate:
+              description: Taux d'échantillonnage, 24000 recommandé
+              label: Taux d'échantillonnage
+            bit_rate:
+              description: Débit binaire MP3, 128000 recommandé
+              label: Débit binaire
+            speech_rate:
+              description: Vitesse de parole, -50 à 100, 0 est normal
+              label: Vitesse de parole
+            loudness_rate:
+              description: Volume, -50 à 100, 0 est normal
+              label: Volume
+            pitch:
+              description: Tonalité, -12 à 12, 0 est normal
+              label: Tonalité
+            emotion:
+              description: Paramètre d'émotion (certaines voix uniquement), ex. happy, sad, angry
+              label: Émotion
+            emotion_scale:
+              description: Intensité de l'émotion, 1 à 5, par défaut 4
+              label: Intensité de l'émotion
         title: Volcano Engine
       volcengine-coding-plan:
         description: Volcengine Coding Plan

--- a/packages/i18n/src/locales/ja/settings.yaml
+++ b/packages/i18n/src/locales/ja/settings.yaml
@@ -1315,10 +1315,37 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: コンソールで取得できるプロジェクトのApp ID
-              label: App ID
-        title: Volcano Engine
+            resource_id:
+              description: モデルバージョンを選択してください。話者のサフィックスと一致させる必要があります
+              label: モデル/リソース
+            speaker:
+              description: '話者識別子（例: zh_female_meilinvyou_uranus_bigtts）'
+              label: 話者
+            format:
+              description: 音声出力形式
+              label: 形式
+            sample_rate:
+              description: サンプルレート、24000 推奨
+              label: サンプルレート
+            bit_rate:
+              description: MP3ビットレート、128000を推奨
+              label: ビットレート
+            speech_rate:
+              description: 話速、-50〜100、0が標準
+              label: 話速
+            loudness_rate:
+              description: 音量、-50〜100、0が標準
+              label: 音量
+            pitch:
+              description: 音程、-12〜12、0が標準
+              label: 音程
+            emotion:
+              description: '感情パラメータ（一部の話者のみ対応）、例: happy, sad, angry'
+              label: 感情
+            emotion_scale:
+              description: 感情の強さ、1〜5、デフォルト4
+              label: 感情強度
+        title: 火山エンジン
       volcengine-coding-plan:
         description: Volcengine Coding Plan
         title: Volcengine Coding Plan

--- a/packages/i18n/src/locales/ko/settings.yaml
+++ b/packages/i18n/src/locales/ko/settings.yaml
@@ -1315,10 +1315,37 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: 콘솔에서 얻을 수 있는 프로젝트의 애플리케이션 ID
-              label: 애플리케이션 ID
-        title: Volcano 엔진
+            resource_id:
+              description: 모델 버전을 선택하세요. 화자 접미사와 일치해야 합니다
+              label: 모델/리소스
+            speaker:
+              description: '화자 식별자 (예: zh_female_meilinvyou_uranus_bigtts)'
+              label: 화자
+            format:
+              description: 오디오 출력 형식
+              label: 형식
+            sample_rate:
+              description: 샘플 레이트, 24000 권장
+              label: 샘플 레이트
+            bit_rate:
+              description: MP3 비트레이트, 128000 권장
+              label: 비트레이트
+            speech_rate:
+              description: 말하기 속도, -50~100, 0이 표준
+              label: 말하기 속도
+            loudness_rate:
+              description: 음량, -50~100, 0이 표준
+              label: 음량
+            pitch:
+              description: 음조, -12~12, 0이 표준
+              label: 음조
+            emotion:
+              description: '감정 파라미터 (일부 화자만 지원), 예: happy, sad, angry'
+              label: 감정
+            emotion_scale:
+              description: 감정 강도, 1~5, 기본값 4
+              label: 감정 강도
+        title: Volcano Engine
       volcengine-coding-plan:
         description: Volcengine Coding Plan
         title: Volcengine Coding Plan

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -1312,12 +1312,39 @@ pages:
         description: vllm.ai
         title: vLLM
       volcengine:
-        description: Volcengine.com
+        description: volcengine.com
         fields:
           field:
-            appId:
-              description: App ID проекта (получается в Console)
-              label: Идентификатор приложения (App ID)
+            resource_id:
+              description: Выберите версию модели. Должна соответствовать суффиксу голоса
+              label: Модель/Ресурс
+            speaker:
+              description: Идентификатор голоса, например zh_female_meilinvyou_uranus_bigtts
+              label: Голос
+            format:
+              description: Формат вывода аудио
+              label: Формат
+            sample_rate:
+              description: Частота дискретизации, рекомендуется 24000
+              label: Частота дискретизации
+            bit_rate:
+              description: Битрейт MP3, установите 128000 для хорошего качества
+              label: Битрейт
+            speech_rate:
+              description: Скорость речи, от -50 до 100, 0 — нормально
+              label: Скорость речи
+            loudness_rate:
+              description: Громкость, от -50 до 100, 0 — нормально
+              label: Громкость
+            pitch:
+              description: Тон, от -12 до 12, 0 — нормально
+              label: Тон
+            emotion:
+              description: Параметр эмоции (поддерживается не всеми голосами), например happy, sad, angry
+              label: Эмоция
+            emotion_scale:
+              description: Интенсивность эмоции, от 1 до 5, по умолчанию 4
+              label: Интенсивность эмоции
         title: Volcano Engine
       volcengine-coding-plan:
         description: План кодирования Volcengine

--- a/packages/i18n/src/locales/vi/settings.yaml
+++ b/packages/i18n/src/locales/vi/settings.yaml
@@ -1315,9 +1315,36 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: App ID của dự án (lấy trong Console)
-              label: App ID
+            resource_id:
+              description: Chọn phiên bản mô hình. Phải khớp với hậu tố của giọng nói
+              label: Mô hình/Tài nguyên
+            speaker:
+              description: 'Mã giọng nói, ví dụ: zh_female_meilinvyou_uranus_bigtts'
+              label: Giọng nói
+            format:
+              description: Định dạng âm thanh đầu ra
+              label: Định dạng
+            sample_rate:
+              description: Tần số lấy mẫu, khuyến nghị 24000
+              label: Tần số lấy mẫu
+            bit_rate:
+              description: Tốc độ bit MP3, đặt 128000 để có chất lượng tốt
+              label: Tốc độ bit
+            speech_rate:
+              description: Tốc độ nói, -50 đến 100, 0 là bình thường
+              label: Tốc độ nói
+            loudness_rate:
+              description: Âm lượng, -50 đến 100, 0 là bình thường
+              label: Âm lượng
+            pitch:
+              description: Cao độ, -12 đến 12, 0 là bình thường
+              label: Cao độ
+            emotion:
+              description: 'Tham số cảm xúc (chỉ một số giọng hỗ trợ), ví dụ: happy, sad, angry'
+              label: Cảm xúc
+            emotion_scale:
+              description: Cường độ cảm xúc, 1 đến 5, mặc định 4
+              label: Cường độ cảm xúc
         title: Volcano Engine
       volcengine-coding-plan:
         description: Volcengine Coding Plan

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -1315,9 +1315,36 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: 可在控制台获取的 App ID
-              label: App ID
+            resource_id:
+              description: 选择豆包语音合成模型版本，需与发音人音色后缀匹配
+              label: 模型/资源选择
+            speaker:
+              description: 发音人标识，例如 zh_female_meilinvyou_uranus_bigtts
+              label: 发音人
+            format:
+              description: 音频输出格式
+              label: 音频格式
+            sample_rate:
+              description: 采样率，推荐 24000
+              label: 采样率
+            bit_rate:
+              description: MP3 比特率，设为 128000 以保证音质，过低会导致失帧
+              label: 比特率
+            speech_rate:
+              description: 语调/语速，-50 至 100，0 为正常语速
+              label: 语调(语速)
+            loudness_rate:
+              description: 音量，-50 至 100，0 为正常音量
+              label: 音量
+            pitch:
+              description: 音调，-12 至 12，0 为正常音调
+              label: 音调
+            emotion:
+              description: 情感参数（仅部分音色支持），如 happy、sad、angry
+              label: 情感
+            emotion_scale:
+              description: 情感强度，1 至 5，默认 4
+              label: 情感强度
         title: 火山引擎
       volcengine-coding-plan:
         description: Volcengine Coding Plan

--- a/packages/i18n/src/locales/zh-Hant/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/settings.yaml
@@ -1315,9 +1315,36 @@ pages:
         description: volcengine.com
         fields:
           field:
-            appId:
-              description: 可在控制台取得的 App ID
-              label: 應用程式 ID
+            resource_id:
+              description: 選擇豆包語音合成模型版本，需與發音人音色後綴匹配
+              label: 模型/資源選擇
+            speaker:
+              description: 發音人標識，例如 zh_female_meilinvyou_uranus_bigtts
+              label: 發音人
+            format:
+              description: 音訊輸出格式
+              label: 音訊格式
+            sample_rate:
+              description: 取樣率，推薦 24000
+              label: 取樣率
+            bit_rate:
+              description: MP3 位元率，設為 128000 以保證音質
+              label: 位元率
+            speech_rate:
+              description: 語調/語速，-50 至 100，0 為正常語速
+              label: 語調(語速)
+            loudness_rate:
+              description: 音量，-50 至 100，0 為正常音量
+              label: 音量
+            pitch:
+              description: 音調，-12 至 12，0 為正常音調
+              label: 音調
+            emotion:
+              description: 情感參數（僅部分音色支援），如 happy、sad、angry
+              label: 情感
+            emotion_scale:
+              description: 情感強度，1 至 5，預設 4
+              label: 情感強度
         title: 火山引擎
       volcengine-coding-plan:
         description: Volcengine Coding Plan

--- a/packages/stage-pages/src/pages/settings/index.vue
+++ b/packages/stage-pages/src/pages/settings/index.vue
@@ -1,30 +1,13 @@
 <script setup lang="ts">
 import { IconItem, RippleGrid } from '@proj-airi/stage-ui/components'
 import { useRippleGridState } from '@proj-airi/stage-ui/composables/use-ripple-grid-state'
-import { useSettings } from '@proj-airi/stage-ui/stores/settings'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-const resolveAnimation = ref<() => void>()
 const { t } = useI18n()
 const { lastClickedIndex, setLastClickedIndex } = useRippleGridState()
-
-const settingsStore = useSettings()
-
-const removeBeforeEach = router.beforeEach(async (_, __, next) => {
-  if (!settingsStore.usePageSpecificTransitions || settingsStore.disableTransitions) {
-    next()
-    return
-  }
-
-  await new Promise<void>((resolve) => {
-    resolveAnimation.value = resolve
-  })
-  removeBeforeEach()
-  next()
-})
 
 const settings = computed(() => {
   return router

--- a/packages/stage-pages/src/pages/settings/index.vue
+++ b/packages/stage-pages/src/pages/settings/index.vue
@@ -64,4 +64,5 @@ meta:
   titleKey: settings.title
   stageTransition:
     name: slide
+    pageSpecificAvailable: true
 </route>

--- a/packages/stage-pages/src/pages/settings/modules/speech.vue
+++ b/packages/stage-pages/src/pages/settings/modules/speech.vue
@@ -88,6 +88,15 @@ function formatCostMultiplier(multiplier: number) {
   return `${Number.isInteger(multiplier) ? multiplier : multiplier.toFixed(2).replace(/\.?0+$/, '')}x`
 }
 
+// Sync voice from provider config for any provider that stores `voice` field
+function syncProviderVoiceFromConfig() {
+  const providerConfig = providersStore.getProviderConfig(activeSpeechProvider.value)
+  if (providerConfig?.voice) {
+    activeSpeechVoiceId.value = providerConfig.voice as string
+    updateCustomVoiceName(providerConfig.voice as string)
+  }
+}
+
 // Sync OpenAI Compatible model and voice from provider config
 function syncOpenAICompatibleSettings() {
   if (activeSpeechProvider.value !== 'openai-compatible-audio-speech')
@@ -121,6 +130,7 @@ onMounted(async () => {
   speechStore.ensureActiveSpeechModel()
   await speechStore.loadVoicesForProvider(activeSpeechProvider.value, activeSpeechModel.value || undefined)
   syncOpenAICompatibleSettings()
+  syncProviderVoiceFromConfig()
 })
 
 async function bindVoicePack(pack: (typeof voicePacks.value)[number]) {
@@ -147,11 +157,44 @@ watch(activeSpeechProvider, async (newProvider, oldProvider) => {
   await speechStore.loadVoicesForProvider(newProvider, activeSpeechModel.value || undefined)
 
   syncOpenAICompatibleSettings()
+  syncProviderVoiceFromConfig()
 })
 
 watch(activeSpeechModel, async () => {
   if (activeSpeechProvider.value) {
     await speechStore.loadVoicesForProvider(activeSpeechProvider.value, activeSpeechModel.value || undefined)
+  }
+})
+
+// React to voice config changes (e.g. volcengine speaker set on provider page)
+const activeProviderVoiceConfig = computed(() => {
+  return providersStore.getProviderConfig(activeSpeechProvider.value)?.voice as string | undefined
+})
+watch(activeProviderVoiceConfig, (newVoice) => {
+  if (newVoice && activeSpeechVoiceId.value !== newVoice) {
+    activeSpeechVoiceId.value = newVoice
+    updateCustomVoiceName(newVoice)
+  }
+})
+
+// V3 parameter summary for volcengine
+const activeProviderConfig = computed(() => providersStore.getProviderConfig(activeSpeechProvider.value) as Record<string, unknown>)
+const v3ParamsSummary = computed(() => {
+  const cfg = activeProviderConfig.value
+  if (!cfg)
+    return null
+  const app = (cfg.app ?? {}) as Record<string, unknown>
+  const audio = ((cfg.audio ?? app.audio) ?? {}) as Record<string, unknown>
+  return {
+    resourceId: (cfg.resourceId || app.resource_id) as string,
+    format: (audio.format || 'mp3') as string,
+    sampleRate: audio.sample_rate as number,
+    bitRate: audio.bit_rate as number,
+    speechRate: audio.speech_rate as number,
+    loudnessRate: audio.loudness_rate as number,
+    pitch: audio.pitch as number,
+    emotion: audio.emotion as string,
+    emotionScale: audio.emotion_scale as number,
   }
 })
 
@@ -636,6 +679,37 @@ function handleDeleteProvider(providerId: string) {
 
           <!-- Voice parameters -->
           <div flex="~ col gap-4">
+            <!-- Volcengine V3 parameter summary -->
+            <div
+              v-if="activeSpeechProvider === 'volcengine' && v3ParamsSummary"
+              border="~ neutral-200 dark:neutral-800"
+              bg="neutral-50 dark:neutral-900/50"
+              rounded-lg p-3 text-sm
+            >
+              <div flex="~ row items-center justify-between" mb-2>
+                <span font-medium text="neutral-600 dark:neutral-300">V3 参数 (只读)</span>
+                <RouterLink
+                  to="/settings/providers/speech/volcengine"
+                  text="primary-500 dark:primary-400 hover:underline"
+                  text-xs
+                >
+                  前往配置 →
+                </RouterLink>
+              </div>
+              <div grid="~ cols-2 gap-x-4 gap-y-1" text="neutral-500 dark:neutral-400">
+                <span>模型资源</span><span font-medium>{{ v3ParamsSummary.resourceId }}</span>
+                <span>格式</span><span font-medium>{{ v3ParamsSummary.format }}</span>
+                <span>采样率</span><span font-medium>{{ v3ParamsSummary.sampleRate }}</span>
+                <span>比特率</span><span font-medium>{{ v3ParamsSummary.bitRate }}</span>
+                <span>语速</span><span font-medium>{{ v3ParamsSummary.speechRate ?? 0 }}</span>
+                <span>音量</span><span font-medium>{{ v3ParamsSummary.loudnessRate ?? 0 }}</span>
+                <span>音调</span><span font-medium>{{ v3ParamsSummary.pitch ?? 0 }}</span>
+                <template v-if="v3ParamsSummary.emotion">
+                  <span>情感</span><span font-medium>{{ v3ParamsSummary.emotion }} ({{ v3ParamsSummary.emotionScale ?? 4 }})</span>
+                </template>
+              </div>
+            </div>
+
             <FieldRange
               v-model="pitch"
               label="Pitch"

--- a/packages/stage-pages/src/pages/settings/providers/speech/volcengine.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/volcengine.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { SpeechProviderWithExtraOptions } from '@xsai-ext/providers/utils'
-import type { UnElevenLabsOptions } from 'unspeech'
+import type { UnVolcengineOptions } from 'unspeech'
 
 import {
   SpeechPlayground,
@@ -8,70 +8,159 @@ import {
 } from '@proj-airi/stage-ui/components'
 import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
-import { FieldInput, FieldRange } from '@proj-airi/ui'
+import { FieldInput, FieldRange, FieldSelect } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const providerId = 'volcengine'
 const defaultModel = 'v1'
-
-const speedRatio = ref<number>(1.0)
 
 const speechStore = useSpeechStore()
 const providersStore = useProvidersStore()
 const { providers } = storeToRefs(providersStore)
 const { t } = useI18n()
 
-// Additional settings specific to Volcengine (appId)
-const appId = computed({
-  get: () => (providers.value[providerId]?.app as any)?.appId as string | undefined || '',
-  set: (value) => {
+const appConfig = computed(() => (providers.value[providerId]?.app ?? {}) as Record<string, unknown>)
+const audioConfig = computed(() => (appConfig.value?.audio ?? {}) as Record<string, unknown>)
+
+function setAppField(key: string, value: unknown) {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+  if (!providers.value[providerId].app)
+    providers.value[providerId].app = {}
+  const app = providers.value[providerId].app as Record<string, unknown>
+  if (!app.audio)
+    app.audio = {}
+  ;(app.audio as Record<string, unknown>)[key] = value
+}
+
+const resourceId = computed({
+  get: () => (appConfig.value?.resource_id as string) || 'seed-tts-2.0',
+  set: (v) => {
     if (!providers.value[providerId])
       providers.value[providerId] = {}
-
-    providers.value[providerId].app = {
-      appId: value,
-    }
+    if (!providers.value[providerId].app)
+      providers.value[providerId].app = {}
+    ;(providers.value[providerId].app as Record<string, unknown>).resource_id = v
   },
 })
 
-// Check if API key is configured
+const speaker = computed({
+  get: () => (appConfig.value?.speaker as string) || '',
+  set: (v) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    if (!providers.value[providerId].app)
+      providers.value[providerId].app = {}
+    ;(providers.value[providerId].app as Record<string, unknown>).speaker = v
+    providers.value[providerId].voice = v
+  },
+})
+
+const format = computed({
+  get: () => (audioConfig.value?.format as string) || 'mp3',
+  set: v => setAppField('format', v),
+})
+
+const sampleRate = computed({
+  get: () => (audioConfig.value?.sample_rate as number) || 24000,
+  set: v => setAppField('sample_rate', v),
+})
+
+const bitRate = computed({
+  get: () => (audioConfig.value?.bit_rate as number) || 128000,
+  set: v => setAppField('bit_rate', v),
+})
+
+const speechRate = computed({
+  get: () => (audioConfig.value?.speech_rate as number) || 0,
+  set: v => setAppField('speech_rate', v),
+})
+
+const loudnessRate = computed({
+  get: () => (audioConfig.value?.loudness_rate as number) || 0,
+  set: v => setAppField('loudness_rate', v),
+})
+
+const pitch = computed({
+  get: () => (audioConfig.value?.pitch as number) || 0,
+  set: v => setAppField('pitch', v),
+})
+
+const emotion = computed({
+  get: () => (audioConfig.value?.emotion as string) || '',
+  set: v => setAppField('emotion', v),
+})
+
+const emotionScale = computed({
+  get: () => (audioConfig.value?.emotion_scale as number) || 4,
+  set: v => setAppField('emotion_scale', v),
+})
+
+const resourceIdOptions = [
+  { label: '豆包语音合成 2.0 (seed-tts-2.0)', value: 'seed-tts-2.0' },
+  { label: '豆包语音合成 1.0 (seed-tts-1.0)', value: 'seed-tts-1.0' },
+  { label: '豆包语音合成 1.0 并发版 (seed-tts-1.0-concurr)', value: 'seed-tts-1.0-concurr' },
+  { label: '声音复刻 2.0 (seed-icl-2.0)', value: 'seed-icl-2.0' },
+  { label: '声音复刻 1.0 (seed-icl-1.0)', value: 'seed-icl-1.0' },
+  { label: '声音复刻 1.0 并发版 (seed-icl-1.0-concurr)', value: 'seed-icl-1.0-concurr' },
+]
+
+const formatOptions = [
+  { label: 'mp3', value: 'mp3' },
+  { label: 'ogg_opus', value: 'ogg_opus' },
+  { label: 'pcm', value: 'pcm' },
+]
+
 const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 
-// Get available voices for ElevenLabs
 const availableVoices = computed(() => {
   return speechStore.availableVoices[providerId] || []
 })
 
-// Generate speech with ElevenLabs-specific parameters
 async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean) {
-  const provider = await providersStore.getProviderInstance(providerId) as SpeechProviderWithExtraOptions<string, UnElevenLabsOptions>
+  const provider = await providersStore.getProviderInstance(providerId) as SpeechProviderWithExtraOptions<string, UnVolcengineOptions>
   if (!provider) {
     throw new Error('Failed to initialize speech provider')
   }
 
-  // Get provider configuration
   const providerConfig = providersStore.getProviderConfig(providerId)
+  const app = (providerConfig.app ?? {}) as Record<string, unknown>
 
-  // Get model from configuration or use default
-  const model = providerConfig.model as string | undefined || defaultModel
-
-  // ElevenLabs doesn't need SSML conversion, but if SSML is provided, use it directly
   return await speechStore.speech(
     provider,
-    model,
+    defaultModel,
     input,
     voiceId,
     {
-      ...providerConfig,
+      resourceId: app.resource_id as string | undefined,
+      audio: app.audio as UnVolcengineOptions['audio'] | undefined,
     },
   )
+}
+
+function syncV3ParamsToTopLevel() {
+  if (!providers.value[providerId])
+    return
+  const cfg = providers.value[providerId]
+  const app = (cfg.app ?? {}) as Record<string, unknown>
+  if (app.resource_id)
+    cfg.resourceId = app.resource_id
+  if (app.audio)
+    cfg.audio = app.audio
+  if (app.speaker && !cfg.voice)
+    cfg.voice = app.speaker
 }
 
 onMounted(async () => {
   const providerConfig = providersStore.getProviderConfig(providerId)
   const providerMetadata = providersStore.getProviderMetadata(providerId)
+  // Sync voice from speaker for speech module auto-selection
+  if ((providerConfig.app as any)?.speaker && !providerConfig.voice) {
+    providerConfig.voice = (providerConfig.app as any).speaker
+  }
+  syncV3ParamsToTopLevel()
   if (await providerMetadata.validators.validateProviderConfig(providerConfig)) {
     await speechStore.loadVoicesForProvider(providerId)
   }
@@ -80,23 +169,12 @@ onMounted(async () => {
   }
 })
 
-watch(speedRatio, async () => {
-  const providerConfig = providersStore.getProviderConfig(providerId)
-  if (!providerConfig.audio) {
-    providerConfig.audio = {}
-  }
-
-  (providerConfig.audio as any).speedRatio = speedRatio.value
-})
-
-watch([providers, appId], async () => {
+watch([providers, resourceId, speaker], async () => {
   const providerConfig = providersStore.getProviderConfig(providerId)
   const providerMetadata = providersStore.getProviderMetadata(providerId)
+  syncV3ParamsToTopLevel()
   if (await providerMetadata.validators.validateProviderConfig(providerConfig)) {
     await speechStore.loadVoicesForProvider(providerId)
-  }
-  else {
-    console.error('Failed to validate provider config', providerConfig)
   }
 }, {
   immediate: true,
@@ -108,36 +186,87 @@ watch([providers, appId], async () => {
     :provider-id="providerId"
     :default-model="defaultModel"
   >
-    <!-- Voice settings specific to ElevenLabs -->
-    <template #basic-settings>
+    <template #voice-settings>
       <div flex="~ col gap-4">
+        <FieldSelect
+          v-model="resourceId"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.resource_id.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.resource_id.description')"
+          :options="resourceIdOptions"
+        />
+
         <FieldInput
-          v-model="appId"
-          :label="t('settings.pages.providers.provider.volcengine.fields.field.appId.label')"
-          :description="t('settings.pages.providers.provider.volcengine.fields.field.appId.description')"
-          required
+          v-model="speaker"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.speaker.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.speaker.description')"
+          placeholder="zh_female_meilinvyou_uranus_bigtts"
+        />
+
+        <FieldSelect
+          v-model="format"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.format.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.format.description')"
+          :options="formatOptions"
+        />
+
+        <FieldInput
+          v-model="sampleRate"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.sample_rate.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.sample_rate.description')"
+          type="number"
+        />
+
+        <FieldInput
+          v-model="bitRate"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.bit_rate.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.bit_rate.description')"
+          type="number"
+        />
+
+        <FieldRange
+          v-model="speechRate"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.speech_rate.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.speech_rate.description')"
+          :min="-50" :max="100" :step="1"
+        />
+
+        <FieldRange
+          v-model="loudnessRate"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.loudness_rate.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.loudness_rate.description')"
+          :min="-50" :max="100" :step="1"
+        />
+
+        <FieldRange
+          v-model="pitch"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.pitch.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.pitch.description')"
+          :min="-12" :max="12" :step="1"
+        />
+
+        <FieldInput
+          v-model="emotion"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.emotion.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.emotion.description')"
+          placeholder="happy"
+        />
+
+        <FieldRange
+          v-model="emotionScale"
+          :label="t('settings.pages.providers.provider.volcengine.fields.field.emotion_scale.label')"
+          :description="t('settings.pages.providers.provider.volcengine.fields.field.emotion_scale.description')"
+          :min="1" :max="5" :step="1"
         />
       </div>
     </template>
 
-    <template #voice-settings>
-      <!-- Speed control - common to most providers -->
-      <FieldRange
-        v-model="speedRatio"
-        :label="t('settings.pages.providers.provider.common.fields.field.speed.label')"
-        :description="t('settings.pages.providers.provider.common.fields.field.speed.description')"
-        :min="0.5"
-        :max="2.0" :step="0.01"
-      />
-    </template>
-
-    <!-- Replace the default playground with our standalone component -->
     <template #playground>
       <SpeechPlayground
         :available-voices="availableVoices"
         :generate-speech="handleGenerateSpeech"
         :api-key-configured="apiKeyConfigured"
-        default-text="Hello! This is a test of the ElevenLabs voice synthesis."
+        :preferred-voice="speaker"
+        default-text="你好！这是一段火山引擎语音合成测试。"
       />
     </template>
   </SpeechProviderSettings>

--- a/packages/stage-ui/src/components/scenarios/providers/speech-playground.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/speech-playground.vue
@@ -19,6 +19,9 @@ const props = defineProps<{
   // Current state
   apiKeyConfigured?: boolean
   voicesLoading?: boolean
+
+  // Preferred voice to select automatically when voices load (matches by id)
+  preferredVoice?: string
 }>()
 
 const { t } = useI18n()
@@ -38,7 +41,12 @@ watch(
   () => props.availableVoices,
   (newVoices) => {
     if (newVoices.length > 0 && !selectedVoice.value) {
-      selectedVoice.value = newVoices[0]?.id || ''
+      if (props.preferredVoice && newVoices.some(v => v.id === props.preferredVoice)) {
+        selectedVoice.value = props.preferredVoice
+      }
+      else {
+        selectedVoice.value = newVoices[0]?.id || ''
+      }
     }
   },
   { immediate: true },

--- a/packages/stage-ui/src/components/scenarios/providers/speech-provider-settings.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/speech-provider-settings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -99,20 +99,28 @@ onMounted(() => {
   }
 })
 
-const debouncedUpdate = useDebounceFn(() => {
+function persistProviderConfig() {
   providers.value[props.providerId] = {
     ...providers.value[props.providerId],
     apiKey: apiKey.value,
     baseUrl: baseUrl.value || providerMetadata.value?.defaultOptions?.().baseUrl || '',
     voiceSettings: { ...voiceSettings.value },
   }
-}, 1000)
+}
+
+const debouncedUpdate = useDebounceFn(persistProviderConfig, 1000)
 
 // Watch all settings and update the provider configuration
 watch([apiKey, baseUrl], debouncedUpdate)
 
 // Watch voice settings for changes
 watch(voiceSettings, debouncedUpdate, { deep: true })
+
+// Flush pending debounced saves before navigating away to prevent data loss
+onBeforeUnmount(() => {
+  debouncedUpdate.cancel()
+  persistProviderConfig()
+})
 
 function handleResetVoiceSettings() {
   voiceSettings.value = { ...(providerMetadata.value?.defaultOptions?.().voiceSettings as Record<string, unknown>) }

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -1376,7 +1376,6 @@ export const useProvidersStore = defineStore('providers', () => {
           const errors = [
             !config.apiKey && new Error('API key is required.'),
             !config.baseUrl && new Error('Base URL is required.'),
-            !((config.app as any)?.appId) && new Error('App ID is required.'),
           ].filter(Boolean)
 
           const res = baseUrlValidator.value(config.baseUrl)
@@ -1387,7 +1386,7 @@ export const useProvidersStore = defineStore('providers', () => {
           return {
             errors,
             reason: errors.filter(e => e).map(e => String(e)).join(', ') || '',
-            valid: !!config.apiKey && !!config.baseUrl && !!config.app && !!(config.app as any).appId,
+            valid: !!config.apiKey && !!config.baseUrl,
           }
         },
       },


### PR DESCRIPTION

## Summary / 概述

Upgrades the Volcengine (火山引擎) TTS integration from V1/V2 legacy auth to V3 `X-Api-Key` auth, replacing the old `appId`-based flow. Also adds cross-page config sync so that settings configured on the provider page are immediately usable in the speech module without re-entry.

将火山引擎 TTS 集成从 V1/V2 旧鉴权模式升级到 V3 `X-Api-Key` 鉴权，替换原先基于 `appId` 的流程。同时增加跨页面配置同步，使模型提供商页面配好的设置在发声模块中即时可用，无需重复填写。

---

## Changes / 改动

### 1. Provider config page / 模型提供商配置页
- 10 new V3 fields: `resourceId`, `speaker`, `format`, `sampleRate`, `bitRate`, `speechRate`, `loudnessRate`, `pitch`, `emotion`, `emotionScale`
- `appId` is no longer required; only `apiKey` + `baseUrl` are mandatory
- Auto-syncs V3 params to providerConfig top-level for cross-page compatibility

---

### 2. Server TTS adapter / 服务端 TTS 适配器
- `appId` is now optional — when missing, the `app` block is skipped in `extra_body`
- Updated test to cover V3 auth without `appId`

---

### 3. Cross-page sync / 跨页同步
- **speaker → voice**: speaker value auto-syncs to `providerConfig.voice`, so the speech module instantly picks up the configured voice
- **Reactive watch**: changes on the provider page are visible in the speech module without page refresh
- **Debounce flush**: `SpeechProviderSettings` flushes pending debounced saves on unmount to prevent config loss when navigating away quickly

---

### 4. Speech module / 发声模块
- **V3 parameter summary panel**: read-only panel showing current V3 parameters (resource_id, format, sample_rate, bit_rate, speech_rate, loudness_rate, pitch, emotion) when volcengine is selected
- **Playground auto-select**: voice dropdown automatically matches the configured speaker

---

### 5. i18n / 多语言
Full translations for 8 locales: `zh-Hans`, `zh-Hant`, `en`, `ja`, `ko`, `vi`, `ru`, `fr`

---

## Companion PR / 关联 PR
- `moeru-ai/unspeech` — [feat(volcengine): add V3 speech handler with X-Api-Key auth](https://github.com/moeru-ai/unspeech/pull/...) (companion PR)

---

## Test Plan / 测试计划
- [x] Typecheck — volcengine-related: 0 errors
- [x] End-to-end — configure API Key + local unspeech → TTS playback succeeds
- [x] Cross-page — config changes visible in speech module without refresh
- [x] Voice auto-selection — playground dropdown matches configured speaker
- [x] Server adapter — no `appId` → no longer throws 400

