### PR TITLE
fix(stage-pages): restore speech none option

### DIFF
--- a/packages/stage-pages/src/pages/settings/modules/speech.vue
+++ b/packages/stage-pages/src/pages/settings/modules/speech.vue
@@ -35,7 +35,7 @@ const providersStore = useProvidersStore()
 const speechStore = useSpeechStore()
 const airiCardStore = useAiriCardStore()
 const voicePacksStore = useVoicePacksStore()
-const { configuredSpeechProvidersMetadata } = storeToRefs(providersStore)
+const { allAudioSpeechProvidersMetadata, configuredSpeechProvidersMetadata } = storeToRefs(providersStore)
 const { activeCard } = storeToRefs(airiCardStore)
 const { packs: voicePacks, loading: isLoadingVoicePacks, error: voicePacksError } = storeToRefs(voicePacksStore)
 const {
@@ -71,6 +71,13 @@ const shouldShowVoicePackSection = computed(() =>
   supportsVoicePackSelection.value
   && (isLoadingVoicePacks.value || voicePacksError.value != null || voicePacks.value.length > 0),
 )
+
+const selectableSpeechProvidersMetadata = computed(() => {
+  return [
+    ...configuredSpeechProvidersMetadata.value.filter(metadata => metadata.id !== 'speech-noop'),
+    ...allAudioSpeechProvidersMetadata.value.filter(metadata => metadata.id === 'speech-noop'),
+  ]
+})
 
 function createVoicePackVoice(voicePack: VoicePackSnapshot): VoiceInfo {
   return {
@@ -386,11 +393,11 @@ function handleDeleteProvider(providerId: string) {
         </div>
         <div max-w-full>
           <fieldset
-            v-if="configuredSpeechProvidersMetadata.length > 0" flex="~ row gap-4"
+            v-if="selectableSpeechProvidersMetadata.length > 0" flex="~ row gap-4"
             min-w-0 of-x-auto scroll-smooth role="radiogroup"
           >
             <RadioCardSimple
-              v-for="metadata in configuredSpeechProvidersMetadata"
+              v-for="metadata in selectableSpeechProvidersMetadata"
               :id="metadata.id"
               :key="metadata.id"
               v-model="activeSpeechProvider"

--- a/packages/stage-pages/src/pages/settings/providers/index.vue
+++ b/packages/stage-pages/src/pages/settings/providers/index.vue
@@ -165,6 +165,8 @@ const providerBlocks = computed(() => {
     .map((block) => {
       const filteredProviders = block.providersRef.value
         .filter((p) => {
+          if (p.id === 'speech-noop')
+            return false
           if (filterPricing.value !== 'all' && p.pricing !== filterPricing.value)
             return false
           if (filterDeployment.value !== 'all' && p.deployment !== filterDeployment.value)


### PR DESCRIPTION
## Summary

- Restore the speech module "None" option.
- Hide `speech-noop` from the provider configuration page.

## Context

[#1899](https://github.com/moeru-ai/airi/pull/1899) limited validation to listed providers. `speech-noop` is a built-in "disable speech" option, so clean profiles stopped showing "None" in the speech module.

This PR keeps that validation behavior and only restores the UI option.