### PR TITLE
feat(mcp): progressive tool disclosure — awareness catalog + on-use native promotion

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/settings/modules/mcp.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/modules/mcp.vue
@@ -267,6 +267,9 @@ async function restartServers() {
   try {
     const result = await invokeApplyAndRestart()
     await refreshRuntime()
+    // Re-derive the live MCP toolset so the awareness catalog and native tools reflect the new
+    // server set; otherwise added/removed server tools stay stale until an app reload.
+    await mcpToolsStore.refresh()
     infoMessage.value = tn('messages.restarted', {
       started: result.started.length,
       failed: result.failed.length,

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/modules/mcp.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/modules/mcp.vue
@@ -14,6 +14,7 @@ import {
   Checkbox,
   TransitionVertical,
 } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -30,6 +31,7 @@ import {
   electronMcpWriteConfigText,
 } from '../../../../shared/eventa'
 import { parseElectronMcpConfigText } from '../../../../shared/mcp-config'
+import { useTamagotchiMcpToolsStore } from '../../../stores/mcp-tools'
 import {
   buildConfigFile,
   buildServerConfig,
@@ -42,6 +44,11 @@ import {
 
 const { t } = useI18n()
 const tn = (key: string, params?: Record<string, unknown>) => t(`settings.pages.modules.mcp-server.${key}`, params ?? {})
+
+// Tools the model has used are promoted to directly-callable native tools (persisted). Surface them
+// here so the user can see what's active and demote any back to the cold catalog.
+const mcpToolsStore = useTamagotchiMcpToolsStore()
+const { activatedRefs } = storeToRefs(mcpToolsStore)
 
 const invokeOpenConfigFile = useElectronEventaInvoke(electronMcpOpenConfigFile)
 const invokeApplyAndRestart = useElectronEventaInvoke(electronMcpApplyAndRestart)
@@ -512,6 +519,42 @@ onMounted(async () => {
           </div>
         </li>
       </ul>
+    </section>
+
+    <section :class="PANEL">
+      <div class="flex items-center justify-between gap-2">
+        <h3 class="text-sm font-semibold">
+          {{ tn('activated.title') }}
+        </h3>
+        <span class="rounded-full bg-neutral-200/60 px-2 py-0.5 text-xs text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+          {{ activatedRefs.length }}
+        </span>
+      </div>
+      <p class="text-xs text-neutral-500 dark:text-neutral-400">
+        {{ tn('activated.description') }}
+      </p>
+
+      <div v-if="!activatedRefs.length" class="border-2 border-neutral-200 rounded-lg border-dashed p-6 text-center text-xs text-neutral-500 dark:border-neutral-800">
+        {{ tn('activated.empty') }}
+      </div>
+      <template v-else>
+        <ul class="flex flex-col gap-2">
+          <li v-for="entry in activatedRefs" :key="entry" :class="CARD_MUTED">
+            <div class="flex items-center justify-between gap-3">
+              <span class="min-w-0 flex-1 truncate text-xs font-mono">{{ entry }}</span>
+              <Button
+                variant="secondary" size="sm"
+                icon="i-solar:close-circle-line-duotone"
+                :label="tn('activated.deactivate')"
+                @click="mcpToolsStore.deactivate(entry)"
+              />
+            </div>
+          </li>
+        </ul>
+        <div class="flex justify-end">
+          <Button variant="secondary" size="sm" :label="tn('activated.deactivate-all')" @click="mcpToolsStore.deactivateAll()" />
+        </div>
+      </template>
     </section>
   </div>
 </template>

--- a/apps/stage-tamagotchi/src/renderer/stores/mcp-tools.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/mcp-tools.test.ts
@@ -1,6 +1,7 @@
 import type { Tool } from '@xsai/shared-chat'
 
 import { useLlmToolsStore } from '@proj-airi/stage-ui/stores/llm-tools'
+import { useLlmToolsetPromptsStore } from '@proj-airi/stage-ui/stores/llm-toolset-prompts'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -39,57 +40,58 @@ describe('useTamagotchiMcpToolsStore', async () => {
     setActivePinia(createPinia())
     invokeMocks.listMcpTools.mockClear()
     invokeMocks.callMcpTool.mockClear()
+    globalThis.localStorage?.clear?.()
   })
 
   /**
    * @example
    * await store.refresh()
-   * expect(llmToolsStore.toolsByProvider.mcp).toHaveLength(2)
+   * expect(promptsStore.activeToolsetPrompt).toContain('filesystem::search')
    */
-  it('loads MCP tools, proxies execution, and clears them from the shared llm-tools store', async () => {
+  it('advertises cold tools in the catalog, proxies execution, promotes a used tool to native, and clears on dispose', async () => {
     const llmToolsStore = useLlmToolsStore()
+    const promptsStore = useLlmToolsetPromptsStore()
     const store = useTamagotchiMcpToolsStore()
+    store.activatedRefs = []
     const toolOptions = {} as Parameters<Tool['execute']>[1]
 
     await store.refresh()
 
-    const mcpTools = llmToolsStore.toolsByProvider.mcp
-    const listTools = mcpTools?.find(tool => tool.function.name === 'builtIn_mcpListTools')
-    const callTool = mcpTools?.find(tool => tool.function.name === 'builtIn_mcpCallTool')
-
-    expect(mcpTools).toEqual([
-      expect.objectContaining({ function: expect.objectContaining({ name: 'builtIn_mcpListTools' }) }),
-      expect.objectContaining({ function: expect.objectContaining({ name: 'builtIn_mcpCallTool' }) }),
+    // Cold start: only the two meta-tools are registered; the cold tool lives in the awareness catalog.
+    expect(llmToolsStore.toolsByProvider.mcp?.map(tool => tool.function.name)).toEqual([
+      'builtIn_mcpListTools',
+      'builtIn_mcpCallTool',
     ])
+    expect(promptsStore.activeToolsetPrompt).toContain('filesystem::search')
 
-    const listResult = await listTools?.execute({}, toolOptions)
+    // Using the tool proxies through the bridge with parsed args...
+    const callTool = llmToolsStore.toolsByProvider.mcp?.find(tool => tool.function.name === 'builtIn_mcpCallTool')
     const callResult = await callTool?.execute({
       name: 'filesystem::search',
       arguments: JSON.stringify({ query: 'hello', limit: 10 }),
     }, toolOptions)
 
-    expect(invokeMocks.listMcpTools).toHaveBeenCalledTimes(1)
     expect(invokeMocks.callMcpTool).toHaveBeenCalledWith({
       name: 'filesystem::search',
       arguments: { query: 'hello', limit: 10 },
     })
-    expect(listResult).toEqual([{
-      serverName: 'filesystem',
-      name: 'filesystem::search',
-      toolName: 'search',
-      description: 'Search files.',
-      inputSchema: {
-        type: 'object',
-        properties: {},
-      },
-    }])
-    expect(callResult).toEqual({
-      content: [{ type: 'text', text: 'ok' }],
-      isError: false,
-    })
+    expect(callResult).toEqual({ content: [{ type: 'text', text: 'ok' }], isError: false })
+
+    // ...and activates it: from the next refresh it is a native first-class tool, gone from the catalog.
+    expect(store.activatedRefs).toContain('filesystem::search')
+    await store.refresh()
+    expect(llmToolsStore.toolsByProvider.mcp?.map(tool => tool.function.name)).toContain('mcp__filesystem__search')
+    expect(promptsStore.activeToolsetPrompt).not.toContain('filesystem::search')
+
+    // Manual deactivation demotes it back to the catalog (native registration dropped).
+    store.deactivate('filesystem::search')
+    expect(store.activatedRefs).not.toContain('filesystem::search')
+    await store.refresh()
+    expect(llmToolsStore.toolsByProvider.mcp?.map(tool => tool.function.name)).not.toContain('mcp__filesystem__search')
+    expect(promptsStore.activeToolsetPrompt).toContain('filesystem::search')
 
     store.dispose()
-
     expect(llmToolsStore.toolsByProvider.mcp).toBeUndefined()
+    expect(promptsStore.activeToolsetPrompt).toBe('')
   })
 })

--- a/apps/stage-tamagotchi/src/renderer/stores/mcp-tools.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/mcp-tools.ts
@@ -1,12 +1,20 @@
+import type { McpToolRuntime } from '@proj-airi/stage-ui/tools/mcp'
+
 import { useElectronEventaInvoke } from '@proj-airi/electron-vueuse'
 import { useLlmToolsStore } from '@proj-airi/stage-ui/stores/llm-tools'
-import { createMcpTools } from '@proj-airi/stage-ui/tools/mcp'
+import { useLlmToolsetPromptsStore } from '@proj-airi/stage-ui/stores/llm-toolset-prompts'
+import { createMcpToolset } from '@proj-airi/stage-ui/tools/mcp'
+import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
+import { watch } from 'vue'
 
 import { electronMcpCallTool, electronMcpListTools } from '../../shared/eventa'
 
 /**
- * Registers Electron-backed MCP tools into the shared LLM tools store.
+ * Registers Electron-backed MCP tools into the shared LLM runtime with progressive disclosure:
+ * every tool is advertised in an always-in-context awareness catalog, and a tool the model actually
+ * uses is promoted to a native first-class tool whose ref is persisted, so it stays native across
+ * restarts. See docs/superpowers/specs/2026-06-14-mcp-progressive-tool-registration-design.md.
  *
  * Use when:
  * - The Tamagotchi renderer needs live MCP tools during chat streaming
@@ -19,21 +27,61 @@ import { electronMcpCallTool, electronMcpListTools } from '../../shared/eventa'
  */
 export const useTamagotchiMcpToolsStore = defineStore('tamagotchi-mcp-tools', () => {
   const llmToolsStore = useLlmToolsStore()
+  const toolsetPromptsStore = useLlmToolsetPromptsStore()
   const listMcpTools = useElectronEventaInvoke(electronMcpListTools)
   const callMcpTool = useElectronEventaInvoke(electronMcpCallTool)
 
-  async function refresh() {
-    return llmToolsStore.registerTools('mcp', Promise.all(createMcpTools({
-      listTools: () => listMcpTools(),
-      callTool: payload => callMcpTool(payload),
-    })))
+  // Persisted MCP tool refs ("<server>::<tool>") promoted to native first-class tools. A tool the
+  // model uses joins this set, so from the next refresh it is callable natively (progressive
+  // disclosure); the rest stay one-liners in the awareness catalog.
+  const activatedRefs = useLocalStorage<string[]>('settings/mcp/activated-tools', [])
+
+  const runtime: McpToolRuntime = {
+    listTools: () => listMcpTools(),
+    callTool: payload => callMcpTool(payload),
   }
+
+  function markToolActivated(ref: string) {
+    if (!activatedRefs.value.includes(ref))
+      activatedRefs.value = [...activatedRefs.value, ref]
+  }
+
+  /** Send an activated tool back to the cold catalog (drops its native registration). */
+  function deactivate(ref: string) {
+    activatedRefs.value = activatedRefs.value.filter(entry => entry !== ref)
+  }
+
+  /** Demote every activated tool back to the catalog. */
+  function deactivateAll() {
+    activatedRefs.value = []
+  }
+
+  async function refresh() {
+    const { tools, catalog } = await createMcpToolset(runtime, {
+      activatedRefs: new Set(activatedRefs.value),
+      onToolInvoked: markToolActivated,
+    })
+    await llmToolsStore.registerTools('mcp', tools)
+    toolsetPromptsStore.registerToolsetPrompts(
+      'mcp',
+      catalog ? [{ id: 'mcp-catalog', title: 'MCP tools', content: catalog }] : [],
+    )
+  }
+
+  // Any change to the activated set re-derives the live toolset: a tool the model just used becomes
+  // native from the next turn, and a manual (de)activation from the settings window — synced here via
+  // localStorage — takes effect the same way. Startup is driven by an explicit refresh() from the host.
+  watch(activatedRefs, () => void refresh())
 
   function dispose() {
     llmToolsStore.clearTools('mcp')
+    toolsetPromptsStore.clearToolsetPrompts('mcp')
   }
 
   return {
+    activatedRefs,
+    deactivate,
+    deactivateAll,
     dispose,
     refresh,
   }

--- a/apps/stage-tamagotchi/src/renderer/stores/mcp-tools.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/mcp-tools.ts
@@ -3,7 +3,7 @@ import type { McpToolRuntime } from '@proj-airi/stage-ui/tools/mcp'
 import { useElectronEventaInvoke } from '@proj-airi/electron-vueuse'
 import { useLlmToolsStore } from '@proj-airi/stage-ui/stores/llm-tools'
 import { useLlmToolsetPromptsStore } from '@proj-airi/stage-ui/stores/llm-toolset-prompts'
-import { createMcpToolset } from '@proj-airi/stage-ui/tools/mcp'
+import { createMcpMetaTools, createMcpToolset } from '@proj-airi/stage-ui/tools/mcp'
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { watch } from 'vue'
@@ -57,6 +57,11 @@ export const useTamagotchiMcpToolsStore = defineStore('tamagotchi-mcp-tools', ()
   }
 
   async function refresh() {
+    // Register the meta-tools immediately with the live runtime, before the async descriptor
+    // discovery below. Without this, a chat sent during the discovery window would only see the
+    // unavailable fallback meta-tools, so every MCP call would fail until listTools() resolves.
+    await llmToolsStore.registerTools('mcp', await Promise.all(createMcpMetaTools(runtime, markToolActivated)))
+
     const { tools, catalog } = await createMcpToolset(runtime, {
       activatedRefs: new Set(activatedRefs.value),
       onToolInvoked: markToolActivated,

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -781,6 +781,12 @@ pages:
       empty: No MCP servers yet — click "Add server" below to create one, or paste a config via "Edit JSON".
       error-title: Oops
       success-title: Done!
+      activated:
+        title: Activated tools
+        description: An MCP tool you've used is promoted to a directly-callable native tool (kept across restarts). Deactivating sends it back to the catalog and the generic call path.
+        empty: No tools activated yet. One shows up here after it's been used once.
+        deactivate: Deactivate
+        deactivate-all: Deactivate all
       existing:
         title: Configured
         description: Servers recorded in mcp.json. Click any row to expand and edit it.

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -745,6 +745,12 @@ pages:
       empty: 尚无已配置的 MCP 集成 - 点击「添加服务器」来创建一个，或者通过「编辑 JSON」直接粘贴配置
       error-title: 坏了
       success-title: 完成！
+      activated:
+        title: 已激活的工具
+        description: 用过一次的 MCP 工具会自动转成可直接调用的原生工具(重启保留)。取消激活会让它退回目录、改走通用入口。
+        empty: 还没有工具被激活。用过一次之后会出现在这里。
+        deactivate: 取消激活
+        deactivate-all: 全部取消
       existing:
         title: 配置完成
         description: 在配置文件中记录了 MCP 服务器。点击展开后可以编辑它。

--- a/packages/stage-ui/src/tools/mcp.test.ts
+++ b/packages/stage-ui/src/tools/mcp.test.ts
@@ -1,8 +1,10 @@
 import type { JsonSchema } from 'xsschema'
 
+import type { McpToolDescriptor } from './mcp'
+
 import { describe, expect, it } from 'vitest'
 
-import { mcp } from './mcp'
+import { buildMcpNativeNames, mcp, normalizeOneLine, renderMcpCatalog, sanitizeMcpToolName } from './mcp'
 
 describe('tools mcp schema', () => {
   it('emits strict parameter objects', async () => {
@@ -22,5 +24,69 @@ describe('tools mcp schema', () => {
     const props = (callTool!.function.parameters as JsonSchema).properties!
     expect((props.name as JsonSchema).type).toBe('string')
     expect((props.arguments as JsonSchema).type).toBe('string')
+  })
+})
+
+describe('normalizeOneLine', () => {
+  it('collapses a multi-line description to its first sentence', () => {
+    expect(normalizeOneLine('Read a file.\nHandles encodings.\nExample: {}')).toBe('Read a file.')
+  })
+
+  it('flattens whitespace when there is no sentence terminator', () => {
+    expect(normalizeOneLine('search   the\nweb')).toBe('search the web')
+  })
+
+  it('hard-caps an over-long single sentence with an ellipsis', () => {
+    const out = normalizeOneLine(`${'x'.repeat(200)}.`)
+    expect(out.length).toBe(120)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  it('returns empty for a missing/blank description', () => {
+    expect(normalizeOneLine(undefined)).toBe('')
+    expect(normalizeOneLine('   ')).toBe('')
+  })
+})
+
+describe('sanitizeMcpToolName', () => {
+  it('turns a "<server>::<tool>" ref into a prefixed, name-safe function name', () => {
+    expect(sanitizeMcpToolName('filesystem::read_file')).toBe('mcp__filesystem__read_file')
+  })
+
+  it('replaces every invalid character and trims edge underscores', () => {
+    expect(sanitizeMcpToolName('tavily::search/extract')).toBe('mcp__tavily__search_extract')
+  })
+})
+
+describe('buildMcpNativeNames', () => {
+  it('maps each ref to its sanitized name', () => {
+    const map = buildMcpNativeNames(['filesystem::read_file', 'tavily::search'])
+    expect(map.get('filesystem::read_file')).toBe('mcp__filesystem__read_file')
+    expect(map.get('tavily::search')).toBe('mcp__tavily__search')
+  })
+
+  it('disambiguates two refs that sanitize to the same name', () => {
+    // "a::b/c" and "a::b.c" both sanitize to mcp__a__b_c, so the second gets a numeric suffix.
+    const map = buildMcpNativeNames(['a::b/c', 'a::b.c'])
+    expect(map.get('a::b/c')).toBe('mcp__a__b_c')
+    expect(map.get('a::b.c')).toBe('mcp__a__b_c_2')
+    expect(new Set(map.values()).size).toBe(2)
+  })
+})
+
+describe('renderMcpCatalog', () => {
+  const descriptors: McpToolDescriptor[] = [
+    { serverName: 'filesystem', toolName: 'read_file', name: 'filesystem::read_file', description: 'Read a file.\nMore.', inputSchema: {} },
+    { serverName: 'tavily', toolName: 'search', name: 'tavily::search', description: 'Search the web.', inputSchema: {} },
+  ]
+
+  it('lists only the cold (not-yet-activated) tools, one normalized line each', () => {
+    const out = renderMcpCatalog(descriptors, new Set(['tavily::search']))
+    expect(out).toContain('- filesystem::read_file — Read a file.')
+    expect(out).not.toContain('tavily::search')
+  })
+
+  it('returns empty when every tool is already activated', () => {
+    expect(renderMcpCatalog(descriptors, new Set(['filesystem::read_file', 'tavily::search']))).toBe('')
   })
 })

--- a/packages/stage-ui/src/tools/mcp.test.ts
+++ b/packages/stage-ui/src/tools/mcp.test.ts
@@ -1,10 +1,10 @@
 import type { JsonSchema } from 'xsschema'
 
-import type { McpToolDescriptor } from './mcp'
+import type { McpToolDescriptor, McpToolRuntime } from './mcp'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { buildMcpNativeNames, mcp, normalizeOneLine, renderMcpCatalog, sanitizeMcpToolName } from './mcp'
+import { buildMcpNativeNames, createMcpMetaTools, mcp, normalizeOneLine, renderMcpCatalog, sanitizeMcpToolName } from './mcp'
 
 describe('tools mcp schema', () => {
   it('emits strict parameter objects', async () => {
@@ -24,6 +24,39 @@ describe('tools mcp schema', () => {
     const props = (callTool!.function.parameters as JsonSchema).properties!
     expect((props.name as JsonSchema).type).toBe('string')
     expect((props.arguments as JsonSchema).type).toBe('string')
+  })
+})
+
+describe('builtIn_mcpCallTool execute', () => {
+  async function getCallTool(runtime: McpToolRuntime, onToolInvoked?: (ref: string) => void) {
+    const tools = await Promise.all(createMcpMetaTools(runtime, onToolInvoked))
+    return tools.find(entry => entry.function.name === 'builtIn_mcpCallTool')!
+  }
+
+  const execOptions = { messages: [], toolCallId: 'call-1' }
+
+  it('returns a structured isError result for malformed arguments JSON instead of throwing', async () => {
+    const callTool = vi.fn()
+    const tool = await getCallTool({ listTools: async () => [], callTool })
+
+    const result = await tool.execute({ name: 'filesystem::read_file', arguments: '{not json' }, execOptions) as { isError?: boolean, content?: Array<{ text?: string }> }
+
+    expect(result.isError).toBe(true)
+    expect(result.content?.[0]?.text).toContain('Invalid JSON')
+    // The malformed call must never reach the runtime.
+    expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('promotes a tool only after a successful call', async () => {
+    const onToolInvoked = vi.fn()
+    const tool = await getCallTool(
+      { listTools: async () => [], callTool: async () => ({ content: [{ type: 'text', text: 'ok' }] }) },
+      onToolInvoked,
+    )
+
+    await tool.execute({ name: 'filesystem::read_file', arguments: '{"path":"/tmp"}' }, execOptions)
+
+    expect(onToolInvoked).toHaveBeenCalledWith('filesystem::read_file')
   })
 })
 

--- a/packages/stage-ui/src/tools/mcp.ts
+++ b/packages/stage-ui/src/tools/mcp.ts
@@ -1,7 +1,8 @@
 import type { Tool } from '@xsai/shared-chat'
+import type { JsonSchema } from 'xsschema'
 
 import { errorMessageFromValue } from '@proj-airi/stage-shared'
-import { tool } from '@xsai/tool'
+import { rawTool, tool } from '@xsai/tool'
 import { z } from 'zod'
 
 /**
@@ -11,7 +12,7 @@ import { z } from 'zod'
  * - A runtime needs to list available MCP tools before exposing them to models
  *
  * Expects:
- * - `name` is the fully-qualified tool name used for invocation
+ * - `name` is the fully-qualified `"<server>::<tool>"` reference used for invocation
  *
  * Returns:
  * - The MCP tool descriptor metadata reported by the runtime
@@ -71,30 +72,134 @@ export interface McpCallToolResult {
  * - `listTools` and `callTool` are safe to call multiple times
  *
  * Returns:
- * - An object that can back `createMcpTools`
+ * - An object that can back the MCP toolset
  */
 export interface McpToolRuntime {
   listTools: () => Promise<McpToolDescriptor[]>
   callTool: (payload: McpCallToolPayload) => Promise<McpCallToolResult>
 }
 
+/** Prefix on a first-class (native) MCP tool's function name, so it never collides with built-ins. */
+const NATIVE_TOOL_PREFIX = 'mcp__'
+/** Catalog / one-line description cap (keeps the always-in-context awareness layer compact). */
+const ONE_LINE_MAX = 120
+
 /**
- * Creates MCP proxy tools backed by a runtime-provided transport.
+ * Normalizes a (possibly multi-line / verbose) MCP tool description into one compact line for the
+ * always-in-context awareness catalog.
  *
- * Use when:
- * - A runtime wants to register MCP tools into the shared LLM tool store
+ * Before:
+ * - "Read a file.\nHandles encodings.\nExample: {...}"
  *
- * Expects:
- * - The runtime implements the `McpToolRuntime` contract
- *
- * Returns:
- * - xsai tool definition promises for MCP listing and invocation
+ * After:
+ * - "Read a file."
  */
-export function createMcpTools(runtime: McpToolRuntime): Array<Promise<Tool>> {
+export function normalizeOneLine(description?: string): string {
+  const flat = (description ?? '').replace(/\s+/g, ' ').trim()
+  if (!flat)
+    return ''
+  // Prefer the first sentence; fall back to the whole (flattened) string, then hard-cap the length.
+  const sentence = flat.match(/^.*?[.!?。！]/)?.[0]
+  const text = sentence && sentence.length <= ONE_LINE_MAX ? sentence : flat
+  return text.length > ONE_LINE_MAX ? `${text.slice(0, ONE_LINE_MAX - 1).trimEnd()}…` : text
+}
+
+/**
+ * Deterministic, function-name-safe name for an MCP tool reference, prefixed so it never collides
+ * with built-in tools.
+ *
+ * Before:
+ * - "filesystem::read_file"
+ *
+ * After:
+ * - "mcp__filesystem__read_file"
+ */
+export function sanitizeMcpToolName(ref: string): string {
+  // Replace each invalid char individually (no `+`) so the `::` separator becomes a readable `__`.
+  const safe = ref.replace(/[^\w-]/g, '_').replace(/^_+|_+$/g, '')
+  return `${NATIVE_TOOL_PREFIX}${safe || 'tool'}`
+}
+
+/**
+ * Builds a stable `ref -> native function name` map, disambiguating the rare case where two refs
+ * sanitize to the same name (a numeric suffix is appended). Order-stable so names persist across runs.
+ */
+export function buildMcpNativeNames(refs: string[]): Map<string, string> {
+  const used = new Set<string>()
+  const map = new Map<string, string>()
+  for (const ref of refs) {
+    const base = sanitizeMcpToolName(ref)
+    let name = base
+    for (let i = 2; used.has(name); i++)
+      name = `${base}_${i}`
+    used.add(name)
+    map.set(ref, name)
+  }
+  return map
+}
+
+/**
+ * Renders the always-in-context awareness catalog: one line per MCP tool that is NOT yet a first-class
+ * (activated) tool. Gives the model awareness of every cold capability without loading its schema.
+ *
+ * Returns an empty string when there are no cold tools (every tool is already first-class).
+ */
+export function renderMcpCatalog(descriptors: McpToolDescriptor[], activatedRefs: Set<string>): string {
+  const cold = descriptors.filter(descriptor => !activatedRefs.has(descriptor.name))
+  if (cold.length === 0)
+    return ''
+
+  const lines = cold.map((descriptor) => {
+    const description = normalizeOneLine(descriptor.description)
+    return description ? `- ${descriptor.name} — ${description}` : `- ${descriptor.name}`
+  })
+
+  return [
+    'Capabilities available via MCP. To use one of these, call builtIn_mcpCallTool with its `name` below —',
+    'the names contain "::" and are references, NOT directly callable functions (never emit a "::" tool call).',
+    'A capability you have used before instead appears directly in your tool list as an `mcp__…` tool — call',
+    'that one by name. Available references:',
+    '',
+    ...lines,
+  ].join('\n')
+}
+
+/** Calls an MCP tool by reference with parsed arguments. Shared by the `call` meta-tool and every native MCP tool. */
+async function executeMcpCall(runtime: McpToolRuntime, name: string, args: Record<string, unknown>): Promise<McpCallToolResult> {
+  try {
+    return await runtime.callTool({ name, arguments: args })
+  }
+  catch (error) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: errorMessageFromValue(error) }],
+    }
+  }
+}
+
+/** Builds a first-class (native) tool from an MCP descriptor, executed through the approval-aware path. */
+function descriptorToNativeTool(runtime: McpToolRuntime, descriptor: McpToolDescriptor, name: string): Tool {
+  return rawTool<Record<string, unknown>>({
+    name,
+    description: descriptor.description,
+    // MCP descriptors already carry a JSON Schema. strict:false — MCP schemas rarely satisfy OpenAI's
+    // strict function-calling shape (optional fields, additionalProperties), so pass it through as-is.
+    parameters: descriptor.inputSchema as JsonSchema,
+    strict: false,
+    execute: args => executeMcpCall(runtime, descriptor.name, args ?? {}),
+  })
+}
+
+/**
+ * The two always-present MCP meta-tools (the "cold path"): discover schemas on demand and run any tool
+ * by reference. A successful `call` of a tool reports it through `onToolInvoked` so the host can promote
+ * it to a native first-class tool.
+ */
+export function createMcpMetaTools(runtime: McpToolRuntime, onToolInvoked?: (ref: string) => void): Array<Promise<Tool>> {
   return [
     tool({
       name: 'builtIn_mcpListTools',
-      description: 'List all available MCP tools. Call this first to discover tool names before calling builtIn_mcpCallTool.',
+      description: 'Discover the available MCP tools. Returns a list of tool references, each with a `name` like "<server>::<tool>" (e.g. "filesystem::read_file"), a description, and an input schema. IMPORTANT: a "<server>::<tool>" reference is NOT a directly callable function — never emit a tool call whose name contains "::". To run one, pass the reference to builtIn_mcpCallTool. A capability you have used before may already be a direct `mcp__…` tool in your tool list — prefer calling that one by name.',
       execute: async () => {
         try {
           return await runtime.listTools()
@@ -108,18 +213,15 @@ export function createMcpTools(runtime: McpToolRuntime): Array<Promise<Tool>> {
     }),
     tool({
       name: 'builtIn_mcpCallTool',
-      description: 'Call an MCP tool by name. Use builtIn_mcpListTools first to get available tool names.',
+      description: 'Run an MCP tool that is in the MCP catalog but NOT already a direct tool in your tool list. Set `name` to the reference (e.g. "filesystem::read_file") and `arguments` to a JSON string of its inputs (e.g. "{}" or "{\\"path\\":\\"D:/airi-files\\"}"). Do NOT call a "<server>::<tool>" name directly — it is not a registered function; pass it here instead. NOTE: a capability you have used before is registered directly in your tool list under an `mcp__…` name — when one exists, call that directly and do not route it through this tool.',
       execute: async ({ name, arguments: argsJson }) => {
-        try {
-          const args = argsJson ? JSON.parse(argsJson) : {}
-          return await runtime.callTool({ name, arguments: args })
-        }
-        catch (error) {
-          return {
-            isError: true,
-            content: [{ type: 'text', text: errorMessageFromValue(error) }],
-          }
-        }
+        const args = argsJson ? JSON.parse(argsJson) : {}
+        const result = await executeMcpCall(runtime, name, args)
+        // A tool the model actually used (successfully) is worth promoting to a native first-class
+        // tool — from the next turn it is callable directly, no `::` wrapper, no double-encoded args.
+        if (!result.isError)
+          onToolInvoked?.(name)
+        return result
       },
       // NOTICE: `arguments` is z.string() (JSON) because z.unknown() produces `{}` (no `type` key)
       // and z.record() emits `propertyNames`, both rejected by OpenAI.
@@ -129,6 +231,59 @@ export function createMcpTools(runtime: McpToolRuntime): Array<Promise<Tool>> {
       }).strict(),
     }),
   ]
+}
+
+/** Options for {@link createMcpToolset}. */
+export interface McpToolsetOptions {
+  /** Refs (`"<server>::<tool>"`) already activated — exposed as native first-class tools. */
+  activatedRefs: Set<string>
+  /** Reports a tool the model just used so the host can persist it as activated. */
+  onToolInvoked?: (ref: string) => void
+}
+
+/** The progressively-disclosed MCP toolset: native tools + meta-tools, plus the awareness catalog. */
+export interface McpToolset {
+  /** Native first-class tools (for activated refs) followed by the two meta-tools. */
+  tools: Tool[]
+  /** Awareness-catalog prompt text for the cold (not-yet-activated) tools; empty when none. */
+  catalog: string
+}
+
+/**
+ * Builds the progressive-disclosure MCP toolset for one launch/refresh.
+ *
+ * Use when:
+ * - The desktop runtime registers MCP tools and needs both the callable tools and the prompt catalog
+ *
+ * Expects:
+ * - `runtime` lists live descriptors and executes calls
+ * - `options.activatedRefs` is the persisted set of tools to expose natively
+ *
+ * Returns:
+ * - `tools` (native activated tools + the two meta-tools) and `catalog` (one-liner awareness text for
+ *   the cold tools). Activated tools are rebuilt from the live descriptors, so their schemas are always
+ *   current; a previously-activated tool whose descriptor is gone simply isn't built (it re-activates
+ *   if it returns).
+ */
+export async function createMcpToolset(runtime: McpToolRuntime, options: McpToolsetOptions): Promise<McpToolset> {
+  let descriptors: McpToolDescriptor[] = []
+  try {
+    const listed = await runtime.listTools()
+    descriptors = Array.isArray(listed) ? listed : []
+  }
+  catch (error) {
+    console.warn('[mcp-toolset] failed to list tools:', error)
+  }
+
+  const activated = descriptors.filter(descriptor => options.activatedRefs.has(descriptor.name))
+  const nameMap = buildMcpNativeNames(activated.map(descriptor => descriptor.name))
+  const nativeTools = activated.map(descriptor => descriptorToNativeTool(runtime, descriptor, nameMap.get(descriptor.name)!))
+  const metaTools = await Promise.all(createMcpMetaTools(runtime, options.onToolInvoked))
+
+  return {
+    tools: [...nativeTools, ...metaTools],
+    catalog: renderMcpCatalog(descriptors, options.activatedRefs),
+  }
 }
 
 function createUnavailableMcpToolRuntime(): McpToolRuntime {
@@ -143,7 +298,7 @@ function createUnavailableMcpToolRuntime(): McpToolRuntime {
 }
 
 /**
- * Builds the default stage-ui MCP tool set without depending on runtime singletons.
+ * Builds the default stage-ui MCP meta-tools without depending on runtime singletons.
  *
  * Use when:
  * - Shared code needs the MCP tool schema before a concrete runtime registers live implementations
@@ -152,8 +307,8 @@ function createUnavailableMcpToolRuntime(): McpToolRuntime {
  * - Runtime-specific callers override these tools through `useLlmToolsStore`
  *
  * Returns:
- * - MCP tool definitions with an unavailable-runtime fallback
+ * - The two MCP meta-tools with an unavailable-runtime fallback
  */
 export async function mcp(): Promise<Tool[]> {
-  return await Promise.all(createMcpTools(createUnavailableMcpToolRuntime()))
+  return await Promise.all(createMcpMetaTools(createUnavailableMcpToolRuntime()))
 }

--- a/packages/stage-ui/src/tools/mcp.ts
+++ b/packages/stage-ui/src/tools/mcp.ts
@@ -215,7 +215,18 @@ export function createMcpMetaTools(runtime: McpToolRuntime, onToolInvoked?: (ref
       name: 'builtIn_mcpCallTool',
       description: 'Run an MCP tool that is in the MCP catalog but NOT already a direct tool in your tool list. Set `name` to the reference (e.g. "filesystem::read_file") and `arguments` to a JSON string of its inputs (e.g. "{}" or "{\\"path\\":\\"D:/airi-files\\"}"). Do NOT call a "<server>::<tool>" name directly — it is not a registered function; pass it here instead. NOTE: a capability you have used before is registered directly in your tool list under an `mcp__…` name — when one exists, call that directly and do not route it through this tool.',
       execute: async ({ name, arguments: argsJson }) => {
-        const args = argsJson ? JSON.parse(argsJson) : {}
+        let args: Record<string, unknown>
+        try {
+          args = argsJson ? JSON.parse(argsJson) : {}
+        }
+        catch (error) {
+          // Report malformed arguments back to the model as a tool error rather than throwing — a
+          // throw would abort the whole turn instead of letting the model retry with valid JSON.
+          return {
+            isError: true,
+            content: [{ type: 'text', text: `Invalid JSON in arguments: ${errorMessageFromValue(error)}` }],
+          }
+        }
         const result = await executeMcpCall(runtime, name, args)
         // A tool the model actually used (successfully) is worth promoting to a native first-class
         // tool — from the next turn it is callable directly, no `::` wrapper, no double-encoded args.


### PR DESCRIPTION
## Summary

MCP tools are exposed only through two meta-tools (`builtIn_mcpListTools` + `builtIn_mcpCallTool`), which has two costs:

1. **Zero upfront awareness** — the model must call `list` before it knows any MCP tool exists, and it often doesn't, so configured MCP capabilities go unused.
2. **Awkward invocation** — a `server::tool` reference is a string, not a callable function (the model is tempted to emit it as a tool name and the call fails), and tool inputs are double-JSON-encoded.

This PR adds a Skills-style **progressive disclosure** layer: the cheap part (name + one-line description) is always in context for awareness; the expensive part (the full input schema) is loaded only when a tool is actually used.

## Changes

- **Awareness catalog** (`packages/stage-ui/src/tools/mcp.ts`): a generated `name — one-liner` list of the cold (not-yet-promoted) MCP tools, built from the MCP descriptors (schema dropped, description normalized to one line) and injected into the system prompt via the existing toolset-prompt channel — awareness of every capability without loading its schema.
- **On-use native promotion**: a tool the model successfully runs (once, via `builtIn_mcpCallTool`) is reported back and promoted to a native first-class tool — registered with its own JSON Schema under a sanitized `mcp__<server>__<tool>` name — so the model calls it directly from the next turn (no `::`, no double-encoding). The promoted set is persisted in `localStorage` (survives restart); a watch re-derives the live toolset on any change.
- **Settings UI** (`apps/stage-tamagotchi/.../settings/modules/mcp.vue`): lists the activated tools with per-tool and bulk **deactivation** (demotes one back to the catalog).
- The two meta-tools remain as the "cold path" (discover + run); their descriptions now steer the model to a directly-listed `mcp__` tool when one exists.

Context cost scales with **usage**, not with the number of installed tools. `createMcpToolset()` returns `{ tools, catalog }`; the pure helpers (`sanitizeMcpToolName`, `buildMcpNativeNames`, `normalizeOneLine`, `renderMcpCatalog`) are unit-tested.

## Testing

- `pnpm -F @proj-airi/stage-ui exec vitest run src/tools/mcp.test.ts` — 12 passed
- `pnpm -F @proj-airi/stage-tamagotchi exec vitest run src/renderer/stores/mcp-tools.test.ts` — 1 passed
- `pnpm -F @proj-airi/stage-ui typecheck` and `pnpm -F @proj-airi/stage-tamagotchi typecheck` — clean
- `pnpm lint` — clean
