### PR TITLE
feat(stage-ui): configurable chat response length limits (max tokens + reply-length hint)

### DIFF
--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -112,6 +112,56 @@ describe('streamFrom tool error capture', () => {
   })
 })
 
+describe('streamFrom maxTokens forwarding', () => {
+  function mockImmediateFinish() {
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => Promise<void> }) => {
+      const steps = Promise.resolve([]).then(async (value) => {
+        await options.onEvent({ type: 'finish', finishReason: 'stop' })
+        return value
+      })
+      return createMockStreamResult(steps)
+    })
+  }
+
+  /**
+   * @example
+   * await streamFrom({ model, chatProvider, messages, options: { maxTokens: 1024 } })
+   * // -> streamText receives `maxTokens: 1024`, serialized to the `max_tokens` body field
+   */
+  it('forwards options.maxTokens into the streamText call', async () => {
+    mockImmediateFinish()
+
+    await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hi' }] as Message[],
+      options: { maxTokens: 1024 },
+    })
+
+    const streamOptions = streamTextMock.mock.calls.at(-1)?.[0]
+    expect(streamOptions.maxTokens).toBe(1024)
+  })
+
+  /**
+   * @example
+   * await streamFrom({ model, chatProvider, messages })
+   * // -> streamText receives `maxTokens: undefined`; xsAI's requestBody strips
+   * //    undefined values, so the request body omits `max_tokens` entirely
+   */
+  it('leaves maxTokens undefined when no cap is configured', async () => {
+    mockImmediateFinish()
+
+    await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hi' }] as Message[],
+    })
+
+    const streamOptions = streamTextMock.mock.calls.at(-1)?.[0]
+    expect(streamOptions.maxTokens).toBeUndefined()
+  })
+})
+
 describe('sanitizeMessages', () => {
   it('rewrites internal `error`-role messages as user-role narrations', () => {
     /**

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -160,6 +160,47 @@ describe('streamFrom maxTokens forwarding', () => {
     const streamOptions = streamTextMock.mock.calls.at(-1)?.[0]
     expect(streamOptions.maxTokens).toBeUndefined()
   })
+
+  /**
+   * @example
+   * await streamFrom({ model: 'openai/gpt-5-mini', ..., options: { maxTokens: 512 } })
+   * // -> streamText receives `maxCompletionTokens: 512` and no `maxTokens`, because OpenAI
+   * //    reasoning models reject the legacy `max_tokens` field.
+   */
+  it('routes the cap to maxCompletionTokens for OpenAI reasoning models', async () => {
+    mockImmediateFinish()
+
+    await streamFrom({
+      model: 'openai/gpt-5-mini',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hi' }] as Message[],
+      options: { maxTokens: 512 },
+    })
+
+    const streamOptions = streamTextMock.mock.calls.at(-1)?.[0]
+    expect(streamOptions.maxCompletionTokens).toBe(512)
+    expect(streamOptions.maxTokens).toBeUndefined()
+  })
+
+  /**
+   * @example
+   * await streamFrom({ model: 'o3-mini', ..., options: { maxTokens: 256 } })
+   * // -> the o-series is also a reasoning family, so the cap uses maxCompletionTokens
+   */
+  it('treats the o-series as a reasoning family', async () => {
+    mockImmediateFinish()
+
+    await streamFrom({
+      model: 'o3-mini',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hi' }] as Message[],
+      options: { maxTokens: 256 },
+    })
+
+    const streamOptions = streamTextMock.mock.calls.at(-1)?.[0]
+    expect(streamOptions.maxCompletionTokens).toBe(256)
+    expect(streamOptions.maxTokens).toBeUndefined()
+  })
 })
 
 describe('sanitizeMessages', () => {

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -162,6 +162,19 @@ function resolveCapturedToolErrorEvent(
   }
 }
 
+/**
+ * Whether the model belongs to an OpenAI reasoning family (o1/o3/o4…, gpt-5) that rejects the legacy
+ * `max_tokens` field and only accepts `max_completion_tokens`.
+ *
+ * NOTICE: id-pattern heuristic. The final path segment is matched so provider-prefixed ids
+ * (e.g. "openai/gpt-5-mini", "openrouter/openai/o3") still resolve. Extend the prefixes as new
+ * reasoning families ship.
+ */
+function usesCompletionTokenLimit(model: string): boolean {
+  const name = model.toLowerCase().split('/').pop() ?? ''
+  return /^o[1-9]/.test(name) || name.startsWith('gpt-5')
+}
+
 export async function streamFrom({
   model,
   chatProvider,
@@ -170,6 +183,7 @@ export async function streamFrom({
   builtinToolsResolver,
 }: StreamFromOptions) {
   const chatConfig = chatProvider.chat(model)
+  const reasoningTokenLimit = usesCompletionTokenLimit(model)
   const supportsContentArray = streamOptionsContentArrayCompatibilityOk(model, chatProvider, options)
   const sanitized = sanitizeMessages(messages as unknown[], supportsContentArray)
 
@@ -226,10 +240,14 @@ export async function streamFrom({
         messages: sanitized,
         headers: options?.headers,
         // NOTICE:
-        // xsAI's `requestBody` camel→snake-cases every option key into the chat
-        // body and strips `undefined`, so this lands as the standard OpenAI
-        // `max_tokens` field — and is omitted entirely when unset.
-        maxTokens: options?.maxTokens,
+        // xsAI's `requestBody` camel→snake-cases every option key into the chat body and strips
+        // `undefined`. Non-reasoning models take the standard `max_tokens`; OpenAI reasoning models
+        // (o1/o3/…, gpt-5) reject `max_tokens` and require `max_completion_tokens`, so the cap is
+        // routed to the field the model accepts. The limit is omitted entirely when unset.
+        maxTokens: reasoningTokenLimit ? undefined : options?.maxTokens,
+        ...(reasoningTokenLimit && options?.maxTokens != null
+          ? { maxCompletionTokens: options.maxTokens }
+          : {}),
         stopWhen: stepCountAtLeast(10),
         // NOTICE:
         // Do not pass xsAI's `captureToolErrors` option here. In the installed

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -225,6 +225,11 @@ export async function streamFrom({
         abortSignal: options?.abortSignal,
         messages: sanitized,
         headers: options?.headers,
+        // NOTICE:
+        // xsAI's `requestBody` camel→snake-cases every option key into the chat
+        // body and strips `undefined`, so this lands as the standard OpenAI
+        // `max_tokens` field — and is omitted entirely when unset.
+        maxTokens: options?.maxTokens,
         stopWhen: stepCountAtLeast(10),
         // NOTICE:
         // Do not pass xsAI's `captureToolErrors` option here. In the installed

--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -13,6 +13,12 @@ export type StreamEvent
 export interface StreamOptions {
   abortSignal?: AbortSignal
   headers?: Record<string, string>
+  /**
+   * Hard cap on completion tokens for one LLM call, forwarded to the provider
+   * as the OpenAI-compatible `max_tokens` body field. Leave undefined to use
+   * the provider/model default (no cap).
+   */
+  maxTokens?: number
   onStreamEvent?: (event: StreamEvent) => void | Promise<void>
   toolsCompatibility?: Map<string, boolean>
   supportsTools?: boolean

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -616,6 +616,17 @@ pages:
             show_more: Show more
             subtitle: Select a default model from the provider
             title: Model
+          response-limits:
+            title: Response Length
+            description: Keep replies short and snappy — or leave both off for unlimited responses
+            max-tokens:
+              label: Max output tokens
+              description: Hard cap sent to the provider as max_tokens. 0 disables the cap.
+              unlimited: Unlimited
+            length-hint:
+              label: Reply length guideline (characters)
+              description: Adds a soft instruction asking the character to keep replies within this many characters. 0 disables it.
+              off: 'Off'
       title: Consciousness
     description: Thinking, vision, speech synthesis, gaming, etc.
     gaming-factorio:

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -592,6 +592,17 @@ pages:
             show_more: 收起
             subtitle: 选择一个默认模型
             title: 模型
+          response-limits:
+            title: 回复长度
+            description: 让回复更简短利落——两项都关闭则不限制
+            max-tokens:
+              label: 最大输出 token 数
+              description: 以 max_tokens 形式发送给提供商的硬上限。0 表示不限制。
+              unlimited: 不限制
+            length-hint:
+              label: 回复字数建议（字符）
+              description: 在提示词中加入软性约束，请角色将单次回复控制在该字数内。0 表示关闭。
+              off: 关闭
       title: 意识
     description: 思维，视觉，言语综合，游戏等
     gaming-factorio:

--- a/packages/i18n/src/locales/zh-Hant/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/settings.yaml
@@ -592,6 +592,17 @@ pages:
             show_more: 顯示更多
             subtitle: 從該提供者中選擇預設模型
             title: 模型
+          response-limits:
+            title: 回覆長度
+            description: 讓回覆更簡短俐落——兩項都關閉則不限制
+            max-tokens:
+              label: 最大輸出 token 數
+              description: 以 max_tokens 形式傳送給提供者的硬上限。0 表示不限制。
+              unlimited: 不限制
+            length-hint:
+              label: 回覆字數建議（字元）
+              description: 在提示詞中加入軟性約束，請角色將單次回覆控制在該字數內。0 表示關閉。
+              off: 關閉
       title: 意識
     description: 思維、視覺、語音綜合、遊戲等
     gaming-factorio:

--- a/packages/stage-pages/src/pages/settings/modules/consciousness.vue
+++ b/packages/stage-pages/src/pages/settings/modules/consciousness.vue
@@ -3,6 +3,7 @@ import { Alert, ErrorContainer, RadioCardManySelect, RadioCardSimple } from '@pr
 import { useAnalytics } from '@proj-airi/stage-ui/composables'
 import { useConsciousnessStore } from '@proj-airi/stage-ui/stores/modules/consciousness'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { FieldRange } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -20,6 +21,8 @@ const {
   providerModels,
   isLoadingActiveProviderModels,
   activeProviderModelError,
+  responseMaxTokens,
+  responseLengthHint,
 } = storeToRefs(consciousnessStore)
 
 const { t } = useI18n()
@@ -264,6 +267,38 @@ function handleDeleteProvider(providerId: string) {
             :placeholder="t('settings.pages.modules.consciousness.sections.section.provider-model-selection.manual_model_placeholder')"
           >
         </div>
+      </div>
+    </div>
+
+    <!-- Response length limits -->
+    <div>
+      <div flex="~ col gap-4">
+        <div>
+          <h2 class="text-lg text-neutral-500 md:text-2xl dark:text-neutral-500">
+            {{ t('settings.pages.modules.consciousness.sections.section.response-limits.title') }}
+          </h2>
+          <div text="neutral-400 dark:neutral-400">
+            <span>{{ t('settings.pages.modules.consciousness.sections.section.response-limits.description') }}</span>
+          </div>
+        </div>
+        <FieldRange
+          v-model="responseMaxTokens"
+          :min="0"
+          :max="8192"
+          :step="64"
+          :label="t('settings.pages.modules.consciousness.sections.section.response-limits.max-tokens.label')"
+          :description="t('settings.pages.modules.consciousness.sections.section.response-limits.max-tokens.description')"
+          :format-value="value => value > 0 ? String(value) : t('settings.pages.modules.consciousness.sections.section.response-limits.max-tokens.unlimited')"
+        />
+        <FieldRange
+          v-model="responseLengthHint"
+          :min="0"
+          :max="1000"
+          :step="20"
+          :label="t('settings.pages.modules.consciousness.sections.section.response-limits.length-hint.label')"
+          :description="t('settings.pages.modules.consciousness.sections.section.response-limits.length-hint.description')"
+          :format-value="value => value > 0 ? String(value) : t('settings.pages.modules.consciousness.sections.section.response-limits.length-hint.off')"
+        />
       </div>
     </div>
   </div>

--- a/packages/stage-ui/src/constants/prompts/response-length.test.ts
+++ b/packages/stage-ui/src/constants/prompts/response-length.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { responseLengthGuidelinePrompt } from './response-length'
+
+describe('responseLengthGuidelinePrompt', () => {
+  /**
+   * @example
+   * responseLengthGuidelinePrompt(200)
+   * // -> 'Keep each reply within roughly 200 characters. ...'
+   */
+  it('interpolates the configured character budget', () => {
+    const prompt = responseLengthGuidelinePrompt(200)
+    expect(prompt).toContain('within roughly 200 characters')
+  })
+
+  /**
+   * @example
+   * responseLengthGuidelinePrompt(80)
+   * // -> single-line instruction, safe to join with other supplements via '\n\n'
+   */
+  it('produces a single-line instruction without trailing whitespace', () => {
+    const prompt = responseLengthGuidelinePrompt(80)
+    expect(prompt).not.toContain('\n')
+    expect(prompt).toBe(prompt.trim())
+  })
+
+  it('keeps the trimming guidance so models shorten instead of truncating', () => {
+    const prompt = responseLengthGuidelinePrompt(120)
+    expect(prompt).toContain('rather than cutting off mid-sentence')
+  })
+})

--- a/packages/stage-ui/src/constants/prompts/response-length.ts
+++ b/packages/stage-ui/src/constants/prompts/response-length.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds the optional reply-length guideline injected as a system prompt
+ * supplement when the user configures a response length limit for the
+ * consciousness (chat) module.
+ *
+ * Use when:
+ * - `useConsciousnessStore().responseLengthHint` is set to a positive value.
+ *
+ * Expects:
+ * - `maxChars` to be a positive integer (callers gate on `> 0`).
+ *
+ * Returns:
+ * - A short instruction the character LLM follows best-effort. This is a soft
+ *   guideline only — pair it with `StreamOptions.maxTokens` (the hard cap sent
+ *   as `max_tokens`) when the model must not exceed a budget.
+ */
+export function responseLengthGuidelinePrompt(maxChars: number): string {
+  return [
+    `Keep each reply within roughly ${maxChars} characters.`,
+    'Prefer one or two short, natural spoken sentences over long paragraphs;',
+    'when trimming, drop pleasantries and filler rather than cutting off mid-sentence.',
+  ].join(' ')
+}

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -12,6 +12,7 @@ import { ref, toRaw, watch } from 'vue'
 
 import { useAnalytics } from '../composables'
 import { activeTurnSpan, startSpan } from '../composables/use-io-tracer'
+import { responseLengthGuidelinePrompt } from '../constants/prompts/response-length'
 import { extractMessageText, isCloudSyncableMessage } from '../libs/chat-sync'
 import { createMinecraftContext } from './chat/context-providers'
 import { useChatContextStore } from './chat/context-store'
@@ -95,6 +96,8 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     try {
       await llmStore.stream(model, chatProvider, messages, {
         ...options,
+        // 0 means "no cap" — leave the field undefined so the request omits `max_tokens`.
+        maxTokens: consciousnessStore.responseMaxTokens > 0 ? consciousnessStore.responseMaxTokens : undefined,
         onStreamEvent: async (event: StreamEvent) => {
           if (isTextDelta(event)) {
             if (!llmFirstTokenEmitted) {
@@ -156,7 +159,12 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     },
     getActiveSessionId: () => activeSessionId.value,
     getActiveProvider: () => activeProvider.value,
-    getSystemPromptSupplement: () => llmToolsetPromptsStore.activeToolsetPrompt,
+    getSystemPromptSupplement: () => {
+      const parts = [llmToolsetPromptsStore.activeToolsetPrompt]
+      if (consciousnessStore.responseLengthHint > 0)
+        parts.push(responseLengthGuidelinePrompt(consciousnessStore.responseLengthHint))
+      return parts.filter(Boolean).join('\n\n')
+    },
     runtimeContextProviders: [
       createMinecraftContext,
     ],

--- a/packages/stage-ui/src/stores/modules/consciousness.ts
+++ b/packages/stage-ui/src/stores/modules/consciousness.ts
@@ -12,6 +12,16 @@ export const useConsciousnessStore = defineStore('consciousness', () => {
   const activeProvider = useLocalStorageManualReset<string>('settings/consciousness/active-provider', '')
   const activeModel = useLocalStorageManualReset<string>('settings/consciousness/active-model', '')
   const activeCustomModelName = useLocalStorageManualReset<string>('settings/consciousness/active-custom-model', '')
+  /**
+   * Hard cap on completion tokens per chat request, sent to the provider as
+   * `max_tokens`. `0` (default) means no cap — the request omits the field.
+   */
+  const responseMaxTokens = useLocalStorageManualReset<number>('settings/consciousness/response-max-tokens', 0)
+  /**
+   * Soft reply-length guideline in characters, injected into the system prompt
+   * supplement. `0` (default) disables the guideline.
+   */
+  const responseLengthHint = useLocalStorageManualReset<number>('settings/consciousness/response-length-hint', 0)
   const expandedDescriptions = refManualReset<Record<string, boolean>>(() => ({}))
   const modelSearchQuery = refManualReset<string>('')
 
@@ -72,6 +82,8 @@ export const useConsciousnessStore = defineStore('consciousness', () => {
 
   function resetState() {
     activeProvider.reset()
+    responseMaxTokens.reset()
+    responseLengthHint.reset()
     resetModelSelection()
   }
 
@@ -81,6 +93,8 @@ export const useConsciousnessStore = defineStore('consciousness', () => {
     activeProvider,
     activeModel,
     customModelName: activeCustomModelName,
+    responseMaxTokens,
+    responseLengthHint,
     expandedDescriptions,
     modelSearchQuery,
 


### PR DESCRIPTION
## Summary

Two opt-in controls in the consciousness module settings to keep replies snappy (inspired by how galgame-style companions keep replies short):

- **Max output tokens** — a hard cap forwarded through `StreamOptions.maxTokens`, serialized by xsAI as the OpenAI-compatible `max_tokens` body field. Omitted entirely when disabled.
- **Reply length guideline** — a soft character-budget instruction appended to the system-prompt supplement.

Both default to `0` (off), so existing behavior is unchanged.

## Changes

- `core-agent`: `StreamOptions.maxTokens` plumbed into the `streamText` request (lands as `max_tokens`).
- `stage-ui`: a `response-length` prompt helper (the soft guideline), consciousness-module settings, and chat-store wiring.
- `stage-pages`: the two controls on the consciousness settings page.
- i18n (en / zh-Hans / zh-Hant).

## Testing

- `pnpm -F @proj-airi/stage-ui exec vitest run src/constants/prompts/response-length.test.ts` — 3 passed
- `pnpm -F @proj-airi/core-agent exec vitest run src/runtime/llm-service.test.ts` — 12 passed
- typecheck (feature files) + lint — clean
