### PR TITLE
fix(server): auth UI callback trust

### DIFF
--- a/apps/server/src/utils/origin.ts
+++ b/apps/server/src/utils/origin.ts
@@ -20,6 +20,15 @@ const TRUSTED_EXACT_ORIGINS = [
 ]
 
 // NOTICE:
+// Better Auth accepts non-http(s) origins by prefix (`url.startsWith(pattern)`),
+// so native deep-link schemes must not be copied from TRUSTED_EXACT_ORIGINS
+// into auth callback validation. Browser auth callbacks only need web origins.
+const TRUSTED_AUTH_CALLBACK_ORIGINS = TRUSTED_EXACT_ORIGINS.filter((origin) => {
+  const protocol = new URL(origin).protocol
+  return protocol === 'http:' || protocol === 'https:'
+})
+
+// NOTICE:
 // Private LAN / CGNAT-style dev hosts (e.g. https://10.x:5273 from cap-vite) are NOT matched
 // by regex here — list them explicitly via env `ADDITIONAL_TRUSTED_ORIGINS` (see env.ts).
 const TRUSTED_ORIGIN_PATTERNS = [
@@ -149,7 +158,7 @@ export function getAuthTrustedOrigins(
     origins.add(apiServerOrigin)
   }
 
-  for (const origin of TRUSTED_EXACT_ORIGINS) {
+  for (const origin of TRUSTED_AUTH_CALLBACK_ORIGINS) {
     origins.add(origin)
   }
 

--- a/apps/server/src/utils/origin.ts
+++ b/apps/server/src/utils/origin.ts
@@ -10,9 +10,9 @@ function getOriginFromUrl(url: string): string | undefined {
 }
 
 const TRUSTED_EXACT_ORIGINS = [
+  'https://airi.moeru.ai', // Production web app
   'capacitor://localhost', // Capacitor mobile (iOS)
   'ai.moeru.airi-pocket://links', // Android deep link
-  'https://airi.moeru.ai', // Production
   'https://accounts.airi.build', // Standalone auth UI
   'https://server-dev.airi-server-auth.pages.dev', // Server-dev standalone auth UI
   'https://admin.airi.build', // Standalone admin UI
@@ -147,6 +147,10 @@ export function getAuthTrustedOrigins(
   const apiServerOrigin = getOriginFromUrl(env.API_SERVER_URL)
   if (apiServerOrigin) {
     origins.add(apiServerOrigin)
+  }
+
+  for (const origin of TRUSTED_EXACT_ORIGINS) {
+    origins.add(origin)
   }
 
   for (const origin of env.ADDITIONAL_TRUSTED_ORIGINS) {

--- a/apps/server/src/utils/tests/origin.test.ts
+++ b/apps/server/src/utils/tests/origin.test.ts
@@ -68,8 +68,6 @@ describe('origin utils', () => {
     }, request)).toEqual([
       'https://api.airi.moeru.ai',
       'https://airi.moeru.ai',
-      'capacitor://localhost',
-      'ai.moeru.airi-pocket://links',
       'https://accounts.airi.build',
       'https://server-dev.airi-server-auth.pages.dev',
       'https://admin.airi.build',
@@ -130,8 +128,6 @@ describe('origin utils', () => {
     })).toEqual([
       'https://api.airi.moeru.ai',
       'https://airi.moeru.ai',
-      'capacitor://localhost',
-      'ai.moeru.airi-pocket://links',
       'https://accounts.airi.build',
       'https://server-dev.airi-server-auth.pages.dev',
       'https://admin.airi.build',
@@ -140,6 +136,19 @@ describe('origin utils', () => {
       'http://localhost:*',
       'http://127.0.0.1:*',
     ])
+  })
+
+  it('does not include native deep-link schemes in Better Auth trustedOrigins', () => {
+    expect(getTrustedOrigin('capacitor://localhost')).toBe('capacitor://localhost')
+    expect(getTrustedOrigin('ai.moeru.airi-pocket://links')).toBe('ai.moeru.airi-pocket://links')
+
+    const authOrigins = getAuthTrustedOrigins({
+      API_SERVER_URL: 'https://api.airi.build',
+      ADDITIONAL_TRUSTED_ORIGINS: [],
+    })
+
+    expect(authOrigins).not.toContain('capacitor://localhost')
+    expect(authOrigins).not.toContain('ai.moeru.airi-pocket://links')
   })
 
   // ROOT CAUSE:

--- a/apps/server/src/utils/tests/origin.test.ts
+++ b/apps/server/src/utils/tests/origin.test.ts
@@ -67,6 +67,13 @@ describe('origin utils', () => {
       ADDITIONAL_TRUSTED_ORIGINS: [],
     }, request)).toEqual([
       'https://api.airi.moeru.ai',
+      'https://airi.moeru.ai',
+      'capacitor://localhost',
+      'ai.moeru.airi-pocket://links',
+      'https://accounts.airi.build',
+      'https://server-dev.airi-server-auth.pages.dev',
+      'https://admin.airi.build',
+      'https://server-dev.airi-server-admin.pages.dev',
       'http://localhost:*',
       'http://127.0.0.1:*',
       'http://localhost:5173',
@@ -122,9 +129,36 @@ describe('origin utils', () => {
       ADDITIONAL_TRUSTED_ORIGINS: ['https://10.0.0.129:5273'],
     })).toEqual([
       'https://api.airi.moeru.ai',
+      'https://airi.moeru.ai',
+      'capacitor://localhost',
+      'ai.moeru.airi-pocket://links',
+      'https://accounts.airi.build',
+      'https://server-dev.airi-server-auth.pages.dev',
+      'https://admin.airi.build',
+      'https://server-dev.airi-server-admin.pages.dev',
       'https://10.0.0.129:5273',
       'http://localhost:*',
       'http://127.0.0.1:*',
     ])
+  })
+
+  // ROOT CAUSE:
+  //
+  // Email verification links carry a callbackURL query parameter that Better
+  // Auth validates only against its trustedOrigins list. The standalone auth
+  // UI sends callbackURL=https://accounts.airi.build/ui/verify-email?verified=true,
+  // but getAuthTrustedOrigins previously listed only API_SERVER_URL,
+  // additional env origins, and localhost wildcards. Clicking the email from
+  // a normal inbox has no usable Origin/Referer header, so request-derived
+  // trust could not add the auth UI origin and Better Auth returned
+  // INVALID_CALLBACK_URL.
+  //
+  // Before patch: auth UI callback -> not in trustedOrigins -> 403.
+  // After patch: built-in first-party exact origins are always present.
+  it('includes built-in first-party origins for email verification callbacks without request headers', () => {
+    expect(getAuthTrustedOrigins({
+      API_SERVER_URL: 'https://api.airi.build',
+      ADDITIONAL_TRUSTED_ORIGINS: [],
+    })).toContain('https://accounts.airi.build')
   })
 })


### PR DESCRIPTION
## Summary
- Include built-in first-party exact origins in Better Auth trusted origins.
- Cover standalone auth UI email verification callbacks without request headers.

## Root Cause
Better Auth validates email verification `callbackURL` values against `trustedOrigins`. The standalone auth UI callback can be opened from an email client without usable `Origin` or `Referer` headers, so request-derived trust cannot add the auth UI origin. Built-in first-party origins were accepted by `getTrustedOrigin`, but were not returned from `getAuthTrustedOrigins`.

## Test Plan
- `pnpm exec vitest run --config apps/server/vitest.config.ts apps/server/src/utils/tests/origin.test.ts`
- `pnpm -F @proj-airi/server typecheck`
- `pnpm exec moeru-lint apps/server/src/utils/origin.ts apps/server/src/utils/tests/origin.test.ts`

## Notes
- Root-level `pnpm exec vitest run apps/server/src/utils/tests/origin.test.ts` currently fails before running tests because `apps/ui-admin/vitest.config.ts` cannot resolve local Vite/Vue plugin dependencies in this checkout.
- `pnpm install --frozen-lockfile` was interrupted during postinstall package builds by SIGKILL; `pnpm install --frozen-lockfile --ignore-scripts` completed dependency linking for the targeted checks.