### PR TITLE
feat(core-agent): add channel ingress runtime

### DIFF
--- a/packages/core-agent/src/index.ts
+++ b/packages/core-agent/src/index.ts
@@ -12,6 +12,11 @@ export type { ContextSnapshot } from './messages/context-prompt'
 export { formatTimePrefix } from './messages/datetime-prefix'
 export { createChatHooks } from './runtime/agent-hooks'
 export type {
+  ChannelAgentExecutionOptions,
+  ChannelAgentRuntime,
+} from './runtime/channel-agent-runtime'
+export { createChannelAgentRuntime } from './runtime/channel-agent-runtime'
+export type {
   ChatOrchestratorLifecycleRecord,
   ChatOrchestratorLLMPort,
   ChatOrchestratorPromptProjection,
@@ -45,6 +50,10 @@ export type {
   ResponseCategory,
 } from './runtime/response-categoriser'
 export { mergeLoadedSessionMessages } from './session/merge-loaded-session-messages'
+export type {
+  AgentChannelIngressContext,
+  AgentChannelMessage,
+} from './types/channel'
 export type {
   ChatAssistantMessage,
   ChatHistoryItem,

--- a/packages/core-agent/src/runtime/channel-agent-runtime.test.ts
+++ b/packages/core-agent/src/runtime/channel-agent-runtime.test.ts
@@ -1,0 +1,251 @@
+import type { ChatProvider } from '@xsai-ext/providers/utils'
+import type { Message } from '@xsai/shared-chat'
+
+import type { ChatHistoryItem, ChatStreamEventContext, StreamingAssistantMessage } from '../types/chat'
+import type { StreamEvent } from '../types/llm'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createChannelAgentRuntime } from './channel-agent-runtime'
+
+const provider = {
+  chat: () => ({ baseURL: 'https://example.com/' }),
+} as unknown as ChatProvider
+
+function createHarness() {
+  const sessionMessages: Record<string, ChatHistoryItem[]> = {}
+  const foregroundPatches: StreamingAssistantMessage[] = []
+  const foregroundResets: StreamingAssistantMessage[] = []
+  const stateChanges: unknown[] = []
+  const ensureSession = vi.fn((sessionId: string) => {
+    sessionMessages[sessionId] ??= [
+      {
+        role: 'system',
+        content: 'system prompt',
+        createdAt: 1,
+        id: 'system',
+      },
+    ]
+  })
+  const stream = vi.fn(async (_model: string, _chatProvider: ChatProvider, _messages: Message[], options?: {
+    onStreamEvent?: (event: StreamEvent) => Promise<void> | void
+  }) => {
+    await options?.onStreamEvent?.({ type: 'text-delta', text: 'channel reply' })
+    await options?.onStreamEvent?.({ type: 'finish', finishReason: 'stop' })
+  })
+
+  const runtime = createChannelAgentRuntime({
+    session: {
+      ensureSession,
+      getSessionMessages: sessionId => sessionMessages[sessionId] ?? [],
+      appendSessionMessage: (sessionId, message) => {
+        sessionMessages[sessionId] ??= []
+        sessionMessages[sessionId].push(message)
+      },
+      getSessionGeneration: () => 1,
+    },
+    context: {
+      ingest: vi.fn(),
+      snapshot: () => ({}),
+    },
+    foregroundStream: {
+      patch: message => foregroundPatches.push(message),
+      reset: () => foregroundResets.push({ role: 'assistant', content: '', slices: [], tool_results: [] }),
+    },
+    llm: {
+      stream,
+    },
+    getActiveSessionId: () => 'session-1',
+    getActiveProvider: () => 'mock-provider',
+    now: () => 200,
+    monotonicNow: () => 100,
+    createId: () => 'generated-id',
+    onStateChange: state => stateChanges.push(state),
+  })
+
+  return {
+    ensureSession,
+    foregroundPatches,
+    foregroundResets,
+    runtime,
+    sessionMessages,
+    stateChanges,
+    stream,
+  }
+}
+
+/**
+ * @example
+ * const runtime = createChannelAgentRuntime(deps)
+ * await runtime.ingestMessage(channelMessage, { model, chatProvider })
+ */
+describe('createChannelAgentRuntime', () => {
+  /**
+   * @example
+   * Channel message facts are preserved in hook context while existing chat composition handles attachments.
+   */
+  it('maps channel messages into chat sends and preserves channel facts in turn context', async () => {
+    const harness = createHarness()
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    let composedMessages: Message[] = []
+
+    harness.runtime.hooks.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+    harness.stream.mockImplementationOnce(async (_model, _chatProvider, messages, options) => {
+      composedMessages = messages
+      await options?.onStreamEvent?.({ type: 'text-delta', text: 'visible reply' })
+      await options?.onStreamEvent?.({ type: 'finish', finishReason: 'stop' })
+    })
+
+    await harness.runtime.ingestMessage({
+      id: 'channel-message-1',
+      channelId: 'stage-ui',
+      sessionId: 'session-channel',
+      role: 'user',
+      content: 'see image',
+      createdAt: 777,
+      attachments: [
+        {
+          type: 'image',
+          data: 'aW1hZ2U=',
+          mimeType: 'image/png',
+        },
+      ],
+      input: {
+        type: 'input:text',
+        data: {
+          text: 'see image',
+        },
+      },
+      metadata: {
+        source: 'contract-test',
+      },
+    }, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(harness.ensureSession).toHaveBeenCalledWith('session-channel')
+    expect(hookContext?.input).toEqual({
+      type: 'input:text',
+      data: {
+        text: 'see image',
+      },
+    })
+    expect(hookContext?.channel).toEqual({
+      channelId: 'stage-ui',
+      channelMessageId: 'channel-message-1',
+      sessionId: 'session-channel',
+      createdAt: 777,
+      metadata: {
+        source: 'contract-test',
+      },
+    })
+    const userMessageContent = composedMessages[1]?.content
+    if (!Array.isArray(userMessageContent))
+      throw new TypeError('Expected composed channel user message content to be an array')
+    expect(userMessageContent[0]).toEqual({
+      type: 'text',
+      text: expect.stringMatching(/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] see image$/),
+    })
+    expect(userMessageContent[1]).toEqual(
+      {
+        type: 'image_url',
+        image_url: {
+          url: 'data:image/png;base64,aW1hZ2U=',
+        },
+      },
+    )
+    expect(harness.sessionMessages['session-channel']).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'user',
+        createdAt: 200,
+      }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'visible reply',
+      }),
+    ]))
+  })
+
+  /**
+   * @example
+   * runtime.cancelPendingSends(sessionId)
+   * await expect(queuedSend).rejects.toThrow()
+   */
+  it('keeps queue, cancel, snapshot, and sending state behavior delegated to chat runtime', async () => {
+    const harness = createHarness()
+    let releaseFirstSend: (() => void) | undefined
+    harness.stream.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirstSend = resolve
+      })
+    })
+
+    const firstSend = harness.runtime.ingestMessage({
+      id: 'first-channel-message',
+      channelId: 'stage-ui',
+      sessionId: 'session-1',
+      role: 'user',
+      content: 'hold queue',
+      createdAt: 100,
+    }, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+    const secondSend = harness.runtime.ingestMessage({
+      id: 'second-channel-message',
+      channelId: 'stage-ui',
+      sessionId: 'session-1',
+      role: 'user',
+      content: 'cancel me',
+      createdAt: 101,
+    }, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    await vi.waitFor(() => {
+      expect(harness.stream).toHaveBeenCalledTimes(1)
+    })
+    await vi.waitFor(() => {
+      expect(harness.runtime.getPendingQueuedSendCount()).toBe(1)
+    })
+
+    expect(harness.runtime.getSending()).toBe(true)
+    expect(harness.runtime.getPendingQueuedSendSnapshot()).toEqual([
+      {
+        sessionId: 'session-1',
+        generation: 1,
+        cancelled: false,
+        messagePreview: 'cancel me',
+        hasAttachments: false,
+        inputType: undefined,
+      },
+    ])
+
+    harness.runtime.cancelPendingSends('session-1')
+    expect(harness.runtime.getPendingQueuedSendCount()).toBe(0)
+    releaseFirstSend?.()
+
+    await expect(secondSend).rejects.toThrow('Chat session was reset before send could start')
+    await firstSend
+    expect(harness.runtime.getSending()).toBe(false)
+
+    harness.runtime.setSending(true)
+    expect(harness.runtime.getSending()).toBe(true)
+    harness.runtime.setSending(false)
+    expect(harness.runtime.getSending()).toBe(false)
+    expect(harness.stateChanges).toEqual(expect.arrayContaining([
+      {
+        sending: true,
+        pendingQueuedSendCount: 0,
+      },
+      {
+        sending: false,
+        pendingQueuedSendCount: 0,
+      },
+    ]))
+  })
+})

--- a/packages/core-agent/src/runtime/channel-agent-runtime.ts
+++ b/packages/core-agent/src/runtime/channel-agent-runtime.ts
@@ -1,0 +1,68 @@
+import type { AgentChannelMessage } from '../types/channel'
+import type { ChatOrchestratorRuntime, ChatOrchestratorRuntimeDeps, ChatOrchestratorSendOptions } from './chat-orchestrator-runtime'
+
+import { createChatOrchestratorRuntime } from './chat-orchestrator-runtime'
+
+/**
+ * Execution options supplied by a caller after channel message normalization.
+ */
+export type ChannelAgentExecutionOptions = Omit<ChatOrchestratorSendOptions, 'attachments' | 'input' | 'channel'>
+
+/**
+ * Channel-facing runtime that accepts normalized channel messages before delegating to chat orchestration.
+ */
+export interface ChannelAgentRuntime extends Pick<
+  ChatOrchestratorRuntime,
+  | 'cancelPendingSends'
+  | 'getPendingQueuedSendSnapshot'
+  | 'getPendingQueuedSendCount'
+  | 'getSending'
+  | 'setSending'
+  | 'hooks'
+> {
+  /** Enqueues a normalized channel user message for the existing chat orchestrator runtime. */
+  ingestMessage: (message: AgentChannelMessage, options: ChannelAgentExecutionOptions) => Promise<void>
+}
+
+/**
+ * Creates a channel ingress runtime in front of the existing chat orchestrator.
+ *
+ * Use when:
+ * - A platform has normalized inbound events into `AgentChannelMessage`.
+ * - Channel facts must be preserved in turn context without changing session or streaming ownership.
+ *
+ * Expects:
+ * - `message.sessionId` points at the core chat session that should receive the turn.
+ * - Provider/model execution details are passed separately as execution options.
+ *
+ * Returns:
+ * - A runtime with channel ingress plus the existing queue, hook, and state surfaces.
+ */
+export function createChannelAgentRuntime(deps: ChatOrchestratorRuntimeDeps): ChannelAgentRuntime {
+  const chatRuntime = createChatOrchestratorRuntime(deps)
+
+  function ingestMessage(message: AgentChannelMessage, options: ChannelAgentExecutionOptions) {
+    return chatRuntime.ingest(message.content, {
+      ...options,
+      attachments: message.attachments,
+      input: message.input,
+      channel: {
+        channelId: message.channelId,
+        channelMessageId: message.id,
+        sessionId: message.sessionId,
+        createdAt: message.createdAt,
+        metadata: message.metadata,
+      },
+    }, message.sessionId)
+  }
+
+  return {
+    ingestMessage,
+    cancelPendingSends: chatRuntime.cancelPendingSends,
+    getPendingQueuedSendSnapshot: chatRuntime.getPendingQueuedSendSnapshot,
+    getPendingQueuedSendCount: chatRuntime.getPendingQueuedSendCount,
+    getSending: chatRuntime.getSending,
+    setSending: chatRuntime.setSending,
+    hooks: chatRuntime.hooks,
+  }
+}

--- a/packages/core-agent/src/runtime/chat-orchestrator-runtime.ts
+++ b/packages/core-agent/src/runtime/chat-orchestrator-runtime.ts
@@ -3,6 +3,7 @@ import type { CommonContentPart, Message, ToolMessage } from '@xsai/shared-chat'
 
 import type { AgentContextPort } from '../contracts/context-port'
 import type { AgentForegroundStreamPort } from '../contracts/stream-port'
+import type { AgentChannelIngressContext } from '../types/channel'
 import type { ChatAssistantMessage, ChatHistoryItem, ChatSlices, ChatStreamEventContext, ContextMessage, StreamingAssistantMessage } from '../types/chat'
 import type { StreamEvent, StreamOptions } from '../types/llm'
 
@@ -60,6 +61,8 @@ export interface ChatOrchestratorSendOptions {
   tools?: StreamOptions['tools']
   /** Original transport input metadata used by bridge/devtools observers. */
   input?: ChatStreamEventContext['input']
+  /** Channel facts preserved for hooks, observability, and future channel runtimes. */
+  channel?: AgentChannelIngressContext
 }
 
 interface QueuedSend {
@@ -374,6 +377,7 @@ export function createChatOrchestratorRuntime(deps: ChatOrchestratorRuntimeDeps)
       contexts: deps.context.snapshot(),
       composedMessage: [],
       input: options.input,
+      channel: options.channel,
     }
     deps.onLifecycle?.({
       phase: 'before-compose',

--- a/packages/core-agent/src/types/channel.ts
+++ b/packages/core-agent/src/types/channel.ts
@@ -1,0 +1,45 @@
+import type { WebSocketEventInputs } from '@proj-airi/server-shared/types'
+
+/**
+ * Channel-side user message accepted by the core agent ingress seam.
+ *
+ * @param TMetadata - Structured metadata preserved from the originating channel.
+ */
+export interface AgentChannelMessage<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
+  /** Channel-scoped message identifier. */
+  id: string
+  /** Logical channel that produced this message, for example `stage-ui` or `satori`. */
+  channelId: string
+  /** Core chat session that should receive this message. */
+  sessionId: string
+  /** User-authored ingress is the only supported channel role in this first seam. */
+  role: 'user'
+  /** Text payload forwarded into the existing chat orchestrator turn. */
+  content: string
+  /** Original channel timestamp. This does not replace persisted session message time. */
+  createdAt: number
+  /** Image attachments provided by the channel adapter. */
+  attachments?: Array<{ type: 'image', data: string, mimeType: string }>
+  /** Original transport input metadata used by bridge/devtools observers. */
+  input?: WebSocketEventInputs
+  /** Channel-specific metadata preserved for hooks, observability, and future runtimes. */
+  metadata?: TMetadata
+}
+
+/**
+ * Channel facts attached to a core chat turn context.
+ *
+ * @param TMetadata - Structured metadata preserved from the originating channel.
+ */
+export interface AgentChannelIngressContext<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
+  /** Logical channel that produced the user turn. */
+  channelId: string
+  /** Channel-scoped source message identifier. */
+  channelMessageId: string
+  /** Core chat session that owns the turn. */
+  sessionId: string
+  /** Original channel timestamp. This is informational for the turn context. */
+  createdAt: number
+  /** Channel-specific metadata preserved without interpretation by the chat runtime. */
+  metadata?: TMetadata
+}

--- a/packages/core-agent/src/types/chat.ts
+++ b/packages/core-agent/src/types/chat.ts
@@ -1,6 +1,8 @@
 import type { ContextUpdate, MetadataEventSource, WebSocketEventInputs } from '@proj-airi/server-shared/types'
 import type { AssistantMessage, CommonContentPart, CompletionToolCall, Message, SystemMessage, ToolMessage, UserMessage } from '@xsai/shared-chat'
 
+import type { AgentChannelIngressContext } from './channel'
+
 export interface ChatSlicesText {
   type: 'text'
   text: string
@@ -54,6 +56,7 @@ export interface ChatStreamEventContext {
   contexts: Record<string, ContextMessage[]>
   composedMessage: Array<Message>
   input?: WebSocketEventInputs
+  channel?: AgentChannelIngressContext
 }
 
 export type ChatStreamEvent

--- a/packages/stage-ui/src/stores/chat.contract.test.ts
+++ b/packages/stage-ui/src/stores/chat.contract.test.ts
@@ -1,3 +1,4 @@
+import type { AgentChannelMessage, ChatStreamEventContext } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
@@ -307,6 +308,138 @@ describe('chat orchestrator contract', () => {
 
   /**
    * @example
+   * await store.ingest('hello', { model, chatProvider })
+   * // hook context includes channelId: 'stage-ui'
+   */
+  it('wraps legacy ingest calls as stage-ui channel messages', async () => {
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    llmStreamMock.mockImplementationOnce(async (_model, _provider, _messages, options) => {
+      await options.onStreamEvent({ type: 'text-delta', text: 'legacy reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+    store.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+
+    await store.ingest('legacy stage message', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(hookContext?.channel).toMatchObject({
+      channelId: 'stage-ui',
+      sessionId: 'session-1',
+    })
+    expect(hookContext?.channel?.channelMessageId).toEqual(expect.any(String))
+    expect(hookContext?.channel?.createdAt).toEqual(expect.any(Number))
+  })
+
+  /**
+   * @example
+   * await store.ingest('hello', { model, chatProvider }, '')
+   * // hook context still uses the active session instead of a blank session id
+   */
+  it('falls back to the active session when legacy ingest receives a blank target session id', async () => {
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    llmStreamMock.mockImplementationOnce(async (_model, _provider, _messages, options) => {
+      await options.onStreamEvent({ type: 'text-delta', text: 'blank target reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+    store.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+
+    await store.ingest('blank target session id', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    }, '')
+
+    expect(ensureSessionMock).toHaveBeenCalledWith('session-1')
+    expect(ensureSessionMock).not.toHaveBeenCalledWith('')
+    expect(hookContext?.channel?.sessionId).toBe('session-1')
+  })
+
+  /**
+   * @example
+   * await store.ingestChannelMessage(channelMessage, { model, chatProvider })
+   * // explicit channel facts survive into hook context
+   */
+  it('accepts explicit stage-ui channel messages through the store facade', async () => {
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    let composedMessages: Message[] = []
+    llmStreamMock.mockImplementationOnce(async (_model, _provider, messages, options) => {
+      composedMessages = messages
+      await options.onStreamEvent({ type: 'text-delta', text: 'channel reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+    const message: AgentChannelMessage = {
+      id: 'stage-channel-message',
+      channelId: 'stage-ui',
+      sessionId: 'session-channel',
+      role: 'user',
+      content: 'channel direct',
+      createdAt: 777,
+      attachments: [
+        {
+          type: 'image',
+          data: 'aW1hZ2U=',
+          mimeType: 'image/png',
+        },
+      ],
+      input: {
+        type: 'input:text',
+        data: {
+          text: 'channel direct',
+        },
+      },
+      metadata: {
+        source: 'stage-ui-contract',
+      },
+    }
+    store.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+
+    await store.ingestChannelMessage(message, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(ensureSessionMock).toHaveBeenCalledWith('session-channel')
+    expect(hookContext?.input).toEqual(message.input)
+    expect(hookContext?.channel).toEqual({
+      channelId: 'stage-ui',
+      channelMessageId: 'stage-channel-message',
+      sessionId: 'session-channel',
+      createdAt: 777,
+      metadata: {
+        source: 'stage-ui-contract',
+      },
+    })
+
+    const userMessageContent = composedMessages[1]?.content
+    if (!Array.isArray(userMessageContent))
+      throw new TypeError('Expected composed stage-ui channel message content to be an array')
+    expect(userMessageContent[0]).toEqual({
+      type: 'text',
+      text: expect.stringMatching(/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] channel direct$/),
+    })
+    expect(userMessageContent[1]).toEqual({
+      type: 'image_url',
+      image_url: {
+        url: 'data:image/png;base64,aW1hZ2U=',
+      },
+    })
+  })
+
+  /**
+   * @example
    * store.sending = true
    * await nextTick()
    * expect(store.sending).toBe(true)
@@ -549,6 +682,7 @@ describe('chat orchestrator contract', () => {
 
     expect(store.$id).toBe('chat-orchestrator')
     expect(typeof store.ingest).toBe('function')
+    expect(typeof store.ingestChannelMessage).toBe('function')
     expect(typeof store.ingestOnFork).toBe('function')
     expect(typeof store.cancelPendingSends).toBe('function')
     expect(typeof store.onBeforeSend).toBe('function')

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -1,10 +1,10 @@
-import type { ChatOrchestratorRuntimeState, ChatOrchestratorSendOptions, StreamEvent, StreamOptions } from '@proj-airi/core-agent'
+import type { AgentChannelMessage, ChannelAgentExecutionOptions, ChatOrchestratorRuntimeState, ChatOrchestratorSendOptions, StreamEvent, StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
 import type { ChatHistoryItem } from '../types/chat'
 
-import { createChatOrchestratorRuntime } from '@proj-airi/core-agent'
+import { createChannelAgentRuntime } from '@proj-airi/core-agent'
 import { IOAttributes, IOEvents, IOSpanNames, IOSubsystems } from '@proj-airi/stage-shared'
 import { nanoid } from 'nanoid'
 import { defineStore, storeToRefs } from 'pinia'
@@ -41,7 +41,7 @@ function isTextDelta(event: StreamEvent): event is Extract<StreamEvent, { type: 
   return event.type === 'text-delta'
 }
 
-export type { QueuedSendSnapshot, ChatOrchestratorSendOptions as SendOptions } from '@proj-airi/core-agent'
+export type { AgentChannelMessage, ChannelAgentExecutionOptions, QueuedSendSnapshot, ChatOrchestratorSendOptions as SendOptions } from '@proj-airi/core-agent'
 
 export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
   const llmStore = useLLM()
@@ -132,7 +132,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     ownedActiveTurnSpan = undefined
   }
 
-  const runtime = createChatOrchestratorRuntime({
+  const runtime = createChannelAgentRuntime({
     session: {
       ensureSession: sessionId => chatSession.ensureSession(sessionId),
       getSessionMessages: sessionId => chatSession.getSessionMessages(sessionId).map(message => toRaw(message)),
@@ -224,12 +224,35 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       runtime.setSending(next)
   })
 
+  function toChannelExecutionOptions(options: ChatOrchestratorSendOptions): ChannelAgentExecutionOptions {
+    const { attachments: _attachments, input: _input, channel: _channel, ...executionOptions } = options
+    return executionOptions
+  }
+
+  async function ingestChannelMessage(
+    message: AgentChannelMessage,
+    options: ChannelAgentExecutionOptions,
+  ) {
+    return runtime.ingestMessage(message, options)
+  }
+
   async function ingest(
     sendingMessage: string,
     options: ChatOrchestratorSendOptions,
     targetSessionId?: string,
   ) {
-    return runtime.ingest(sendingMessage, options, targetSessionId)
+    const message: AgentChannelMessage = {
+      id: nanoid(),
+      channelId: 'stage-ui',
+      sessionId: targetSessionId || activeSessionId.value,
+      role: 'user',
+      content: sendingMessage,
+      createdAt: Date.now(),
+      attachments: options.attachments,
+      input: options.input,
+    }
+
+    return ingestChannelMessage(message, toChannelExecutionOptions(options))
   }
 
   async function ingestOnFork(
@@ -263,6 +286,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     pendingQueuedSendCount,
 
     ingest,
+    ingestChannelMessage,
     ingestOnFork,
     cancelPendingSends,
     getPendingQueuedSendSnapshot,


### PR DESCRIPTION
## Summary

Add a channel ingress runtime for `@proj-airi/core-agent` so normalized channel messages can enter the existing chat orchestrator while preserving channel metadata in the turn context.

This creates a stable ingress boundary for platform and channel adapters without changing the existing session, queue, streaming, or hook ownership in the chat orchestrator.

## Changes

- Added `AgentChannelMessage` and `AgentChannelIngressContext` types.
- Added `createChannelAgentRuntime`, which wraps the existing chat orchestrator and maps normalized channel messages into chat sends.
- Exposed the new channel ingress runtime and channel types from `packages/core-agent`.
- Updated the stage UI chat store to use the channel runtime internally.
- Added `ingestChannelMessage` while keeping the existing `ingest` API by adapting stage UI sends into channel messages.
- Added coverage for channel metadata preservation, attachment forwarding, queue/cancel delegation, and the stage UI chat store contract.

## Validation

Passed:

- `pnpm exec vitest run packages/core-agent/src/runtime/channel-agent-runtime.test.ts packages/stage-ui/src/stores/chat.contract.test.ts`
- `pnpm -F @proj-airi/stage-ui exec vitest run src/stores/chat.contract.test.ts`
- `pnpm -F @proj-airi/core-agent exec vitest run`
- `pnpm -F @proj-airi/stage-ui exec vitest run`
- `pnpm lint`