### PR TITLE
feat(core-agent): add execution config

### DIFF
--- a/packages/core-agent/src/index.ts
+++ b/packages/core-agent/src/index.ts
@@ -12,8 +12,16 @@ export type { ContextSnapshot } from './messages/context-prompt'
 export { formatTimePrefix } from './messages/datetime-prefix'
 export { createChatHooks } from './runtime/agent-hooks'
 export type {
+  AgentExecutionProfile,
+  AgentProviderResolver,
+  AgentRuntimeConfig,
+  CreateAgentRuntimeConfigOptions,
+} from './runtime/agent-runtime-config'
+export { createAgentRuntimeConfig } from './runtime/agent-runtime-config'
+export type {
   ChannelAgentExecutionOptions,
   ChannelAgentRuntime,
+  ChannelAgentRuntimeDeps,
 } from './runtime/channel-agent-runtime'
 export { createChannelAgentRuntime } from './runtime/channel-agent-runtime'
 export type {

--- a/packages/core-agent/src/index.ts
+++ b/packages/core-agent/src/index.ts
@@ -12,6 +12,11 @@ export type { ContextSnapshot } from './messages/context-prompt'
 export { formatTimePrefix } from './messages/datetime-prefix'
 export { createChatHooks } from './runtime/agent-hooks'
 export type {
+  ChannelAgentExecutionOptions,
+  ChannelAgentRuntime,
+} from './runtime/channel-agent-runtime'
+export { createChannelAgentRuntime } from './runtime/channel-agent-runtime'
+export type {
   ChatOrchestratorLifecycleRecord,
   ChatOrchestratorLLMPort,
   ChatOrchestratorPromptProjection,
@@ -45,6 +50,10 @@ export type {
   ResponseCategory,
 } from './runtime/response-categoriser'
 export { mergeLoadedSessionMessages } from './session/merge-loaded-session-messages'
+export type {
+  AgentChannelIngressContext,
+  AgentChannelMessage,
+} from './types/channel'
 export type {
   ChatAssistantMessage,
   ChatHistoryItem,

--- a/packages/core-agent/src/runtime/agent-runtime-config.test.ts
+++ b/packages/core-agent/src/runtime/agent-runtime-config.test.ts
@@ -1,0 +1,198 @@
+import type { ChatProvider } from '@xsai-ext/providers/utils'
+
+import type { AgentChannelMessage } from '../types/channel'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createAgentRuntimeConfig } from './agent-runtime-config'
+
+const provider = {
+  chat: () => ({ baseURL: 'https://example.com/' }),
+} as unknown as ChatProvider
+
+const explicitProvider = {
+  chat: () => ({ baseURL: 'https://explicit.example.com/' }),
+} as unknown as ChatProvider
+
+function createMessage(overrides: Partial<AgentChannelMessage> = {}): AgentChannelMessage {
+  return {
+    id: overrides.id ?? 'message-1',
+    channelId: overrides.channelId ?? 'stage-ui',
+    sessionId: overrides.sessionId ?? 'session-1',
+    role: 'user',
+    content: overrides.content ?? 'hello',
+    createdAt: overrides.createdAt ?? 1,
+    ...overrides,
+  }
+}
+
+/**
+ * @example
+ * const config = createAgentRuntimeConfig()
+ * await config.resolveExecutionOptions(message)
+ */
+describe('createAgentRuntimeConfig', () => {
+  /**
+   * @example
+   * Default execution profile resolves the provider id, model, and provider instance.
+   */
+  it('resolves execution options from the shared default profile', async () => {
+    const resolver = vi.fn(async (providerId: string) => ({
+      chatProvider: provider,
+      providerConfig: {
+        headers: {
+          'x-provider-id': providerId,
+        },
+      },
+    }))
+    const config = createAgentRuntimeConfig({
+      defaultExecutionProfile: {
+        providerId: 'mock-provider',
+        model: 'gpt-test',
+      },
+      providerResolver: resolver,
+    })
+
+    const result = await config.resolveExecutionOptions(createMessage())
+
+    expect(resolver).toHaveBeenCalledWith('mock-provider')
+    expect(result.providerId).toBe('mock-provider')
+    expect(result.model).toBe('gpt-test')
+    expect(result.chatProvider).toBe(provider)
+    expect(result.providerConfig).toEqual({
+      headers: {
+        'x-provider-id': 'mock-provider',
+      },
+    })
+  })
+
+  /**
+   * @example
+   * Overrides can replace the default provider, model, and provider config.
+   */
+  it('lets explicit overrides win over the shared default profile and resolver config', async () => {
+    const resolver = vi.fn(async () => ({
+      chatProvider: provider,
+      providerConfig: {
+        headers: {
+          'x-provider-id': 'default-provider',
+        },
+      },
+    }))
+    const config = createAgentRuntimeConfig({
+      defaultExecutionProfile: {
+        providerId: 'default-provider',
+        model: 'default-model',
+      },
+      providerResolver: resolver,
+    })
+
+    const result = await config.resolveExecutionOptions(createMessage(), {
+      providerId: 'override-provider',
+      model: 'override-model',
+      providerConfig: {
+        headers: {
+          'x-provider-id': 'override-provider',
+        },
+      },
+    })
+
+    expect(resolver).toHaveBeenCalledWith('override-provider')
+    expect(result.providerId).toBe('override-provider')
+    expect(result.model).toBe('override-model')
+    expect(result.chatProvider).toBe(provider)
+    expect(result.providerConfig).toEqual({
+      headers: {
+        'x-provider-id': 'override-provider',
+      },
+    })
+  })
+
+  /**
+   * @example
+   * Existing callers with a concrete provider do not need a resolver.
+   */
+  it('preserves explicit chatProvider behavior without requiring a resolver', async () => {
+    const config = createAgentRuntimeConfig()
+
+    const result = await config.resolveExecutionOptions(createMessage(), {
+      model: 'explicit-model',
+      chatProvider: explicitProvider,
+    })
+
+    expect(result.providerId).toBeUndefined()
+    expect(result.model).toBe('explicit-model')
+    expect(result.chatProvider).toBe(explicitProvider)
+  })
+
+  /**
+   * @example
+   * Satori and stage-ui messages resolve through the same default profile in PR1.
+   */
+  it('shares one default execution profile across all channels', async () => {
+    const resolver = vi.fn(async () => ({ chatProvider: provider }))
+    const config = createAgentRuntimeConfig({
+      defaultExecutionProfile: {
+        providerId: 'shared-provider',
+        model: 'shared-model',
+      },
+      providerResolver: resolver,
+    })
+
+    const stageResult = await config.resolveExecutionOptions(createMessage({
+      id: 'stage-message',
+      channelId: 'stage-ui',
+      sessionId: 'stage-session',
+    }))
+    const satoriResult = await config.resolveExecutionOptions(createMessage({
+      id: 'satori-message',
+      channelId: 'satori',
+      sessionId: 'satori-session',
+    }))
+
+    expect(resolver).toHaveBeenCalledTimes(2)
+    expect(resolver).toHaveBeenNthCalledWith(1, 'shared-provider')
+    expect(resolver).toHaveBeenNthCalledWith(2, 'shared-provider')
+    expect(stageResult.providerId).toBe('shared-provider')
+    expect(stageResult.model).toBe('shared-model')
+    expect(satoriResult.providerId).toBe('shared-provider')
+    expect(satoriResult.model).toBe('shared-model')
+  })
+
+  /**
+   * @example
+   * Missing profile errors include channel, session, and message context.
+   */
+  it('fails clearly when no profile or model override is available', async () => {
+    const resolver = vi.fn(async () => ({ chatProvider: provider }))
+    const config = createAgentRuntimeConfig({
+      providerResolver: resolver,
+    })
+
+    await expect(config.resolveExecutionOptions(createMessage({
+      id: 'satori-message',
+      channelId: 'satori',
+      sessionId: 'satori-session',
+    }))).rejects.toThrow('Cannot resolve execution model for channel "satori" session "satori-session" message "satori-message"')
+    expect(resolver).not.toHaveBeenCalled()
+  })
+
+  /**
+   * @example
+   * Missing resolver errors identify the message that could not resolve a provider.
+   */
+  it('fails clearly when no provider resolver is configured', async () => {
+    const config = createAgentRuntimeConfig({
+      defaultExecutionProfile: {
+        providerId: 'mock-provider',
+        model: 'gpt-test',
+      },
+    })
+
+    await expect(config.resolveExecutionOptions(createMessage({
+      id: 'stage-message',
+      channelId: 'stage-ui',
+      sessionId: 'stage-session',
+    }))).rejects.toThrow('Cannot resolve chat provider for channel "stage-ui" session "stage-session" message "stage-message"')
+  })
+})

--- a/packages/core-agent/src/runtime/agent-runtime-config.ts
+++ b/packages/core-agent/src/runtime/agent-runtime-config.ts
@@ -1,0 +1,131 @@
+import type { ChatProvider } from '@xsai-ext/providers/utils'
+
+import type { AgentChannelMessage } from '../types/channel'
+import type { ChannelAgentExecutionOptions } from './channel-agent-runtime'
+import type { ChatOrchestratorSendOptions } from './chat-orchestrator-runtime'
+
+/**
+ * Default execution identity shared by all channels in the first runtime config seam.
+ */
+export interface AgentExecutionProfile {
+  /** Host-owned provider identifier used to resolve a concrete chat provider. */
+  providerId: string
+  /** Provider model identifier used for chat turns. */
+  model: string
+}
+
+/**
+ * Host-provided provider lookup for runtime execution.
+ */
+export type AgentProviderResolver = (providerId: string) => Promise<{
+  /** Concrete chat provider instance for the requested provider id. */
+  chatProvider: ChatProvider
+  /** Optional provider request options, currently used for headers. */
+  providerConfig?: Record<string, unknown>
+}>
+
+/**
+ * In-memory execution config used by channel runtimes before chat orchestration.
+ */
+export interface AgentRuntimeConfig {
+  /** Replaces the default profile shared by every channel. */
+  setDefaultExecutionProfile: (profile: AgentExecutionProfile) => void
+  /** Replaces the host-owned resolver that turns provider ids into provider instances. */
+  setProviderResolver: (resolver: AgentProviderResolver) => void
+  /**
+   * Resolves concrete chat send options for a normalized channel message.
+   *
+   * `message` is used for error context and future expansion only; PR1 does
+   * not route provider/model choices by channel or session.
+   */
+  resolveExecutionOptions: (
+    message: AgentChannelMessage,
+    overrides?: Partial<ChannelAgentExecutionOptions>,
+  ) => Promise<ChatOrchestratorSendOptions>
+}
+
+/**
+ * Initial values for {@link createAgentRuntimeConfig}.
+ */
+export interface CreateAgentRuntimeConfigOptions {
+  /** Initial default profile shared by every channel. */
+  defaultExecutionProfile?: AgentExecutionProfile
+  /** Initial provider resolver owned by the host app. */
+  providerResolver?: AgentProviderResolver
+}
+
+function formatChannelMessageContext(message: AgentChannelMessage) {
+  return `channel "${message.channelId}" session "${message.sessionId}" message "${message.id}"`
+}
+
+/**
+ * Creates an in-memory runtime config for resolving core-agent execution options.
+ *
+ * Use when:
+ * - A host app owns provider/model settings and provider instance creation.
+ * - Channel adapters should submit messages without owning provider/model selection.
+ *
+ * Expects:
+ * - One default execution profile is shared across all channels in PR1.
+ * - The provider resolver is injected by the host and owns credentials/cache access.
+ *
+ * Returns:
+ * - A mutable runtime config that resolves chat send options for channel messages.
+ */
+export function createAgentRuntimeConfig(options: CreateAgentRuntimeConfigOptions = {}): AgentRuntimeConfig {
+  let defaultExecutionProfile = options.defaultExecutionProfile
+  let providerResolver = options.providerResolver
+
+  function setDefaultExecutionProfile(profile: AgentExecutionProfile) {
+    defaultExecutionProfile = { ...profile }
+  }
+
+  function setProviderResolver(resolver: AgentProviderResolver) {
+    providerResolver = resolver
+  }
+
+  async function resolveExecutionOptions(
+    message: AgentChannelMessage,
+    overrides: Partial<ChannelAgentExecutionOptions> = {},
+  ): Promise<ChatOrchestratorSendOptions> {
+    const providerId = overrides.providerId ?? defaultExecutionProfile?.providerId
+    const model = overrides.model ?? defaultExecutionProfile?.model
+
+    if (!model) {
+      throw new Error(`Cannot resolve execution model for ${formatChannelMessageContext(message)}: no default execution profile or model override was provided`)
+    }
+
+    if (overrides.chatProvider) {
+      return {
+        ...overrides,
+        providerId,
+        model,
+        chatProvider: overrides.chatProvider,
+      }
+    }
+
+    if (!providerId) {
+      throw new Error(`Cannot resolve execution provider for ${formatChannelMessageContext(message)}: no default execution profile or providerId override was provided`)
+    }
+
+    if (!providerResolver) {
+      throw new Error(`Cannot resolve chat provider for ${formatChannelMessageContext(message)}: no provider resolver was configured`)
+    }
+
+    const resolved = await providerResolver(providerId)
+
+    return {
+      providerId,
+      model,
+      chatProvider: resolved.chatProvider,
+      providerConfig: resolved.providerConfig,
+      ...overrides,
+    }
+  }
+
+  return {
+    setDefaultExecutionProfile,
+    setProviderResolver,
+    resolveExecutionOptions,
+  }
+}

--- a/packages/core-agent/src/runtime/channel-agent-runtime.test.ts
+++ b/packages/core-agent/src/runtime/channel-agent-runtime.test.ts
@@ -1,0 +1,251 @@
+import type { ChatProvider } from '@xsai-ext/providers/utils'
+import type { Message } from '@xsai/shared-chat'
+
+import type { ChatHistoryItem, ChatStreamEventContext, StreamingAssistantMessage } from '../types/chat'
+import type { StreamEvent } from '../types/llm'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createChannelAgentRuntime } from './channel-agent-runtime'
+
+const provider = {
+  chat: () => ({ baseURL: 'https://example.com/' }),
+} as unknown as ChatProvider
+
+function createHarness() {
+  const sessionMessages: Record<string, ChatHistoryItem[]> = {}
+  const foregroundPatches: StreamingAssistantMessage[] = []
+  const foregroundResets: StreamingAssistantMessage[] = []
+  const stateChanges: unknown[] = []
+  const ensureSession = vi.fn((sessionId: string) => {
+    sessionMessages[sessionId] ??= [
+      {
+        role: 'system',
+        content: 'system prompt',
+        createdAt: 1,
+        id: 'system',
+      },
+    ]
+  })
+  const stream = vi.fn(async (_model: string, _chatProvider: ChatProvider, _messages: Message[], options?: {
+    onStreamEvent?: (event: StreamEvent) => Promise<void> | void
+  }) => {
+    await options?.onStreamEvent?.({ type: 'text-delta', text: 'channel reply' })
+    await options?.onStreamEvent?.({ type: 'finish', finishReason: 'stop' })
+  })
+
+  const runtime = createChannelAgentRuntime({
+    session: {
+      ensureSession,
+      getSessionMessages: sessionId => sessionMessages[sessionId] ?? [],
+      appendSessionMessage: (sessionId, message) => {
+        sessionMessages[sessionId] ??= []
+        sessionMessages[sessionId].push(message)
+      },
+      getSessionGeneration: () => 1,
+    },
+    context: {
+      ingest: vi.fn(),
+      snapshot: () => ({}),
+    },
+    foregroundStream: {
+      patch: message => foregroundPatches.push(message),
+      reset: () => foregroundResets.push({ role: 'assistant', content: '', slices: [], tool_results: [] }),
+    },
+    llm: {
+      stream,
+    },
+    getActiveSessionId: () => 'session-1',
+    getActiveProvider: () => 'mock-provider',
+    now: () => 200,
+    monotonicNow: () => 100,
+    createId: () => 'generated-id',
+    onStateChange: state => stateChanges.push(state),
+  })
+
+  return {
+    ensureSession,
+    foregroundPatches,
+    foregroundResets,
+    runtime,
+    sessionMessages,
+    stateChanges,
+    stream,
+  }
+}
+
+/**
+ * @example
+ * const runtime = createChannelAgentRuntime(deps)
+ * await runtime.ingestMessage(channelMessage, { model, chatProvider })
+ */
+describe('createChannelAgentRuntime', () => {
+  /**
+   * @example
+   * Channel message facts are preserved in hook context while existing chat composition handles attachments.
+   */
+  it('maps channel messages into chat sends and preserves channel facts in turn context', async () => {
+    const harness = createHarness()
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    let composedMessages: Message[] = []
+
+    harness.runtime.hooks.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+    harness.stream.mockImplementationOnce(async (_model, _chatProvider, messages, options) => {
+      composedMessages = messages
+      await options?.onStreamEvent?.({ type: 'text-delta', text: 'visible reply' })
+      await options?.onStreamEvent?.({ type: 'finish', finishReason: 'stop' })
+    })
+
+    await harness.runtime.ingestMessage({
+      id: 'channel-message-1',
+      channelId: 'stage-ui',
+      sessionId: 'session-channel',
+      role: 'user',
+      content: 'see image',
+      createdAt: 777,
+      attachments: [
+        {
+          type: 'image',
+          data: 'aW1hZ2U=',
+          mimeType: 'image/png',
+        },
+      ],
+      input: {
+        type: 'input:text',
+        data: {
+          text: 'see image',
+        },
+      },
+      metadata: {
+        source: 'contract-test',
+      },
+    }, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(harness.ensureSession).toHaveBeenCalledWith('session-channel')
+    expect(hookContext?.input).toEqual({
+      type: 'input:text',
+      data: {
+        text: 'see image',
+      },
+    })
+    expect(hookContext?.channel).toEqual({
+      channelId: 'stage-ui',
+      channelMessageId: 'channel-message-1',
+      sessionId: 'session-channel',
+      createdAt: 777,
+      metadata: {
+        source: 'contract-test',
+      },
+    })
+    const userMessageContent = composedMessages[1]?.content
+    if (!Array.isArray(userMessageContent))
+      throw new TypeError('Expected composed channel user message content to be an array')
+    expect(userMessageContent[0]).toEqual({
+      type: 'text',
+      text: expect.stringMatching(/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] see image$/),
+    })
+    expect(userMessageContent[1]).toEqual(
+      {
+        type: 'image_url',
+        image_url: {
+          url: 'data:image/png;base64,aW1hZ2U=',
+        },
+      },
+    )
+    expect(harness.sessionMessages['session-channel']).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'user',
+        createdAt: 200,
+      }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'visible reply',
+      }),
+    ]))
+  })
+
+  /**
+   * @example
+   * runtime.cancelPendingSends(sessionId)
+   * await expect(queuedSend).rejects.toThrow()
+   */
+  it('keeps queue, cancel, snapshot, and sending state behavior delegated to chat runtime', async () => {
+    const harness = createHarness()
+    let releaseFirstSend: (() => void) | undefined
+    harness.stream.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirstSend = resolve
+      })
+    })
+
+    const firstSend = harness.runtime.ingestMessage({
+      id: 'first-channel-message',
+      channelId: 'stage-ui',
+      sessionId: 'session-1',
+      role: 'user',
+      content: 'hold queue',
+      createdAt: 100,
+    }, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+    const secondSend = harness.runtime.ingestMessage({
+      id: 'second-channel-message',
+      channelId: 'stage-ui',
+      sessionId: 'session-1',
+      role: 'user',
+      content: 'cancel me',
+      createdAt: 101,
+    }, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    await vi.waitFor(() => {
+      expect(harness.stream).toHaveBeenCalledTimes(1)
+    })
+    await vi.waitFor(() => {
+      expect(harness.runtime.getPendingQueuedSendCount()).toBe(1)
+    })
+
+    expect(harness.runtime.getSending()).toBe(true)
+    expect(harness.runtime.getPendingQueuedSendSnapshot()).toEqual([
+      {
+        sessionId: 'session-1',
+        generation: 1,
+        cancelled: false,
+        messagePreview: 'cancel me',
+        hasAttachments: false,
+        inputType: undefined,
+      },
+    ])
+
+    harness.runtime.cancelPendingSends('session-1')
+    expect(harness.runtime.getPendingQueuedSendCount()).toBe(0)
+    releaseFirstSend?.()
+
+    await expect(secondSend).rejects.toThrow('Chat session was reset before send could start')
+    await firstSend
+    expect(harness.runtime.getSending()).toBe(false)
+
+    harness.runtime.setSending(true)
+    expect(harness.runtime.getSending()).toBe(true)
+    harness.runtime.setSending(false)
+    expect(harness.runtime.getSending()).toBe(false)
+    expect(harness.stateChanges).toEqual(expect.arrayContaining([
+      {
+        sending: true,
+        pendingQueuedSendCount: 0,
+      },
+      {
+        sending: false,
+        pendingQueuedSendCount: 0,
+      },
+    ]))
+  })
+})

--- a/packages/core-agent/src/runtime/channel-agent-runtime.test.ts
+++ b/packages/core-agent/src/runtime/channel-agent-runtime.test.ts
@@ -6,16 +6,21 @@ import type { StreamEvent } from '../types/llm'
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { createAgentRuntimeConfig } from './agent-runtime-config'
 import { createChannelAgentRuntime } from './channel-agent-runtime'
 
 const provider = {
   chat: () => ({ baseURL: 'https://example.com/' }),
 } as unknown as ChatProvider
 
-function createHarness() {
+function createHarness(options: {
+  activeProvider?: string
+  runtimeConfig?: ReturnType<typeof createAgentRuntimeConfig>
+} = {}) {
   const sessionMessages: Record<string, ChatHistoryItem[]> = {}
   const foregroundPatches: StreamingAssistantMessage[] = []
   const foregroundResets: StreamingAssistantMessage[] = []
+  const llmRequestStarted: unknown[] = []
   const stateChanges: unknown[] = []
   const ensureSession = vi.fn((sessionId: string) => {
     sessionMessages[sessionId] ??= [
@@ -56,10 +61,12 @@ function createHarness() {
       stream,
     },
     getActiveSessionId: () => 'session-1',
-    getActiveProvider: () => 'mock-provider',
+    getActiveProvider: () => options.activeProvider ?? 'mock-provider',
+    runtimeConfig: options.runtimeConfig,
     now: () => 200,
     monotonicNow: () => 100,
     createId: () => 'generated-id',
+    onLlmRequestStarted: event => llmRequestStarted.push(event),
     onStateChange: state => stateChanges.push(state),
   })
 
@@ -67,6 +74,7 @@ function createHarness() {
     ensureSession,
     foregroundPatches,
     foregroundResets,
+    llmRequestStarted,
     runtime,
     sessionMessages,
     stateChanges,
@@ -167,6 +175,79 @@ describe('createChannelAgentRuntime', () => {
         content: 'visible reply',
       }),
     ]))
+  })
+
+  /**
+   * @example
+   * await runtime.ingestMessage(channelMessage)
+   * // execution config supplies provider/model for all channels
+   */
+  it('resolves omitted execution options from the shared runtime config', async () => {
+    const resolver = vi.fn(async () => ({ chatProvider: provider }))
+    const runtimeConfig = createAgentRuntimeConfig({
+      defaultExecutionProfile: {
+        providerId: 'shared-provider',
+        model: 'shared-model',
+      },
+      providerResolver: resolver,
+    })
+    const harness = createHarness({
+      activeProvider: 'fallback-provider',
+      runtimeConfig,
+    })
+
+    await harness.runtime.ingestMessage({
+      id: 'satori-message',
+      channelId: 'satori',
+      sessionId: 'satori-session',
+      role: 'user',
+      content: 'hello from satori',
+      createdAt: 300,
+    })
+
+    expect(resolver).toHaveBeenCalledWith('shared-provider')
+    expect(harness.stream).toHaveBeenCalledWith(
+      'shared-model',
+      provider,
+      expect.any(Array),
+      expect.objectContaining({
+        waitForTools: true,
+      }),
+    )
+    expect(harness.llmRequestStarted).toEqual([
+      {
+        model: 'shared-model',
+        provider: 'shared-provider',
+        hasVoice: false,
+      },
+    ])
+    expect(harness.sessionMessages['satori-session']).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'user',
+        content: 'hello from satori',
+      }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'channel reply',
+      }),
+    ]))
+  })
+
+  /**
+   * @example
+   * await expect(runtime.ingestMessage(channelMessage)).rejects.toThrow()
+   */
+  it('fails clearly when omitted execution options have no runtime config fallback', async () => {
+    const harness = createHarness()
+
+    await expect(harness.runtime.ingestMessage({
+      id: 'missing-config-message',
+      channelId: 'satori',
+      sessionId: 'satori-session',
+      role: 'user',
+      content: 'hello from satori',
+      createdAt: 300,
+    })).rejects.toThrow('Cannot ingest channel message "missing-config-message" for channel "satori" session "satori-session"')
   })
 
   /**

--- a/packages/core-agent/src/runtime/channel-agent-runtime.ts
+++ b/packages/core-agent/src/runtime/channel-agent-runtime.ts
@@ -1,4 +1,5 @@
 import type { AgentChannelMessage } from '../types/channel'
+import type { AgentRuntimeConfig } from './agent-runtime-config'
 import type { ChatOrchestratorRuntime, ChatOrchestratorRuntimeDeps, ChatOrchestratorSendOptions } from './chat-orchestrator-runtime'
 
 import { createChatOrchestratorRuntime } from './chat-orchestrator-runtime'
@@ -7,6 +8,14 @@ import { createChatOrchestratorRuntime } from './chat-orchestrator-runtime'
  * Execution options supplied by a caller after channel message normalization.
  */
 export type ChannelAgentExecutionOptions = Omit<ChatOrchestratorSendOptions, 'attachments' | 'input' | 'channel'>
+
+/**
+ * Dependencies for the channel-facing runtime facade.
+ */
+export interface ChannelAgentRuntimeDeps extends ChatOrchestratorRuntimeDeps {
+  /** Optional core-owned runtime config for resolving execution options from channel messages. */
+  runtimeConfig?: AgentRuntimeConfig
+}
 
 /**
  * Channel-facing runtime that accepts normalized channel messages before delegating to chat orchestration.
@@ -21,7 +30,7 @@ export interface ChannelAgentRuntime extends Pick<
   | 'hooks'
 > {
   /** Enqueues a normalized channel user message for the existing chat orchestrator runtime. */
-  ingestMessage: (message: AgentChannelMessage, options: ChannelAgentExecutionOptions) => Promise<void>
+  ingestMessage: (message: AgentChannelMessage, options?: Partial<ChannelAgentExecutionOptions>) => Promise<void>
 }
 
 /**
@@ -33,17 +42,31 @@ export interface ChannelAgentRuntime extends Pick<
  *
  * Expects:
  * - `message.sessionId` points at the core chat session that should receive the turn.
- * - Provider/model execution details are passed separately as execution options.
+ * - Provider/model execution details are passed explicitly or resolved by one shared runtime config profile.
  *
  * Returns:
  * - A runtime with channel ingress plus the existing queue, hook, and state surfaces.
  */
-export function createChannelAgentRuntime(deps: ChatOrchestratorRuntimeDeps): ChannelAgentRuntime {
+export function createChannelAgentRuntime(deps: ChannelAgentRuntimeDeps): ChannelAgentRuntime {
   const chatRuntime = createChatOrchestratorRuntime(deps)
 
-  function ingestMessage(message: AgentChannelMessage, options: ChannelAgentExecutionOptions) {
+  async function resolveExecutionOptions(message: AgentChannelMessage, options?: Partial<ChannelAgentExecutionOptions>) {
+    if (options?.model && options.chatProvider) {
+      return options as ChannelAgentExecutionOptions
+    }
+
+    if (deps.runtimeConfig) {
+      return deps.runtimeConfig.resolveExecutionOptions(message, options)
+    }
+
+    throw new Error(`Cannot ingest channel message "${message.id}" for channel "${message.channelId}" session "${message.sessionId}": pass model/chatProvider options or configure runtimeConfig`)
+  }
+
+  async function ingestMessage(message: AgentChannelMessage, options?: Partial<ChannelAgentExecutionOptions>) {
+    const executionOptions = await resolveExecutionOptions(message, options)
+
     return chatRuntime.ingest(message.content, {
-      ...options,
+      ...executionOptions,
       attachments: message.attachments,
       input: message.input,
       channel: {

--- a/packages/core-agent/src/runtime/channel-agent-runtime.ts
+++ b/packages/core-agent/src/runtime/channel-agent-runtime.ts
@@ -1,0 +1,68 @@
+import type { AgentChannelMessage } from '../types/channel'
+import type { ChatOrchestratorRuntime, ChatOrchestratorRuntimeDeps, ChatOrchestratorSendOptions } from './chat-orchestrator-runtime'
+
+import { createChatOrchestratorRuntime } from './chat-orchestrator-runtime'
+
+/**
+ * Execution options supplied by a caller after channel message normalization.
+ */
+export type ChannelAgentExecutionOptions = Omit<ChatOrchestratorSendOptions, 'attachments' | 'input' | 'channel'>
+
+/**
+ * Channel-facing runtime that accepts normalized channel messages before delegating to chat orchestration.
+ */
+export interface ChannelAgentRuntime extends Pick<
+  ChatOrchestratorRuntime,
+  | 'cancelPendingSends'
+  | 'getPendingQueuedSendSnapshot'
+  | 'getPendingQueuedSendCount'
+  | 'getSending'
+  | 'setSending'
+  | 'hooks'
+> {
+  /** Enqueues a normalized channel user message for the existing chat orchestrator runtime. */
+  ingestMessage: (message: AgentChannelMessage, options: ChannelAgentExecutionOptions) => Promise<void>
+}
+
+/**
+ * Creates a channel ingress runtime in front of the existing chat orchestrator.
+ *
+ * Use when:
+ * - A platform has normalized inbound events into `AgentChannelMessage`.
+ * - Channel facts must be preserved in turn context without changing session or streaming ownership.
+ *
+ * Expects:
+ * - `message.sessionId` points at the core chat session that should receive the turn.
+ * - Provider/model execution details are passed separately as execution options.
+ *
+ * Returns:
+ * - A runtime with channel ingress plus the existing queue, hook, and state surfaces.
+ */
+export function createChannelAgentRuntime(deps: ChatOrchestratorRuntimeDeps): ChannelAgentRuntime {
+  const chatRuntime = createChatOrchestratorRuntime(deps)
+
+  function ingestMessage(message: AgentChannelMessage, options: ChannelAgentExecutionOptions) {
+    return chatRuntime.ingest(message.content, {
+      ...options,
+      attachments: message.attachments,
+      input: message.input,
+      channel: {
+        channelId: message.channelId,
+        channelMessageId: message.id,
+        sessionId: message.sessionId,
+        createdAt: message.createdAt,
+        metadata: message.metadata,
+      },
+    }, message.sessionId)
+  }
+
+  return {
+    ingestMessage,
+    cancelPendingSends: chatRuntime.cancelPendingSends,
+    getPendingQueuedSendSnapshot: chatRuntime.getPendingQueuedSendSnapshot,
+    getPendingQueuedSendCount: chatRuntime.getPendingQueuedSendCount,
+    getSending: chatRuntime.getSending,
+    setSending: chatRuntime.setSending,
+    hooks: chatRuntime.hooks,
+  }
+}

--- a/packages/core-agent/src/runtime/chat-orchestrator-runtime.ts
+++ b/packages/core-agent/src/runtime/chat-orchestrator-runtime.ts
@@ -49,6 +49,8 @@ function cloneStreamingMessage(message: StreamingAssistantMessage): StreamingAss
  * Options accepted by the chat orchestrator runtime for one user send.
  */
 export interface ChatOrchestratorSendOptions {
+  /** Provider identifier used for this turn's telemetry and response policy. */
+  providerId?: string
   /** Provider model identifier used for the outbound LLM request. */
   model: string
   /** Concrete chat provider implementation selected by the caller. */
@@ -466,7 +468,8 @@ export function createChatOrchestratorRuntime(deps: ChatOrchestratorRuntimeDeps)
         sessionMessages: sessionMessagesForSend,
       })
 
-      const categorizer = createStreamingCategorizer(deps.getActiveProvider())
+      const turnProviderId = options.providerId ?? deps.getActiveProvider()
+      const categorizer = createStreamingCategorizer(turnProviderId)
       let streamPosition = 0
 
       const parser = useLlmmarkerParser({
@@ -507,7 +510,7 @@ export function createChatOrchestratorRuntime(deps: ChatOrchestratorRuntimeDeps)
           if (isStaleGeneration())
             return
 
-          const finalCategorization = categorizeResponse(fullText, deps.getActiveProvider())
+          const finalCategorization = categorizeResponse(fullText, turnProviderId)
 
           const reasoningContentField = buildingMessage.categorization?.reasoning?.trim()
           buildingMessage.categorization = {
@@ -610,7 +613,7 @@ export function createChatOrchestratorRuntime(deps: ChatOrchestratorRuntimeDeps)
       let llmFirstTokenEmitted = false
       deps.onLlmRequestStarted?.({
         model: options.model,
-        provider: deps.getActiveProvider() || 'unknown',
+        provider: turnProviderId || 'unknown',
         hasVoice: !!options.input,
       })
 

--- a/packages/core-agent/src/runtime/chat-orchestrator-runtime.ts
+++ b/packages/core-agent/src/runtime/chat-orchestrator-runtime.ts
@@ -3,6 +3,7 @@ import type { CommonContentPart, Message, ToolMessage } from '@xsai/shared-chat'
 
 import type { AgentContextPort } from '../contracts/context-port'
 import type { AgentForegroundStreamPort } from '../contracts/stream-port'
+import type { AgentChannelIngressContext } from '../types/channel'
 import type { ChatAssistantMessage, ChatHistoryItem, ChatSlices, ChatStreamEventContext, ContextMessage, StreamingAssistantMessage } from '../types/chat'
 import type { StreamEvent, StreamOptions } from '../types/llm'
 
@@ -60,6 +61,8 @@ export interface ChatOrchestratorSendOptions {
   tools?: StreamOptions['tools']
   /** Original transport input metadata used by bridge/devtools observers. */
   input?: ChatStreamEventContext['input']
+  /** Channel facts preserved for hooks, observability, and future channel runtimes. */
+  channel?: AgentChannelIngressContext
 }
 
 interface QueuedSend {
@@ -374,6 +377,7 @@ export function createChatOrchestratorRuntime(deps: ChatOrchestratorRuntimeDeps)
       contexts: deps.context.snapshot(),
       composedMessage: [],
       input: options.input,
+      channel: options.channel,
     }
     deps.onLifecycle?.({
       phase: 'before-compose',

--- a/packages/core-agent/src/types/channel.ts
+++ b/packages/core-agent/src/types/channel.ts
@@ -1,0 +1,45 @@
+import type { WebSocketEventInputs } from '@proj-airi/server-shared/types'
+
+/**
+ * Channel-side user message accepted by the core agent ingress seam.
+ *
+ * @param TMetadata - Structured metadata preserved from the originating channel.
+ */
+export interface AgentChannelMessage<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
+  /** Channel-scoped message identifier. */
+  id: string
+  /** Logical channel that produced this message, for example `stage-ui` or `satori`. */
+  channelId: string
+  /** Core chat session that should receive this message. */
+  sessionId: string
+  /** User-authored ingress is the only supported channel role in this first seam. */
+  role: 'user'
+  /** Text payload forwarded into the existing chat orchestrator turn. */
+  content: string
+  /** Original channel timestamp. This does not replace persisted session message time. */
+  createdAt: number
+  /** Image attachments provided by the channel adapter. */
+  attachments?: Array<{ type: 'image', data: string, mimeType: string }>
+  /** Original transport input metadata used by bridge/devtools observers. */
+  input?: WebSocketEventInputs
+  /** Channel-specific metadata preserved for hooks, observability, and future runtimes. */
+  metadata?: TMetadata
+}
+
+/**
+ * Channel facts attached to a core chat turn context.
+ *
+ * @param TMetadata - Structured metadata preserved from the originating channel.
+ */
+export interface AgentChannelIngressContext<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
+  /** Logical channel that produced the user turn. */
+  channelId: string
+  /** Channel-scoped source message identifier. */
+  channelMessageId: string
+  /** Core chat session that owns the turn. */
+  sessionId: string
+  /** Original channel timestamp. This is informational for the turn context. */
+  createdAt: number
+  /** Channel-specific metadata preserved without interpretation by the chat runtime. */
+  metadata?: TMetadata
+}

--- a/packages/core-agent/src/types/chat.ts
+++ b/packages/core-agent/src/types/chat.ts
@@ -1,6 +1,8 @@
 import type { ContextUpdate, MetadataEventSource, WebSocketEventInputs } from '@proj-airi/server-shared/types'
 import type { AssistantMessage, CommonContentPart, CompletionToolCall, Message, SystemMessage, ToolMessage, UserMessage } from '@xsai/shared-chat'
 
+import type { AgentChannelIngressContext } from './channel'
+
 export interface ChatSlicesText {
   type: 'text'
   text: string
@@ -54,6 +56,7 @@ export interface ChatStreamEventContext {
   contexts: Record<string, ContextMessage[]>
   composedMessage: Array<Message>
   input?: WebSocketEventInputs
+  channel?: AgentChannelIngressContext
 }
 
 export type ChatStreamEvent

--- a/packages/stage-ui/src/stores/chat.contract.test.ts
+++ b/packages/stage-ui/src/stores/chat.contract.test.ts
@@ -1,3 +1,4 @@
+import type { AgentChannelMessage, ChatStreamEventContext } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
@@ -307,6 +308,138 @@ describe('chat orchestrator contract', () => {
 
   /**
    * @example
+   * await store.ingest('hello', { model, chatProvider })
+   * // hook context includes channelId: 'stage-ui'
+   */
+  it('wraps legacy ingest calls as stage-ui channel messages', async () => {
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    llmStreamMock.mockImplementationOnce(async (_model, _provider, _messages, options) => {
+      await options.onStreamEvent({ type: 'text-delta', text: 'legacy reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+    store.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+
+    await store.ingest('legacy stage message', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(hookContext?.channel).toMatchObject({
+      channelId: 'stage-ui',
+      sessionId: 'session-1',
+    })
+    expect(hookContext?.channel?.channelMessageId).toEqual(expect.any(String))
+    expect(hookContext?.channel?.createdAt).toEqual(expect.any(Number))
+  })
+
+  /**
+   * @example
+   * await store.ingest('hello', { model, chatProvider }, '')
+   * // hook context still uses the active session instead of a blank session id
+   */
+  it('falls back to the active session when legacy ingest receives a blank target session id', async () => {
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    llmStreamMock.mockImplementationOnce(async (_model, _provider, _messages, options) => {
+      await options.onStreamEvent({ type: 'text-delta', text: 'blank target reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+    store.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+
+    await store.ingest('blank target session id', {
+      model: 'gpt-test',
+      chatProvider: provider,
+    }, '')
+
+    expect(ensureSessionMock).toHaveBeenCalledWith('session-1')
+    expect(ensureSessionMock).not.toHaveBeenCalledWith('')
+    expect(hookContext?.channel?.sessionId).toBe('session-1')
+  })
+
+  /**
+   * @example
+   * await store.ingestChannelMessage(channelMessage, { model, chatProvider })
+   * // explicit channel facts survive into hook context
+   */
+  it('accepts explicit stage-ui channel messages through the store facade', async () => {
+    let hookContext: Omit<ChatStreamEventContext, 'composedMessage'> | undefined
+    let composedMessages: Message[] = []
+    llmStreamMock.mockImplementationOnce(async (_model, _provider, messages, options) => {
+      composedMessages = messages
+      await options.onStreamEvent({ type: 'text-delta', text: 'channel reply' })
+      await options.onStreamEvent({ type: 'finish', finishReason: 'stop' })
+    })
+
+    const store = useChatOrchestratorStore()
+    const message: AgentChannelMessage = {
+      id: 'stage-channel-message',
+      channelId: 'stage-ui',
+      sessionId: 'session-channel',
+      role: 'user',
+      content: 'channel direct',
+      createdAt: 777,
+      attachments: [
+        {
+          type: 'image',
+          data: 'aW1hZ2U=',
+          mimeType: 'image/png',
+        },
+      ],
+      input: {
+        type: 'input:text',
+        data: {
+          text: 'channel direct',
+        },
+      },
+      metadata: {
+        source: 'stage-ui-contract',
+      },
+    }
+    store.onBeforeMessageComposed(async (_message, context) => {
+      hookContext = context
+    })
+
+    await store.ingestChannelMessage(message, {
+      model: 'gpt-test',
+      chatProvider: provider,
+    })
+
+    expect(ensureSessionMock).toHaveBeenCalledWith('session-channel')
+    expect(hookContext?.input).toEqual(message.input)
+    expect(hookContext?.channel).toEqual({
+      channelId: 'stage-ui',
+      channelMessageId: 'stage-channel-message',
+      sessionId: 'session-channel',
+      createdAt: 777,
+      metadata: {
+        source: 'stage-ui-contract',
+      },
+    })
+
+    const userMessageContent = composedMessages[1]?.content
+    if (!Array.isArray(userMessageContent))
+      throw new TypeError('Expected composed stage-ui channel message content to be an array')
+    expect(userMessageContent[0]).toEqual({
+      type: 'text',
+      text: expect.stringMatching(/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] channel direct$/),
+    })
+    expect(userMessageContent[1]).toEqual({
+      type: 'image_url',
+      image_url: {
+        url: 'data:image/png;base64,aW1hZ2U=',
+      },
+    })
+  })
+
+  /**
+   * @example
    * store.sending = true
    * await nextTick()
    * expect(store.sending).toBe(true)
@@ -549,6 +682,7 @@ describe('chat orchestrator contract', () => {
 
     expect(store.$id).toBe('chat-orchestrator')
     expect(typeof store.ingest).toBe('function')
+    expect(typeof store.ingestChannelMessage).toBe('function')
     expect(typeof store.ingestOnFork).toBe('function')
     expect(typeof store.cancelPendingSends).toBe('function')
     expect(typeof store.onBeforeSend).toBe('function')

--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -1,10 +1,10 @@
-import type { ChatOrchestratorRuntimeState, ChatOrchestratorSendOptions, StreamEvent, StreamOptions } from '@proj-airi/core-agent'
+import type { AgentChannelMessage, ChannelAgentExecutionOptions, ChatOrchestratorRuntimeState, ChatOrchestratorSendOptions, StreamEvent, StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
 import type { ChatHistoryItem } from '../types/chat'
 
-import { createChatOrchestratorRuntime } from '@proj-airi/core-agent'
+import { createChannelAgentRuntime } from '@proj-airi/core-agent'
 import { IOAttributes, IOEvents, IOSpanNames, IOSubsystems } from '@proj-airi/stage-shared'
 import { nanoid } from 'nanoid'
 import { defineStore, storeToRefs } from 'pinia'
@@ -41,7 +41,7 @@ function isTextDelta(event: StreamEvent): event is Extract<StreamEvent, { type: 
   return event.type === 'text-delta'
 }
 
-export type { QueuedSendSnapshot, ChatOrchestratorSendOptions as SendOptions } from '@proj-airi/core-agent'
+export type { AgentChannelMessage, ChannelAgentExecutionOptions, QueuedSendSnapshot, ChatOrchestratorSendOptions as SendOptions } from '@proj-airi/core-agent'
 
 export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
   const llmStore = useLLM()
@@ -132,7 +132,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     ownedActiveTurnSpan = undefined
   }
 
-  const runtime = createChatOrchestratorRuntime({
+  const runtime = createChannelAgentRuntime({
     session: {
       ensureSession: sessionId => chatSession.ensureSession(sessionId),
       getSessionMessages: sessionId => chatSession.getSessionMessages(sessionId).map(message => toRaw(message)),
@@ -224,12 +224,35 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
       runtime.setSending(next)
   })
 
+  function toChannelExecutionOptions(options: ChatOrchestratorSendOptions): ChannelAgentExecutionOptions {
+    const { attachments: _attachments, input: _input, channel: _channel, ...executionOptions } = options
+    return executionOptions
+  }
+
+  async function ingestChannelMessage(
+    message: AgentChannelMessage,
+    options: ChannelAgentExecutionOptions,
+  ) {
+    return runtime.ingestMessage(message, options)
+  }
+
   async function ingest(
     sendingMessage: string,
     options: ChatOrchestratorSendOptions,
     targetSessionId?: string,
   ) {
-    return runtime.ingest(sendingMessage, options, targetSessionId)
+    const message: AgentChannelMessage = {
+      id: nanoid(),
+      channelId: 'stage-ui',
+      sessionId: targetSessionId || activeSessionId.value,
+      role: 'user',
+      content: sendingMessage,
+      createdAt: Date.now(),
+      attachments: options.attachments,
+      input: options.input,
+    }
+
+    return ingestChannelMessage(message, toChannelExecutionOptions(options))
   }
 
   async function ingestOnFork(
@@ -263,6 +286,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     pendingQueuedSendCount,
 
     ingest,
+    ingestChannelMessage,
     ingestOnFork,
     cancelPendingSends,
     getPendingQueuedSendSnapshot,


### PR DESCRIPTION
Depends on #1981

## Summary

This adds the core execution config seam for channel-owned ingress.

All channels share one host-injected default execution profile in this first version. Channel adapters can submit `AgentChannelMessage` without owning provider/model selection, and `core-agent` resolves concrete execution options through a host-provided provider resolver.

## Changes

- Add `createAgentRuntimeConfig` with:
  - `AgentExecutionProfile`
  - `AgentProviderResolver`
  - `AgentRuntimeConfig`
- Allow `ChannelAgentRuntime.ingestMessage(message)` to resolve omitted execution options from runtime config.
- Preserve the existing explicit `ingestMessage(message, options)` behavior.
- Add turn-scoped `providerId` to chat send options for telemetry and response categorization.
- Cover shared-profile resolution, explicit override behavior, and missing config errors.

## Validation

- `pnpm exec vitest run packages/core-agent/src/runtime/channel-agent-runtime.test.ts packages/core-agent/src/runtime/agent-runtime-config.test.ts`
- `pnpm -F @proj-airi/core-agent typecheck`
- `pnpm lint`
- `pnpm typecheck`