### PR TITLE
Stabilize desktop extracted styles

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/caption.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/caption.vue
@@ -136,7 +136,7 @@ onUnmounted(() => {
         <div
           :class="[
             'b-primary/50',
-            'h-full w-full animate-flash animate-duration-3s animate-count-infinite b-4 rounded-2xl',
+            'h-full w-full animate-flash stage-animation-loop-3s b-4 rounded-2xl',
           ]"
         />
       </div>
@@ -145,6 +145,10 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+.stage-animation-loop-3s {
+  animation-duration: 3s;
+  animation-iteration-count: infinite;
+}
 </style>
 
 <route lang="yaml">

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/system/window-shortcuts.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/system/window-shortcuts.vue
@@ -129,7 +129,7 @@ onMounted(async () => {
         ]"
         @click="recording = true"
       >
-        <span :class="recording ? ['animate-pulse animate-duration-2s animate-count-infinite'] : []">
+        <span :class="recording ? ['animate-pulse shortcut-recording-loop'] : []">
           {{ shortcutLabel }}
         </span>
       </button>
@@ -141,6 +141,13 @@ onMounted(async () => {
     </div>
   </section>
 </template>
+
+<style scoped>
+.shortcut-recording-loop {
+  animation-duration: 2s;
+  animation-iteration-count: infinite;
+}
+</style>
 
 <route lang="yaml">
 meta:

--- a/packages/stage-ui/src/components/scenarios/settings/model-settings/vrm.vue
+++ b/packages/stage-ui/src/components/scenarios/settings/model-settings/vrm.vue
@@ -132,6 +132,7 @@ const envOptions = computed(() => [
       </div>
       <div />
       <template v-for="option in trackingOptions" :key="option.value">
+        <!-- Keep grid placement inline so UnoCSS extraction does not have to discover computed col-start-* classes. -->
         <Button
           class="w-auto"
           :style="{ gridColumnStart: option.columnStart }"

--- a/packages/stage-ui/src/components/scenarios/settings/model-settings/vrm.vue
+++ b/packages/stage-ui/src/components/scenarios/settings/model-settings/vrm.vue
@@ -52,11 +52,11 @@ const canExtractColors = computed(() => props.runtimeSnapshot.canCapturePreview)
 const trackingOptions = computed<{
   value: 'camera' | 'mouse' | 'none'
   label: string
-  class: string
+  columnStart: number
 }[]>(() => [
-  { value: 'camera', label: t('settings.vrm.scale-and-position.eye-tracking-mode.options.option.camera'), class: 'col-start-3' },
-  { value: 'mouse', label: t('settings.vrm.scale-and-position.eye-tracking-mode.options.option.mouse'), class: 'col-start-4' },
-  { value: 'none', label: t('settings.vrm.scale-and-position.eye-tracking-mode.options.option.disabled'), class: 'col-start-5' },
+  { value: 'camera', label: t('settings.vrm.scale-and-position.eye-tracking-mode.options.option.camera'), columnStart: 3 },
+  { value: 'mouse', label: t('settings.vrm.scale-and-position.eye-tracking-mode.options.option.mouse'), columnStart: 4 },
+  { value: 'none', label: t('settings.vrm.scale-and-position.eye-tracking-mode.options.option.disabled'), columnStart: 5 },
 ])
 
 // switch between hemisphere light and sky box
@@ -133,7 +133,8 @@ const envOptions = computed(() => [
       <div />
       <template v-for="option in trackingOptions" :key="option.value">
         <Button
-          :class="[option.class, 'w-auto']"
+          class="w-auto"
+          :style="{ gridColumnStart: option.columnStart }"
           :disabled="controlsLocked"
           size="sm"
           :variant="trackingMode === option.value ? 'primary' : 'secondary'"

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -138,6 +138,7 @@ export function sharedUnoConfig() {
         },
       }),
       presetScrollbar({
+        // Electron's packaged Chromium build still needs the legacy scrollbar selectors.
         compatible: true,
       }),
       presetChromatic({

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -137,7 +137,9 @@ export function sharedUnoConfig() {
           ...createExternalPackageIconLoader('@proj-airi/iconify-meteocons'),
         },
       }),
-      presetScrollbar(),
+      presetScrollbar({
+        compatible: true,
+      }),
       presetChromatic({
         baseHue: 220.44,
         colors: {


### PR DESCRIPTION
## Summary

- Add targeted class/style updates for desktop settings and caption pages affected by extracted UnoCSS styles.
- Extend the UnoCSS config for the needed safelist coverage.
- Keep this split limited to build/style stability changes that do not depend on voice-input behavior.

## Split From

Split from #1988. This PR is intentionally small and independent.

## Merge Order

- Independent: can land before or after #2001, #2002, and #2004.

## Test Plan

- `pnpm -F @proj-airi/stage-tamagotchi typecheck`
- `pnpm exec moeru-lint apps/stage-tamagotchi/src/renderer/pages/caption.vue apps/stage-tamagotchi/src/renderer/pages/settings/system/window-shortcuts.vue packages/stage-ui/src/components/scenarios/settings/model-settings/vrm.vue uno.config.ts`
- `git diff --check origin/main...HEAD`