### PR TITLE
fix(computer-use-mcp): don't orphan background processes on terminal timeout

### DIFF
--- a/services/computer-use-mcp/src/terminal/runner.test.ts
+++ b/services/computer-use-mcp/src/terminal/runner.test.ts
@@ -5,6 +5,24 @@ import { describe, expect, it } from 'vitest'
 import { createTestConfig } from '../test-fixtures'
 import { createLocalShellRunner, TERMINAL_OUTPUT_MAX_CHARS } from './runner'
 
+/**
+ * Polls until `pid` no longer exists. Signal 0 probes liveness without
+ * delivering a signal — it throws `ESRCH` once the process has been reaped.
+ */
+async function expectProcessReaped(pid: number, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0)
+    }
+    catch {
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+  throw new Error(`process ${pid} still alive after ${timeoutMs}ms — its process group was not reaped`)
+}
+
 describe('createLocalShellRunner', () => {
   it('executes commands and keeps cwd sticky across calls', async () => {
     const runner = createLocalShellRunner(createTestConfig({
@@ -62,5 +80,36 @@ describe('createLocalShellRunner', () => {
     expect(reset.effectiveCwd).toBe(process.cwd())
     expect(reset.lastExitCode).toBeUndefined()
     expect(reset.lastCommandSummary).toBeUndefined()
+  })
+
+  // ROOT CAUSE:
+  //
+  // `terminal_exec` ran commands under `shell -lc "..."` without `detached`, so
+  // the shell shared the runner's process group. On timeout the runner called
+  // `child.kill('SIGTERM')`, which signals only the shell PID. A command that
+  // had forked a background grandchild (`cmd &`, `nohup`, a server) left that
+  // grandchild reparented to init instead of being reaped.
+  //
+  // We fixed this by spawning the shell `detached` (making it a process-group
+  // leader) and signalling the whole group on timeout, so background
+  // grandchildren are reaped together with the shell.
+  it('reaps background grandchildren when a command times out', async () => {
+    const runner = createLocalShellRunner(createTestConfig({ timeoutMs: 300 }))
+
+    // `sleep 30 &` forks a background grandchild; `$!` is its pid. The trailing
+    // `sleep 30` keeps the shell busy so the runner hits its timeout.
+    const result = await runner.execute({
+      command: 'sleep 30 & echo "BG_PID:$!"; sleep 30',
+    })
+
+    expect(result.timedOut).toBe(true)
+    expect(result.exitCode).toBe(124)
+
+    const match = result.stdout.match(/BG_PID:(\d+)/)
+    expect(match).not.toBeNull()
+    const backgroundPid = Number(match?.[1])
+    expect(Number.isInteger(backgroundPid)).toBe(true)
+
+    await expectProcessReaped(backgroundPid)
   })
 })

--- a/services/computer-use-mcp/src/terminal/runner.ts
+++ b/services/computer-use-mcp/src/terminal/runner.ts
@@ -1,3 +1,5 @@
+import type { ChildProcess } from 'node:child_process'
+
 import type {
   ApprovalGrantScope,
   ComputerUseConfig,
@@ -8,9 +10,50 @@ import type {
 } from '../types'
 
 import { spawn } from 'node:child_process'
-import { env, cwd as processCwd } from 'node:process'
+import { env, kill as killProcess, cwd as processCwd } from 'node:process'
 
 export const TERMINAL_OUTPUT_MAX_CHARS = 16_384
+
+/**
+ * Grace period between SIGTERM and SIGKILL when reaping a timed-out command's
+ * process group. Mirrors the SIGTERM -> 5s -> SIGKILL escalation already used
+ * by the stage-tamagotchi desktop-overlay smoke harness.
+ */
+const PROCESS_GROUP_KILL_GRACE_MS = 5_000
+
+/**
+ * Signals the timed-out command's entire process group instead of only the
+ * shell process.
+ *
+ * The shell is spawned `detached`, which makes it a process-group leader on
+ * POSIX, so a negative PID reaches every descendant — including background
+ * grandchildren (`cmd &`, `nohup`, long-lived servers) that a bare
+ * `child.kill()` would leave orphaned when the command times out.
+ *
+ * Falls back to signalling just the shell process when group signalling is
+ * unavailable: the group already exited, or the platform has no POSIX process
+ * groups (e.g. Windows, where the detached child still receives the direct
+ * signal).
+ */
+function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals) {
+  const pid = child.pid
+  if (pid != null) {
+    try {
+      killProcess(-pid, signal)
+      return
+    }
+    catch {
+      // group already gone, or pid is not a group leader — fall through
+    }
+  }
+
+  try {
+    child.kill(signal)
+  }
+  catch {
+    // process already exited
+  }
+}
 
 interface OutputCapture {
   value: string
@@ -88,12 +131,16 @@ export function createLocalShellRunner(config: ComputerUseConfig): TerminalRunne
           cwd: effectiveCwd,
           env,
           stdio: ['ignore', 'pipe', 'pipe'],
+          // Become a process-group leader so a timeout can reap the whole group
+          // (the shell plus any background grandchildren), not just the shell.
+          detached: true,
         })
 
         const stdout = createOutputCapture()
         const stderr = createOutputCapture()
         let finished = false
         let timedOut = false
+        let escalationTimer: ReturnType<typeof setTimeout> | undefined
 
         const stopTimer = setTimeout(() => {
           if (finished)
@@ -101,7 +148,14 @@ export function createLocalShellRunner(config: ComputerUseConfig): TerminalRunne
 
           timedOut = true
           finished = true
-          child.kill('SIGTERM')
+
+          // Reap the command's whole process group, not just the shell, so
+          // background grandchildren don't outlive the timeout. Escalate to
+          // SIGKILL after a grace period if the group ignores SIGTERM.
+          signalProcessGroup(child, 'SIGTERM')
+          escalationTimer = setTimeout(signalProcessGroup, PROCESS_GROUP_KILL_GRACE_MS, child, 'SIGKILL')
+          escalationTimer.unref()
+
           const timeoutStderr = appendTimeoutMessage(stderr, timeoutMs)
           resolve({
             command: input.command,
@@ -118,7 +172,11 @@ export function createLocalShellRunner(config: ComputerUseConfig): TerminalRunne
           })
         }, timeoutMs)
 
-        const cleanup = () => clearTimeout(stopTimer)
+        const cleanup = () => {
+          clearTimeout(stopTimer)
+          if (escalationTimer != null)
+            clearTimeout(escalationTimer)
+        }
 
         child.stdout.on('data', (chunk) => {
           appendOutput(stdout, chunk.toString('utf-8'))
@@ -138,11 +196,13 @@ export function createLocalShellRunner(config: ComputerUseConfig): TerminalRunne
         })
 
         child.on('close', (code) => {
+          // Always clear pending timers, including the post-timeout SIGKILL
+          // escalation once the group has actually exited.
+          cleanup()
           if (finished)
             return
 
           finished = true
-          cleanup()
           resolve({
             command: input.command,
             stdout: stdout.value,


### PR DESCRIPTION
## Description

Noticed this reading the terminal runner: when a `terminal_exec` command times out we only `SIGTERM` the shell. The shell isn't spawned `detached`, so anything it backgrounded (`server &`, `nohup`, a dev server) gets reparented to init and keeps running — an orphan leak on every timed-out command that backgrounded something.

Fix: spawn the shell `detached` and signal the whole process group (negative PID) on timeout, SIGTERM → 5s → SIGKILL — same pattern as `apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts`. Falls back to a single-process kill, non-timeout path unchanged.

## Linked Issues

None — just something I noticed.

## Additional Context

Added a regression test (backgrounds a `sleep`, times out, asserts the pid is gone) — fails on `main`, passes here. `moeru-lint` clean. Left PTY teardown (`pty-runner.ts`) out on purpose: job control puts background jobs in their own groups, needs session-wide cleanup — happy to follow up.
