### PR TITLE
feat(docs): add character card template reference

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -157,6 +157,7 @@ export default defineConfig<ThemeConfig>({
                 text: 'Configuration',
                 items: [
                   { text: 'Configuration Guide', link: withBase('/en/docs/manual/config/') },
+                  { text: 'Character Card Template', link: withBase('/en/docs/manual/tamagotchi/character-card-template') },
                 ],
               },
             ],
@@ -302,6 +303,10 @@ export default defineConfig<ThemeConfig>({
                 text: '配置',
                 items: [
                   { text: '配置指南', link: withBase('/zh-Hans/docs/manual/config/') },
+                  {
+                    text: '角色卡模板',
+                    link: withBase('/zh-Hans/docs/manual/tamagotchi/character-card-template'),
+                  },
                 ],
               },
             ],
@@ -443,6 +448,7 @@ export default defineConfig<ThemeConfig>({
                 text: '設定',
                 items: [
                   { text: '設定ガイド', link: withBase('/ja/docs/manual/config/') },
+                  { text: 'キャラクターカードテンプレート', link: withBase('/ja/docs/manual/tamagotchi/character-card-template') },
                 ],
               },
             ],

--- a/docs/content/en/docs/manual/tamagotchi/character-card-template.md
+++ b/docs/content/en/docs/manual/tamagotchi/character-card-template.md
@@ -1,0 +1,39 @@
+---
+title: Character Card Template
+description: A Character Card V3 JSON template for Project AIRI.
+---
+
+This template gives you a minimal Character Card V3 structure for creating a new AIRI character. Copy the JSON below, replace the example values with your own character settings, and keep the field names and nesting unchanged.
+
+::: tip Editing tips
+- Start with `name`, `description`, `personality`, `scenario`, and `first_mes`.
+- Keep optional fields empty when you do not need them yet.
+- Make sure the final content is still valid JSON before importing or sharing it.
+:::
+
+## Template
+
+```json
+{
+  "spec": "chara_card_v3",
+  "spec_version": "3.0",
+  "data": {
+    "name": "Example Character",
+    "nickname": "Example",
+    "description": "A short description of who this character is.",
+    "personality": "Curious, warm, and playful.",
+    "scenario": "The character is meeting the user for the first time.",
+    "first_mes": "Hello! I'm happy to meet you.",
+    "alternate_greetings": [],
+    "group_only_greetings": [],
+    "mes_example": "",
+    "creator": "Your name",
+    "creator_notes": "",
+    "character_version": "1.0.0",
+    "system_prompt": "",
+    "post_history_instructions": "",
+    "tags": ["example"],
+    "extensions": {}
+  }
+}
+```

--- a/docs/content/ja/docs/manual/tamagotchi/character-card-template.md
+++ b/docs/content/ja/docs/manual/tamagotchi/character-card-template.md
@@ -1,0 +1,39 @@
+---
+title: キャラクターカードテンプレート
+description: Project AIRI 用の Character Card V3 JSON テンプレートです。
+---
+
+このテンプレートは、AIRI のキャラクターカードを作成するための最小構成の Character Card V3 JSON です。下の JSON をコピーし、サンプルの値を自分のキャラクター設定に置き換えてください。フィールド名と階層構造はそのまま残します。
+
+::: tip 編集のヒント
+- まずは `name`、`description`、`personality`、`scenario`、`first_mes` から入力します。
+- まだ使わない任意項目は空のままで問題ありません。
+- インポートまたは共有する前に、最終的な内容が正しい JSON であることを確認してください。
+:::
+
+## テンプレート
+
+```json
+{
+  "spec": "chara_card_v3",
+  "spec_version": "3.0",
+  "data": {
+    "name": "サンプルキャラクター",
+    "nickname": "サンプル",
+    "description": "このキャラクターがどのような存在かを短く説明します。",
+    "personality": "好奇心が強く、温かく、少し遊び心があります。",
+    "scenario": "このキャラクターはユーザーとはじめて出会います。",
+    "first_mes": "こんにちは！お会いできてうれしいです。",
+    "alternate_greetings": [],
+    "group_only_greetings": [],
+    "mes_example": "",
+    "creator": "あなたの名前",
+    "creator_notes": "",
+    "character_version": "1.0.0",
+    "system_prompt": "",
+    "post_history_instructions": "",
+    "tags": ["サンプル"],
+    "extensions": {}
+  }
+}
+```

--- a/docs/content/zh-Hans/docs/manual/tamagotchi/character-card-template.md
+++ b/docs/content/zh-Hans/docs/manual/tamagotchi/character-card-template.md
@@ -1,0 +1,39 @@
+---
+title: 角色卡模板
+description: Project AIRI 的 Character Card V3 JSON 模板。
+---
+
+这个模板提供了一份最小可用的 Character Card V3 结构，可以作为创建 AIRI 角色卡时的起点。你可以复制下面的 JSON，把示例内容替换成自己的角色设定，并保持字段名和层级结构不变。
+
+::: tip 编辑提示
+- 可以先填写 `name`、`description`、`personality`、`scenario` 和 `first_mes`。
+- 暂时用不到的可选字段可以先留空。
+- 导入或分享之前，请确认最终内容仍然是合法的 JSON。
+:::
+
+## 模板
+
+```json
+{
+  "spec": "chara_card_v3",
+  "spec_version": "3.0",
+  "data": {
+    "name": "示例角色",
+    "nickname": "示例",
+    "description": "关于这个角色是谁的简短描述。",
+    "personality": "好奇、温暖，也有一点俏皮。",
+    "scenario": "这个角色正在第一次见到用户。",
+    "first_mes": "你好！很高兴见到你。",
+    "alternate_greetings": [],
+    "group_only_greetings": [],
+    "mes_example": "",
+    "creator": "你的名字",
+    "creator_notes": "",
+    "character_version": "1.0.0",
+    "system_prompt": "",
+    "post_history_instructions": "",
+    "tags": ["示例"],
+    "extensions": {}
+  }
+}
+```


### PR DESCRIPTION
## Description

I have committed a character card template to let people insert character card easily.

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

It is a little commit but I think it will be useful. 我提交了一个角色卡片的模板，便于用户做角色卡。