### PR TITLE
chore: ignore .env files to prevent credential leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ lerna-debug.log*
 # e.g. Claude Code settings.local.json
 *.local.*
 .env
-.env.development
-.env.production
+.env.*
 !.env.example
 
 # Audio binaries

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ lerna-debug.log*
 *.local
 # e.g. Claude Code settings.local.json
 *.local.*
+.env
+.env.development
+.env.production
+!.env.example
 
 # Audio binaries
 *.pcm


### PR DESCRIPTION
`.env` and `.env.*` were not gitignored, so a `git add .` from the repo root would commit provider credentials that developers paste into local `.env` files (LLM API keys, ASR/TTS provider keys, etc.).

Ignore `.env`, `.env.development`, and `.env.production`, and explicitly allow `.env.example` via negation so any documented template stays tracked.

## Why

Several apps in this monorepo already expect a `.env`-style local configuration (e.g. `apps/stage-tamagotchi/.env.example`), but the root `.gitignore` only excluded `*.local` and `*.local.*` — a `git add .` from a developer who pasted real credentials into a plain `.env` would commit those secrets. This was caught when one of the dev branches started carrying plaintext provider keys.

## Test plan

- `git check-ignore -v .env`           → matches `.gitignore`
- `git check-ignore -v .env.example`   → exit 1 (not ignored, due to `!` negation)
- `git add .env`                       → no-op
- `git add .env.example`               → stages normally

## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
