### PR TITLE
feat(server): add provider catalog and capability alias gating

### DIFF
--- a/apps/server/src/routes/admin/capability-aliases/index.ts
+++ b/apps/server/src/routes/admin/capability-aliases/index.ts
@@ -59,17 +59,10 @@ async function syncAliasesFromConfig(deps: AdminCapabilityAliasRoutesDeps, surfa
   const config = await deps.configKV.getOrThrow('LLM_ROUTER_CONFIG')
   if (surface === 'llm') {
     const defaultModel = await deps.configKV.getOrThrow('DEFAULT_CHAT_MODEL')
-    const modelIds = [
-      defaultModel,
-      ...Object.keys(config.llm.models).sort().filter(modelId => modelId !== defaultModel),
-    ]
-    return await deps.service.syncAliasesFromRouterConfig({ surface, modelIds })
+    return await deps.service.syncLlmAliasesFromRouterConfig({ config, defaultModel })
   }
 
-  return await deps.service.syncAliasesFromRouterConfig({
-    surface,
-    modelIds: Object.keys(config.asr?.models ?? {}).sort(),
-  })
+  return await deps.service.syncAsrAliasesFromRouterConfig({ config })
 }
 
 /**

--- a/apps/server/src/routes/admin/capability-aliases/route.test.ts
+++ b/apps/server/src/routes/admin/capability-aliases/route.test.ts
@@ -43,7 +43,8 @@ function createConfigKV(): ConfigKVService {
 
 function createService(): ProviderCatalogService {
   return {
-    syncAliasesFromRouterConfig: vi.fn(async () => []),
+    syncLlmAliasesFromRouterConfig: vi.fn(async () => []),
+    syncAsrAliasesFromRouterConfig: vi.fn(async () => []),
     listAliases: vi.fn(async () => []),
     resolveEnabledAlias: vi.fn(),
     updateAlias: vi.fn(async (_id, input) => ({ id: 'alias-1', ...input })),
@@ -99,9 +100,16 @@ describe('admin capability alias routes', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(service.syncAliasesFromRouterConfig).toHaveBeenCalledWith({
-      surface: 'llm',
-      modelIds: ['chat-default', 'chat-fallback'],
+    expect(service.syncLlmAliasesFromRouterConfig).toHaveBeenCalledWith({
+      config: expect.objectContaining({
+        llm: expect.objectContaining({
+          models: expect.objectContaining({
+            'chat-default': expect.any(Object),
+            'chat-fallback': expect.any(Object),
+          }),
+        }),
+      }),
+      defaultModel: 'chat-default',
     })
   })
 
@@ -114,9 +122,14 @@ describe('admin capability alias routes', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(service.syncAliasesFromRouterConfig).toHaveBeenCalledWith({
-      surface: 'asr',
-      modelIds: ['aliyun/asr-primary'],
+    expect(service.syncAsrAliasesFromRouterConfig).toHaveBeenCalledWith({
+      config: expect.objectContaining({
+        asr: expect.objectContaining({
+          models: expect.objectContaining({
+            'aliyun/asr-primary': expect.any(Object),
+          }),
+        }),
+      }),
     })
   })
 

--- a/apps/server/src/routes/admin/provider-catalog/index.ts
+++ b/apps/server/src/routes/admin/provider-catalog/index.ts
@@ -76,14 +76,7 @@ async function readBody<S extends GenericSchema>(c: Context<HonoEnv>, schema: S)
 
 async function syncTtsModelsFromConfig(deps: AdminProviderCatalogRoutesDeps) {
   const config = await deps.configKV.getOrThrow('LLM_ROUTER_CONFIG')
-  return await deps.service.syncTtsModelsFromRouterConfig({
-    models: Object.fromEntries(
-      Object.entries(config.tts.models).map(([routerModelId, model]) => [
-        routerModelId,
-        { provider: model.provider },
-      ]),
-    ),
-  })
+  return await deps.service.syncTtsModelsFromRouterConfig({ config })
 }
 
 /**

--- a/apps/server/src/routes/admin/provider-catalog/route.test.ts
+++ b/apps/server/src/routes/admin/provider-catalog/route.test.ts
@@ -54,7 +54,6 @@ function createLlmRouter(): LlmRouterService {
 
 function createService(): ProviderCatalogService {
   return {
-    syncAliasesFromRouterConfig: vi.fn(async () => []),
     listAliases: vi.fn(async () => []),
     resolveEnabledAlias: vi.fn(),
     updateAlias: vi.fn(async (_id, input) => ({ id: 'alias-1', ...input })),
@@ -157,7 +156,13 @@ describe('admin provider catalog routes', () => {
 
     expect(res.status).toBe(200)
     expect(service.syncTtsModelsFromRouterConfig).toHaveBeenCalledWith({
-      models: { 'microsoft/v1': { provider: 'azure' } },
+      config: expect.objectContaining({
+        tts: expect.objectContaining({
+          models: expect.objectContaining({
+            'microsoft/v1': expect.objectContaining({ provider: 'azure' }),
+          }),
+        }),
+      }),
     })
     expect(llmRouter.listTtsVoices).toHaveBeenCalledWith('microsoft/v1')
     expect(service.syncTtsVoices).toHaveBeenCalledWith({

--- a/apps/server/src/routes/audio-transcription-stream/route.test.ts
+++ b/apps/server/src/routes/audio-transcription-stream/route.test.ts
@@ -24,7 +24,7 @@ function createRouterConfig(overrides?: Partial<RouterConfig>): RouterConfig {
 
 function createProviderCatalogService(routeModelId = 'auto'): ProviderCatalogService {
   return {
-    syncAliasesFromRouterConfig: vi.fn(async () => []),
+    syncAsrAliasesFromRouterConfig: vi.fn(async () => []),
     resolveEnabledAlias: vi.fn(async () => ({
       id: 'alias-auto',
       surface: 'asr',
@@ -136,7 +136,7 @@ describe('resolveOfficialAliyunNlsCredentials', () => {
       accessKeySecret: 'secret',
       appKey: 'app',
     })
-    expect(providerCatalogService.syncAliasesFromRouterConfig).not.toHaveBeenCalled()
+    expect(providerCatalogService.syncAsrAliasesFromRouterConfig).not.toHaveBeenCalled()
     expect(providerCatalogService.resolveEnabledAlias).toHaveBeenCalledWith('asr', 'auto')
   })
 

--- a/apps/server/src/routes/openai/v1/route.test.ts
+++ b/apps/server/src/routes/openai/v1/route.test.ts
@@ -176,8 +176,12 @@ function createMockProviderCatalogService(impl?: Partial<ProviderCatalogService>
   const syncedVoicesByModel = new Map<string, Awaited<ReturnType<ProviderCatalogService['syncTtsVoices']>>>()
 
   return {
-    syncAliasesFromRouterConfig: vi.fn(async (input: Parameters<ProviderCatalogService['syncAliasesFromRouterConfig']>[0]) => {
-      const { surface, modelIds } = input
+    syncLlmAliasesFromRouterConfig: vi.fn(async (input: Parameters<ProviderCatalogService['syncLlmAliasesFromRouterConfig']>[0]) => {
+      const { config, defaultModel } = input
+      const modelIds = [
+        defaultModel,
+        ...Object.keys(config.llm.models).sort().filter(modelId => modelId !== defaultModel),
+      ]
       syncedAliasRoutes = Array.from(new Set(modelIds)).map((routerModelId, index) => ({
         id: `alias-route-${index}`,
         aliasId: 'alias-auto',
@@ -191,7 +195,33 @@ function createMockProviderCatalogService(impl?: Partial<ProviderCatalogService>
       }))
       return [{
         id: 'alias-auto',
-        surface,
+        surface: 'llm',
+        aliasId: 'auto',
+        displayName: 'Auto',
+        enabled: true,
+        displayOrder: 0,
+        fallbackEnabled: true,
+        loadBalancingEnabled: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }]
+    }),
+    syncAsrAliasesFromRouterConfig: vi.fn(async (input: Parameters<ProviderCatalogService['syncAsrAliasesFromRouterConfig']>[0]) => {
+      const modelIds = Object.keys(input.config.asr?.models ?? {}).sort()
+      syncedAliasRoutes = Array.from(new Set(modelIds)).map((routerModelId, index) => ({
+        id: `alias-route-${index}`,
+        aliasId: 'alias-auto',
+        routerModelId,
+        pool: 'primary',
+        enabled: true,
+        weight: 1,
+        displayOrder: index,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }))
+      return [{
+        id: 'alias-auto',
+        surface: 'asr',
         aliasId: 'auto',
         displayName: 'Auto',
         enabled: true,
@@ -241,7 +271,12 @@ function createMockProviderCatalogService(impl?: Partial<ProviderCatalogService>
           }],
     })),
     syncTtsModelsFromRouterConfig: vi.fn(async (input: Parameters<ProviderCatalogService['syncTtsModelsFromRouterConfig']>[0]) => {
-      const { models } = input
+      const models = Object.fromEntries(
+        Object.entries(input.config.tts.models).map(([routerModelId, model]) => [
+          routerModelId,
+          { provider: model.provider },
+        ]),
+      )
       syncedModels = Object.entries(models).sort(([a], [b]) => a.localeCompare(b)).map(([routerModelId, model], index) => ({
         id: `tts-model-${index}`,
         routerModelId,
@@ -618,7 +653,7 @@ describe('v1CompletionsRoutes', () => {
           body: expect.stringContaining('"model":"openai/gpt-5-mini"'),
         }),
       )
-      expect(providerCatalogService.syncAliasesFromRouterConfig).not.toHaveBeenCalled()
+      expect(providerCatalogService.syncLlmAliasesFromRouterConfig).not.toHaveBeenCalled()
     })
 
     it('resolves an enabled non-auto model alias through the provider catalog', async () => {

--- a/apps/server/src/services/domain/provider-catalog/index.test.ts
+++ b/apps/server/src/services/domain/provider-catalog/index.test.ts
@@ -1,4 +1,5 @@
 import type { Database } from '../../../libs/db'
+import type { RouterConfig } from '../llm-router/types'
 
 import { eq } from 'drizzle-orm'
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -9,6 +10,48 @@ import { capabilityAliases, capabilityAliasRoutes, providerCatalogTtsModels, pro
 import { ApiError } from '../../../utils/error'
 
 import * as schema from '../../../schemas'
+
+function routerConfig(input: {
+  llmModels?: string[]
+  ttsModels?: Record<string, 'azure' | 'dashscope-cosyvoice' | 'stepfun' | 'volcengine'>
+  asrModels?: string[]
+}): RouterConfig {
+  const key = { id: 'key-1', ciphertext: 'ciphertext' }
+  const fallbackTriggers = { httpCodes: [401, 429, 500], onTimeout: true }
+
+  return {
+    llm: {
+      models: Object.fromEntries((input.llmModels ?? []).map(modelId => [
+        modelId,
+        {
+          upstreams: [{ baseURL: 'https://llm.example.com', keys: [key], headerTemplate: 'Bearer {KEY}' }],
+          fallbackTriggers,
+        },
+      ])),
+    },
+    tts: {
+      models: Object.fromEntries(Object.entries(input.ttsModels ?? {}).map(([modelId, provider]) => [
+        modelId,
+        {
+          provider,
+          upstreams: [{ baseURL: 'https://tts.example.com', keys: [key], adapterParams: {} }],
+          fallbackTriggers,
+        },
+      ])),
+    },
+    asr: {
+      models: Object.fromEntries((input.asrModels ?? []).map(modelId => [
+        modelId,
+        { provider: 'aliyun-nls', upstreams: [{ keys: [key], adapterParams: {} }] },
+      ])),
+    },
+    defaults: {
+      perAttemptTimeoutMs: 30000,
+      fullChainTimeoutMs: 60000,
+      fallbackHttpCodes: [401, 429, 500],
+    },
+  }
+}
 
 describe('providerCatalogService', () => {
   let db: Database
@@ -27,9 +70,9 @@ describe('providerCatalogService', () => {
   })
 
   it('syncs the default LLM auto alias and runtime model routes as enabled', async () => {
-    const aliases = await service.syncAliasesFromRouterConfig({
-      surface: 'llm',
-      modelIds: ['chat-b', 'chat-a'],
+    const aliases = await service.syncLlmAliasesFromRouterConfig({
+      config: routerConfig({ llmModels: ['chat-b', 'chat-a'] }),
+      defaultModel: 'chat-b',
     })
 
     expect(aliases).toHaveLength(1)
@@ -49,7 +92,10 @@ describe('providerCatalogService', () => {
   })
 
   it('preserves alias and route curation across repeated syncs', async () => {
-    await service.syncAliasesFromRouterConfig({ surface: 'llm', modelIds: ['chat-a'] })
+    await service.syncLlmAliasesFromRouterConfig({
+      config: routerConfig({ llmModels: ['chat-a'] }),
+      defaultModel: 'chat-a',
+    })
     const [alias] = await db.select().from(capabilityAliases)
     const [route] = await db.select().from(capabilityAliasRoutes)
 
@@ -60,7 +106,10 @@ describe('providerCatalogService', () => {
       .set({ enabled: false, displayOrder: 9 })
       .where(eq(capabilityAliasRoutes.id, route.id))
 
-    await service.syncAliasesFromRouterConfig({ surface: 'llm', modelIds: ['chat-a', 'chat-b'] })
+    await service.syncLlmAliasesFromRouterConfig({
+      config: routerConfig({ llmModels: ['chat-a', 'chat-b'] }),
+      defaultModel: 'chat-a',
+    })
     const aliases = await service.listAliases('llm')
     const preservedRoute = aliases[0].routes.find(item => item.routerModelId === 'chat-a')
     const newRoute = aliases[0].routes.find(item => item.routerModelId === 'chat-b')
@@ -72,19 +121,14 @@ describe('providerCatalogService', () => {
 
   it('syncs runtime TTS models as enabled but preserves admin display fields', async () => {
     const first = await service.syncTtsModelsFromRouterConfig({
-      models: {
-        'alibaba/cosyvoice-v2': { provider: 'dashscope-cosyvoice' },
-      },
+      config: routerConfig({ ttsModels: { 'alibaba/cosyvoice-v2': 'dashscope-cosyvoice' } }),
     })
     await db.update(providerCatalogTtsModels)
       .set({ enabled: false, displayName: 'Curated CosyVoice', displayOrder: 7 })
       .where(eq(providerCatalogTtsModels.id, first[0].id))
 
     await service.syncTtsModelsFromRouterConfig({
-      models: {
-        'alibaba/cosyvoice-v2': { provider: 'dashscope-cosyvoice' },
-        'microsoft/v1': { provider: 'azure' },
-      },
+      config: routerConfig({ ttsModels: { 'alibaba/cosyvoice-v2': 'dashscope-cosyvoice', 'microsoft/v1': 'azure' } }),
     })
 
     const models = await service.listTtsModels()
@@ -104,7 +148,7 @@ describe('providerCatalogService', () => {
 
   it('syncs provider voices as disabled by default and preserves curation on resync', async () => {
     await service.syncTtsModelsFromRouterConfig({
-      models: { 'microsoft/v1': { provider: 'azure' } },
+      config: routerConfig({ ttsModels: { 'microsoft/v1': 'azure' } }),
     })
 
     const first = await service.syncTtsVoices({
@@ -157,7 +201,7 @@ describe('providerCatalogService', () => {
 
   it('lists and gates only enabled TTS models and voices', async () => {
     const [model] = await service.syncTtsModelsFromRouterConfig({
-      models: { 'microsoft/v1': { provider: 'azure' } },
+      config: routerConfig({ ttsModels: { 'microsoft/v1': 'azure' } }),
     })
     const [voice] = await service.syncTtsVoices({
       routerModelId: 'microsoft/v1',
@@ -189,7 +233,10 @@ describe('providerCatalogService', () => {
       errorCode: 'CAPABILITY_ALIAS_NOT_FOUND',
     })
 
-    await service.syncAliasesFromRouterConfig({ surface: 'llm', modelIds: ['chat-a'] })
+    await service.syncLlmAliasesFromRouterConfig({
+      config: routerConfig({ llmModels: ['chat-a'] }),
+      defaultModel: 'chat-a',
+    })
     const [alias] = await db.select().from(capabilityAliases)
     await db.update(capabilityAliases)
       .set({ enabled: false })
@@ -199,7 +246,7 @@ describe('providerCatalogService', () => {
       errorCode: 'CAPABILITY_ALIAS_DISABLED',
     })
 
-    await service.syncTtsModelsFromRouterConfig({ models: { 'microsoft/v1': { provider: 'azure' } } })
+    await service.syncTtsModelsFromRouterConfig({ config: routerConfig({ ttsModels: { 'microsoft/v1': 'azure' } }) })
     await expect(service.assertTtsVoiceEnabled('microsoft/v1', 'missing')).rejects.toBeInstanceOf(ApiError)
     await expect(service.assertTtsVoiceEnabled('microsoft/v1', 'missing')).rejects.toMatchObject({
       errorCode: 'PROVIDER_CATALOG_TTS_VOICE_NOT_FOUND',

--- a/apps/server/src/services/domain/provider-catalog/index.ts
+++ b/apps/server/src/services/domain/provider-catalog/index.ts
@@ -9,6 +9,7 @@ import type {
   ProviderCatalogTtsVoiceLabels,
   ProviderCatalogTtsVoiceLanguage,
 } from '../../../schemas/provider-catalog'
+import type { RouterConfig } from '../llm-router/types'
 
 import { and, asc, eq, inArray } from 'drizzle-orm'
 
@@ -71,6 +72,26 @@ export interface ProviderCatalogTtsVoiceUpdateInput {
   languages?: ProviderCatalogTtsVoiceLanguage[]
   labels?: ProviderCatalogTtsVoiceLabels
   previewAudioUrl?: string | null
+}
+
+function llmAliasModelIds(config: RouterConfig, defaultModel: string): string[] {
+  return [
+    defaultModel,
+    ...Object.keys(config.llm.models).sort().filter(modelId => modelId !== defaultModel),
+  ]
+}
+
+function asrAliasModelIds(config: RouterConfig): string[] {
+  return Object.keys(config.asr?.models ?? {}).sort()
+}
+
+function ttsModelInputs(config: RouterConfig): Record<string, ProviderCatalogTtsModelSyncInput> {
+  return Object.fromEntries(
+    Object.entries(config.tts.models).map(([routerModelId, model]) => [
+      routerModelId,
+      { provider: model.provider },
+    ]),
+  )
 }
 
 function defaultAliasDisplayName(surface: CapabilityAliasSurface, aliasId: string): string {
@@ -180,25 +201,44 @@ export function createProviderCatalogService(db: Database) {
     return route
   }
 
-  return {
-    async syncAliasesFromRouterConfig(input: {
-      surface: CapabilityAliasSurface
-      modelIds: string[]
-    }) {
-      const alias = await ensureAlias(input.surface, DEFAULT_ALIAS_ID)
-      const uniqueModelIds = Array.from(new Set(input.modelIds))
-      for (const [index, routerModelId] of uniqueModelIds.entries()) {
-        await syncAliasRoute({
-          aliasRowId: alias.id,
-          routerModelId,
-          pool: 'primary',
-          order: index,
-        })
-      }
+  async function syncAliases(input: {
+    surface: CapabilityAliasSurface
+    modelIds: string[]
+  }) {
+    const alias = await ensureAlias(input.surface, DEFAULT_ALIAS_ID)
+    const uniqueModelIds = Array.from(new Set(input.modelIds))
+    for (const [index, routerModelId] of uniqueModelIds.entries()) {
+      await syncAliasRoute({
+        aliasRowId: alias.id,
+        routerModelId,
+        pool: 'primary',
+        order: index,
+      })
+    }
 
-      return await db.query.capabilityAliases.findMany({
-        where: eq(capabilityAliases.surface, input.surface),
-        orderBy: [asc(capabilityAliases.displayOrder), asc(capabilityAliases.aliasId)],
+    return await db.query.capabilityAliases.findMany({
+      where: eq(capabilityAliases.surface, input.surface),
+      orderBy: [asc(capabilityAliases.displayOrder), asc(capabilityAliases.aliasId)],
+    })
+  }
+
+  return {
+    async syncLlmAliasesFromRouterConfig(input: {
+      config: RouterConfig
+      defaultModel: string
+    }) {
+      return await syncAliases({
+        surface: 'llm',
+        modelIds: llmAliasModelIds(input.config, input.defaultModel),
+      })
+    },
+
+    async syncAsrAliasesFromRouterConfig(input: {
+      config: RouterConfig
+    }) {
+      return await syncAliases({
+        surface: 'asr',
+        modelIds: asrAliasModelIds(input.config),
       })
     },
 
@@ -260,13 +300,13 @@ export function createProviderCatalogService(db: Database) {
     },
 
     async syncTtsModelsFromRouterConfig(input: {
-      models: Record<string, ProviderCatalogTtsModelSyncInput>
+      config: RouterConfig
     }) {
       const existingModels = await db.query.providerCatalogTtsModels.findMany()
       const synced: ProviderCatalogTtsModel[] = []
       const now = new Date()
 
-      for (const [routerModelId, model] of Object.entries(input.models).sort(([a], [b]) => a.localeCompare(b))) {
+      for (const [routerModelId, model] of Object.entries(ttsModelInputs(input.config)).sort(([a], [b]) => a.localeCompare(b))) {
         const [syncedModel] = await db.insert(providerCatalogTtsModels).values({
           routerModelId,
           provider: model.provider,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2257,7 +2257,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: 'catalog:'
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: 'catalog:'
         version: 4.0.0(electron@41.2.1)
@@ -2296,7 +2296,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: 'catalog:'
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -2332,10 +2332,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: 'catalog:'
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -2362,7 +2362,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: 'catalog:'
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -2395,7 +2395,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: 'catalog:'
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -2416,31 +2416,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: 'catalog:'
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: 'catalog:'
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: 'catalog:'
-        version: 4.1.0(@nuxt/kit@3.20.2(magicast@0.5.2))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: 'catalog:'
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: 'catalog:'
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: 'catalog:'
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: 'catalog:'
-        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.6(typescript@5.9.3)
@@ -20677,9 +20677,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -21579,6 +21579,31 @@ snapshots:
       picocolors: 1.1.1
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.6.1))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
@@ -23591,10 +23616,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -25142,6 +25191,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -25418,6 +25473,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -27496,7 +27560,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -27504,7 +27568,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33495,11 +33559,6 @@ snapshots:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
   unocss@66.6.8(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@unocss/cli': 66.6.8
@@ -33566,6 +33625,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -33584,6 +33651,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 2.80.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -33679,6 +33759,17 @@ snapshots:
       rolldown: 1.0.0-rc.16
       rollup: 2.80.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -33907,11 +33998,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -33958,6 +34059,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -33989,6 +34105,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -34007,6 +34130,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -34021,6 +34158,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -34033,6 +34185,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -34288,6 +34450,54 @@ snapshots:
       '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       unplugin: 2.3.11
       unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@2.80.0)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
+  vue-macros@3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- add admin-managed provider catalog controls for TTS models and voices
- add product capability aliases for LLM/ASR routing and keep them separate from provider catalog inventory
- enforce disabled or missing LLM/ASR/TTS catalog entries at gateway request time instead of pass-through
- add admin TTS voice sync and preview generation support

## Verification
- pnpm exec vitest run apps/server/src/services/domain/provider-catalog/index.test.ts apps/server/src/routes/admin/provider-catalog/route.test.ts apps/server/src/routes/admin/capability-aliases/route.test.ts apps/server/src/routes/openai/v1/route.test.ts apps/server/src/routes/audio-transcription-stream/route.test.ts apps/server/src/routes/audio-speech-ws/route.test.ts apps/server/src/app.test.ts
- pnpm -F @proj-airi/server typecheck
- apps/ui-admin/node_modules/.bin/vue-tsc --noEmit -p apps/ui-admin/tsconfig.json
- node_modules/.bin/moeru-lint .

## Notes
- local unrelated docs change was left unstaged: apps/server/docs/ai-context/product-analytics-instrumentation.md