### PR TITLE
docs(ui-server-auth): fix stale server-dev auth UI domain in README

### DIFF
--- a/apps/ui-server-auth/README.md
+++ b/apps/ui-server-auth/README.md
@@ -42,4 +42,4 @@ VITE_SERVER_URL=https://api.airi.build
 
 The server redirects historical `/auth/*` URLs to `AUTH_UI_URL`, which defaults to `https://accounts.airi.build/ui`.
 
-The `server-dev` workflow deploys a Cloudflare Pages branch build at `https://server-dev.moeru-ai-airi-auth.pages.dev/ui/` with `VITE_SERVER_URL=https://airi-server-dev.up.railway.app`. Set the server-dev API environment variable `AUTH_UI_URL=https://server-dev.moeru-ai-airi-auth.pages.dev/ui` when the full dev auth redirect chain should stay on server-dev.
+The `server-dev` workflow deploys a Cloudflare Pages branch build at `https://server-dev.airi-server-auth.pages.dev/ui/` with `VITE_SERVER_URL=https://airi-server-dev.up.railway.app`. Set the server-dev API environment variable `AUTH_UI_URL=https://server-dev.airi-server-auth.pages.dev/ui` when the full dev auth redirect chain should stay on server-dev.


### PR DESCRIPTION
## Summary
- `apps/ui-server-auth/README.md` documented the `server-dev` preview at `server-dev.moeru-ai-airi-auth.pages.dev`, which is dead (HTTP 000).
- The live, server-trusted dev auth UI is `server-dev.airi-server-auth.pages.dev` (HTTP 200, listed in `apps/server/src/utils/auth-ui.ts` `SERVER_DEV_AUTH_UI_URL` and `apps/server/src/utils/origin.ts` `TRUSTED_EXACT_ORIGINS`).
- Aligned the documented dev URL and the `AUTH_UI_URL` example to the live/trusted domain. The production project name `moeru-ai-airi-auth` (→ `accounts.airi.build`) is correct and unchanged.

## Note
`deploy-cloudflare-workers-dev-server.yml` still deploys the dev auth UI with `--project-name=moeru-ai-airi-auth`, which would produce `server-dev.moeru-ai-airi-auth.pages.dev`. The live `server-dev.airi-server-auth.pages.dev` suggests the dev auth UI actually lives in a separate Cloudflare Pages project `airi-server-auth`. That workflow project-name mismatch is out of scope for this docs fix and worth a separate follow-up once confirmed against the Cloudflare account.

## Test plan
- [x] `curl -I https://server-dev.airi-server-auth.pages.dev/ui/` → 200
- [x] `curl -I https://server-dev.moeru-ai-airi-auth.pages.dev/ui/` → 000 (dead)
- [x] `apps/server/src/utils/auth-ui.ts:5` trusts `server-dev.airi-server-auth.pages.dev`

Made with [Cursor](https://cursor.com)