### PR TITLE
fix(ui): safelist settings entry icons

### DIFF
--- a/packages/stage-shared/src/uno-settings-icons.test.ts
+++ b/packages/stage-shared/src/uno-settings-icons.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { safelistSettingsEntryIcons, sharedUnoConfig } from '../../../uno.config'
+
+describe('settings entry icon safelist', () => {
+  it('keeps settings entry icons in the shared Uno safelist', () => {
+    const icons = safelistSettingsEntryIcons()
+    expect(icons).toEqual([
+      'i-solar:emoji-funny-square-bold-duotone',
+      'i-solar:people-nearby-bold-duotone',
+      'i-solar:leaf-bold-duotone',
+      'i-solar:armchair-2-bold-duotone',
+      'i-solar:database-bold-duotone',
+      'i-solar:wi-fi-router-bold-duotone',
+      'i-solar:layers-bold-duotone',
+      'i-solar:box-minimalistic-bold-duotone',
+      'i-solar:filters-bold-duotone',
+    ])
+
+    const config = sharedUnoConfig()
+    const safelist = Array.isArray(config.safelist) ? config.safelist : []
+    expect(safelist).toEqual(expect.arrayContaining(icons))
+  })
+})

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -66,6 +66,21 @@ export function safelistAllPrimaryBackgrounds(): string[] {
   }).flat()
 }
 
+
+export function safelistSettingsEntryIcons(): string[] {
+  return [
+    'i-solar:emoji-funny-square-bold-duotone',
+    'i-solar:people-nearby-bold-duotone',
+    'i-solar:leaf-bold-duotone',
+    'i-solar:armchair-2-bold-duotone',
+    'i-solar:database-bold-duotone',
+    'i-solar:wi-fi-router-bold-duotone',
+    'i-solar:layers-bold-duotone',
+    'i-solar:box-minimalistic-bold-duotone',
+    'i-solar:filters-bold-duotone',
+  ]
+}
+
 export function presetWebFontsFonts(provider: 'fontsource' | 'none'): Record<string, string | WebFontMeta | (string | WebFontMeta)[]> {
   return {
     'sans': {
@@ -155,6 +170,7 @@ export function sharedUnoConfig() {
     safelist: [
       ...'prose prose-sm m-auto text-left'.split(' '),
       ...safelistAllPrimaryBackgrounds(),
+      ...safelistSettingsEntryIcons(),
     ],
     // hyoban/unocss-preset-shadcn: Use shadcn ui with UnoCSS
     // https://github.com/hyoban/unocss-preset-shadcn

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -66,7 +66,6 @@ export function safelistAllPrimaryBackgrounds(): string[] {
   }).flat()
 }
 
-
 export function safelistSettingsEntryIcons(): string[] {
   return [
     'i-solar:emoji-funny-square-bold-duotone',


### PR DESCRIPTION
## Summary

Fixes #1852.

Source-run builds derive settings entry icons from route metadata, but the shared Uno safelist does not keep those icon classes alive. Add the missing safelist entries and a focused regression test so the right-side settings icons remain available.

## Validation

- `pnpm exec vitest run packages/stage-shared/src/uno-settings-icons.test.ts`
- `git diff --check`
