### PR TITLE
fix(stage-ui): hide provider setup in Steam onboarding

### DIFF
--- a/packages/stage-ui/src/components/scenarios/dialogs/onboarding/onboarding.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/onboarding/onboarding.vue
@@ -9,6 +9,7 @@ import type {
   ProviderConfigData,
 } from './types'
 
+import { isCustomProvidersDisabled } from '@proj-airi/stage-shared'
 import { storeToRefs } from 'pinia'
 import { computed, nextTick, onMounted, ref } from 'vue'
 
@@ -121,6 +122,9 @@ const allSteps = computed<OnboardingStep[]>(() => {
     {
       id: 'welcome',
       component: StepWelcome,
+      props: () => ({
+        customProviderSetupEnabled: !isCustomProvidersDisabled(),
+      }),
     },
     {
       id: 'provider-selection',

--- a/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-welcome.browser.test.ts
+++ b/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-welcome.browser.test.ts
@@ -1,0 +1,68 @@
+import en from '@proj-airi/i18n/locales/en'
+
+import { createPinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import { createI18n } from 'vue-i18n'
+
+import StepWelcome from './step-welcome.vue'
+
+/** Creates the production English localization surface used by onboarding stores. */
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en,
+    },
+  })
+}
+
+/** Renders the welcome step with real Pinia and i18n plugins. */
+async function renderWelcomeStep(customProviderSetupEnabled: boolean) {
+  return render(StepWelcome, {
+    props: {
+      customProviderSetupEnabled,
+      onNext: vi.fn(),
+    },
+    global: {
+      directives: {
+        motion: {},
+      },
+      plugins: [createPinia(), createTestI18n()],
+    },
+  })
+}
+
+/**
+ * @example
+ * describe('Steam onboarding provider restrictions', () => {})
+ */
+describe('steam onboarding provider restrictions', () => {
+  /**
+   * @example
+   * it('keeps login without custom provider setup in Steam builds', async () => {})
+   */
+  it('keeps login without custom provider setup in Steam builds', async () => {
+    // ROOT CAUSE:
+    //
+    // The welcome step rendered its local-provider action without consulting
+    // the distribution restriction already used by settings and provider stores.
+    // A clean Steam install therefore exposed BYOK during onboarding even though
+    // the same provider paths were hidden after setup.
+    await renderWelcomeStep(false)
+
+    expect(document.body.textContent).toContain('Sign in')
+    expect(document.body.textContent).not.toContain('Setup with your provider')
+  })
+
+  /**
+   * @example
+   * it('keeps custom provider setup in direct builds', async () => {})
+   */
+  it('keeps custom provider setup in direct builds', async () => {
+    await renderWelcomeStep(true)
+
+    expect(document.body.textContent).toContain('Setup with your provider')
+  })
+})

--- a/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-welcome.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/onboarding/step-welcome.vue
@@ -21,6 +21,7 @@ import { useOnboardingStore } from '../../../../stores/onboarding'
 import { useSettingsGeneral } from '../../../../stores/settings'
 
 interface Props {
+  customProviderSetupEnabled: boolean
   onNext: OnboardingStepNextHandler
 }
 
@@ -133,6 +134,7 @@ function handleLocalSetup() {
         @click="handleLogin"
       />
       <Button
+        v-if="props.customProviderSetupEnabled"
         v-motion
         :initial="{ opacity: 0 }"
         :enter="{ opacity: 1 }"


### PR DESCRIPTION
## Description

Steam builds disable custom providers, but a clean installation still exposed the onboarding action for configuring a local provider. This PR keeps AIRI sign-in available while hiding that BYOK action whenever `VITE_DISABLE_CUSTOM_PROVIDERS=true`.

The Steam and Web clients continue to use the same AIRI account, OIDC client, and existing Flux balance. This PR does not add Steam-specific balance tables, transaction ledgers, grants, or billing branches. Steam purchase UI remains disabled; a future in-client purchase flow must use Steam Wallet.

### Validation

- Browser component test: 1 file and 2 tests passed.
- `pnpm -F @proj-airi/stage-ui typecheck` passed.
- `pnpm -F @proj-airi/stage-tamagotchi typecheck` passed.
- `pnpm typecheck` passed for 52 workspace projects.
- `pnpm lint` passed with 0 warnings and 0 errors.
- Steam-configured Electron build completed successfully.
- Live Electron onboarding kept `Sign in` visible and removed `Setup with your provider`.
- Compiled output uses `airi-stage-electron`, disables custom providers and Flux purchases, disables the auto-updater, and contains no unresolved Steam build variables.
- `git diff --check` passed.

## Linked Issues

- Depends on #1827.

## Additional Context

This branch is based exactly on PR #1827 at `e2fc90ebf`. Until #1827 merges, GitHub also shows its Steam build and packaging changes here. After #1827 merges, this PR reduces to three `stage-ui` onboarding files and one focused commit.

Please focus review on the onboarding policy boundary: the parent derives the distribution restriction and passes a boolean prop to the welcome step, while the login action remains unchanged.
