### PR TITLE
fix(stage-pages): default Alibaba TTS to CosyVoice v2

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/speech/alibaba-cloud-model-studio.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/alibaba-cloud-model-studio.vue
@@ -14,7 +14,9 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const providerId = 'alibaba-cloud-model-studio'
-const defaultModel = 'cosyvoice-v1'
+// Keep the page fallback aligned with the current provider catalog: v1 no
+// longer has a maintained voice roster, while v2 IDs carry the intended voice.
+const defaultModel = 'cosyvoice-v2'
 
 // Default voice settings specific to ElevenLabs
 const defaultVoiceSettings = {


### PR DESCRIPTION
## Summary

- default the Alibaba Model Studio speech settings page to `cosyvoice-v2`

## Root cause and impact

The page fell back to `cosyvoice-v1` when no model was saved, while the server-side DashScope adapter and curated defaults use `cosyvoice-v2` with versioned voice IDs. This could send a selected current voice through the obsolete model and lose the intended voice identity.

## Validation

- source-level fallback contract check: the configured default is consumed by the test-voice request
- `git diff --check`
- attempted `corepack pnpm install --frozen-lockfile --ignore-scripts`, but the install did not complete within the local two-minute command limit, so the stage-pages typecheck was not runnable

## Scope

This changes only the no-config fallback. Explicitly saved model choices are unchanged.

Fixes #2059
