### PR TITLE
feat(stage-tamagotchi): add desktop chat list

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -4,7 +4,7 @@ import type { ChatHistoryItem } from '@proj-airi/stage-ui/types/chat'
 
 import { errorMessageFrom } from '@moeru/std'
 import { useStopSpeakingButton } from '@proj-airi/stage-layouts/composables/useStopSpeakingButton'
-import { ChatHistory, ChatSessionsDrawer, JournalPreviewModal } from '@proj-airi/stage-ui/components'
+import { ChatHistory, JournalPreviewModal } from '@proj-airi/stage-ui/components'
 import { useAnalytics } from '@proj-airi/stage-ui/composables/use-analytics'
 import { useBackgroundStore } from '@proj-airi/stage-ui/stores/background'
 import { useChatOrchestratorStore } from '@proj-airi/stage-ui/stores/chat'
@@ -16,7 +16,7 @@ import { BasicTextarea } from '@proj-airi/ui'
 import { useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuRoot, DropdownMenuTrigger } from 'reka-ui'
-import { computed, onMounted, ref, shallowRef, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -44,7 +44,7 @@ const { activeCard, activeCardId } = storeToRefs(airiCardStore)
 const { t } = useI18n()
 const { openImagePreview } = journalPreviewStore
 const isComposing = ref(false)
-const sessionsDrawerOpen = shallowRef(false)
+const sessionsDrawerOpen = defineModel<boolean>('sessionsDrawerOpen', { default: false })
 const DOUBLE_ENTER_INTERVAL_MS = 300
 const TRAILING_NEWLINES_REGEX = /[\r\n]+$/
 const SEND_MODES = ['enter', 'ctrl-enter', 'double-enter'] as const
@@ -340,8 +340,6 @@ async function handleCleanupMessages() {
       >
         <div class="i-solar:chat-line-bold-duotone" />
       </button>
-      <ChatSessionsDrawer v-model="sessionsDrawerOpen" />
-
       <DropdownMenuRoot>
         <DropdownMenuTrigger as-child>
           <button

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -4,7 +4,7 @@ import type { ChatHistoryItem } from '@proj-airi/stage-ui/types/chat'
 
 import { errorMessageFrom } from '@moeru/std'
 import { useStopSpeakingButton } from '@proj-airi/stage-layouts/composables/useStopSpeakingButton'
-import { ChatHistory, JournalPreviewModal } from '@proj-airi/stage-ui/components'
+import { ChatHistory, ChatSessionsDrawer, JournalPreviewModal } from '@proj-airi/stage-ui/components'
 import { useAnalytics } from '@proj-airi/stage-ui/composables/use-analytics'
 import { useBackgroundStore } from '@proj-airi/stage-ui/stores/background'
 import { useChatOrchestratorStore } from '@proj-airi/stage-ui/stores/chat'
@@ -16,7 +16,7 @@ import { BasicTextarea } from '@proj-airi/ui'
 import { useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuRoot, DropdownMenuTrigger } from 'reka-ui'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -44,6 +44,7 @@ const { activeCard, activeCardId } = storeToRefs(airiCardStore)
 const { t } = useI18n()
 const { openImagePreview } = journalPreviewStore
 const isComposing = ref(false)
+const sessionsDrawerOpen = shallowRef(false)
 const DOUBLE_ENTER_INTERVAL_MS = 300
 const TRAILING_NEWLINES_REGEX = /[\r\n]+$/
 const SEND_MODES = ['enter', 'ctrl-enter', 'double-enter'] as const
@@ -328,6 +329,19 @@ async function handleCleanupMessages() {
       </div>
     </div>
     <div :class="['flex items-center justify-end gap-2 py-1']">
+      <button
+        :class="[
+          'max-h-[10lh] min-h-[1lh] flex items-center justify-center rounded-md p-2 outline-none',
+          'bg-neutral-100 text-lg text-neutral-500 transition-colors transition-transform active:scale-95',
+          'dark:bg-neutral-800 dark:text-neutral-400 hover:text-primary-500 dark:hover:text-primary-400',
+        ]"
+        title="Conversations"
+        @click="sessionsDrawerOpen = true"
+      >
+        <div class="i-solar:chat-line-bold-duotone" />
+      </button>
+      <ChatSessionsDrawer v-model="sessionsDrawerOpen" />
+
       <DropdownMenuRoot>
         <DropdownMenuTrigger as-child>
           <button

--- a/apps/stage-tamagotchi/src/renderer/components/Window/TitleBar.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/Window/TitleBar.vue
@@ -6,6 +6,10 @@ defineProps<{
   icon: string
 }>()
 
+const emit = defineEmits<{
+  titleClick: []
+}>()
+
 const { platform } = useAppRuntime()
 </script>
 
@@ -23,6 +27,7 @@ const { platform } = useAppRuntime()
         bg="hover:neutral-200 hover:dark:neutral-800"
         transition="all duration-200 ease-in-out"
         flex cursor-pointer select-none items-center gap-2 rounded-md px-1.5 py-0.5
+        @click="emit('titleClick')"
       >
         <div :class="icon" select-none text="neutral-400 dark:neutral-500" whitespace-nowrap />
         <div><span select-none whitespace-nowrap text-sm>{{ title }}</span></div>

--- a/apps/stage-tamagotchi/src/renderer/components/Window/TitleBar.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/Window/TitleBar.vue
@@ -27,6 +27,7 @@ const { platform } = useAppRuntime()
         bg="hover:neutral-200 hover:dark:neutral-800"
         transition="all duration-200 ease-in-out"
         flex cursor-pointer select-none items-center gap-2 rounded-md px-1.5 py-0.5
+        class="[-webkit-app-region:no-drag]"
         @click="emit('titleClick')"
       >
         <div :class="icon" select-none text="neutral-400 dark:neutral-500" whitespace-nowrap />

--- a/apps/stage-tamagotchi/src/renderer/pages/chat.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/chat.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
+import { ChatSessionsDrawer } from '@proj-airi/stage-ui/components'
+import { shallowRef } from 'vue'
+
 import InteractiveArea from '../components/InteractiveArea.vue'
 import WindowTitleBar from '../components/Window/TitleBar.vue'
+
+const sessionsDrawerOpen = shallowRef(false)
 </script>
 
 <template>
@@ -8,11 +13,14 @@ import WindowTitleBar from '../components/Window/TitleBar.vue'
     <WindowTitleBar
       title="Chat"
       icon="i-solar:chat-line-bold"
+      @title-click="sessionsDrawerOpen = true"
     />
     <InteractiveArea
+      v-model:sessions-drawer-open="sessionsDrawerOpen"
       class="interaction-area block"
       h-full w-full p-4 transition="opacity duration-250"
     />
+    <ChatSessionsDrawer v-model="sessionsDrawerOpen" />
   </div>
 </template>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17681,6 +17681,7 @@ packages:
 
   telegram@2.26.22:
     resolution: {integrity: sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg==}
+    deprecated: This package is archived and no longer maintained. Development continues in teleproto (https://npmjs.com/package/teleproto), a largely compatible, actively maintained fork. See the migration guide at https://docs.teleproto.dev/migrating-from-gramjs
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}


### PR DESCRIPTION
## Summary

Adds a shared Conversations drawer entry point to the standalone Electron desktop chat window.

## Changes

- Add a Conversations button beside the desktop chat composer controls.
- Make the top-left Chat title control open the same drawer.
- Lift drawer state to the chat route so both controls share one source of truth.
- Preserve existing session switching, creation, deletion, previews, and cloud-sync behavior.

## User impact

Desktop users can browse and switch conversations from either the top-left chat control or the composer controls without leaving the chat window.

## Validation

- Verified both entry points in the running Electron app.
- Verified the drawer displays existing sessions and the `+ New` action.
- Targeted ESLint passed.
- Package TypeScript typecheck passed.
- Full `pnpm lint` completed with existing warnings and no errors.
- `git diff --check` passed.