### PR TITLE
feat(stage-tamagotchi): add optional periodic screen awareness

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/WithScreenCapture.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/WithScreenCapture.vue
@@ -41,9 +41,7 @@ async function checkPermissions() {
   else {
     hasPermissions.value = true
   }
-  if (!hasPermissions.value) {
-    showDialog.value = true
-  }
+  showDialog.value = !hasPermissions.value
 }
 
 async function requestPermission() {

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/screen-awareness-caption.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/screen-awareness-caption.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  response: string
+  responseKey: number | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { t } = useI18n()
+const rootElement = ref<HTMLDivElement | null>(null)
+const scrollContainerRef = ref<HTMLDivElement | null>(null)
+
+defineExpose({ rootElement })
+
+watch(() => props.responseKey, async () => {
+  await nextTick()
+  if (scrollContainerRef.value)
+    scrollContainerRef.value.scrollTop = 0
+})
+</script>
+
+<template>
+  <div
+    ref="rootElement"
+    :class="[
+      'pointer-events-auto',
+      'absolute left-1/2 top-3 z-80 -translate-x-1/2',
+      'w-[min(88vw,38rem)] min-w-[min(15rem,88vw)]',
+      'rounded-xl border border-white/25 bg-neutral-950/78 p-3 text-neutral-50 shadow-xl backdrop-blur-md',
+    ]"
+  >
+    <button
+      type="button"
+      :class="[
+        'absolute right-2 top-2 h-7 w-7 flex items-center justify-center rounded-full',
+        'text-neutral-300 transition-colors hover:bg-white/12 hover:text-white',
+      ]"
+      :aria-label="t('tamagotchi.settings.pages.screen-awareness.caption.close')"
+      :title="t('tamagotchi.settings.pages.screen-awareness.caption.close')"
+      @click="emit('close')"
+    >
+      <div :class="['i-solar:close-circle-line-duotone text-lg']" />
+    </button>
+
+    <div
+      ref="scrollContainerRef"
+      :class="[
+        'max-h-[min(28vh,10rem)] overflow-y-auto overscroll-contain pr-8',
+        'whitespace-pre-wrap break-words text-sm leading-relaxed sm:text-base',
+      ]"
+    >
+      {{ response }}
+    </div>
+  </div>
+</template>

--- a/apps/stage-tamagotchi/src/renderer/composables/use-screen-awareness.ts
+++ b/apps/stage-tamagotchi/src/renderer/composables/use-screen-awareness.ts
@@ -22,16 +22,18 @@ import { useVisionScreenCapture } from './use-vision-screen-capture'
 const sourcesOptions: SourcesOptions = {
   types: ['screen'],
   fetchWindowIcons: false,
-  thumbnailSize: { width: 1280, height: 720 },
+  thumbnailSize: { width: 0, height: 0 },
 }
 
 /**
  * 等待隐藏视频获得可绘制画面
  *
  * @param video 承载显示器捕获流的隐藏视频元素
+ * @param abortSignal 用于在用户停用屏幕感知时终止等待
  * @returns 视频可绘制时解决的 Promise
  */
-async function waitForVideoFrame(video: HTMLVideoElement) {
+async function waitForVideoFrame(video: HTMLVideoElement, abortSignal: AbortSignal) {
+  abortSignal.throwIfAborted()
   if (video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0)
     return
 
@@ -50,6 +52,7 @@ async function waitForVideoFrame(video: HTMLVideoElement) {
       clearTimeout(timeout)
       video.removeEventListener('loadeddata', handleLoaded)
       video.removeEventListener('error', handleError)
+      abortSignal.removeEventListener('abort', handleAbort)
     }
 
     /**
@@ -72,8 +75,21 @@ async function waitForVideoFrame(video: HTMLVideoElement) {
       reject(new Error('Screen capture video failed to load'))
     }
 
+    /**
+     * 在观察任务被停用时终止画面等待
+     *
+     * 返回值为 void
+     */
+    function handleAbort() {
+      cleanup()
+      reject(abortSignal.reason)
+    }
+
     video.addEventListener('loadeddata', handleLoaded, { once: true })
     video.addEventListener('error', handleError, { once: true })
+    abortSignal.addEventListener('abort', handleAbort, { once: true })
+    if (abortSignal.aborted)
+      handleAbort()
   })
 }
 
@@ -167,10 +183,13 @@ export function useScreenAwareness(videoRef: Ref<HTMLVideoElement | null>) {
   /**
    * 捕获当前显示器并通过现有 Vision 管线生成隐私安全描述
    *
+   * @param abortSignal 用于在用户停用屏幕感知时终止捕获和 Vision 请求
    * @returns 仅包含安全屏幕上下文的文本
    */
-  async function observeScreen() {
+  async function observeScreen(abortSignal: AbortSignal) {
+    abortSignal.throwIfAborted()
     const selectedSourceId = await ensureSelectedSource()
+    abortSignal.throwIfAborted()
     const video = videoRef.value
     if (!video)
       throw new Error('Screen awareness video element is unavailable')
@@ -178,13 +197,16 @@ export function useScreenAwareness(videoRef: Ref<HTMLVideoElement | null>) {
     let imageDataUrl = ''
     try {
       const stream = await startStream()
+      abortSignal.throwIfAborted()
       video.srcObject = stream
       await video.play()
-      await waitForVideoFrame(video)
+      await waitForVideoFrame(video, abortSignal)
+      abortSignal.throwIfAborted()
 
       imageDataUrl = captureFrame(video) ?? ''
       if (!imageDataUrl)
         throw new Error('Screen capture returned an empty frame')
+      abortSignal.throwIfAborted()
 
       const result = await visionOrchestrator.processCapture({
         imageDataUrl,
@@ -194,6 +216,7 @@ export function useScreenAwareness(videoRef: Ref<HTMLVideoElement | null>) {
         capturedAt: Date.now(),
         publishContext: false,
         retainResult: false,
+        abortSignal,
       })
 
       return protectScreenDescription(result.text)
@@ -210,9 +233,11 @@ export function useScreenAwareness(videoRef: Ref<HTMLVideoElement | null>) {
    * 将屏幕描述交给现有角色主动回应和语音动作管线
    *
    * @param description 已完成隐私保护的屏幕描述
-   * @returns 移除内部标记后的可见角色回应
+   * @param abortSignal 用于在角色请求开始前确认观察任务仍获授权
+   * @returns 包含内部标记的原始角色回应
    */
-  async function respondToScreen(description: string) {
+  async function respondToScreen(description: string, abortSignal: AbortSignal) {
+    abortSignal.throwIfAborted()
     const eventId = crypto.randomUUID()
     const event: WebSocketEventOf<'spark:notify'> = {
       type: 'spark:notify',
@@ -237,6 +262,7 @@ export function useScreenAwareness(videoRef: Ref<HTMLVideoElement | null>) {
       },
     })
 
+    abortSignal.throwIfAborted()
     return rawResponse
   }
 

--- a/apps/stage-tamagotchi/src/renderer/composables/use-screen-awareness.ts
+++ b/apps/stage-tamagotchi/src/renderer/composables/use-screen-awareness.ts
@@ -1,0 +1,317 @@
+import type { WebSocketEventOf } from '@proj-airi/server-sdk'
+import type { SourcesOptions } from 'electron'
+import type { Ref } from 'vue'
+
+import type { ScreenAwarenessChannelEvent, ScreenAwarenessSnapshot } from '../stores/screen-awareness-channel'
+
+import { errorMessageFrom } from '@moeru/std'
+import { useSpeakingStore } from '@proj-airi/stage-ui/stores/audio'
+import { extractVisibleReactionText, useCharacterOrchestratorStore } from '@proj-airi/stage-ui/stores/character'
+import { useChatOrchestratorStore } from '@proj-airi/stage-ui/stores/chat'
+import { useVisionOrchestratorStore } from '@proj-airi/stage-ui/stores/modules/vision'
+import { useBroadcastChannel } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+import { useScreenAwarenessStore } from '../stores/screen-awareness'
+import { screenAwarenessChannelName } from '../stores/screen-awareness-channel'
+import { protectScreenDescription, SCREEN_AWARENESS_RESPONSE_INSTRUCTIONS, SCREEN_AWARENESS_VISION_PROMPT } from '../stores/screen-awareness-policy'
+import { ScreenAwarenessRuntime } from '../stores/screen-awareness-runtime'
+import { useVisionScreenCapture } from './use-vision-screen-capture'
+
+const sourcesOptions: SourcesOptions = {
+  types: ['screen'],
+  fetchWindowIcons: false,
+  thumbnailSize: { width: 1280, height: 720 },
+}
+
+/**
+ * 等待隐藏视频获得可绘制画面
+ *
+ * @param video 承载显示器捕获流的隐藏视频元素
+ * @returns 视频可绘制时解决的 Promise
+ */
+async function waitForVideoFrame(video: HTMLVideoElement) {
+  if (video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0)
+    return
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timed out waiting for a screen capture frame'))
+    }, 5_000)
+
+    /**
+     * 清理视频就绪等待期间注册的监听器和超时
+     *
+     * 返回值为 void
+     */
+    function cleanup() {
+      clearTimeout(timeout)
+      video.removeEventListener('loadeddata', handleLoaded)
+      video.removeEventListener('error', handleError)
+    }
+
+    /**
+     * 在视频可以绘制时完成等待
+     *
+     * 返回值为 void
+     */
+    function handleLoaded() {
+      cleanup()
+      resolve()
+    }
+
+    /**
+     * 在视频加载失败时终止等待
+     *
+     * 返回值为 void
+     */
+    function handleError() {
+      cleanup()
+      reject(new Error('Screen capture video failed to load'))
+    }
+
+    video.addEventListener('loadeddata', handleLoaded, { once: true })
+    video.addEventListener('error', handleError, { once: true })
+  })
+}
+
+/**
+ * 在主舞台中管理屏幕感知捕获、调度、角色回复和跨窗口状态
+ *
+ * @param videoRef 承载显示器捕获流的隐藏视频元素引用
+ * @returns 屏幕感知运行快照和手动关闭字幕操作
+ */
+export function useScreenAwareness(videoRef: Ref<HTMLVideoElement | null>) {
+  const settingsStore = useScreenAwarenessStore()
+  const { enabled, intervalMs, sourceId } = storeToRefs(settingsStore)
+  const chatOrchestrator = useChatOrchestratorStore()
+  const characterOrchestrator = useCharacterOrchestratorStore()
+  const speakingStore = useSpeakingStore()
+  const visionOrchestrator = useVisionOrchestratorStore()
+  const { sending, pendingQueuedSendCount } = storeToRefs(chatOrchestrator)
+  const { processing: characterProcessing } = storeToRefs(characterOrchestrator)
+  const { nowSpeaking } = storeToRefs(speakingStore)
+
+  const {
+    sources,
+    activeSourceId,
+    refetchSources,
+    startStream,
+    stopStream,
+    cleanup: cleanupCapture,
+    captureFrame,
+  } = useVisionScreenCapture(sourcesOptions)
+
+  const snapshot = ref<ScreenAwarenessSnapshot>({
+    phase: 'idle',
+    lastResponse: '',
+    lastObservedAt: null,
+    error: null,
+  })
+  const responseVisible = ref(false)
+  const { data: channelEvent, post: postChannelEvent, close: closeChannel } = useBroadcastChannel<ScreenAwarenessChannelEvent, ScreenAwarenessChannelEvent>({
+    name: screenAwarenessChannelName,
+  })
+
+  /**
+   * 向设置窗口发布不含截图的屏幕感知运行快照
+   *
+   * 返回值为 void
+   */
+  function publishSnapshot() {
+    postChannelEvent({ type: 'state', snapshot: { ...snapshot.value } })
+  }
+
+  /**
+   * 更新屏幕感知局部状态并同步到设置窗口
+   *
+   * @param patch 需要合并到当前快照的字段
+   * 返回值为 void
+   */
+  function updateSnapshot(patch: Partial<ScreenAwarenessSnapshot>) {
+    snapshot.value = { ...snapshot.value, ...patch }
+    publishSnapshot()
+  }
+
+  /**
+   * 判断普通聊天、角色回复或语音播放是否正忙
+   *
+   * @returns 任一前台交互正在运行时返回 true
+   */
+  function isForegroundBusy() {
+    return sending.value
+      || pendingQueuedSendCount.value > 0
+      || characterProcessing.value
+      || nowSpeaking.value
+  }
+
+  /**
+   * 选择仍然存在的显示器并同步持久化配置
+   *
+   * @returns 当前可用显示器源标识
+   */
+  async function ensureSelectedSource() {
+    await refetchSources()
+    const selectedSource = sources.value.find(source => source.id === sourceId.value) ?? sources.value[0]
+    if (!selectedSource)
+      throw new Error('No display is available for screen awareness')
+
+    activeSourceId.value = selectedSource.id
+    if (sourceId.value !== selectedSource.id)
+      sourceId.value = selectedSource.id
+    return selectedSource.id
+  }
+
+  /**
+   * 捕获当前显示器并通过现有 Vision 管线生成隐私安全描述
+   *
+   * @returns 仅包含安全屏幕上下文的文本
+   */
+  async function observeScreen() {
+    const selectedSourceId = await ensureSelectedSource()
+    const video = videoRef.value
+    if (!video)
+      throw new Error('Screen awareness video element is unavailable')
+
+    let imageDataUrl = ''
+    try {
+      const stream = await startStream()
+      video.srcObject = stream
+      await video.play()
+      await waitForVideoFrame(video)
+
+      imageDataUrl = captureFrame(video) ?? ''
+      if (!imageDataUrl)
+        throw new Error('Screen capture returned an empty frame')
+
+      const result = await visionOrchestrator.processCapture({
+        imageDataUrl,
+        workloadId: 'screen:interpret',
+        promptOverride: SCREEN_AWARENESS_VISION_PROMPT,
+        sourceId: selectedSourceId,
+        capturedAt: Date.now(),
+        publishContext: false,
+        retainResult: false,
+      })
+
+      return protectScreenDescription(result.text)
+    }
+    finally {
+      imageDataUrl = ''
+      video.pause()
+      video.srcObject = null
+      stopStream()
+    }
+  }
+
+  /**
+   * 将屏幕描述交给现有角色主动回应和语音动作管线
+   *
+   * @param description 已完成隐私保护的屏幕描述
+   * @returns 移除内部标记后的可见角色回应
+   */
+  async function respondToScreen(description: string) {
+    const eventId = crypto.randomUUID()
+    const event: WebSocketEventOf<'spark:notify'> = {
+      type: 'spark:notify',
+      source: 'screen-awareness',
+      data: {
+        id: eventId,
+        eventId,
+        kind: 'ping',
+        urgency: 'immediate',
+        headline: 'Current screen context',
+        note: description,
+        destinations: ['character'],
+        payload: {},
+      },
+    }
+
+    const rawResponse = await characterOrchestrator.handleSparkNotifyWithReaction(event, {
+      forceTextResponse: true,
+      messageOverride: {
+        appendSystemInstructions: [SCREEN_AWARENESS_RESPONSE_INSTRUCTIONS],
+        replaceUserMessage: `Current screen context:\n${description}`,
+      },
+    })
+
+    return rawResponse
+  }
+
+  const runtime = new ScreenAwarenessRuntime({
+    isBusy: isForegroundBusy,
+    observe: observeScreen,
+    respond: respondToScreen,
+    onResponse: async (response) => {
+      const visibleResponse = await extractVisibleReactionText(response)
+      if (!visibleResponse)
+        return
+      responseVisible.value = true
+      updateSnapshot({
+        phase: 'idle',
+        lastResponse: visibleResponse,
+        lastObservedAt: Date.now(),
+        error: null,
+      })
+    },
+    onStatus: (status) => {
+      updateSnapshot({
+        phase: status.phase,
+        error: status.error ? errorMessageFrom(status.error) : null,
+      })
+    },
+  }, {
+    getIntervalMs: () => intervalMs.value,
+  })
+
+  /**
+   * 隐藏当前持久字幕但保留最近回应供设置页查看
+   *
+   * 返回值为 void
+   */
+  function dismissResponse() {
+    responseVisible.value = false
+  }
+
+  watch(channelEvent, (event) => {
+    if (!event)
+      return
+    if (event.type === 'observe-now')
+      void runtime.requestNow()
+    if (event.type === 'request-state')
+      publishSnapshot()
+  })
+
+  watch([enabled, intervalMs], ([isEnabled], [wasEnabled, previousInterval]) => {
+    if (!isEnabled) {
+      runtime.stop()
+      stopStream()
+      return
+    }
+
+    if (!wasEnabled || previousInterval !== intervalMs.value) {
+      runtime.stop()
+      runtime.start()
+    }
+  })
+
+  onMounted(() => {
+    if (enabled.value)
+      runtime.start()
+    publishSnapshot()
+  })
+
+  onBeforeUnmount(() => {
+    runtime.stop()
+    cleanupCapture()
+    closeChannel()
+  })
+
+  return {
+    snapshot: computed(() => snapshot.value),
+    responseVisible: computed(() => responseVisible.value && !!snapshot.value.lastResponse),
+    dismissResponse,
+  }
+}

--- a/apps/stage-tamagotchi/src/renderer/layouts/settings.vue
+++ b/apps/stage-tamagotchi/src/renderer/layouts/settings.vue
@@ -17,11 +17,14 @@ const scrollContainer = ref<HTMLElement>()
 useRestoreScroll(scrollContainer)
 
 const routeMeta = computed(() => route.meta as {
+  fillSettingsViewport?: boolean
   titleKey?: string
   subtitleKey?: string
   title?: string
   subtitle?: string
 })
+
+const fillSettingsViewport = computed(() => routeMeta.value.fillSettingsViewport === true)
 
 const providerTitle = computed(() => {
   if (!route.path.startsWith('/settings/providers/'))
@@ -79,7 +82,11 @@ const routeHeaderMetadata = computed(() => {
 
       min-h-0 flex-1
     >
-      <div ref="scrollContainer" relative h-full w-full overflow-y-auto scrollbar-none>
+      <div
+        ref="scrollContainer"
+        relative h-full w-full scrollbar-none
+        :class="fillSettingsViewport ? ['overflow-hidden'] : ['overflow-y-auto']"
+      >
         <div flex="~ col" mx-auto h-full max-w-screen-xl>
           <PageHeader
             :title="routeHeaderMetadata?.title ?? ''"
@@ -87,7 +94,10 @@ const routeHeaderMetadata = computed(() => {
             :disable-back-button="isStageTamagotchi() && route.path === '/settings'"
             px-4
           />
-          <div min-h-0 flex-1 px-4>
+          <div
+            min-h-0 flex-1 px-4
+            :class="fillSettingsViewport ? ['overflow-hidden', 'pb-4'] : []"
+          >
             <RouterView />
           </div>
         </div>

--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -34,10 +34,12 @@ import { toast } from 'vue-sonner'
 
 import ControlsIsland from '../components/stage-islands/controls-island/index.vue'
 import ResourceStatusIsland from '../components/stage-islands/resource-status-island/index.vue'
+import ScreenAwarenessCaption from '../components/stage-islands/screen-awareness-caption.vue'
 import StatusIsland from '../components/stage-islands/status-island/index.vue'
 
 import { electronOpenOnboarding } from '../../shared/eventa'
 import { modelSettingsRuntimeSnapshotChannelName } from '../../shared/model-settings-runtime'
+import { useScreenAwareness } from '../composables/use-screen-awareness'
 import { useChatSyncStore } from '../stores/chat-sync'
 import { useControlsIslandStore } from '../stores/controls-island'
 import { useStageWindowLifecycleStore } from '../stores/stage-window-lifecycle'
@@ -51,6 +53,9 @@ import {
 
 const controlsIslandRef = ref<InstanceType<typeof ControlsIsland>>()
 const statusIslandRef = ref<InstanceType<typeof StatusIsland>>()
+const screenAwarenessCaptionRef = ref<InstanceType<typeof ScreenAwarenessCaption>>()
+const screenAwarenessCaptionElement = toRef(() => screenAwarenessCaptionRef.value?.rootElement)
+const screenAwarenessVideoRef = ref<HTMLVideoElement | null>(null)
 const widgetStageRef = ref<InstanceType<typeof WidgetStage>>()
 const stageCanvas = toRef(() => widgetStageRef.value?.canvasElement())
 const componentStateStage = ref<'pending' | 'loading' | 'mounted'>('pending')
@@ -66,8 +71,10 @@ const openOnboarding = useElectronEventaInvoke(electronOpenOnboarding)
 const { isOutside: isOutsideWindow } = useElectronMouseInWindow()
 const { isOutside } = useElectronMouseInElement(controlsIslandRef)
 const { isOutside: isOutsideStatusIsland } = useElectronMouseInElement(statusIslandRef)
+const { isOutside: isOutsideScreenAwarenessCaption } = useElectronMouseInElement(screenAwarenessCaptionElement)
 const isOutsideFor250Ms = refDebounced(isOutside, 250)
 const isOutsideStatusIslandFor250Ms = refDebounced(isOutsideStatusIsland, 250)
+const isOutsideScreenAwarenessCaptionFor250Ms = refDebounced(isOutsideScreenAwarenessCaption, 250)
 const { x: relativeMouseX, y: relativeMouseY } = useElectronRelativeMouse()
 // NOTICE: In real-world use cases of Fade on Hover feature, the cursor may move around the edge of the
 // model rapidly, causing flickering effects when checking pixel transparency strictly.
@@ -186,7 +193,7 @@ const modelSettingsRuntimeSnapshot = computed<ModelSettingsRuntimeSnapshot>(() =
   })
 })
 
-watch([isOutsideFor250Ms, isOutsideStatusIslandFor250Ms, isAroundWindowBorderFor250Ms, isOutsideWindow, isTransparent, hearingDialogOpen, fadeOnHoverEnabled, stagePaused], () => {
+watch([isOutsideFor250Ms, isOutsideStatusIslandFor250Ms, isOutsideScreenAwarenessCaptionFor250Ms, isAroundWindowBorderFor250Ms, isOutsideWindow, isTransparent, hearingDialogOpen, fadeOnHoverEnabled, stagePaused], () => {
   if (stagePaused.value) {
     isIgnoringMouseEvents.value = false
     shouldFadeOnCursorWithin.value = false
@@ -204,7 +211,9 @@ watch([isOutsideFor250Ms, isOutsideStatusIslandFor250Ms, isAroundWindowBorderFor
     return
   }
 
-  const insideControls = !isOutsideFor250Ms.value || !isOutsideStatusIslandFor250Ms.value
+  const insideControls = !isOutsideFor250Ms.value
+    || !isOutsideStatusIslandFor250Ms.value
+    || (!!screenAwarenessCaptionRef.value && !isOutsideScreenAwarenessCaptionFor250Ms.value)
   const nearBorder = isAroundWindowBorderFor250Ms.value
 
   if (insideControls || nearBorder) {
@@ -641,6 +650,12 @@ const cursorPosition = computed(() => ({
   x: relativeMouseX.value,
   y: relativeMouseY.value,
 }))
+
+const {
+  snapshot: screenAwarenessSnapshot,
+  responseVisible: screenAwarenessResponseVisible,
+  dismissResponse: dismissScreenAwarenessResponse,
+} = useScreenAwareness(screenAwarenessVideoRef)
 </script>
 
 <template>
@@ -678,6 +693,14 @@ const cursorPosition = computed(() => ({
           :cursor-position="cursorPosition"
           :paused="stagePaused"
         />
+        <ScreenAwarenessCaption
+          v-if="screenAwarenessResponseVisible"
+          ref="screenAwarenessCaptionRef"
+          :response="screenAwarenessSnapshot.lastResponse"
+          :response-key="screenAwarenessSnapshot.lastObservedAt"
+          @close="dismissScreenAwarenessResponse"
+        />
+        <video ref="screenAwarenessVideoRef" :class="['hidden']" muted playsinline />
         <HoloCoupon />
         <ControlsIsland ref="controlsIslandRef" />
       </div>

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/screen-awareness/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/screen-awareness/index.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import type { ScreenAwarenessChannelEvent, ScreenAwarenessSnapshot } from '../../../stores/screen-awareness-channel'
+
+import { Button, Callout, FieldCheckbox, FieldSelect } from '@proj-airi/ui'
+import { useBroadcastChannel } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { useVisionScreenCapture } from '../../../composables/use-vision-screen-capture'
+import { SCREEN_AWARENESS_INTERVAL_OPTIONS, useScreenAwarenessStore } from '../../../stores/screen-awareness'
+import { screenAwarenessChannelName } from '../../../stores/screen-awareness-channel'
+
+const { locale, t } = useI18n()
+const settingsStore = useScreenAwarenessStore()
+const { enabled, intervalMs, sourceId } = storeToRefs(settingsStore)
+
+const {
+  sources,
+  activeSourceId,
+  isRefetching,
+  refetchSources,
+  cleanup: cleanupCapture,
+} = useVisionScreenCapture({
+  types: ['screen'],
+  fetchWindowIcons: false,
+  thumbnailSize: { width: 320, height: 180 },
+})
+
+const snapshot = ref<ScreenAwarenessSnapshot>({
+  phase: 'idle',
+  lastResponse: '',
+  lastObservedAt: null,
+  error: null,
+})
+const sourceLoadFailed = ref(false)
+const showRecentResponse = ref(false)
+const responseContainer = ref<HTMLElement>()
+
+const { data: channelEvent, post: postChannelEvent, close: closeChannel } = useBroadcastChannel<ScreenAwarenessChannelEvent, ScreenAwarenessChannelEvent>({
+  name: screenAwarenessChannelName,
+})
+
+const sourceOptions = computed(() => sources.value.map(source => ({
+  label: source.name,
+  value: source.id,
+})))
+
+const intervalOptions = computed(() => SCREEN_AWARENESS_INTERVAL_OPTIONS.map(value => ({
+  label: value < 60_000
+    ? t('tamagotchi.settings.pages.screen-awareness.interval.seconds', { count: value / 1_000 })
+    : t('tamagotchi.settings.pages.screen-awareness.interval.minutes', { count: value / 60_000 }),
+  value,
+})))
+
+const phaseLabel = computed(() => t(`tamagotchi.settings.pages.screen-awareness.status.${snapshot.value.phase}`))
+const observationRunning = computed(() => snapshot.value.phase === 'observing' || snapshot.value.phase === 'responding')
+const canObserveNow = computed(() => !observationRunning.value && sourceOptions.value.length > 0 && !!sourceId.value)
+const lastObservedLabel = computed(() => {
+  if (!snapshot.value.lastObservedAt)
+    return t('tamagotchi.settings.pages.screen-awareness.status.never')
+
+  return new Intl.DateTimeFormat(locale.value, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  }).format(snapshot.value.lastObservedAt)
+})
+
+/**
+ * 刷新当前可用的显示器来源并保留仍然有效的用户选择
+ *
+ * 返回值为 void
+ */
+async function refreshSources() {
+  sourceLoadFailed.value = false
+  activeSourceId.value = sourceId.value
+
+  try {
+    await refetchSources()
+  }
+  catch {
+    sourceLoadFailed.value = true
+  }
+}
+
+/**
+ * 通过跨窗口频道请求主舞台立即执行一次屏幕观察
+ *
+ * 返回值为 void
+ */
+function observeNow() {
+  postChannelEvent({ type: 'observe-now' })
+}
+
+watch(activeSourceId, (value) => {
+  if (value && value !== sourceId.value)
+    sourceId.value = value
+})
+
+watch(sourceId, (value) => {
+  if (value && value !== activeSourceId.value && sources.value.some(source => source.id === value))
+    activeSourceId.value = value
+})
+
+watch(channelEvent, (event) => {
+  if (event?.type === 'state')
+    snapshot.value = event.snapshot
+})
+
+watch(() => snapshot.value.lastObservedAt, async () => {
+  if (!snapshot.value.lastResponse)
+    return
+
+  showRecentResponse.value = true
+  await nextTick()
+  responseContainer.value?.scrollTo({ top: 0 })
+})
+
+onMounted(() => {
+  postChannelEvent({ type: 'request-state' })
+  void refreshSources()
+})
+
+onBeforeUnmount(() => {
+  cleanupCapture()
+  closeChannel()
+})
+</script>
+
+<template>
+  <div :class="['h-full', 'overflow-y-auto', 'overscroll-contain', 'scrollbar-none', 'pb-6']">
+    <div :class="['mx-auto', 'flex', 'max-w-3xl', 'flex-col', 'gap-4']">
+      <section
+        :class="[
+          'flex', 'flex-col', 'gap-4',
+          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+          'bg-white', 'p-4', 'md:p-5',
+          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+        ]"
+      >
+        <div :class="['flex', 'items-start', 'justify-between', 'gap-3']">
+          <FieldCheckbox
+            v-model="enabled"
+            :label="t('tamagotchi.settings.pages.screen-awareness.enable.label')"
+            :description="t('tamagotchi.settings.pages.screen-awareness.enable.description')"
+          />
+          <span
+            :class="[
+              'shrink-0', 'rounded-full', 'px-2.5', 'py-1', 'text-xs', 'font-medium',
+              enabled
+                ? ['bg-lime-500/15', 'text-lime-700', 'dark:text-lime-300']
+                : ['bg-neutral-500/10', 'text-neutral-500', 'dark:text-neutral-400'],
+            ]"
+          >
+            {{ enabled
+              ? t('tamagotchi.settings.pages.screen-awareness.enable.enabled')
+              : t('tamagotchi.settings.pages.screen-awareness.enable.disabled') }}
+          </span>
+        </div>
+
+        <Callout
+          theme="orange"
+          :label="t('tamagotchi.settings.pages.screen-awareness.privacy.title')"
+        >
+          {{ t('tamagotchi.settings.pages.screen-awareness.privacy.description') }}
+        </Callout>
+      </section>
+
+      <section
+        :class="[
+          'flex', 'flex-col', 'gap-4',
+          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+          'bg-white', 'p-4', 'md:p-5',
+          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+        ]"
+      >
+        <div :class="['flex', 'flex-col', 'gap-1']">
+          <h2 :class="['text-sm', 'font-semibold']">
+            {{ t('tamagotchi.settings.pages.screen-awareness.capture.title') }}
+          </h2>
+          <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+            {{ t('tamagotchi.settings.pages.screen-awareness.capture.description') }}
+          </p>
+        </div>
+
+        <div :class="['flex', 'flex-col', 'gap-3', 'sm:flex-row', 'sm:items-end']">
+          <FieldSelect
+            v-model="sourceId"
+            layout="vertical"
+            :class="['min-w-0', 'flex-1']"
+            :label="t('tamagotchi.settings.pages.screen-awareness.capture.display-label')"
+            :placeholder="t('tamagotchi.settings.pages.screen-awareness.capture.display-placeholder')"
+            :options="sourceOptions"
+            :disabled="isRefetching || sourceOptions.length === 0"
+          />
+          <Button
+            variant="secondary"
+            icon="i-solar:refresh-bold-duotone"
+            :label="t('tamagotchi.settings.pages.screen-awareness.capture.refresh')"
+            :loading="isRefetching"
+            @click="refreshSources"
+          />
+        </div>
+
+        <p
+          v-if="!isRefetching && sourceOptions.length === 0"
+          :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']"
+        >
+          {{ t('tamagotchi.settings.pages.screen-awareness.capture.no-displays') }}
+        </p>
+        <Callout
+          v-if="sourceLoadFailed"
+          theme="orange"
+          :label="t('tamagotchi.settings.pages.screen-awareness.capture.load-error')"
+        />
+
+        <FieldSelect
+          v-model="intervalMs"
+          layout="vertical"
+          :label="t('tamagotchi.settings.pages.screen-awareness.interval.label')"
+          :description="t('tamagotchi.settings.pages.screen-awareness.interval.description')"
+          :options="intervalOptions"
+        />
+      </section>
+
+      <section
+        :class="[
+          'flex', 'flex-col', 'gap-4',
+          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+          'bg-white', 'p-4', 'md:p-5',
+          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+        ]"
+      >
+        <div :class="['flex', 'flex-wrap', 'items-center', 'justify-between', 'gap-3']">
+          <div :class="['flex', 'flex-col', 'gap-1']">
+            <h2 :class="['text-sm', 'font-semibold']">
+              {{ t('tamagotchi.settings.pages.screen-awareness.status.title') }}
+            </h2>
+            <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+              {{ t('tamagotchi.settings.pages.screen-awareness.status.current', { status: phaseLabel }) }}
+            </p>
+            <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+              {{ t('tamagotchi.settings.pages.screen-awareness.status.last-observed', { time: lastObservedLabel }) }}
+            </p>
+          </div>
+          <Button
+            icon="i-solar:eye-bold-duotone"
+            :label="t('tamagotchi.settings.pages.screen-awareness.observe-now.label')"
+            :loading="observationRunning"
+            :disabled="!canObserveNow"
+            @click="observeNow"
+          />
+        </div>
+
+        <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+          {{ t('tamagotchi.settings.pages.screen-awareness.observe-now.description') }}
+        </p>
+
+        <Callout
+          v-if="snapshot.error"
+          theme="orange"
+          :label="t('tamagotchi.settings.pages.screen-awareness.status.error-label')"
+        />
+      </section>
+
+      <section
+        :class="[
+          'flex', 'min-h-0', 'flex-col', 'gap-3',
+          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+          'bg-white', 'p-4', 'md:p-5',
+          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+        ]"
+      >
+        <div :class="['flex', 'items-center', 'justify-between', 'gap-3']">
+          <h2 :class="['text-sm', 'font-semibold']">
+            {{ t('tamagotchi.settings.pages.screen-awareness.recent-response.title') }}
+          </h2>
+          <Button
+            v-if="snapshot.lastResponse"
+            variant="ghost"
+            size="sm"
+            :icon="showRecentResponse ? 'i-solar:alt-arrow-up-line-duotone' : 'i-solar:alt-arrow-down-line-duotone'"
+            :label="showRecentResponse
+              ? t('tamagotchi.settings.pages.screen-awareness.recent-response.collapse')
+              : t('tamagotchi.settings.pages.screen-awareness.recent-response.expand')"
+            @click="showRecentResponse = !showRecentResponse"
+          />
+        </div>
+
+        <p
+          v-if="!snapshot.lastResponse"
+          :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']"
+        >
+          {{ t('tamagotchi.settings.pages.screen-awareness.recent-response.empty') }}
+        </p>
+        <div
+          v-else-if="showRecentResponse"
+          ref="responseContainer"
+          :class="[
+            'max-h-64', 'overflow-y-auto', 'overscroll-contain',
+            'whitespace-pre-wrap', 'break-words',
+            'rounded-xl', 'bg-neutral-100/70', 'p-3', 'text-sm', 'leading-relaxed',
+            'dark:bg-neutral-950/50',
+          ]"
+        >
+          {{ snapshot.lastResponse }}
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  titleKey: tamagotchi.settings.pages.screen-awareness.title
+  subtitleKey: settings.title
+  descriptionKey: tamagotchi.settings.pages.screen-awareness.description
+  icon: i-solar:eye-scan-bold-duotone
+  settingsEntry: true
+  order: 5.5
+  fillSettingsViewport: true
+  stageTransition:
+    name: slide
+    pageSpecificAvailable: true
+</route>

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/screen-awareness/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/screen-awareness/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { SourcesOptions } from 'electron'
+
 import type { ScreenAwarenessChannelEvent, ScreenAwarenessSnapshot } from '../../../stores/screen-awareness-channel'
 
 import { Button, Callout, FieldCheckbox, FieldSelect } from '@proj-airi/ui'
@@ -7,6 +9,8 @@ import { storeToRefs } from 'pinia'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import WithScreenCapture from '../../../components/WithScreenCapture.vue'
+
 import { useVisionScreenCapture } from '../../../composables/use-vision-screen-capture'
 import { SCREEN_AWARENESS_INTERVAL_OPTIONS, useScreenAwarenessStore } from '../../../stores/screen-awareness'
 import { screenAwarenessChannelName } from '../../../stores/screen-awareness-channel'
@@ -14,6 +18,11 @@ import { screenAwarenessChannelName } from '../../../stores/screen-awareness-cha
 const { locale, t } = useI18n()
 const settingsStore = useScreenAwarenessStore()
 const { enabled, intervalMs, sourceId } = storeToRefs(settingsStore)
+const sourcesOptions: SourcesOptions = {
+  types: ['screen'],
+  fetchWindowIcons: false,
+  thumbnailSize: { width: 0, height: 0 },
+}
 
 const {
   sources,
@@ -21,11 +30,7 @@ const {
   isRefetching,
   refetchSources,
   cleanup: cleanupCapture,
-} = useVisionScreenCapture({
-  types: ['screen'],
-  fetchWindowIcons: false,
-  thumbnailSize: { width: 320, height: 180 },
-})
+} = useVisionScreenCapture(sourcesOptions)
 
 const snapshot = ref<ScreenAwarenessSnapshot>({
   phase: 'idle',
@@ -118,7 +123,6 @@ watch(() => snapshot.value.lastObservedAt, async () => {
 
 onMounted(() => {
   postChannelEvent({ type: 'request-state' })
-  void refreshSources()
 })
 
 onBeforeUnmount(() => {
@@ -128,186 +132,215 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div :class="['h-full', 'overflow-y-auto', 'overscroll-contain', 'scrollbar-none', 'pb-6']">
-    <div :class="['mx-auto', 'flex', 'max-w-3xl', 'flex-col', 'gap-4']">
-      <section
-        :class="[
-          'flex', 'flex-col', 'gap-4',
-          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
-          'bg-white', 'p-4', 'md:p-5',
-          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
-        ]"
+  <WithScreenCapture
+    :sources-options="sourcesOptions"
+    @permission-granted="refreshSources"
+  >
+    <template #default="{ hasPermissions, requestPermission }">
+      <div
+        v-if="hasPermissions"
+        :class="['h-full', 'overflow-y-auto', 'overscroll-contain', 'scrollbar-none', 'pb-6']"
       >
-        <div :class="['flex', 'items-start', 'justify-between', 'gap-3']">
-          <FieldCheckbox
-            v-model="enabled"
-            :label="t('tamagotchi.settings.pages.screen-awareness.enable.label')"
-            :description="t('tamagotchi.settings.pages.screen-awareness.enable.description')"
-          />
-          <span
+        <div :class="['mx-auto', 'flex', 'max-w-3xl', 'flex-col', 'gap-4']">
+          <section
             :class="[
-              'shrink-0', 'rounded-full', 'px-2.5', 'py-1', 'text-xs', 'font-medium',
-              enabled
-                ? ['bg-lime-500/15', 'text-lime-700', 'dark:text-lime-300']
-                : ['bg-neutral-500/10', 'text-neutral-500', 'dark:text-neutral-400'],
+              'flex', 'flex-col', 'gap-4',
+              'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+              'bg-white', 'p-4', 'md:p-5',
+              'dark:border-neutral-900', 'dark:bg-neutral-900/30',
             ]"
           >
-            {{ enabled
-              ? t('tamagotchi.settings.pages.screen-awareness.enable.enabled')
-              : t('tamagotchi.settings.pages.screen-awareness.enable.disabled') }}
-          </span>
-        </div>
+            <div :class="['flex', 'items-start', 'justify-between', 'gap-3']">
+              <FieldCheckbox
+                v-model="enabled"
+                :label="t('tamagotchi.settings.pages.screen-awareness.enable.label')"
+                :description="t('tamagotchi.settings.pages.screen-awareness.enable.description')"
+              />
+              <span
+                :class="[
+                  'shrink-0', 'rounded-full', 'px-2.5', 'py-1', 'text-xs', 'font-medium',
+                  enabled
+                    ? ['bg-lime-500/15', 'text-lime-700', 'dark:text-lime-300']
+                    : ['bg-neutral-500/10', 'text-neutral-500', 'dark:text-neutral-400'],
+                ]"
+              >
+                {{ enabled
+                  ? t('tamagotchi.settings.pages.screen-awareness.enable.enabled')
+                  : t('tamagotchi.settings.pages.screen-awareness.enable.disabled') }}
+              </span>
+            </div>
 
+            <Callout
+              theme="orange"
+              :label="t('tamagotchi.settings.pages.screen-awareness.privacy.title')"
+            >
+              {{ t('tamagotchi.settings.pages.screen-awareness.privacy.description') }}
+            </Callout>
+          </section>
+
+          <section
+            :class="[
+              'flex', 'flex-col', 'gap-4',
+              'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+              'bg-white', 'p-4', 'md:p-5',
+              'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+            ]"
+          >
+            <div :class="['flex', 'flex-col', 'gap-1']">
+              <h2 :class="['text-sm', 'font-semibold']">
+                {{ t('tamagotchi.settings.pages.screen-awareness.capture.title') }}
+              </h2>
+              <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+                {{ t('tamagotchi.settings.pages.screen-awareness.capture.description') }}
+              </p>
+            </div>
+
+            <div :class="['flex', 'flex-col', 'gap-3', 'sm:flex-row', 'sm:items-end']">
+              <FieldSelect
+                v-model="sourceId"
+                layout="vertical"
+                :class="['min-w-0', 'flex-1']"
+                :label="t('tamagotchi.settings.pages.screen-awareness.capture.display-label')"
+                :placeholder="t('tamagotchi.settings.pages.screen-awareness.capture.display-placeholder')"
+                :options="sourceOptions"
+                :disabled="isRefetching || sourceOptions.length === 0"
+              />
+              <Button
+                variant="secondary"
+                icon="i-solar:refresh-bold-duotone"
+                :label="t('tamagotchi.settings.pages.screen-awareness.capture.refresh')"
+                :loading="isRefetching"
+                @click="refreshSources"
+              />
+            </div>
+
+            <p
+              v-if="!isRefetching && sourceOptions.length === 0"
+              :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']"
+            >
+              {{ t('tamagotchi.settings.pages.screen-awareness.capture.no-displays') }}
+            </p>
+            <Callout
+              v-if="sourceLoadFailed"
+              theme="orange"
+              :label="t('tamagotchi.settings.pages.screen-awareness.capture.load-error')"
+            />
+
+            <FieldSelect
+              v-model="intervalMs"
+              layout="vertical"
+              :label="t('tamagotchi.settings.pages.screen-awareness.interval.label')"
+              :description="t('tamagotchi.settings.pages.screen-awareness.interval.description')"
+              :options="intervalOptions"
+            />
+          </section>
+
+          <section
+            :class="[
+              'flex', 'flex-col', 'gap-4',
+              'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+              'bg-white', 'p-4', 'md:p-5',
+              'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+            ]"
+          >
+            <div :class="['flex', 'flex-wrap', 'items-center', 'justify-between', 'gap-3']">
+              <div :class="['flex', 'flex-col', 'gap-1']">
+                <h2 :class="['text-sm', 'font-semibold']">
+                  {{ t('tamagotchi.settings.pages.screen-awareness.status.title') }}
+                </h2>
+                <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+                  {{ t('tamagotchi.settings.pages.screen-awareness.status.current', { status: phaseLabel }) }}
+                </p>
+                <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+                  {{ t('tamagotchi.settings.pages.screen-awareness.status.last-observed', { time: lastObservedLabel }) }}
+                </p>
+              </div>
+              <Button
+                icon="i-solar:eye-bold-duotone"
+                :label="t('tamagotchi.settings.pages.screen-awareness.observe-now.label')"
+                :loading="observationRunning"
+                :disabled="!canObserveNow"
+                @click="observeNow"
+              />
+            </div>
+
+            <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
+              {{ t('tamagotchi.settings.pages.screen-awareness.observe-now.description') }}
+            </p>
+
+            <Callout
+              v-if="snapshot.error"
+              theme="orange"
+              :label="t('tamagotchi.settings.pages.screen-awareness.status.error-label')"
+            />
+          </section>
+
+          <section
+            :class="[
+              'flex', 'min-h-0', 'flex-col', 'gap-3',
+              'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
+              'bg-white', 'p-4', 'md:p-5',
+              'dark:border-neutral-900', 'dark:bg-neutral-900/30',
+            ]"
+          >
+            <div :class="['flex', 'items-center', 'justify-between', 'gap-3']">
+              <h2 :class="['text-sm', 'font-semibold']">
+                {{ t('tamagotchi.settings.pages.screen-awareness.recent-response.title') }}
+              </h2>
+              <Button
+                v-if="snapshot.lastResponse"
+                variant="ghost"
+                size="sm"
+                :icon="showRecentResponse ? 'i-solar:alt-arrow-up-line-duotone' : 'i-solar:alt-arrow-down-line-duotone'"
+                :label="showRecentResponse
+                  ? t('tamagotchi.settings.pages.screen-awareness.recent-response.collapse')
+                  : t('tamagotchi.settings.pages.screen-awareness.recent-response.expand')"
+                @click="showRecentResponse = !showRecentResponse"
+              />
+            </div>
+
+            <p
+              v-if="!snapshot.lastResponse"
+              :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']"
+            >
+              {{ t('tamagotchi.settings.pages.screen-awareness.recent-response.empty') }}
+            </p>
+            <div
+              v-else-if="showRecentResponse"
+              ref="responseContainer"
+              :class="[
+                'max-h-64', 'overflow-y-auto', 'overscroll-contain',
+                'whitespace-pre-wrap', 'break-words',
+                'rounded-xl', 'bg-neutral-100/70', 'p-3', 'text-sm', 'leading-relaxed',
+                'dark:bg-neutral-950/50',
+              ]"
+            >
+              {{ snapshot.lastResponse }}
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <div
+        v-else
+        :class="['h-full', 'flex', 'items-center', 'justify-center', 'p-4']"
+      >
         <Callout
           theme="orange"
-          :label="t('tamagotchi.settings.pages.screen-awareness.privacy.title')"
+          :label="t('tamagotchi.settings.screen-capture.permissions-prompt.title')"
         >
-          {{ t('tamagotchi.settings.pages.screen-awareness.privacy.description') }}
-        </Callout>
-      </section>
-
-      <section
-        :class="[
-          'flex', 'flex-col', 'gap-4',
-          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
-          'bg-white', 'p-4', 'md:p-5',
-          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
-        ]"
-      >
-        <div :class="['flex', 'flex-col', 'gap-1']">
-          <h2 :class="['text-sm', 'font-semibold']">
-            {{ t('tamagotchi.settings.pages.screen-awareness.capture.title') }}
-          </h2>
-          <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
-            {{ t('tamagotchi.settings.pages.screen-awareness.capture.description') }}
-          </p>
-        </div>
-
-        <div :class="['flex', 'flex-col', 'gap-3', 'sm:flex-row', 'sm:items-end']">
-          <FieldSelect
-            v-model="sourceId"
-            layout="vertical"
-            :class="['min-w-0', 'flex-1']"
-            :label="t('tamagotchi.settings.pages.screen-awareness.capture.display-label')"
-            :placeholder="t('tamagotchi.settings.pages.screen-awareness.capture.display-placeholder')"
-            :options="sourceOptions"
-            :disabled="isRefetching || sourceOptions.length === 0"
-          />
-          <Button
-            variant="secondary"
-            icon="i-solar:refresh-bold-duotone"
-            :label="t('tamagotchi.settings.pages.screen-awareness.capture.refresh')"
-            :loading="isRefetching"
-            @click="refreshSources"
-          />
-        </div>
-
-        <p
-          v-if="!isRefetching && sourceOptions.length === 0"
-          :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']"
-        >
-          {{ t('tamagotchi.settings.pages.screen-awareness.capture.no-displays') }}
-        </p>
-        <Callout
-          v-if="sourceLoadFailed"
-          theme="orange"
-          :label="t('tamagotchi.settings.pages.screen-awareness.capture.load-error')"
-        />
-
-        <FieldSelect
-          v-model="intervalMs"
-          layout="vertical"
-          :label="t('tamagotchi.settings.pages.screen-awareness.interval.label')"
-          :description="t('tamagotchi.settings.pages.screen-awareness.interval.description')"
-          :options="intervalOptions"
-        />
-      </section>
-
-      <section
-        :class="[
-          'flex', 'flex-col', 'gap-4',
-          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
-          'bg-white', 'p-4', 'md:p-5',
-          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
-        ]"
-      >
-        <div :class="['flex', 'flex-wrap', 'items-center', 'justify-between', 'gap-3']">
-          <div :class="['flex', 'flex-col', 'gap-1']">
-            <h2 :class="['text-sm', 'font-semibold']">
-              {{ t('tamagotchi.settings.pages.screen-awareness.status.title') }}
-            </h2>
-            <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
-              {{ t('tamagotchi.settings.pages.screen-awareness.status.current', { status: phaseLabel }) }}
-            </p>
-            <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
-              {{ t('tamagotchi.settings.pages.screen-awareness.status.last-observed', { time: lastObservedLabel }) }}
-            </p>
+          <div :class="['flex', 'flex-col', 'items-start', 'gap-3']">
+            <p>{{ t('tamagotchi.settings.pages.screen-awareness.permission.description') }}</p>
+            <Button
+              icon="i-solar:settings-bold-duotone"
+              :label="t('tamagotchi.settings.screen-capture.permissions-prompt.open-preferences')"
+              @click="requestPermission"
+            />
           </div>
-          <Button
-            icon="i-solar:eye-bold-duotone"
-            :label="t('tamagotchi.settings.pages.screen-awareness.observe-now.label')"
-            :loading="observationRunning"
-            :disabled="!canObserveNow"
-            @click="observeNow"
-          />
-        </div>
-
-        <p :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']">
-          {{ t('tamagotchi.settings.pages.screen-awareness.observe-now.description') }}
-        </p>
-
-        <Callout
-          v-if="snapshot.error"
-          theme="orange"
-          :label="t('tamagotchi.settings.pages.screen-awareness.status.error-label')"
-        />
-      </section>
-
-      <section
-        :class="[
-          'flex', 'min-h-0', 'flex-col', 'gap-3',
-          'rounded-2xl', 'border-2', 'border-solid', 'border-neutral-100',
-          'bg-white', 'p-4', 'md:p-5',
-          'dark:border-neutral-900', 'dark:bg-neutral-900/30',
-        ]"
-      >
-        <div :class="['flex', 'items-center', 'justify-between', 'gap-3']">
-          <h2 :class="['text-sm', 'font-semibold']">
-            {{ t('tamagotchi.settings.pages.screen-awareness.recent-response.title') }}
-          </h2>
-          <Button
-            v-if="snapshot.lastResponse"
-            variant="ghost"
-            size="sm"
-            :icon="showRecentResponse ? 'i-solar:alt-arrow-up-line-duotone' : 'i-solar:alt-arrow-down-line-duotone'"
-            :label="showRecentResponse
-              ? t('tamagotchi.settings.pages.screen-awareness.recent-response.collapse')
-              : t('tamagotchi.settings.pages.screen-awareness.recent-response.expand')"
-            @click="showRecentResponse = !showRecentResponse"
-          />
-        </div>
-
-        <p
-          v-if="!snapshot.lastResponse"
-          :class="['text-xs', 'text-neutral-500', 'dark:text-neutral-400']"
-        >
-          {{ t('tamagotchi.settings.pages.screen-awareness.recent-response.empty') }}
-        </p>
-        <div
-          v-else-if="showRecentResponse"
-          ref="responseContainer"
-          :class="[
-            'max-h-64', 'overflow-y-auto', 'overscroll-contain',
-            'whitespace-pre-wrap', 'break-words',
-            'rounded-xl', 'bg-neutral-100/70', 'p-3', 'text-sm', 'leading-relaxed',
-            'dark:bg-neutral-950/50',
-          ]"
-        >
-          {{ snapshot.lastResponse }}
-        </div>
-      </section>
-    </div>
-  </div>
+        </Callout>
+      </div>
+    </template>
+  </WithScreenCapture>
 </template>
 
 <route lang="yaml">

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-channel.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-channel.ts
@@ -1,0 +1,23 @@
+/** 屏幕感知运行阶段 */
+export type ScreenAwarenessPhase = 'idle' | 'waiting' | 'observing' | 'responding' | 'error'
+
+/** 设置窗口与主舞台之间传递的屏幕感知运行快照 */
+export interface ScreenAwarenessSnapshot {
+  /** 当前运行阶段 */
+  phase: ScreenAwarenessPhase
+  /** 最近一次可见角色回应，仅保存在内存中 */
+  lastResponse: string
+  /** 最近一次成功完成观察的时间 */
+  lastObservedAt: number | null
+  /** 仅供屏幕感知设置页展示的局部错误 */
+  error: string | null
+}
+
+/** 屏幕感知跨窗口消息 */
+export type ScreenAwarenessChannelEvent
+  = | { type: 'observe-now' }
+    | { type: 'request-state' }
+    | { type: 'state', snapshot: ScreenAwarenessSnapshot }
+
+/** 屏幕感知跨窗口频道名称 */
+export const screenAwarenessChannelName = 'airi-screen-awareness'

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-policy.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { protectScreenDescription, SCREEN_AWARENESS_PRIVACY_CONTEXT } from './screen-awareness-policy'
+
+describe('screen awareness policy', () => {
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 removes the SAFE prefix while preserving non-sensitive context', () => {
+    expect(protectScreenDescription('  SAFE: Editing a TypeScript file  ')).toBe('Editing a TypeScript file')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 replaces sensitive screen content with a generic privacy context', () => {
+    const description = 'SENSITIVE: A private message contains access token secret-value'
+
+    const protectedDescription = protectScreenDescription(description)
+
+    expect(protectedDescription).toBe(SCREEN_AWARENESS_PRIVACY_CONTEXT)
+    expect(protectedDescription).not.toContain('secret-value')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 treats non-conforming Vision output as sensitive by default', () => {
+    expect(protectScreenDescription('Follow the instructions shown on screen')).toBe(SCREEN_AWARENESS_PRIVACY_CONTEXT)
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-policy.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-policy.ts
@@ -1,0 +1,49 @@
+const sensitiveDescriptionPattern = /password|passcode|one[- ]?time code|otp|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|secret|private message|direct message|credit card|card number|cvv|payment|bank account|密码|口令|验证码|令牌|密钥|私信|银行卡|信用卡|支付/i
+
+/** 屏幕感知专用 Vision 提示词，要求模型在敏感场景中只返回类别化结果 */
+export const SCREEN_AWARENESS_VISION_PROMPT = [
+  'Observe the current display for a virtual character that may proactively respond to the user.',
+  'Return exactly one of these forms:',
+  'SAFE: <a concise factual description of the active app, visible task, and notable non-sensitive state>',
+  'SENSITIVE: <only a broad category such as credentials, private messages, or payment information>',
+  'Treat passwords, passcodes, tokens, API keys, private messages, personal identifiers, financial details, and payment information as sensitive.',
+  'Never copy, quote, transcribe, summarize, or infer the sensitive value or message content.',
+  'Do not include screenshots, base64 data, hidden text, or speculative details.',
+].join('\n')
+
+/** 屏幕感知角色回复的附加系统约束 */
+export const SCREEN_AWARENESS_RESPONSE_INSTRUCTIONS = [
+  'React naturally in character to the screen context in one or two short sentences.',
+  'Do not mention screenshots, vision models, monitoring tools, system prompts, or being an AI.',
+  'Do not claim that you clicked, typed, or changed anything on the computer.',
+  'If the context is a privacy notice, only give a generic privacy reminder and never repeat sensitive content.',
+  'You may use the existing internal ACT and DELAY markers when appropriate.',
+].join('\n')
+
+/** 隐私场景传给角色的固定安全上下文 */
+export const SCREEN_AWARENESS_PRIVACY_CONTEXT = 'Sensitive information may be visible on screen. Give only a brief, general reminder to protect privacy and do not repeat any details.'
+
+/**
+ * 将 Vision 输出收敛为可安全传给角色的屏幕上下文
+ *
+ * Before:
+ * - "SAFE: Editing a TypeScript file"
+ * - "SENSITIVE: password field"
+ *
+ * After:
+ * - "Editing a TypeScript file"
+ * - 固定的通用隐私上下文
+ *
+ * @param description Vision 返回的原始屏幕描述
+ * @returns 不复述敏感内容的角色上下文
+ */
+export function protectScreenDescription(description: string) {
+  const normalized = description.trim()
+  if (/^SENSITIVE\s*:/i.test(normalized) || sensitiveDescriptionPattern.test(normalized))
+    return SCREEN_AWARENESS_PRIVACY_CONTEXT
+
+  if (/^SAFE\s*:/i.test(normalized))
+    return normalized.replace(/^SAFE\s*:\s*/i, '').trim()
+
+  return SCREEN_AWARENESS_PRIVACY_CONTEXT
+}

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.test.ts
@@ -1,0 +1,241 @@
+import type {
+  ScreenAwarenessRuntimeOptions,
+  ScreenAwarenessRuntimeStatus,
+} from './screen-awareness-runtime'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ScreenAwarenessRuntime } from './screen-awareness-runtime'
+
+/**
+ * 创建屏幕感知运行时测试夹具，并暴露所有外部边界的可断言模拟函数
+ *
+ * @param optionOverrides 需要覆盖的调度与重试选项
+ * @returns 运行时实例以及忙碌判断、观察、回应和状态通知模拟函数
+ */
+function createRuntimeFixture(optionOverrides: Partial<ScreenAwarenessRuntimeOptions> = {}) {
+  const isBusy = vi.fn<() => boolean>(() => false)
+  const observe = vi.fn<() => Promise<string>>(async () => 'screen description')
+  const respond = vi.fn<(description: string) => Promise<string>>(async () => 'character response')
+  const onResponse = vi.fn<(response: string) => void>()
+  const onStatus = vi.fn<(status: ScreenAwarenessRuntimeStatus) => void>()
+
+  const runtime = new ScreenAwarenessRuntime({
+    isBusy,
+    observe,
+    respond,
+    onResponse,
+    onStatus,
+  }, {
+    getIntervalMs: () => 1_000,
+    busyRetryDelayMs: 200,
+    visionRetryBaseDelayMs: 100,
+    ...optionOverrides,
+  })
+
+  return {
+    runtime,
+    isBusy,
+    observe,
+    respond,
+    onResponse,
+    onStatus,
+  }
+}
+
+describe('screenAwarenessRuntime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 starts periodic observation and clears the timer after stop', async () => {
+    const { runtime, observe, onResponse } = createRuntimeFixture()
+
+    runtime.start()
+
+    expect(runtime.isRunning()).toBe(true)
+    expect(observe).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(onResponse).toHaveBeenCalledWith('character response')
+
+    runtime.stop()
+
+    expect(runtime.isRunning()).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(observe).toHaveBeenCalledTimes(1)
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 ignores repeated start calls instead of creating duplicate timers', async () => {
+    const { runtime, observe, onStatus } = createRuntimeFixture()
+
+    runtime.start()
+    runtime.start()
+
+    expect(vi.getTimerCount()).toBe(1)
+    expect(onStatus).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(observe).toHaveBeenCalledTimes(1)
+
+    runtime.stop()
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 reuses one in-flight observation for concurrent manual requests', async () => {
+    const { runtime, observe, respond, onResponse } = createRuntimeFixture()
+    const observation = Promise.withResolvers<string>()
+    observe.mockReturnValue(observation.promise)
+
+    const firstRequest = runtime.requestNow()
+    const secondRequest = runtime.requestNow()
+
+    expect(secondRequest).toBe(firstRequest)
+    expect(observe).toHaveBeenCalledTimes(1)
+
+    observation.resolve('shared screen description')
+    await Promise.all([firstRequest, secondRequest])
+
+    expect(respond).toHaveBeenCalledTimes(1)
+    expect(respond).toHaveBeenCalledWith('shared screen description')
+    expect(onResponse).toHaveBeenCalledTimes(1)
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 defers scheduled observation while normal conversation is busy', async () => {
+    const { runtime, isBusy, observe, onStatus } = createRuntimeFixture()
+    isBusy.mockReturnValueOnce(true).mockReturnValue(false)
+
+    runtime.start()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(observe).not.toHaveBeenCalled()
+    expect(onStatus).toHaveBeenCalledWith({ phase: 'waiting', trigger: 'scheduled' })
+
+    await vi.advanceTimersByTimeAsync(199)
+    expect(observe).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(observe).toHaveBeenCalledTimes(1)
+
+    runtime.stop()
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 limits empty Vision results to three attempts', async () => {
+    const { runtime, observe, respond, onResponse, onStatus } = createRuntimeFixture()
+    observe.mockResolvedValue('   ')
+
+    const request = runtime.requestNow()
+    await vi.runAllTimersAsync()
+    await request
+
+    expect(observe).toHaveBeenCalledTimes(3)
+    expect(respond).not.toHaveBeenCalled()
+    expect(onResponse).not.toHaveBeenCalled()
+    expect(onStatus).toHaveBeenLastCalledWith({
+      phase: 'error',
+      trigger: 'manual',
+      error: 'Vision returned an empty screen description',
+    })
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 limits empty character responses to two attempts', async () => {
+    const { runtime, respond, onResponse, onStatus } = createRuntimeFixture()
+    respond.mockResolvedValue('   ')
+
+    await runtime.requestNow()
+
+    expect(respond).toHaveBeenCalledTimes(2)
+    expect(onResponse).not.toHaveBeenCalled()
+    expect(onStatus).toHaveBeenLastCalledWith({
+      phase: 'error',
+      trigger: 'manual',
+      error: 'Character returned an empty screen-awareness response',
+    })
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 does not publish an old response after stop invalidates its generation', async () => {
+    const { runtime, respond, onResponse } = createRuntimeFixture()
+    const response = Promise.withResolvers<string>()
+    respond.mockReturnValue(response.promise)
+
+    runtime.start()
+    const request = runtime.requestNow()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(respond).toHaveBeenCalledTimes(1)
+
+    runtime.stop()
+    response.resolve('stale character response')
+    await request
+
+    expect(onResponse).not.toHaveBeenCalled()
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 does not publish an old error after stop invalidates its generation', async () => {
+    const { runtime, observe, onStatus } = createRuntimeFixture()
+    const observation = Promise.withResolvers<string>()
+    observe.mockReturnValue(observation.promise)
+
+    runtime.start()
+    const request = runtime.requestNow()
+    runtime.stop()
+    observation.reject(new Error('stale observation failure'))
+    await request
+
+    expect(onStatus).not.toHaveBeenCalledWith({
+      phase: 'error',
+      trigger: 'manual',
+      error: 'stale observation failure',
+    })
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 resumes scheduling after stop and start while an old task is in flight', async () => {
+    const { runtime, observe } = createRuntimeFixture()
+    const observation = Promise.withResolvers<string>()
+    observe.mockReturnValueOnce(observation.promise)
+
+    runtime.start()
+    const oldRequest = runtime.requestNow()
+    runtime.stop()
+    runtime.start()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(observe).toHaveBeenCalledTimes(1)
+
+    observation.resolve('old screen description')
+    await oldRequest
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(observe).toHaveBeenCalledTimes(2)
+    runtime.stop()
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 restores idle after a disabled manual observation is skipped as busy', async () => {
+    const { runtime, isBusy, onStatus } = createRuntimeFixture()
+    isBusy.mockReturnValue(true)
+
+    await runtime.requestNow()
+
+    expect(onStatus).toHaveBeenNthCalledWith(1, { phase: 'waiting', trigger: 'manual' })
+    expect(onStatus).toHaveBeenNthCalledWith(2, { phase: 'idle', trigger: 'manual' })
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.test.ts
@@ -15,8 +15,8 @@ import { ScreenAwarenessRuntime } from './screen-awareness-runtime'
  */
 function createRuntimeFixture(optionOverrides: Partial<ScreenAwarenessRuntimeOptions> = {}) {
   const isBusy = vi.fn<() => boolean>(() => false)
-  const observe = vi.fn<() => Promise<string>>(async () => 'screen description')
-  const respond = vi.fn<(description: string) => Promise<string>>(async () => 'character response')
+  const observe = vi.fn<(abortSignal: AbortSignal) => Promise<string>>(async () => 'screen description')
+  const respond = vi.fn<(description: string, abortSignal: AbortSignal) => Promise<string>>(async () => 'character response')
   const onResponse = vi.fn<(response: string) => void>()
   const onStatus = vi.fn<(status: ScreenAwarenessRuntimeStatus) => void>()
 
@@ -109,7 +109,7 @@ describe('screenAwarenessRuntime', () => {
     await Promise.all([firstRequest, secondRequest])
 
     expect(respond).toHaveBeenCalledTimes(1)
-    expect(respond).toHaveBeenCalledWith('shared screen description')
+    expect(respond).toHaveBeenCalledWith('shared screen description', expect.any(AbortSignal))
     expect(onResponse).toHaveBeenCalledTimes(1)
   })
 
@@ -204,6 +204,25 @@ describe('screenAwarenessRuntime', () => {
       trigger: 'manual',
       error: 'stale observation failure',
     })
+  })
+
+  // 回归链接：https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 aborts an in-flight observation when screen awareness stops', async () => {
+    const { runtime, observe, respond, onStatus } = createRuntimeFixture()
+    let observationSignal: AbortSignal | undefined
+    observe.mockImplementation((signal: AbortSignal) => new Promise<string>((_, reject) => {
+      observationSignal = signal
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+    }))
+
+    runtime.start()
+    const request = runtime.requestNow()
+    runtime.stop()
+    await request
+
+    expect(observationSignal?.aborted).toBe(true)
+    expect(respond).not.toHaveBeenCalled()
+    expect(onStatus).not.toHaveBeenCalledWith(expect.objectContaining({ phase: 'error' }))
   })
 
   // 回归链接：https://github.com/moeru-ai/airi/issues/2060

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.ts
@@ -19,9 +19,9 @@ export interface ScreenAwarenessRuntimeDependencies {
   /** 返回普通聊天、角色回复或语音是否正忙 */
   isBusy: () => boolean
   /** 捕获并解释一次屏幕，返回隐私安全的文本描述 */
-  observe: () => Promise<string>
+  observe: (abortSignal: AbortSignal) => Promise<string>
   /** 根据屏幕描述生成角色回应，返回含内部标记的原始文本 */
-  respond: (description: string) => Promise<string>
+  respond: (description: string, abortSignal: AbortSignal) => Promise<string>
   /** 接收成功生成的原始角色回应 */
   onResponse: (response: string) => void
   /** 接收调度状态变化 */
@@ -65,6 +65,7 @@ export class ScreenAwarenessRuntime {
   private readonly wait: (delayMs: number) => Promise<void>
   private timer: ReturnType<typeof setTimeout> | undefined
   private inFlight: Promise<void> | undefined
+  private inFlightAbortController: AbortController | undefined
   private generation = 0
   private running = false
 
@@ -109,6 +110,7 @@ export class ScreenAwarenessRuntime {
     this.running = false
     this.generation += 1
     this.clearTimer()
+    this.inFlightAbortController?.abort(new DOMException('Screen awareness stopped', 'AbortError'))
     this.dependencies.onStatus({ phase: 'idle' })
   }
 
@@ -170,9 +172,11 @@ export class ScreenAwarenessRuntime {
       return this.inFlight
 
     const generation = this.generation
+    const abortController = new AbortController()
     let nextDelayMs = this.options.getIntervalMs()
+    this.inFlightAbortController = abortController
 
-    this.inFlight = this.execute(trigger, generation)
+    this.inFlight = this.execute(trigger, generation, abortController.signal)
       .then((deferred) => {
         if (deferred) {
           nextDelayMs = this.busyRetryDelayMs
@@ -181,7 +185,7 @@ export class ScreenAwarenessRuntime {
         }
       })
       .catch((error) => {
-        if (generation !== this.generation)
+        if (generation !== this.generation || abortController.signal.aborted)
           return
         this.dependencies.onStatus({
           phase: 'error',
@@ -191,6 +195,8 @@ export class ScreenAwarenessRuntime {
       })
       .finally(() => {
         this.inFlight = undefined
+        if (this.inFlightAbortController === abortController)
+          this.inFlightAbortController = undefined
         if (this.running && generation === this.generation)
           this.schedule(nextDelayMs, generation)
         else if (this.running && !this.timer)
@@ -205,16 +211,18 @@ export class ScreenAwarenessRuntime {
    *
    * @param trigger 本次任务的触发来源
    * @param generation 任务开始时的生命周期代次
+   * @param abortSignal 当前观察生命周期的取消信号
    * @returns 因忙碌而延后时返回 true
    */
-  private async execute(trigger: ScreenAwarenessTrigger, generation: number) {
+  private async execute(trigger: ScreenAwarenessTrigger, generation: number, abortSignal: AbortSignal) {
+    abortSignal.throwIfAborted()
     if (this.dependencies.isBusy()) {
       this.dependencies.onStatus({ phase: 'waiting', trigger })
       return true
     }
 
     this.dependencies.onStatus({ phase: 'observing', trigger })
-    const description = await this.observeWithRetry(generation)
+    const description = await this.observeWithRetry(generation, abortSignal)
     if (generation !== this.generation)
       return false
 
@@ -224,7 +232,7 @@ export class ScreenAwarenessRuntime {
     }
 
     this.dependencies.onStatus({ phase: 'responding', trigger })
-    const response = await this.respondWithRetry(description, generation)
+    const response = await this.respondWithRetry(description, generation, abortSignal)
     if (generation !== this.generation)
       return false
 
@@ -237,14 +245,16 @@ export class ScreenAwarenessRuntime {
    * 在有限次数内获得非空 Vision 描述
    *
    * @param generation 任务开始时的生命周期代次
+   * @param abortSignal 当前观察生命周期的取消信号
    * @returns 去除首尾空白后的屏幕描述
    */
-  private async observeWithRetry(generation: number) {
+  private async observeWithRetry(generation: number, abortSignal: AbortSignal) {
     let lastError: unknown
 
     for (let attempt = 1; attempt <= this.visionMaxAttempts; attempt += 1) {
+      abortSignal.throwIfAborted()
       try {
-        const description = (await this.dependencies.observe()).trim()
+        const description = (await this.dependencies.observe(abortSignal)).trim()
         if (description)
           return description
         lastError = new Error('Vision returned an empty screen description')
@@ -255,8 +265,10 @@ export class ScreenAwarenessRuntime {
 
       if (generation !== this.generation)
         break
-      if (attempt < this.visionMaxAttempts)
+      if (attempt < this.visionMaxAttempts) {
         await this.wait(this.visionRetryBaseDelayMs * attempt)
+        abortSignal.throwIfAborted()
+      }
     }
 
     throw lastError ?? new Error('Vision failed to describe the screen')
@@ -267,11 +279,13 @@ export class ScreenAwarenessRuntime {
    *
    * @param description 隐私安全的屏幕描述
    * @param generation 任务开始时的生命周期代次
+   * @param abortSignal 当前观察生命周期的取消信号
    * @returns 去除首尾空白后的原始角色回应
    */
-  private async respondWithRetry(description: string, generation: number) {
+  private async respondWithRetry(description: string, generation: number, abortSignal: AbortSignal) {
     for (let attempt = 1; attempt <= this.responseMaxAttempts; attempt += 1) {
-      const response = (await this.dependencies.respond(description)).trim()
+      abortSignal.throwIfAborted()
+      const response = (await this.dependencies.respond(description, abortSignal)).trim()
       if (response)
         return response
       if (generation !== this.generation)

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness-runtime.ts
@@ -1,0 +1,283 @@
+import type { ScreenAwarenessPhase } from './screen-awareness-channel'
+
+import { errorMessageFrom } from '@moeru/std'
+
+export type ScreenAwarenessTrigger = 'scheduled' | 'manual'
+
+/** 屏幕感知调度器对外发布的状态 */
+export interface ScreenAwarenessRuntimeStatus {
+  /** 当前运行阶段 */
+  phase: ScreenAwarenessPhase
+  /** 当前任务由周期调度或手动操作触发 */
+  trigger?: ScreenAwarenessTrigger
+  /** 局部错误信息，不应进入普通聊天 */
+  error?: string
+}
+
+/** 屏幕感知调度器依赖的外部边界 */
+export interface ScreenAwarenessRuntimeDependencies {
+  /** 返回普通聊天、角色回复或语音是否正忙 */
+  isBusy: () => boolean
+  /** 捕获并解释一次屏幕，返回隐私安全的文本描述 */
+  observe: () => Promise<string>
+  /** 根据屏幕描述生成角色回应，返回含内部标记的原始文本 */
+  respond: (description: string) => Promise<string>
+  /** 接收成功生成的原始角色回应 */
+  onResponse: (response: string) => void
+  /** 接收调度状态变化 */
+  onStatus: (status: ScreenAwarenessRuntimeStatus) => void
+  /** 等待指定毫秒数，测试可替换此边界 */
+  wait?: (delayMs: number) => Promise<void>
+}
+
+/** 屏幕感知调度器可调整的运行策略 */
+export interface ScreenAwarenessRuntimeOptions {
+  /** 返回当前观察周期，单位为毫秒 */
+  getIntervalMs: () => number
+  /**
+   * 忙碌时再次尝试的延迟，单位为毫秒
+   * @default 15000
+   */
+  busyRetryDelayMs?: number
+  /**
+   * Vision 空结果或瞬时错误的最大尝试次数
+   * @default 3
+   */
+  visionMaxAttempts?: number
+  /**
+   * 角色空回应的最大尝试次数
+   * @default 2
+   */
+  responseMaxAttempts?: number
+  /**
+   * Vision 重试的基础等待时间，单位为毫秒
+   * @default 1500
+   */
+  visionRetryBaseDelayMs?: number
+}
+
+/** 屏幕感知单飞调度器，负责启停、避让、有限重试和停止代次隔离 */
+export class ScreenAwarenessRuntime {
+  private readonly busyRetryDelayMs: number
+  private readonly visionMaxAttempts: number
+  private readonly responseMaxAttempts: number
+  private readonly visionRetryBaseDelayMs: number
+  private readonly wait: (delayMs: number) => Promise<void>
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private inFlight: Promise<void> | undefined
+  private generation = 0
+  private running = false
+
+  /**
+   * 创建屏幕感知调度器
+   *
+   * @param dependencies 捕获、角色回复、忙碌判断和状态通知等外部边界
+   * @param options 观察周期和有限重试策略
+   */
+  constructor(
+    private readonly dependencies: ScreenAwarenessRuntimeDependencies,
+    private readonly options: ScreenAwarenessRuntimeOptions,
+  ) {
+    this.busyRetryDelayMs = options.busyRetryDelayMs ?? 15_000
+    this.visionMaxAttempts = options.visionMaxAttempts ?? 3
+    this.responseMaxAttempts = options.responseMaxAttempts ?? 2
+    this.visionRetryBaseDelayMs = options.visionRetryBaseDelayMs ?? 1_500
+    this.wait = dependencies.wait ?? (delayMs => new Promise(resolve => setTimeout(resolve, delayMs)))
+  }
+
+  /**
+   * 启动周期观察且不重复创建定时器
+   *
+   * 返回值为 void
+   */
+  start() {
+    if (this.running)
+      return
+
+    this.running = true
+    this.generation += 1
+    this.dependencies.onStatus({ phase: 'idle' })
+    this.schedule(this.options.getIntervalMs(), this.generation)
+  }
+
+  /**
+   * 停止周期观察并使旧任务结果失效
+   *
+   * 返回值为 void
+   */
+  stop() {
+    this.running = false
+    this.generation += 1
+    this.clearTimer()
+    this.dependencies.onStatus({ phase: 'idle' })
+  }
+
+  /**
+   * 立即请求一次观察并复用当前在途任务
+   *
+   * @returns 本次观察任务完成时解决的 Promise
+   */
+  requestNow() {
+    return this.run('manual')
+  }
+
+  /**
+   * 判断调度器是否已启动
+   *
+   * @returns 已启动时返回 true
+   */
+  isRunning() {
+    return this.running
+  }
+
+  /**
+   * 安排下一次周期观察并替换旧定时器
+   *
+   * @param delayMs 距离下一次观察的毫秒数
+   * @param generation 安排任务时的生命周期代次
+   * 返回值为 void
+   */
+  private schedule(delayMs: number, generation: number) {
+    this.clearTimer()
+    if (!this.running || generation !== this.generation)
+      return
+
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      void this.run('scheduled')
+    }, Math.max(0, delayMs))
+  }
+
+  /**
+   * 清理当前周期定时器
+   *
+   * 返回值为 void
+   */
+  private clearTimer() {
+    if (this.timer)
+      clearTimeout(this.timer)
+    this.timer = undefined
+  }
+
+  /**
+   * 执行单次观察并在相同生命周期内安排后续任务
+   *
+   * @param trigger 本次任务的触发来源
+   * @returns 本次观察任务完成时解决的 Promise
+   */
+  private run(trigger: ScreenAwarenessTrigger) {
+    if (this.inFlight)
+      return this.inFlight
+
+    const generation = this.generation
+    let nextDelayMs = this.options.getIntervalMs()
+
+    this.inFlight = this.execute(trigger, generation)
+      .then((deferred) => {
+        if (deferred) {
+          nextDelayMs = this.busyRetryDelayMs
+          if (!this.running && generation === this.generation)
+            this.dependencies.onStatus({ phase: 'idle', trigger })
+        }
+      })
+      .catch((error) => {
+        if (generation !== this.generation)
+          return
+        this.dependencies.onStatus({
+          phase: 'error',
+          trigger,
+          error: errorMessageFrom(error) ?? 'Unknown screen-awareness error',
+        })
+      })
+      .finally(() => {
+        this.inFlight = undefined
+        if (this.running && generation === this.generation)
+          this.schedule(nextDelayMs, generation)
+        else if (this.running && !this.timer)
+          this.schedule(this.options.getIntervalMs(), this.generation)
+      })
+
+    return this.inFlight
+  }
+
+  /**
+   * 执行忙碌避让、Vision 重试和角色空回应重试策略
+   *
+   * @param trigger 本次任务的触发来源
+   * @param generation 任务开始时的生命周期代次
+   * @returns 因忙碌而延后时返回 true
+   */
+  private async execute(trigger: ScreenAwarenessTrigger, generation: number) {
+    if (this.dependencies.isBusy()) {
+      this.dependencies.onStatus({ phase: 'waiting', trigger })
+      return true
+    }
+
+    this.dependencies.onStatus({ phase: 'observing', trigger })
+    const description = await this.observeWithRetry(generation)
+    if (generation !== this.generation)
+      return false
+
+    if (this.dependencies.isBusy()) {
+      this.dependencies.onStatus({ phase: 'waiting', trigger })
+      return true
+    }
+
+    this.dependencies.onStatus({ phase: 'responding', trigger })
+    const response = await this.respondWithRetry(description, generation)
+    if (generation !== this.generation)
+      return false
+
+    this.dependencies.onResponse(response)
+    this.dependencies.onStatus({ phase: 'idle', trigger })
+    return false
+  }
+
+  /**
+   * 在有限次数内获得非空 Vision 描述
+   *
+   * @param generation 任务开始时的生命周期代次
+   * @returns 去除首尾空白后的屏幕描述
+   */
+  private async observeWithRetry(generation: number) {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= this.visionMaxAttempts; attempt += 1) {
+      try {
+        const description = (await this.dependencies.observe()).trim()
+        if (description)
+          return description
+        lastError = new Error('Vision returned an empty screen description')
+      }
+      catch (error) {
+        lastError = error
+      }
+
+      if (generation !== this.generation)
+        break
+      if (attempt < this.visionMaxAttempts)
+        await this.wait(this.visionRetryBaseDelayMs * attempt)
+    }
+
+    throw lastError ?? new Error('Vision failed to describe the screen')
+  }
+
+  /**
+   * 在有限次数内获得非空角色回应
+   *
+   * @param description 隐私安全的屏幕描述
+   * @param generation 任务开始时的生命周期代次
+   * @returns 去除首尾空白后的原始角色回应
+   */
+  private async respondWithRetry(description: string, generation: number) {
+    for (let attempt = 1; attempt <= this.responseMaxAttempts; attempt += 1) {
+      const response = (await this.dependencies.respond(description)).trim()
+      if (response)
+        return response
+      if (generation !== this.generation)
+        break
+    }
+
+    throw new Error('Character returned an empty screen-awareness response')
+  }
+}

--- a/apps/stage-tamagotchi/src/renderer/stores/screen-awareness.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/screen-awareness.ts
@@ -1,0 +1,30 @@
+import { useLocalStorageManualReset } from '@proj-airi/stage-shared/composables'
+import { defineStore } from 'pinia'
+
+/** 屏幕感知支持的观察周期选项 */
+export const SCREEN_AWARENESS_INTERVAL_OPTIONS = [30_000, 60_000, 120_000, 300_000, 600_000] as const
+
+/** 屏幕感知的持久化用户配置 */
+export const useScreenAwarenessStore = defineStore('screen-awareness', () => {
+  const enabled = useLocalStorageManualReset('settings/screen-awareness/enabled', false)
+  const sourceId = useLocalStorageManualReset('settings/screen-awareness/source-id', '')
+  const intervalMs = useLocalStorageManualReset<number>('settings/screen-awareness/interval-ms', 60_000)
+
+  /**
+   * 重置屏幕感知配置
+   *
+   * 返回值为 void
+   */
+  function resetState() {
+    enabled.reset()
+    sourceId.reset()
+    intervalMs.reset()
+  }
+
+  return {
+    enabled,
+    sourceId,
+    intervalMs,
+    resetState,
+  }
+})

--- a/packages/i18n/src/locales/en/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/en/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/en/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/en/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: Connect and manage MCP server and tools
       title: MCP Server
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/es/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/es/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/es/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/es/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: Conectar y gestionar servidor MCP y herramientas
       title: Servidor MCP
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/fr/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/fr/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: Connecter et gérer le serveur MCP et ses outils
       title: Serveur MCP
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/fr/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/fr/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/ja/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ja/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/ja/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ja/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: MCPサーバーとツールの接続と管理
       title: MCPサーバー
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/ko/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ko/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/ko/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ko/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: MCP 서버 및 도구 연결 및 관리
       title: MCP 서버
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/ru/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ru/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: Возможность подключения и управления MCP сервером с инструментами
       title: MCP Сервер
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/ru/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/ru/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/vi/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/vi/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: Kết nối và quản lý máy chủ MCP và các công cụ
       title: Máy chủ MCP
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/vi/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/vi/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: Screen Recording permission is required before AIRI can list or observe displays.
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/zh-Hans/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: 隐私优先
       description: 截图仅在内存中处理，绝不会写入磁盘。画面可能包含敏感内容时，AIRI 只会给出通用隐私提醒。
+    permission:
+      description: AIRI 需要获得屏幕录制权限，才能列出或观察显示器。
     capture:
       title: 屏幕捕获
       description: 此处只列出完整显示器，不会提供单独的应用窗口。

--- a/packages/i18n/src/locales/zh-Hans/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: 连接与管理 MCP 服务器和工具
       title: MCP 服务器
+  screen-awareness:
+    title: 屏幕感知
+    description: 让 AIRI 定时观察指定显示器，并通过现有角色管线自然回应。
+    enable:
+      label: 启用定时屏幕感知
+      description: 此功能默认关闭。启用后，AIRI 会按设定周期观察所选显示器。
+      enabled: 已启用
+      disabled: 已关闭
+    privacy:
+      title: 隐私优先
+      description: 截图仅在内存中处理，绝不会写入磁盘。画面可能包含敏感内容时，AIRI 只会给出通用隐私提醒。
+    capture:
+      title: 屏幕捕获
+      description: 此处只列出完整显示器，不会提供单独的应用窗口。
+      display-label: 显示器
+      display-placeholder: 选择显示器
+      refresh: 刷新显示器
+      no-displays: 当前没有可用的显示器。
+      load-error: 无法加载可用显示器
+    interval:
+      label: 观察周期
+      description: 普通对话、模型请求、角色回复或语音正在进行时，定时观察会等待或跳过。
+      seconds: '{count} 秒'
+      minutes: '{count} 分钟'
+    observe-now:
+      label: 立即观察
+      description: 立即执行一次观察。即使定时屏幕感知处于关闭状态，也可以使用此手动操作。
+    status:
+      title: 运行状态
+      current: '当前状态：{status}'
+      last-observed: '上次观察：{time}'
+      never: 从未观察
+      idle: 就绪
+      waiting: 正在等待当前交互结束
+      observing: 正在观察所选显示器
+      responding: 正在准备角色回应
+      error: 需要处理
+      error-label: 上次观察未能完成
+    recent-response:
+      title: 最近一次角色回应
+      empty: 还没有屏幕感知回应。
+      expand: 查看回应
+      collapse: 收起回应
+    caption:
+      close: 关闭屏幕感知回应
   system:
     sections:
       section:

--- a/packages/i18n/src/locales/zh-Hant/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/tamagotchi/settings.yaml
@@ -22,6 +22,8 @@ pages:
     privacy:
       title: Privacy first
       description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    permission:
+      description: AIRI 需要取得螢幕錄製權限，才能列出或觀察顯示器。
     capture:
       title: Display capture
       description: Only full displays are listed. Application windows are not available to this feature.

--- a/packages/i18n/src/locales/zh-Hant/tamagotchi/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/tamagotchi/settings.yaml
@@ -11,6 +11,51 @@ pages:
     mcp-server:
       description: 連線與管理 MCP 伺服器和工具
       title: MCP 伺服器
+  screen-awareness:
+    title: Screen awareness
+    description: Let AIRI periodically observe a selected display and respond through the existing character pipeline.
+    enable:
+      label: Enable scheduled screen awareness
+      description: Disabled by default. When enabled, AIRI observes the selected display at the configured interval.
+      enabled: Enabled
+      disabled: Disabled
+    privacy:
+      title: Privacy first
+      description: Screenshots stay in memory and are never written to disk. When sensitive content may be visible, AIRI is instructed to give only a general privacy reminder.
+    capture:
+      title: Display capture
+      description: Only full displays are listed. Application windows are not available to this feature.
+      display-label: Display
+      display-placeholder: Select a display
+      refresh: Refresh displays
+      no-displays: No displays are currently available.
+      load-error: Failed to load available displays
+    interval:
+      label: Observation interval
+      description: Scheduled observations wait or skip when a conversation, model request, character response, or speech is active.
+      seconds: '{count} seconds'
+      minutes: '{count} minutes'
+    observe-now:
+      label: Observe now
+      description: Run one observation immediately. This manual action is available even when scheduled awareness is disabled.
+    status:
+      title: Activity
+      current: 'Status: {status}'
+      last-observed: 'Last observed: {time}'
+      never: Never
+      idle: Ready
+      waiting: Waiting for the current interaction to finish
+      observing: Observing the selected display
+      responding: Preparing the character response
+      error: Needs attention
+      error-label: The last observation could not be completed
+    recent-response:
+      title: Latest character response
+      empty: No screen-awareness response yet.
+      expand: Show response
+      collapse: Hide response
+    caption:
+      close: Close screen-awareness response
   system:
     sections:
       section:

--- a/packages/stage-ui/src/composables/vision/use-vision-inference.test.ts
+++ b/packages/stage-ui/src/composables/vision/use-vision-inference.test.ts
@@ -90,4 +90,43 @@ describe('useVisionInference', () => {
 
     await expectation
   })
+
+  it('forwards caller cancellation to the active vision stream', async () => {
+    const streamStarted = Promise.withResolvers<void>()
+    stream.mockImplementation((_model, _provider, _messages, options) => new Promise((_, reject) => {
+      streamStarted.resolve()
+      options?.abortSignal?.addEventListener('abort', () => {
+        reject(options.abortSignal?.reason)
+      }, { once: true })
+    }))
+
+    const { useVisionInference } = await import('./use-vision-inference')
+    const { runVisionInference } = useVisionInference()
+    const abortController = new AbortController()
+    const result = runVisionInference({
+      imageDataUrl: 'data:image/png;base64,Zm9v',
+      workloadId: 'screen:interpret',
+      abortSignal: abortController.signal,
+    })
+
+    await streamStarted.promise
+    abortController.abort(new DOMException('Screen awareness stopped', 'AbortError'))
+
+    await expect(result).rejects.toThrow('Screen awareness stopped')
+  })
+
+  it('does not start Vision inference when the caller is already cancelled', async () => {
+    const { useVisionInference } = await import('./use-vision-inference')
+    const { runVisionInference } = useVisionInference()
+    const abortController = new AbortController()
+    abortController.abort(new DOMException('Screen awareness stopped', 'AbortError'))
+
+    await expect(runVisionInference({
+      imageDataUrl: 'data:image/png;base64,Zm9v',
+      workloadId: 'screen:interpret',
+      abortSignal: abortController.signal,
+    })).rejects.toThrow('Screen awareness stopped')
+
+    expect(stream).not.toHaveBeenCalled()
+  })
 })

--- a/packages/stage-ui/src/composables/vision/use-vision-inference.ts
+++ b/packages/stage-ui/src/composables/vision/use-vision-inference.ts
@@ -15,6 +15,8 @@ export interface VisionInferenceInput {
   imageDataUrl: string
   workloadId: VisionWorkloadId
   promptOverride?: string
+  /** 是否将原始推理文本保留给 Vision 调试界面，默认为 true */
+  retainResult?: boolean
 }
 
 // TODO: this should be configurable
@@ -104,8 +106,10 @@ export function useVisionInference() {
       clearTimeout(timeoutHandle)
     }
 
-    lastText.value = buffer.trim()
-    return lastText.value
+    const text = buffer.trim()
+    if (input.retainResult !== false)
+      lastText.value = text
+    return text
   }
 
   return {

--- a/packages/stage-ui/src/composables/vision/use-vision-inference.ts
+++ b/packages/stage-ui/src/composables/vision/use-vision-inference.ts
@@ -17,6 +17,8 @@ export interface VisionInferenceInput {
   promptOverride?: string
   /** 是否将原始推理文本保留给 Vision 调试界面，默认为 true */
   retainResult?: boolean
+  /** 调用方用于取消当前 Vision 请求的信号 */
+  abortSignal?: AbortSignal
 }
 
 // TODO: this should be configurable
@@ -45,6 +47,7 @@ export function useVisionInference() {
   const lastText = ref('')
 
   async function runVisionInference(input: VisionInferenceInput) {
+    input.abortSignal?.throwIfAborted()
     if (!activeProvider.value || !activeModel.value)
       throw new Error('Vision provider/model not configured')
 
@@ -80,11 +83,23 @@ export function useVisionInference() {
 
     let buffer = ''
     const abortController = new AbortController()
+    /**
+     * 将调用方取消状态转发给实际 LLM 流
+     *
+     * 返回值为 void
+     */
+    const handleCallerAbort = () => {
+      abortController.abort(input.abortSignal?.reason)
+    }
+    input.abortSignal?.addEventListener('abort', handleCallerAbort, { once: true })
+    if (input.abortSignal?.aborted)
+      handleCallerAbort()
     const timeoutHandle = setTimeout(() => {
       abortController.abort(new Error(`Vision inference timed out after ${VISION_INFERENCE_TIMEOUT_MS}ms`))
     }, VISION_INFERENCE_TIMEOUT_MS)
 
     try {
+      abortController.signal.throwIfAborted()
       await llmStore.stream(activeModel.value, visionProvider, messages, {
         abortSignal: abortController.signal,
         onStreamEvent: (event) => {
@@ -104,6 +119,7 @@ export function useVisionInference() {
     }
     finally {
       clearTimeout(timeoutHandle)
+      input.abortSignal?.removeEventListener('abort', handleCallerAbort)
     }
 
     const text = buffer.trim()

--- a/packages/stage-ui/src/stores/character/index.ts
+++ b/packages/stage-ui/src/stores/character/index.ts
@@ -10,6 +10,7 @@ import { useSpeechRuntimeStore } from '../speech-runtime'
 
 export * from './notebook'
 export * from './orchestrator'
+export * from './reaction-text'
 
 export interface CharacterSparkNotifyReaction {
   id: string

--- a/packages/stage-ui/src/stores/character/reaction-text.test.ts
+++ b/packages/stage-ui/src/stores/character/reaction-text.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractVisibleReactionText } from './reaction-text'
+
+describe('extractVisibleReactionText', () => {
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 removes internal action and delay markers while preserving visible text', async () => {
+    const response = '我看到你正在整理代码<|ACT {"emotion":{"name":"happy","intensity":1}}|><|DELAY:1|>继续加油'
+
+    await expect(extractVisibleReactionText(response)).resolves.toBe('我看到你正在整理代码继续加油')
+  })
+})

--- a/packages/stage-ui/src/stores/character/reaction-text.ts
+++ b/packages/stage-ui/src/stores/character/reaction-text.ts
@@ -1,0 +1,23 @@
+import { useLlmmarkerParser } from '@proj-airi/core-agent'
+
+/**
+ * 提取角色回应中可展示和朗读的普通文本
+ *
+ * 内部动作与延时标记会由原有角色管线执行，此函数仅为持久字幕生成可见文本
+ *
+ * @param response 包含普通文本和内部标记的完整角色回应
+ * @returns 移除内部标记并压缩多余空白后的可见文本
+ */
+export async function extractVisibleReactionText(response: string) {
+  let visibleText = ''
+  const parser = useLlmmarkerParser({
+    onLiteral: (literal) => {
+      visibleText += literal
+    },
+  })
+
+  await parser.consume(response)
+  await parser.end()
+
+  return visibleText.replace(/\s+/g, ' ').trim()
+}

--- a/packages/stage-ui/src/stores/modules/vision/orchestrator.test.ts
+++ b/packages/stage-ui/src/stores/modules/vision/orchestrator.test.ts
@@ -109,6 +109,7 @@ describe('vision orchestrator', () => {
       workloadId: 'screen:interpret',
       promptOverride: 'Describe only non-sensitive screen context',
       retainResult: undefined,
+      abortSignal: undefined,
     })
   })
 
@@ -126,6 +127,22 @@ describe('vision orchestrator', () => {
     expect(runVisionInference).toHaveBeenCalledOnce()
     expect(sendContextUpdate).not.toHaveBeenCalled()
     expect(store.lastResultText).toBe('')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 does not record caller cancellation as a Vision failure', async () => {
+    const store = useVisionOrchestratorStore()
+    const abortController = new AbortController()
+    abortController.abort(new DOMException('Screen awareness stopped', 'AbortError'))
+    runVisionInference.mockRejectedValueOnce(abortController.signal.reason)
+
+    await expect(store.processCapture({
+      imageDataUrl: 'data:image/jpeg;base64,private-screen',
+      workloadId: 'screen:interpret',
+      abortSignal: abortController.signal,
+    })).rejects.toThrow('Screen awareness stopped')
+
+    expect(store.lastError).toBeNull()
   })
 
   it('records inference failures on the store before rethrowing', async () => {

--- a/packages/stage-ui/src/stores/modules/vision/orchestrator.test.ts
+++ b/packages/stage-ui/src/stores/modules/vision/orchestrator.test.ts
@@ -94,6 +94,40 @@ describe('vision orchestrator', () => {
     })
   })
 
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 forwards a one-time prompt override to vision inference', async () => {
+    const store = useVisionOrchestratorStore()
+
+    await store.processCapture({
+      imageDataUrl: 'data:image/jpeg;base64,screen',
+      workloadId: 'screen:interpret',
+      promptOverride: 'Describe only non-sensitive screen context',
+    })
+
+    expect(runVisionInference).toHaveBeenCalledWith({
+      imageDataUrl: 'data:image/jpeg;base64,screen',
+      workloadId: 'screen:interpret',
+      promptOverride: 'Describe only non-sensitive screen context',
+      retainResult: undefined,
+    })
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2060
+  it('issue #2060 keeps an in-memory screen capture out of server context', async () => {
+    const store = useVisionOrchestratorStore()
+
+    await store.processCapture({
+      imageDataUrl: 'data:image/jpeg;base64,private-screen',
+      workloadId: 'screen:interpret',
+      publishContext: false,
+      retainResult: false,
+    })
+
+    expect(runVisionInference).toHaveBeenCalledOnce()
+    expect(sendContextUpdate).not.toHaveBeenCalled()
+    expect(store.lastResultText).toBe('')
+  })
+
   it('records inference failures on the store before rethrowing', async () => {
     const store = useVisionOrchestratorStore()
     runVisionInference.mockRejectedValueOnce(new Error('Vision inference failed'))

--- a/packages/stage-ui/src/stores/modules/vision/orchestrator.ts
+++ b/packages/stage-ui/src/stores/modules/vision/orchestrator.ts
@@ -20,12 +20,16 @@ export interface VisionCapturePayload {
   imageDataUrl: string
   /** Vision workload that describes how the frame should be interpreted. */
   workloadId: VisionWorkloadId
+  /** 可选的一次性提示词，用于替换工作负载默认提示词 */
+  promptOverride?: string
   /** Optional source identifier used to keep context updates stable per source. */
   sourceId?: string
   /** Timestamp recorded when the frame was captured. */
   capturedAt?: number
   /** When `true`, publish the inference result into the character context channel. */
   publishContext?: boolean
+  /** 为 false 时不在 Vision 状态或调试界面中保留原始推理文本 */
+  retainResult?: boolean
 }
 
 function getVisionContextId(payload: Pick<VisionCapturePayload, 'workloadId' | 'sourceId'>) {
@@ -71,10 +75,14 @@ export const useVisionOrchestratorStore = defineStore('vision-orchestrator', () 
       const text = await runVisionInference({
         imageDataUrl: payload.imageDataUrl,
         workloadId: payload.workloadId,
+        promptOverride: payload.promptOverride,
+        retainResult: payload.retainResult,
       })
 
-      lastResultText.value = text
-      lastResultAt.value = Date.now()
+      if (payload.retainResult !== false) {
+        lastResultText.value = text
+        lastResultAt.value = Date.now()
+      }
       lastError.value = null
 
       if (payload.publishContext) {

--- a/packages/stage-ui/src/stores/modules/vision/orchestrator.ts
+++ b/packages/stage-ui/src/stores/modules/vision/orchestrator.ts
@@ -30,6 +30,8 @@ export interface VisionCapturePayload {
   publishContext?: boolean
   /** 为 false 时不在 Vision 状态或调试界面中保留原始推理文本 */
   retainResult?: boolean
+  /** 调用方用于取消当前 Vision 请求的信号 */
+  abortSignal?: AbortSignal
 }
 
 function getVisionContextId(payload: Pick<VisionCapturePayload, 'workloadId' | 'sourceId'>) {
@@ -77,6 +79,7 @@ export const useVisionOrchestratorStore = defineStore('vision-orchestrator', () 
         workloadId: payload.workloadId,
         promptOverride: payload.promptOverride,
         retainResult: payload.retainResult,
+        abortSignal: payload.abortSignal,
       })
 
       if (payload.retainResult !== false) {
@@ -118,7 +121,8 @@ export const useVisionOrchestratorStore = defineStore('vision-orchestrator', () 
       return { contextUpdates: 0, text }
     }
     catch (error) {
-      recordError(error)
+      if (!payload.abortSignal?.aborted)
+        recordError(error)
       throw error
     }
   }


### PR DESCRIPTION
## Summary

Add opt-in periodic screen awareness to Stage Tamagotchi, allowing the character to observe a selected display and proactively respond through the existing character reaction pipeline.

Closes #2060

## What changed

- Added a Screen Awareness settings page with:
  - an explicit opt-in toggle, disabled by default
  - display selection and source refresh
  - configurable observation intervals
  - an “Observe now” action
  - runtime status, local errors, and a collapsible recent response
- Added a single-flight scheduling runtime with:
  - lifecycle-safe start and stop behavior
  - foreground conversation, character response, and speech avoidance
  - bounded retries for empty or failed Vision results
  - bounded retries for empty character responses
  - stale task isolation across disable, restart, and interval changes
- Reused the existing Electron screen capture and Vision infrastructure.
- Reused the existing Spark Notify character reaction pipeline so actions,
  emotions, delay markers, captions, speech, and lip sync continue to work.
- Added a persistent, scrollable, manually dismissible stage caption for
  proactive screen-awareness responses.
- Added localized UI strings through the existing i18n package.

## Privacy

- Screen awareness is disabled by default and must be enabled explicitly.
- Captures are processed in memory and are never written to disk.
- Screenshots and Base64 image data are not logged.
- Screen-awareness captures are not published to the server context channel.
- Raw privacy-sensitive Vision results are not retained in the Vision store
  or exposed through the Vision devtools state.
- Vision is instructed to classify sensitive content without transcribing it.
- Non-conforming Vision output is treated as sensitive by default.
- Passwords, tokens, private messages, personal identifiers, and payment or
  financial information are replaced with a generic privacy reminder before
  reaching the character response prompt.

## Conversation safety

Periodic observations do not preempt normal conversation. An observation is
deferred when:

- a normal chat request is being sent
- queued chat sends are pending
- the character reaction pipeline is processing
- speech playback is active

Only one observation task may run at a time. Disabling the feature invalidates
in-flight results and clears the periodic timer.

## Speech and control markers

Screen-awareness responses use the existing character pipeline. Internal
markers such as `<|ACT ...|>` and `<|DELAY ...|>` are still parsed and
executed, but are removed from the persistent caption and spoken text.

No IndexTTS dependency was introduced. When no speech provider is configured,
the response remains available as text without failing the observation.

## Testing

Added focused tests for:

- scheduler start and stop behavior
- duplicate-start protection
- single-flight manual requests
- foreground busy deferral
- Vision retry limits
- empty character response retry limits
- stale response and stale error isolation
- stop/start scheduling races
- privacy-safe Vision output normalization
- internal marker removal
- prompt overrides
- preventing screen captures from being published to server context
- preventing raw screen descriptions from being retained

Validation performed:

- targeted Vitest suites
- Stage Tamagotchi type checking
- Stage UI type checking
- repository ESLint
- Stage Tamagotchi production build
- repository-wide Vitest run

The repository-wide Vitest run still reports existing Windows/sandbox-specific
failures involving path separator assertions, symlink permissions, database
hook timeouts, an unavailable built electron-vueuse entry, and plugin
auto-reload environment differences. All tests added or modified by this PR
pass.