### PR TITLE
fix(stage-tamagotchi): stabilize plugin auto-reload test

### DIFF
--- a/apps/stage-tamagotchi/src/main/services/airi/plugins/index.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/plugins/index.test.ts
@@ -668,7 +668,16 @@ describe('setupExtensionHost', () => {
     while (Date.now() < deadline && afterSessionId === beforeSession?.id) {
       await new Promise(resolve => setTimeout(resolve, 100))
       const snapshot = await invokeInspect()
-      afterSessionId = snapshot.sessions.find(session => session.extensionId === 'test-auto-reload-reload')?.id
+      const currentSessionId = snapshot.sessions.find(session => session.extensionId === 'test-auto-reload-reload')?.id
+
+      // ROOT CAUSE:
+      //
+      // Reload stops the old session before starting the replacement, so an inspect call can
+      // observe the intentional short-lived gap with no session. Treat that state as pending
+      // instead of ending the poll before the replacement session is available.
+      if (currentSessionId && currentSessionId !== beforeSession?.id) {
+        afterSessionId = currentSessionId
+      }
     }
 
     expect(afterSessionId).toBeDefined()


### PR DESCRIPTION
## Summary

- keep polling while the auto-reload transition has no active session
- prevent the test from failing during the intentional unload/load gap

## Root cause

Auto-reload stops the old plugin session before starting the replacement. The test exited its polling loop when an inspect snapshot observed that temporary empty state, then asserted that the missing session had an ID.

## Validation

- targeted auto-reload regression test
- full `apps/stage-tamagotchi/src/main/services/airi/plugins/index.test.ts`
- `pnpm typecheck`
- `pnpm lint` (0 errors; 6 existing warnings)