### PR TITLE
feat(stage-ui): add Fish Audio speech provider

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1262,6 +1262,9 @@ pages:
           validation:
             error-missing-api-key: Please enter an API key to test the voice.
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Local text-to-speech using Kokoro-82M.
         fields:

--- a/packages/i18n/src/locales/es/settings.yaml
+++ b/packages/i18n/src/locales/es/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: Por favor ingresa una clave API para probar la voz.
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Texto local de voz usando Kokoro-82M.
         fields:

--- a/packages/i18n/src/locales/fr/settings.yaml
+++ b/packages/i18n/src/locales/fr/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: Veuillez entrer une clé API pour tester la voix.
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Synthèse vocale locale utilisant Kokoro-82M.
         fields:

--- a/packages/i18n/src/locales/ja/settings.yaml
+++ b/packages/i18n/src/locales/ja/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: 音声をテストするにはAPIキーを入力してください。
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Kokoro-82Mを使用したローカルテキスト読み上げ機能です。
         fields:

--- a/packages/i18n/src/locales/ko/settings.yaml
+++ b/packages/i18n/src/locales/ko/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: 음성을 테스트하려면 API 키를 입력하세요.
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Kokoro-82M을 사용하여 로컬 텍스트 음성 변환을 생성합니다.
         fields:

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: Введите API-ключ, чтобы протестировать голос.
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Локальный синтезатор речи с помощью Kokoro-82M.
         fields:

--- a/packages/i18n/src/locales/vi/settings.yaml
+++ b/packages/i18n/src/locales/vi/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: Vui lòng nhập khóa API để thử giọng.
         title: ElevenLabs
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: Chuyển văn bản thành giọng nói cục bộ dùng Kokoro-82M.
         fields:

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: 需要填写 API Key 才能用哦！
         title: ElevenLabs (11labs)
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: 基于 Kokoro-82M 的本地语音合成
         fields:

--- a/packages/i18n/src/locales/zh-Hant/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/settings.yaml
@@ -1209,6 +1209,9 @@ pages:
           validation:
             error-missing-api-key: 需要填寫 API Key 才能使用喔！
         title: ElevenLabs (11labs)
+      fish-audio:
+        description: fish.audio
+        title: Fish Audio
       kokoro-local:
         description: 基於 Kokoro-82M 的本地文字轉語音。
         fields:

--- a/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
@@ -46,13 +46,19 @@ const modelOptions = computed(() => {
   }))
 })
 
-const availableVoices = computed(() => speechStore.availableVoices[providerId] || [])
-
 const model = computed({
   get: () => config.value?.model || defaultModel,
   set: (value) => {
     ensureProviderConfig().model = value
   },
+})
+
+// Fish Audio reference voices currently work with every model generation,
+// but honor per-voice compatibility metadata so the picker never offers a
+// voice the selected model can't use if the catalog narrows it later.
+const availableVoices = computed(() => {
+  const voices = speechStore.availableVoices[providerId] || []
+  return voices.filter(voice => !voice.compatibleModels?.length || voice.compatibleModels.includes(model.value))
 })
 
 const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)

--- a/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
@@ -11,7 +11,7 @@ import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
 import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
 import { FieldCombobox } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const speechStore = useSpeechStore()
@@ -92,6 +92,14 @@ const {
   validationMessage,
   forceValid,
 } = useProviderValidation(providerId)
+
+// Voices come from the remote Fish Audio catalog, so the mount-time load
+// returns nothing until credentials are set. Reload whenever the config
+// (re)validates so the voice picker fills in without leaving the page.
+watch(isValid, async (valid) => {
+  if (valid)
+    await speechStore.loadVoicesForProvider(providerId)
+})
 </script>
 
 <template>

--- a/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import type { SpeechProvider } from '@xsai-ext/providers/utils'
+
+import {
+  Alert,
+  SpeechPlayground,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { FieldCombobox } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const speechStore = useSpeechStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore)
+const { t } = useI18n()
+
+interface FishAudioProviderConfig {
+  apiKey?: string
+  baseUrl?: string
+  model?: string
+  voice?: string
+}
+
+const providerId = 'fish-audio'
+const defaultModel = 's1'
+
+const config = computed(() => providers.value[providerId] as FishAudioProviderConfig | undefined)
+
+function ensureProviderConfig(): FishAudioProviderConfig {
+  if (!providers.value[providerId])
+    providers.value[providerId] = {}
+
+  return providers.value[providerId] as FishAudioProviderConfig
+}
+
+const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
+const modelOptions = computed(() => {
+  return (providerModels.value.length > 0 ? providerModels.value : []).map(model => ({
+    value: model.id,
+    label: model.name,
+  }))
+})
+
+const availableVoices = computed(() => speechStore.availableVoices[providerId] || [])
+
+const model = computed({
+  get: () => config.value?.model || defaultModel,
+  set: (value) => {
+    ensureProviderConfig().model = value
+  },
+})
+
+const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
+
+onMounted(async () => {
+  ensureProviderConfig()
+
+  if (!config.value?.model)
+    model.value = defaultModel
+
+  await providersStore.loadModelsForConfiguredProviders()
+  await providersStore.fetchModelsForProvider(providerId)
+  await speechStore.loadVoicesForProvider(providerId)
+})
+
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize speech provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = modelId || model.value || defaultModel
+  const voiceToUse = voiceId || '' as string
+
+  return await speechStore.speech(
+    provider,
+    modelToUse,
+    input,
+    voiceToUse,
+    providerConfig,
+  )
+}
+
+const {
+  isValidating,
+  isValid,
+  validationMessage,
+  forceValid,
+} = useProviderValidation(providerId)
+</script>
+
+<template>
+  <SpeechProviderSettings
+    :provider-id="providerId"
+    :default-model="defaultModel"
+  >
+    <template #voice-settings>
+      <FieldCombobox
+        v-model="model"
+        label="Model"
+        description="Select the Fish Audio model generation to use for speech synthesis"
+        :options="modelOptions"
+        placeholder="Select a Fish Audio model..."
+      />
+    </template>
+
+    <template #playground>
+      <SpeechPlayground
+        :available-voices="availableVoices"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="apiKeyConfigured"
+        :voices-loading="speechStore.isLoadingSpeechProviderVoices"
+        default-text="Hello! This is a test of the Fish Audio speech synthesis."
+      />
+    </template>
+
+    <template #advanced-settings>
+      <Alert v-if="!isValid && isValidating === 0 && validationMessage" type="error">
+        <template #title>
+          <div class="w-full flex items-center justify-between">
+            <span>{{ t('settings.dialogs.onboarding.validationFailed') }}</span>
+            <button
+              type="button"
+              class="ml-2 rounded bg-red-100 px-2 py-0.5 text-xs text-red-600 font-medium transition-colors dark:bg-red-800/30 hover:bg-red-200 dark:text-red-300 dark:hover:bg-red-700/40"
+              @click="forceValid"
+            >
+              {{ t('settings.pages.providers.common.continueAnyway') }}
+            </button>
+          </div>
+        </template>
+        <template v-if="validationMessage" #content>
+          <div class="whitespace-pre-wrap break-all">
+            {{ validationMessage }}
+          </div>
+        </template>
+      </Alert>
+      <Alert v-if="isValid && isValidating === 0" type="success">
+        <template #title>
+          {{ t('settings.dialogs.onboarding.validationSuccess') }}
+        </template>
+      </Alert>
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue
@@ -94,10 +94,12 @@ const {
 } = useProviderValidation(providerId)
 
 // Voices come from the remote Fish Audio catalog, so the mount-time load
-// returns nothing until credentials are set. Reload whenever the config
-// (re)validates so the voice picker fills in without leaving the page.
-watch(isValid, async (valid) => {
-  if (valid)
+// returns nothing until credentials are set. Reload after every completed
+// successful validation (isValidating drains to 0) rather than on isValid
+// transitions: swapping one valid API key or base URL for another keeps
+// isValid true, but the account-specific voice catalog still changes.
+watch([isValidating, isValid], async ([validating, valid], [prevValidating]) => {
+  if (validating === 0 && prevValidating > 0 && valid)
     await speechStore.loadVoicesForProvider(providerId)
 })
 </script>

--- a/packages/stage-ui/src/components/scenarios/providers/speech-playground.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/speech-playground.vue
@@ -33,11 +33,15 @@ const useSSML = ref(false)
 const ssmlText = ref('')
 const selectedVoice = ref('')
 
-// Watch for changes in available voices
+// Watch for changes in available voices. Besides seeding the initial
+// selection, reseed when the current voice drops out of the list (e.g. the
+// page filtered the catalog by model compatibility) so generation can't
+// submit a voice that is no longer offered.
 watch(
   () => props.availableVoices,
   (newVoices) => {
-    if (newVoices.length > 0 && !selectedVoice.value) {
+    const selectionAvailable = newVoices.some(voice => voice.id === selectedVoice.value)
+    if (newVoices.length > 0 && (!selectedVoice.value || !selectionAvailable)) {
       selectedVoice.value = newVoices[0]?.id || ''
     }
   },

--- a/packages/stage-ui/src/components/scenarios/providers/speech-playground.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/speech-playground.vue
@@ -35,13 +35,18 @@ const selectedVoice = ref('')
 
 // Watch for changes in available voices. Besides seeding the initial
 // selection, reseed when the current voice drops out of the list (e.g. the
-// page filtered the catalog by model compatibility) so generation can't
-// submit a voice that is no longer offered.
+// page filtered the catalog by model compatibility) and clear it when no
+// voice is offered at all, so generation can't submit a hidden voice.
 watch(
   () => props.availableVoices,
   (newVoices) => {
+    if (newVoices.length === 0) {
+      selectedVoice.value = ''
+      return
+    }
+
     const selectionAvailable = newVoices.some(voice => voice.id === selectedVoice.value)
-    if (newVoices.length > 0 && (!selectedVoice.value || !selectionAvailable)) {
+    if (!selectedVoice.value || !selectionAvailable) {
       selectedVoice.value = newVoices[0]?.id || ''
     }
   },

--- a/packages/stage-ui/src/stores/modules/speech.test.ts
+++ b/packages/stage-ui/src/stores/modules/speech.test.ts
@@ -323,4 +323,74 @@ describe('speech store helpers', () => {
       vi.unstubAllGlobals()
     }
   })
+
+  // ROOT CAUSE:
+  //
+  // If a voice reload fails (e.g. a valid API key is replaced with an
+  // unauthorized one), loadVoicesForProvider caught the error and returned []
+  // without touching availableVoices, so the catalog fetched with the previous
+  // credentials stayed visible and selectable.
+  //
+  // We fixed this by clearing the provider's availableVoices entry when the
+  // current (non-superseded) reload fails.
+  //
+  // https://github.com/moeru-ai/airi/pull/2070#discussion_r3597444853
+  it('clears the cached catalog when a voice reload fails', async () => {
+    const providersStore = useProvidersStore()
+    const speechStore = useSpeechStore()
+    const metadata = providersStore.providerMetadata['fish-audio']
+
+    metadata.capabilities.listVoices = vi.fn(async () => [
+      { id: 'voice-old', name: 'Old Account Voice', provider: 'fish-audio', languages: [] },
+    ])
+    await speechStore.loadVoicesForProvider('fish-audio')
+    expect(speechStore.availableVoices['fish-audio']).toHaveLength(1)
+
+    metadata.capabilities.listVoices = vi.fn(async () => {
+      throw new Error('401 unauthorized')
+    })
+    const voices = await speechStore.loadVoicesForProvider('fish-audio')
+
+    expect(voices).toEqual([])
+    expect(speechStore.availableVoices['fish-audio']).toEqual([])
+    expect(speechStore.speechProviderError).toContain('401')
+  })
+
+  // ROOT CAUSE:
+  //
+  // Overlapping voice reloads (credentials changed again while an earlier
+  // request was in flight) both wrote to availableVoices[provider], so a slow
+  // superseded response finishing last could overwrite the catalog fetched
+  // with the newer credentials.
+  //
+  // We fixed this by stamping each reload with a per-provider generation and
+  // discarding responses (and errors) from superseded generations.
+  //
+  // https://github.com/moeru-ai/airi/pull/2070#discussion_r3597444860
+  it('ignores responses from superseded voice reloads', async () => {
+    const providersStore = useProvidersStore()
+    const speechStore = useSpeechStore()
+    const metadata = providersStore.providerMetadata['fish-audio']
+
+    let resolveSlow: (voices: { id: string, name: string, provider: string, languages: [] }[]) => void
+    const slowRequest = new Promise<{ id: string, name: string, provider: string, languages: [] }[]>((resolve) => {
+      resolveSlow = resolve
+    })
+
+    metadata.capabilities.listVoices = vi.fn(() => slowRequest)
+    const slowReload = speechStore.loadVoicesForProvider('fish-audio')
+
+    metadata.capabilities.listVoices = vi.fn(async () => [
+      { id: 'voice-new', name: 'New Account Voice', provider: 'fish-audio', languages: [] },
+    ])
+    await speechStore.loadVoicesForProvider('fish-audio')
+    expect(speechStore.availableVoices['fish-audio'].map(voice => voice.id)).toEqual(['voice-new'])
+
+    // The old-credentials request finishes last; it must not clobber the
+    // catalog owned by the newer reload.
+    resolveSlow!([{ id: 'voice-old', name: 'Old Account Voice', provider: 'fish-audio', languages: [] }])
+    await slowReload
+
+    expect(speechStore.availableVoices['fish-audio'].map(voice => voice.id)).toEqual(['voice-new'])
+  })
 })

--- a/packages/stage-ui/src/stores/modules/speech.test.ts
+++ b/packages/stage-ui/src/stores/modules/speech.test.ts
@@ -326,26 +326,28 @@ describe('speech store helpers', () => {
 
   // ROOT CAUSE:
   //
-  // If a voice reload fails (e.g. a valid API key is replaced with an
-  // unauthorized one), loadVoicesForProvider caught the error and returned []
-  // without touching availableVoices, so the catalog fetched with the previous
-  // credentials stayed visible and selectable.
+  // If a voice reload fails after a credential change (e.g. a valid API key
+  // is replaced with an unauthorized one), loadVoicesForProvider caught the
+  // error and returned [] without touching availableVoices, so the catalog
+  // fetched with the previous credentials stayed visible and selectable.
   //
-  // We fixed this by clearing the provider's availableVoices entry when the
-  // current (non-superseded) reload fails.
+  // We fixed this by clearing the provider's availableVoices entry when a
+  // current (non-superseded) reload fails under a changed provider config.
   //
   // https://github.com/moeru-ai/airi/pull/2070#discussion_r3597444853
-  it('clears the cached catalog when a voice reload fails', async () => {
+  it('clears the cached catalog when a reload with changed credentials fails', async () => {
     const providersStore = useProvidersStore()
     const speechStore = useSpeechStore()
     const metadata = providersStore.providerMetadata['fish-audio']
 
+    providersStore.providers['fish-audio'] = { apiKey: 'old-key' }
     metadata.capabilities.listVoices = vi.fn(async () => [
       { id: 'voice-old', name: 'Old Account Voice', provider: 'fish-audio', languages: [] },
     ])
     await speechStore.loadVoicesForProvider('fish-audio')
     expect(speechStore.availableVoices['fish-audio']).toHaveLength(1)
 
+    providersStore.providers['fish-audio'] = { apiKey: 'unauthorized-key' }
     metadata.capabilities.listVoices = vi.fn(async () => {
       throw new Error('401 unauthorized')
     })
@@ -354,6 +356,39 @@ describe('speech store helpers', () => {
     expect(voices).toEqual([])
     expect(speechStore.availableVoices['fish-audio']).toEqual([])
     expect(speechStore.speechProviderError).toContain('401')
+  })
+
+  // ROOT CAUSE:
+  //
+  // The first version of the stale-catalog fix cleared the cache on every
+  // failed reload. A transient voice-list outage under unchanged credentials
+  // then wiped a still-valid catalog and blocked generation until another
+  // reload happened to run.
+  //
+  // We fixed this by snapshotting the config that produced the cached
+  // catalog and clearing only when the failing reload used a different one.
+  //
+  // https://github.com/moeru-ai/airi/pull/2070#discussion_r3597538697
+  it('keeps the cached catalog when a reload with unchanged credentials fails', async () => {
+    const providersStore = useProvidersStore()
+    const speechStore = useSpeechStore()
+    const metadata = providersStore.providerMetadata['fish-audio']
+
+    providersStore.providers['fish-audio'] = { apiKey: 'stable-key' }
+    metadata.capabilities.listVoices = vi.fn(async () => [
+      { id: 'voice-a', name: 'Voice A', provider: 'fish-audio', languages: [] },
+    ])
+    await speechStore.loadVoicesForProvider('fish-audio')
+    expect(speechStore.availableVoices['fish-audio']).toHaveLength(1)
+
+    metadata.capabilities.listVoices = vi.fn(async () => {
+      throw new Error('503 upstream outage')
+    })
+    const voices = await speechStore.loadVoicesForProvider('fish-audio')
+
+    expect(voices).toEqual([])
+    expect(speechStore.availableVoices['fish-audio'].map(voice => voice.id)).toEqual(['voice-a'])
+    expect(speechStore.speechProviderError).toContain('503')
   })
 
   // ROOT CAUSE:

--- a/packages/stage-ui/src/stores/modules/speech.ts
+++ b/packages/stage-ui/src/stores/modules/speech.ts
@@ -97,6 +97,12 @@ export const useSpeechStore = defineStore('speech', () => {
     return ['elevenlabs', 'microsoft-speech', 'azure-speech'].includes(activeSpeechProvider.value)
   })
 
+  // Tracks the latest voice reload per provider. Reloads happen on credential
+  // changes, so a slow superseded request must not overwrite the catalog
+  // fetched with newer credentials, and a failed current reload must not keep
+  // showing the previous credentials' catalog.
+  const voicesRequestGeneration: Record<string, number> = {}
+
   async function loadVoicesForProvider(provider: string, model?: string) {
     if (!provider) {
       return []
@@ -109,11 +115,19 @@ export const useSpeechStore = defineStore('speech', () => {
       return []
     }
 
+    const generation = (voicesRequestGeneration[provider] ?? 0) + 1
+    voicesRequestGeneration[provider] = generation
+
     isLoadingSpeechProviderVoices.value = true
     speechProviderError.value = null
 
     try {
       const voices = await providersStore.getProviderMetadata(provider).capabilities.listVoices?.(providersStore.getProviderConfig(provider), model) || []
+      // A newer reload owns the catalog now; drop this superseded response.
+      if (voicesRequestGeneration[provider] !== generation) {
+        return voices
+      }
+
       // Reassign to trigger reactivity when adding/updating provider entries
       availableVoices.value = {
         ...availableVoices.value,
@@ -123,7 +137,16 @@ export const useSpeechStore = defineStore('speech', () => {
     }
     catch (error) {
       console.error(`Error fetching voices for ${provider}:`, error)
-      speechProviderError.value = errorMessageFrom(error) ?? 'Unknown error'
+      if (voicesRequestGeneration[provider] === generation) {
+        speechProviderError.value = errorMessageFrom(error) ?? 'Unknown error'
+        // Clear the stale catalog: keeping voices fetched with previous
+        // credentials would let users pick voices the current credentials
+        // cannot use.
+        availableVoices.value = {
+          ...availableVoices.value,
+          [provider]: [],
+        }
+      }
       return []
     }
     finally {

--- a/packages/stage-ui/src/stores/modules/speech.ts
+++ b/packages/stage-ui/src/stores/modules/speech.ts
@@ -102,6 +102,12 @@ export const useSpeechStore = defineStore('speech', () => {
   // fetched with newer credentials, and a failed current reload must not keep
   // showing the previous credentials' catalog.
   const voicesRequestGeneration: Record<string, number> = {}
+  // Snapshot of the provider config that produced the currently cached
+  // catalog. Failures clear the cache only when the config changed since the
+  // catalog was fetched: a transient outage under unchanged credentials keeps
+  // the still-valid catalog, while a failed reload after a credential swap
+  // must not leave the previous account's voices selectable.
+  const voicesConfigSnapshot: Record<string, string> = {}
 
   async function loadVoicesForProvider(provider: string, model?: string) {
     if (!provider) {
@@ -118,11 +124,14 @@ export const useSpeechStore = defineStore('speech', () => {
     const generation = (voicesRequestGeneration[provider] ?? 0) + 1
     voicesRequestGeneration[provider] = generation
 
+    const config = providersStore.getProviderConfig(provider)
+    const configSnapshot = JSON.stringify(config ?? {})
+
     isLoadingSpeechProviderVoices.value = true
     speechProviderError.value = null
 
     try {
-      const voices = await providersStore.getProviderMetadata(provider).capabilities.listVoices?.(providersStore.getProviderConfig(provider), model) || []
+      const voices = await providersStore.getProviderMetadata(provider).capabilities.listVoices?.(config, model) || []
       // A newer reload owns the catalog now; drop this superseded response.
       if (voicesRequestGeneration[provider] !== generation) {
         return voices
@@ -133,18 +142,22 @@ export const useSpeechStore = defineStore('speech', () => {
         ...availableVoices.value,
         [provider]: voices,
       }
+      voicesConfigSnapshot[provider] = configSnapshot
       return voices
     }
     catch (error) {
       console.error(`Error fetching voices for ${provider}:`, error)
       if (voicesRequestGeneration[provider] === generation) {
         speechProviderError.value = errorMessageFrom(error) ?? 'Unknown error'
-        // Clear the stale catalog: keeping voices fetched with previous
-        // credentials would let users pick voices the current credentials
-        // cannot use.
-        availableVoices.value = {
-          ...availableVoices.value,
-          [provider]: [],
+        // Clear the stale catalog only when this reload ran with a different
+        // config than the one that produced it: those voices belong to the
+        // previous credentials and must not stay selectable. A failure under
+        // the unchanged config (transient outage) keeps the valid catalog.
+        if (voicesConfigSnapshot[provider] !== configSnapshot) {
+          availableVoices.value = {
+            ...availableVoices.value,
+            [provider]: [],
+          }
         }
       }
       return []

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -60,6 +60,7 @@ import { useAuthStore } from './auth'
 import { createAliyunNLSProvider as createAliyunNlsStreamProvider } from './providers/aliyun/stream-transcription'
 import { convertProviderDefinitionsToMetadata } from './providers/converters'
 import { models as elevenLabsModels } from './providers/elevenlabs/list-models'
+import { buildFishAudioProvider } from './providers/fish-audio'
 import { buildGoogleGeminiSpeechProvider } from './providers/google-gemini-speech'
 import { buildOpenAICompatibleProvider } from './providers/openai-compatible-builder'
 import { buildOpenRouterAudioSpeechProvider } from './providers/openrouter/audio-speech'
@@ -2315,6 +2316,7 @@ export const useProvidersStore = defineStore('providers', () => {
       },
     },
     'google-gemini-audio-speech': buildGoogleGeminiSpeechProvider(v => baseUrlValidator.value(v)),
+    'fish-audio': buildFishAudioProvider(v => baseUrlValidator.value(v)),
   }
 
   const VISION_PROVIDER_ID_PREFIX = 'vision-'

--- a/packages/stage-ui/src/stores/providers/fish-audio.test.ts
+++ b/packages/stage-ui/src/stores/providers/fish-audio.test.ts
@@ -187,6 +187,7 @@ describe('fishAudio voice listing', () => {
       expect(voices?.[0].provider).toBe('fish-audio')
       expect(voices?.[0].previewURL).toBe('https://example.com/sample.mp3')
       expect(voices?.[0].languages).toEqual([{ code: 'en', title: 'English' }])
+      expect(voices?.[0].compatibleModels).toEqual(['s1'])
     }
     finally {
       fetchSpy.mockRestore()

--- a/packages/stage-ui/src/stores/providers/fish-audio.test.ts
+++ b/packages/stage-ui/src/stores/providers/fish-audio.test.ts
@@ -1,0 +1,195 @@
+import type { ModelInfo } from '../providers'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildFishAudioProvider, createUnFishAudio } from './fish-audio'
+
+function createBaseUrlValidator() {
+  return (baseUrl: unknown) => {
+    if (!baseUrl || typeof baseUrl !== 'string' || baseUrl.length === 0) {
+      return { errors: [new Error('Base URL is required.')], reason: 'Base URL is required.', valid: false }
+    }
+    // Simulate the real isUrl check: a bare word without scheme is invalid
+    if (typeof baseUrl === 'string' && !baseUrl.startsWith('http')) {
+      return { errors: [new Error('Base URL is not absolute.')], reason: 'Base URL is not absolute.', valid: false }
+    }
+    return null
+  }
+}
+
+const baseUrlValidator = createBaseUrlValidator()
+
+function buildProvider() {
+  return buildFishAudioProvider(baseUrlValidator)
+}
+
+describe('fishAudio provider metadata', () => {
+  const metadata = buildProvider()
+
+  it('has the correct provider ID', () => {
+    expect(metadata.id).toBe('fish-audio')
+  })
+
+  it('is in the speech category', () => {
+    expect(metadata.category).toBe('speech')
+  })
+
+  it('has text-to-speech task', () => {
+    expect(metadata.tasks).toContain('text-to-speech')
+  })
+
+  it('has a name and description', () => {
+    expect(metadata.name).toBe('Fish Audio')
+    expect(metadata.description).toBe('fish.audio')
+  })
+
+  it('has the correct i18n keys', () => {
+    expect(metadata.nameKey).toBe('settings.pages.providers.provider.fish-audio.title')
+    expect(metadata.descriptionKey).toBe('settings.pages.providers.provider.fish-audio.description')
+  })
+
+  it('defaults baseUrl to the hosted unSpeech proxy', () => {
+    const defaults = metadata.defaultOptions?.()
+    expect(defaults?.baseUrl).toBe('https://unspeech.hyp3r.link/v1/')
+  })
+})
+
+describe('fishAudio listModels', () => {
+  const metadata = buildProvider()
+
+  it('returns the four Fish Audio TTS models', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    expect(models).toHaveLength(4)
+    expect(models?.map((m: ModelInfo) => m.id)).toEqual(['s1', 's2-pro', 's2.1-pro', 's2.1-pro-free'])
+  })
+
+  it('each model has the correct provider ID', async () => {
+    const models = await metadata.capabilities.listModels?.({})
+    for (const model of models ?? []) {
+      expect(model.provider).toBe('fish-audio')
+    }
+  })
+})
+
+describe('fishAudio validation', () => {
+  const metadata = buildProvider()
+
+  it('fails validation without API key', async () => {
+    const result = await metadata.validators.validateProviderConfig({ baseUrl: 'https://unspeech.hyp3r.link/v1/' })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e: any) => e.message?.includes('API key'))).toBe(true)
+  })
+
+  it('fails validation with whitespace-only API key', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: '   ', baseUrl: 'https://unspeech.hyp3r.link/v1/' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('fails validation without base URL', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: 'test-key' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('fails validation with a non-absolute base URL', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: 'test-key', baseUrl: 'invalid' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('passes validation with API key and base URL', async () => {
+    const result = await metadata.validators.validateProviderConfig({ apiKey: 'test-key', baseUrl: 'https://unspeech.hyp3r.link/v1/' })
+    expect(result.valid).toBe(true)
+  })
+})
+
+describe('fishAudio speech request construction', () => {
+  it('prefixes the model with the fishaudio backend for unSpeech routing', () => {
+    const provider = createUnFishAudio('test-key', 'https://unspeech.example.com/v1/')
+    const speechResult = provider.speech('s1')
+
+    expect(speechResult.model).toBe('fishaudio/s1')
+    expect(speechResult.apiKey).toBe('test-key')
+    expect(speechResult.baseURL).toBe('https://unspeech.example.com/v1/')
+  })
+
+  it('falls back to s1 when no model is given', () => {
+    const provider = createUnFishAudio('test-key')
+    const speechResult = provider.speech('')
+    expect(speechResult.model).toBe('fishaudio/s1')
+  })
+
+  it('maps known options into snake_case extra_body', () => {
+    const provider = createUnFishAudio('test-key')
+    const speechResult = provider.speech('s1', {
+      chunkLength: 150,
+      latency: 'balanced',
+      normalize: false,
+      prosody: { speed: 1.2, volume: 0 },
+      temperature: 0.8,
+      topP: 0.9,
+    })
+
+    expect(speechResult.extraBody).toEqual({
+      chunk_length: 150,
+      latency: 'balanced',
+      normalize: false,
+      prosody: { speed: 1.2, volume: 0 },
+      temperature: 0.8,
+      top_p: 0.9,
+    })
+  })
+
+  it('does not leak unrelated config keys into extra_body', () => {
+    const provider = createUnFishAudio('test-key')
+    const speechResult = provider.speech('s1', {
+      apiKey: 'leak',
+      baseUrl: 'leak',
+      voice: 'leak',
+      temperature: 0.5,
+    } as any)
+
+    expect(speechResult.extraBody).toEqual({ temperature: 0.5 })
+  })
+})
+
+describe('fishAudio voice listing', () => {
+  it('queries unSpeech /voices with provider=fishaudio and maps the response', async () => {
+    const mockResponse = new Response(JSON.stringify({
+      voices: [
+        {
+          id: '802e3bc2b27e49c2995d23ef70e6ac89',
+          name: 'Example Voice',
+          description: 'A community voice model',
+          labels: {},
+          tags: [],
+          languages: [{ code: 'en', title: 'English' }],
+          formats: [],
+          compatible_models: ['s1'],
+          preview_audio_url: 'https://example.com/sample.mp3',
+        },
+      ],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse)
+
+    try {
+      const metadata = buildProvider()
+      const voices = await metadata.capabilities.listVoices?.({
+        apiKey: 'test-key',
+        baseUrl: 'https://unspeech.example.com/v1/',
+      })
+
+      const requestedUrl = String(fetchSpy.mock.calls[0][0])
+      expect(requestedUrl).toBe('https://unspeech.example.com/api/voices?provider=fishaudio')
+
+      expect(voices).toHaveLength(1)
+      expect(voices?.[0].id).toBe('802e3bc2b27e49c2995d23ef70e6ac89')
+      expect(voices?.[0].name).toBe('Example Voice')
+      expect(voices?.[0].provider).toBe('fish-audio')
+      expect(voices?.[0].previewURL).toBe('https://example.com/sample.mp3')
+      expect(voices?.[0].languages).toEqual([{ code: 'en', title: 'English' }])
+    }
+    finally {
+      fetchSpy.mockRestore()
+    }
+  })
+})

--- a/packages/stage-ui/src/stores/providers/fish-audio.ts
+++ b/packages/stage-ui/src/stores/providers/fish-audio.ts
@@ -162,6 +162,7 @@ export function buildFishAudioProvider(
           description: voice.description,
           previewURL: voice.preview_audio_url,
           languages: voice.languages,
+          compatibleModels: voice.compatible_models,
         } satisfies VoiceInfo))
       },
     },

--- a/packages/stage-ui/src/stores/providers/fish-audio.ts
+++ b/packages/stage-ui/src/stores/providers/fish-audio.ts
@@ -1,0 +1,191 @@
+import type { SpeechProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+import type { ListVoicesOptions, UnSpeechOptions, VoiceProviderWithExtraOptions } from 'unspeech'
+
+import type { ModelInfo, ProviderMetadata, VoiceInfo } from '../providers'
+
+import { merge } from '@xsai-ext/providers/utils'
+import { listVoices } from 'unspeech'
+
+const PROVIDER_ID = 'fish-audio'
+const DEFAULT_BASE_URL = 'https://unspeech.hyp3r.link/v1/'
+const DEFAULT_MODEL = 's1'
+
+// Model generations selectable on Fish Audio, sent as `fishaudio/<model>`
+// through unSpeech.
+// https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+const FISH_AUDIO_TTS_MODELS: { id: string, name: string, description: string }[] = [
+  { id: 's1', name: 'S1', description: 'Flagship voice cloning and TTS model' },
+  { id: 's2-pro', name: 'S2 Pro', description: 'Multi-speaker dialogue capable model' },
+  { id: 's2.1-pro', name: 'S2.1 Pro', description: 'Latest generation pro model' },
+  { id: 's2.1-pro-free', name: 'S2.1 Pro (Free)', description: 'Free tier variant of S2.1 Pro' },
+]
+
+/** Options accepted by the Fish Audio TTS endpoint through unSpeech. */
+export interface UnFishAudioOptions {
+  /** Text segment length used when splitting long input, 100 to 300. */
+  chunkLength?: number
+  /** `balanced` reduces latency at a slight cost to stability. */
+  latency?: 'balanced' | 'normal'
+  /** Normalize text (e.g. spell out numbers) for better stability. */
+  normalize?: boolean
+  /** Speech pacing controls. */
+  prosody?: {
+    /** Speed multiplier, 1.0 is normal speed. */
+    speed?: number
+    /** Volume gain in dB, 0 is unchanged. */
+    volume?: number
+  }
+  /** Sampling temperature; lower is more deterministic. */
+  temperature?: number
+  /** Nucleus sampling threshold. */
+  topP?: number
+}
+
+function toUnSpeechOptions(options: UnFishAudioOptions): UnSpeechOptions {
+  // Only known Fish Audio options are forwarded: provider configs are spread
+  // into speech() calls wholesale, so unrelated keys (apiKey, baseUrl, model,
+  // voice) must not leak into extra_body.
+  const extraBody: Record<string, unknown> = {}
+
+  if (options.chunkLength !== undefined)
+    extraBody.chunk_length = options.chunkLength
+  if (options.latency !== undefined)
+    extraBody.latency = options.latency
+  if (options.normalize !== undefined)
+    extraBody.normalize = options.normalize
+  if (options.prosody !== undefined)
+    extraBody.prosody = options.prosody
+  if (options.temperature !== undefined)
+    extraBody.temperature = options.temperature
+  if (options.topP !== undefined)
+    extraBody.top_p = options.topP
+
+  return { extraBody }
+}
+
+// NOTICE:
+// Local stand-in for `createUnFishAudio` from the unspeech SDK.
+// The fishaudio backend was contributed to moeru-ai/unspeech together with
+// this provider, but the published `unspeech` npm package does not export the
+// factory yet.
+// Source/context: https://github.com/moeru-ai/unspeech (sdk/typescript/src/backend/fishaudio.ts).
+// Removal condition: once `unspeech` publishes a release including
+// `createUnFishAudio`, bump the catalog version and import it instead.
+export function createUnFishAudio(apiKey: string, baseURL = DEFAULT_BASE_URL) {
+  // UnSpeechOptions is part of the options type so the returned request
+  // options expose the mapped `extraBody` to callers and tests.
+  const speechProvider: SpeechProviderWithExtraOptions<string, UnFishAudioOptions & UnSpeechOptions> = {
+    speech: (model, options) => ({
+      ...(options ? toUnSpeechOptions(options) : {}),
+      apiKey,
+      baseURL,
+      model: `fishaudio/${model || DEFAULT_MODEL}`,
+    }),
+  }
+
+  const voiceProvider: VoiceProviderWithExtraOptions<UnFishAudioOptions> = {
+    voice: (options) => {
+      // unSpeech serves /v1/audio/speech but /voices lives at the server
+      // root, so the version suffix is stripped for voice listing.
+      if (baseURL.endsWith('v1/'))
+        baseURL = baseURL.slice(0, -3)
+      else if (baseURL.endsWith('v1'))
+        baseURL = baseURL.slice(0, -2)
+
+      return {
+        query: 'provider=fishaudio',
+        ...(options ? toUnSpeechOptions(options) : {}),
+        apiKey,
+        baseURL,
+      }
+    },
+  }
+
+  return merge(speechProvider, voiceProvider)
+}
+
+function toListVoicesOptions(provider: VoiceProviderWithExtraOptions<UnFishAudioOptions>): ListVoicesOptions {
+  const { fetch: _fetch, ...voiceOptions } = provider.voice()
+  return voiceOptions
+}
+
+function normalizeApiKey(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeBaseUrl(value: unknown): string {
+  const base = typeof value === 'string' ? value.trim() : ''
+  return base || DEFAULT_BASE_URL
+}
+
+function listModels(): ModelInfo[] {
+  return FISH_AUDIO_TTS_MODELS.map(model => ({
+    id: model.id,
+    name: model.name,
+    provider: PROVIDER_ID,
+    description: model.description,
+    capabilities: ['text-to-speech'],
+  } satisfies ModelInfo))
+}
+
+export function buildFishAudioProvider(
+  baseUrlValidator: (baseUrl: unknown) => { errors: unknown[], reason: string, valid: boolean } | null | undefined,
+): ProviderMetadata {
+  return {
+    id: PROVIDER_ID,
+    category: 'speech',
+    tasks: ['text-to-speech'],
+    nameKey: 'settings.pages.providers.provider.fish-audio.title',
+    name: 'Fish Audio',
+    descriptionKey: 'settings.pages.providers.provider.fish-audio.description',
+    description: 'fish.audio',
+    icon: 'i-lobe-icons:fishaudio',
+    defaultOptions: () => ({
+      baseUrl: DEFAULT_BASE_URL,
+    }),
+    createProvider: async (config: Record<string, unknown>) => {
+      return createUnFishAudio(normalizeApiKey(config.apiKey), normalizeBaseUrl(config.baseUrl))
+    },
+    capabilities: {
+      listModels: async () => listModels(),
+      listVoices: async (config: Record<string, unknown>) => {
+        const provider = createUnFishAudio(normalizeApiKey(config.apiKey), normalizeBaseUrl(config.baseUrl))
+        const voices = await listVoices(toListVoicesOptions(provider))
+
+        if (!voices || !Array.isArray(voices))
+          return []
+
+        return voices.map(voice => ({
+          id: voice.id,
+          name: voice.name,
+          provider: PROVIDER_ID,
+          description: voice.description,
+          previewURL: voice.preview_audio_url,
+          languages: voice.languages,
+        } satisfies VoiceInfo))
+      },
+    },
+    validators: {
+      chatPingCheckAvailable: false,
+      validateProviderConfig: (config: Record<string, unknown>) => {
+        const errors: Error[] = []
+        if (!normalizeApiKey(config.apiKey))
+          errors.push(new Error('API key is required.'))
+        if (!config.baseUrl)
+          errors.push(new Error('Base URL is required.'))
+
+        if (config.baseUrl) {
+          const res = baseUrlValidator(config.baseUrl)
+          if (res)
+            return res
+        }
+
+        return {
+          errors,
+          reason: errors.map(e => e.message).join(', '),
+          valid: errors.length === 0,
+        }
+      },
+    },
+  }
+}


### PR DESCRIPTION
## Description

Adds native [Fish Audio](https://fish.audio/) TTS support as a speech provider.

**Why it goes through unSpeech:** `api.fish.audio` does not answer CORS preflights (verified: `OPTIONS /v1/tts` returns 401 with no `Access-Control-Allow-*` headers), so the browser — both stage-web and the Electron renderer — cannot call it directly. This is the same reason ElevenLabs, Microsoft, Deepgram, Alibaba, and Volcengine route through unSpeech. The server-side backend was contributed in **moeru-ai/unspeech#47**, and this PR wires it into AIRI the same way as the other unSpeech providers.

### What's included

- `packages/stage-ui/src/stores/providers/fish-audio.ts` — provider metadata (`fish-audio`, speech category) with:
  - model listing for Fish Audio's generations (`s1`, `s2-pro`, `s2.1-pro`, `s2.1-pro-free`)
  - voice listing through unSpeech's `/api/voices?provider=fishaudio` (voice = Fish Audio reference model id, with preview audio URLs and languages)
  - config validation (API key + base URL), default base URL `https://unspeech.hyp3r.link/v1/`
  - a local `createUnFishAudio` factory marked with a `NOTICE:` — it mirrors the SDK factory added in moeru-ai/unspeech#47 and will be replaced by the `unspeech` package import once a release including it is published
- `packages/stage-pages/src/pages/settings/providers/speech/fish-audio.vue` — settings page with model picker and voice playground, following the existing speech provider pages
- `fish-audio` i18n entries in all locales
- `packages/stage-ui/src/stores/providers/fish-audio.test.ts` — 18 tests covering metadata, validation, request construction (model prefixing, `extra_body` mapping, no config-key leakage), and voice listing with a mocked fetch

## Linked Issues

Closes #1477

## Additional Context

- Depends on moeru-ai/unspeech#47 being merged and the hosted proxy (`unspeech.hyp3r.link`) redeployed — until then the provider validates but TTS requests will fail with "unsupported backend". Happy to hold this PR until that lands.
- Tested with `pnpm -F @proj-airi/stage-ui typecheck`, `pnpm -F @proj-airi/stage-pages typecheck`, `pnpm exec vitest run packages/stage-ui/src/stores/providers/fish-audio.test.ts` (18/18), and ESLint on all touched files.
- Icon: `i-lobe-icons:fishaudio` (already available in `@proj-airi/lobe-icons`).


