### PR TITLE
fix(stage-ui): promote audio session so TTS survives the iOS mute switch

### DIFF
--- a/packages/stage-ui/src/composables/audio/audio-device.ts
+++ b/packages/stage-ui/src/composables/audio/audio-device.ts
@@ -1,6 +1,7 @@
 import { useDevicesList, useUserMedia } from '@vueuse/core'
 import { computed, nextTick, ref, watch } from 'vue'
 
+import { requestAudioSessionType } from '../../libs/audio/audio-session'
 import { useAnalytics } from '../use-analytics'
 
 const UNKNOWN_STT_PROVIDER_ID = 'unknown'
@@ -114,6 +115,11 @@ export function useAudioDevice(requestPermission: boolean = false) {
 
   async function startStream() {
     selectAvailableAudioInput()
+
+    // Once the microphone is in use the audio session must be a recording
+    // capable category; 'play-and-record' also keeps TTS playback exempt
+    // from the iOS silent switch (see libs/audio/audio-session.ts).
+    requestAudioSessionType('play-and-record')
 
     try {
       return await startUserMediaStream()

--- a/packages/stage-ui/src/libs/audio/audio-session.test.ts
+++ b/packages/stage-ui/src/libs/audio/audio-session.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { requestAudioSessionType } from './audio-session'
+
+type SessionType = 'ambient' | 'auto' | 'play-and-record' | 'playback' | 'transient' | 'transient-solo'
+
+function navigatorWithSession(initial: SessionType = 'auto') {
+  return { audioSession: { type: initial } }
+}
+
+describe('requestAudioSessionType', () => {
+  // ROOT CAUSE:
+  //
+  // On iOS, Web Audio output runs in the ambient-like default audio session
+  // category, which the hardware silent switch mutes — while <audio> elements
+  // keep playing. TTS is played through a shared AudioContext, so with the
+  // switch on, character speech was silent on Safari/PWA.
+  //
+  // We fixed this by promoting the audio session to 'playback' when the
+  // playback AudioContext is created (and 'play-and-record' when microphone
+  // capture starts), via the WebKit Audio Session API where available.
+  //
+  // https://github.com/moeru-ai/airi/issues/894
+  it('promotes the session to playback so TTS survives the iOS mute switch (Issue #894)', () => {
+    const nav = navigatorWithSession('auto')
+
+    expect(requestAudioSessionType('playback', nav)).toBe(true)
+    expect(nav.audioSession.type).toBe('playback')
+  })
+
+  it('promotes the session to play-and-record for microphone capture', () => {
+    const nav = navigatorWithSession('playback')
+
+    expect(requestAudioSessionType('play-and-record', nav)).toBe(true)
+    expect(nav.audioSession.type).toBe('play-and-record')
+  })
+
+  it('does not downgrade an active play-and-record session to playback', () => {
+    const nav = navigatorWithSession('play-and-record')
+
+    expect(requestAudioSessionType('playback', nav)).toBe(true)
+    expect(nav.audioSession.type).toBe('play-and-record')
+  })
+
+  it('is a no-op on platforms without the Audio Session API', () => {
+    expect(requestAudioSessionType('playback', {})).toBe(false)
+  })
+
+  it('tolerates a missing navigator (non-browser environments)', () => {
+    expect(requestAudioSessionType('playback', undefined)).toBe(false)
+  })
+})

--- a/packages/stage-ui/src/libs/audio/audio-session.ts
+++ b/packages/stage-ui/src/libs/audio/audio-session.ts
@@ -1,0 +1,57 @@
+/**
+ * Experimental Audio Session API (W3C draft, implemented by WebKit).
+ * Not part of the TypeScript DOM lib yet, so the shape is declared here.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/AudioSession
+ */
+interface AudioSessionLike {
+  type: 'ambient' | 'auto' | 'play-and-record' | 'playback' | 'transient' | 'transient-solo'
+}
+
+/**
+ * Structural navigator dependency: only the experimental `audioSession`
+ * member matters here, and browsers without it satisfy the type with the
+ * member simply absent.
+ */
+interface NavigatorWithAudioSession {
+  audioSession?: AudioSessionLike
+}
+
+/** Session kinds this app requests; see {@link requestAudioSessionType}. */
+export type RequestableAudioSessionType = 'play-and-record' | 'playback'
+
+/**
+ * Requests the page's audio session category on platforms that expose the
+ * Audio Session API (WebKit on iOS).
+ *
+ * On iOS, Web Audio output runs in the 'ambient'-like default category and
+ * the hardware silent switch mutes it, while `<audio>` elements keep playing.
+ * Promoting the session to 'playback' (TTS output) or 'play-and-record'
+ * (microphone capture) makes character speech audible with the switch on.
+ *
+ * A 'playback' request never downgrades an active 'play-and-record' session:
+ * capture may still be running, and 'play-and-record' already ignores the
+ * ringer switch, so downgrading could only break recording.
+ *
+ * @returns whether the platform exposes the Audio Session API; false means
+ * the request was a no-op (non-WebKit browsers, older iOS).
+ */
+export function requestAudioSessionType(
+  type: RequestableAudioSessionType,
+  targetNavigator: Navigator | NavigatorWithAudioSession | undefined = globalThis.navigator,
+): boolean {
+  // The `in` check both feature-detects the experimental API and narrows the
+  // union: TypeScript's DOM Navigator type has no audioSession member.
+  if (!targetNavigator || !('audioSession' in targetNavigator))
+    return false
+
+  const session = targetNavigator.audioSession
+  if (!session)
+    return false
+
+  if (type === 'playback' && session.type === 'play-and-record')
+    return true
+
+  session.type = type
+  return true
+}

--- a/packages/stage-ui/src/stores/audio.ts
+++ b/packages/stage-ui/src/stores/audio.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import { computed, ref, shallowRef } from 'vue'
 
+import { requestAudioSessionType } from '../libs/audio/audio-session'
+
 function calculateVolumeWithLinearNormalize(analyser: AnalyserNode) {
   const dataBuffer = new Uint8Array(analyser.frequencyBinCount)
   analyser.getByteFrequencyData(dataBuffer)
@@ -65,6 +67,12 @@ function calculateVolume(analyser: AnalyserNode, mode: 'linear' | 'minmax' = 'li
 }
 
 export const useAudioContext = defineStore('audio-context', () => {
+  // This context carries character speech (TTS) to the speakers. On iOS the
+  // hardware silent switch mutes Web Audio output unless the audio session is
+  // promoted to 'playback', which is how users on PWA/Safari end up with
+  // silent TTS: https://github.com/moeru-ai/airi/issues/894
+  requestAudioSessionType('playback')
+
   const audioContext = shallowRef<AudioContext>(new AudioContext())
 
   return {


### PR DESCRIPTION
## Description

Fixes silent TTS on iOS Safari/PWA when the hardware silent switch is on.

**Root cause:** on iOS, Web Audio output runs in the ambient-like default audio session category, which the ringer/silent switch mutes — while `<audio>`/`<video>` elements keep playing. AIRI plays character speech through a shared `AudioContext` (`useAudioContext` in `stores/audio.ts`), so with the switch on, TTS was generated and "played" but produced no sound.

**Fix:** use the [Audio Session API](https://developer.mozilla.org/en-US/docs/Web/API/AudioSession) (WebKit, feature-detected) to promote the page's audio session:

- `'playback'` when the shared playback `AudioContext` is created — media-playback sessions are exempt from the silent switch, matching `<audio>` element behavior;
- `'play-and-record'` when microphone capture starts (`useAudioDevice().startStream()`) — a recording-capable category that is also exempt from the switch, so hearing/VAD keeps working;
- a `'playback'` request never downgrades an active `'play-and-record'` session (capture may still be running).

The policy lives in `packages/stage-ui/src/libs/audio/audio-session.ts` with a structural navigator parameter, so it unit-tests without mocking globals and is a clean no-op on browsers without the API (non-WebKit, older iOS).

## Linked Issues

Fixes #894

## Additional Context

- **On-device verification needed:** I don't have an iOS device to hand, so this is implemented against documented WebKit behavior (Web Audio muted by the ringer switch; audio session categories exempt) — it would be great if the reporter or someone with an iPhone can confirm on iOS with silent mode on. Happy to iterate if the behavior differs.
- Browsers without `navigator.audioSession` are unaffected (feature-detected no-op). If support for older iOS versions without the API is wanted, the known fallback is the silent-`<audio>`-element trick (e.g. `unmute-ios-audio`) — left out deliberately to keep this dependency-free; can follow up if desired.
- Tested with `pnpm exec vitest run packages/stage-ui/src/libs/audio/audio-session.test.ts` (5 tests incl. the Issue #894 regression case), `pnpm -F @proj-airi/stage-ui typecheck`, and ESLint on all touched files.
