### PR TITLE
feat(stage-tamagotchi): configure ComfyUI generation timeout

### DIFF
--- a/apps/stage-tamagotchi/src/main/configs/artistry.ts
+++ b/apps/stage-tamagotchi/src/main/configs/artistry.ts
@@ -6,6 +6,7 @@ export const artistryConfigSchema = object({
   artistryProvider: optional(string(), 'none'),
   artistryGlobals: optional(object({
     comfyuiServerUrl: optional(string(), 'http://localhost:8188'),
+    comfyuiGenerationTimeoutMinutes: optional(number(), 10),
     comfyuiSavedWorkflows: optional(array(any()), []),
     comfyuiActiveWorkflow: optional(string(), ''),
     replicateApiKey: optional(string(), ''),

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.test.ts
@@ -1,0 +1,111 @@
+import type { ArtistryJobStatus, ArtistryProvider } from './providers/base'
+
+import { injeca } from 'injeca'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { artistryProviders, generateHeadless } from './artistry-bridge'
+
+/**
+ * A callback-capable provider double whose job never settles on its own, so the
+ * only thing that can end a headless run is the bridge's own wait timeout.
+ */
+function createNeverSettlingCallbackProvider() {
+  const provider = {
+    id: 'comfyui',
+    name: 'ComfyUI (test double)',
+    jobCallback: undefined as ((status: ArtistryJobStatus) => void) | undefined,
+    initialize: vi.fn(async () => {}),
+    generate: vi.fn(async () => ({ jobId: 'job-1', providerJobId: 'job-1' })),
+    getStatus: vi.fn(async (): Promise<ArtistryJobStatus> => ({ status: 'running' })),
+    setJobCallback: vi.fn((_jobId: string, callback: (status: ArtistryJobStatus) => void) => {
+      provider.jobCallback = callback
+    }),
+  }
+  return provider
+}
+
+describe('generateHeadless', () => {
+  beforeEach(() => {
+    // generateHeadless always resolves the persisted artistry config through injeca,
+    // even when the caller passes explicit globals.
+    injeca.provide('configs:artistry', () => ({
+      get: () => ({ artistryProvider: 'comfyui', artistryGlobals: {} }),
+      update: vi.fn(),
+    }))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // https://github.com/moeru-ai/airi/pull/2083 (Codex review: honor the timeout for headless ComfyUI runs)
+  it('keeps waiting past five minutes when a longer ComfyUI timeout is configured (Issue #2084)', async () => {
+    // ROOT CAUSE:
+    //
+    // generateHeadless wrapped callback-based providers in a hardcoded 5-minute timer,
+    // so image_journal and autonomous generations failed with "Image generation timed
+    // out after 5 minutes." even when comfyuiGenerationTimeoutMinutes was set higher —
+    // the ComfyUI provider itself kept polling until the configured timeout, but the
+    // headless caller had already rejected.
+    //
+    // We fixed this by deriving the headless wait timeout from
+    // globals.comfyuiGenerationTimeoutMinutes (plus a grace margin so the provider's
+    // own timeout error surfaces first), falling back to 5 minutes when unset.
+    vi.useFakeTimers()
+
+    const provider = createNeverSettlingCallbackProvider()
+    const originalProvider = artistryProviders.get('comfyui')
+    artistryProviders.set('comfyui', provider as ArtistryProvider)
+
+    try {
+      const pending = generateHeadless({
+        prompt: 'a very slow image',
+        provider: 'comfyui',
+        globals: { comfyuiGenerationTimeoutMinutes: 10 },
+      })
+
+      let settled = false
+      void pending.then(() => {
+        settled = true
+      })
+
+      // Before the fix, the headless wait had already rejected at this point with
+      // "Image generation timed out after 5 minutes."
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000)
+      expect(settled).toBe(false)
+
+      // The configured 10-minute timeout (plus the grace margin) is what ends the wait.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 30_000)
+      const result = await pending
+      expect(result.error).toBe('Image generation timed out after 10 minutes.')
+    }
+    finally {
+      if (originalProvider)
+        artistryProviders.set('comfyui', originalProvider)
+    }
+  })
+
+  it('still times out after five minutes when no timeout is configured', async () => {
+    vi.useFakeTimers()
+
+    const provider = createNeverSettlingCallbackProvider()
+    const originalProvider = artistryProviders.get('comfyui')
+    artistryProviders.set('comfyui', provider as ArtistryProvider)
+
+    try {
+      const pending = generateHeadless({
+        prompt: 'an image with default timeout',
+        provider: 'comfyui',
+        globals: {},
+      })
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 30_000 + 1000)
+      const result = await pending
+      expect(result.error).toBe('Image generation timed out after 5 minutes.')
+    }
+    finally {
+      if (originalProvider)
+        artistryProviders.set('comfyui', originalProvider)
+    }
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.test.ts
@@ -24,6 +24,22 @@ function createNeverSettlingCallbackProvider() {
   return provider
 }
 
+async function withCallbackProvider<T>(
+  providerId: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const originalProvider = artistryProviders.get(providerId)
+  artistryProviders.set(providerId, createNeverSettlingCallbackProvider() as ArtistryProvider)
+
+  try {
+    return await callback()
+  }
+  finally {
+    if (originalProvider)
+      artistryProviders.set(providerId, originalProvider)
+  }
+}
+
 describe('generateHeadless', () => {
   beforeEach(() => {
     // generateHeadless always resolves the persisted artistry config through injeca,
@@ -107,5 +123,30 @@ describe('generateHeadless', () => {
       if (originalProvider)
         artistryProviders.set('comfyui', originalProvider)
     }
+  })
+
+  // https://github.com/moeru-ai/airi/pull/2083 (Codex review: scope ComfyUI timeout to ComfyUI headless runs)
+  it('keeps the default safety timeout for non-ComfyUI providers (Issue #2084)', async () => {
+    // ROOT CAUSE:
+    //
+    // The shared globals object includes comfyuiGenerationTimeoutMinutes even when
+    // another provider is active. Using that value unconditionally let a ComfyUI
+    // slider selection extend a stalled cloud provider's headless wait.
+    //
+    // We fixed this by applying the configured timeout only to ComfyUI. Other
+    // providers keep the existing five-minute safety-net timeout.
+    vi.useFakeTimers()
+
+    const pending = withCallbackProvider('nanobanana', () => generateHeadless({
+      prompt: 'a stalled cloud image',
+      provider: 'nanobanana',
+      globals: { comfyuiGenerationTimeoutMinutes: 10 },
+    }))
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 30_000 + 1_000)
+
+    await expect(pending).resolves.toEqual({
+      error: 'Image generation timed out after 5 minutes.',
+    })
   })
 })

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
@@ -107,6 +107,24 @@ artistryProviders.set('nanobanana', new NanoBananaProvider())
 // Deduplication map for headless requests
 const pendingHeadlessRequests = new Map<string, Promise<{ imageUrl?: string, base64?: string, error?: string }>>()
 
+/**
+ * Resolves the safety-net timeout (in minutes) for headless generation waits.
+ *
+ * Callback-based providers (all currently registered ones) enforce their own generation
+ * timeout and report failures through `setJobCallback`; ComfyUI derives that timeout from
+ * the user-configured `comfyuiGenerationTimeoutMinutes`. The wrapper timer in
+ * {@link generateHeadless} only guards against a callback that never fires, so it must
+ * outlive the provider's own timeout — otherwise headless callers (image_journal,
+ * autonomous artistry) reject with a generic 5-minute error while the provider is still
+ * legitimately polling.
+ */
+function resolveHeadlessWaitTimeoutMinutes(globals: Record<string, any>): number {
+  const configured = globals?.comfyuiGenerationTimeoutMinutes
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0)
+    return configured
+  return 5
+}
+
 export async function generateHeadless(params: {
   prompt: string
   model?: string
@@ -183,17 +201,23 @@ export async function generateHeadless(params: {
     const job = await provider.generate(request)
     log.log(`[Headless] Job created: ${job.jobId}`)
 
+    // NOTICE: The grace margin beyond the configured timeout exists because ComfyUI only
+    // starts its own timeout clock after the upload/queue requests complete, which happens
+    // after this timer starts. An identical timeout would race and mask the provider's
+    // more specific timeout error with this generic one.
+    const waitTimeoutMinutes = resolveHeadlessWaitTimeoutMinutes(activeGlobals)
+    const waitTimeoutMs = waitTimeoutMinutes * 60 * 1000 + 30_000
+
     // Polling/Wait for result
     if (!supportsJobCallback(provider)) {
       let isDone = false
       let lastStatus = await provider.getStatus(job.jobId)
       const start = Date.now()
-      const timeout = 1000 * 60 * 5 // 5 minutes timeout
 
       while (!isDone) {
-        if (Date.now() - start > timeout) {
-          log.error(`[Headless] Job ${job.jobId} timed out after 5 minutes.`)
-          throw new Error('Image generation timed out after 5 minutes.')
+        if (Date.now() - start > waitTimeoutMs) {
+          log.error(`[Headless] Job ${job.jobId} timed out after ${waitTimeoutMinutes} minutes.`)
+          throw new Error(`Image generation timed out after ${waitTimeoutMinutes} minutes.`)
         }
 
         log.log(`[Headless] Polling status for job: ${job.jobId}...`)
@@ -221,10 +245,9 @@ export async function generateHeadless(params: {
       // For providers with callbacks (like ComfyUI), we wait for the result via the callback
       log.log(`[Headless] Using callback-based wait logic for provider: ${requestedProvider}`)
       return new Promise<{ imageUrl?: string, base64?: string }>((resolve, reject) => {
-        const timeout = 1000 * 60 * 5 // 5 minutes timeout
         const timer = setTimeout(() => {
-          reject(new Error('Image generation timed out after 5 minutes.'))
-        }, timeout)
+          reject(new Error(`Image generation timed out after ${waitTimeoutMinutes} minutes.`))
+        }, waitTimeoutMs)
 
         provider.setJobCallback(request.extra?.internalJobId as string, async (status) => {
           if (status.status === 'succeeded') {

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
@@ -468,6 +468,7 @@ export async function setupArtistryBridge(params: {
         artistryProvider: payload.provider || params.artistryConfig.get()?.artistryProvider || DEFAULT_ARTISTRY_PROVIDER,
         artistryGlobals: payload.globals || params.artistryConfig.get()?.artistryGlobals || {
           comfyuiServerUrl: 'http://localhost:8188',
+          comfyuiGenerationTimeoutMinutes: 10,
           comfyuiSavedWorkflows: [],
           comfyuiActiveWorkflow: '',
           replicateApiKey: '',

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
@@ -110,15 +110,18 @@ const pendingHeadlessRequests = new Map<string, Promise<{ imageUrl?: string, bas
 /**
  * Resolves the safety-net timeout (in minutes) for headless generation waits.
  *
- * Callback-based providers (all currently registered ones) enforce their own generation
- * timeout and report failures through `setJobCallback`; ComfyUI derives that timeout from
- * the user-configured `comfyuiGenerationTimeoutMinutes`. The wrapper timer in
+ * ComfyUI derives its provider timeout from the user-configured
+ * `comfyuiGenerationTimeoutMinutes`; other providers keep the default five-minute
+ * safety-net timeout. The wrapper timer in
  * {@link generateHeadless} only guards against a callback that never fires, so it must
  * outlive the provider's own timeout — otherwise headless callers (image_journal,
  * autonomous artistry) reject with a generic 5-minute error while the provider is still
  * legitimately polling.
  */
-function resolveHeadlessWaitTimeoutMinutes(globals: Record<string, any>): number {
+function resolveHeadlessWaitTimeoutMinutes(providerId: string, globals: Record<string, any>): number {
+  if (providerId !== 'comfyui')
+    return 5
+
   const configured = globals?.comfyuiGenerationTimeoutMinutes
   if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0)
     return configured
@@ -205,7 +208,7 @@ export async function generateHeadless(params: {
     // starts its own timeout clock after the upload/queue requests complete, which happens
     // after this timer starts. An identical timeout would race and mask the provider's
     // more specific timeout error with this generic one.
-    const waitTimeoutMinutes = resolveHeadlessWaitTimeoutMinutes(activeGlobals)
+    const waitTimeoutMinutes = resolveHeadlessWaitTimeoutMinutes(requestedProvider, activeGlobals)
     const waitTimeoutMs = waitTimeoutMinutes * 60 * 1000 + 30_000
 
     // Polling/Wait for result

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ComfyUIProvider } from './comfyui'
+
+describe('comfyui provider', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('waits beyond the former five-minute limit when a longer timeout is configured', async () => {
+    // ROOT CAUSE:
+    //
+    // ComfyUI jobs continue on the remote host after AIRI's polling loop stops.
+    // A workflow that needs more than five minutes therefore produced a failed
+    // tool result even though ComfyUI eventually saved the requested image.
+    //
+    // The timeout is now persisted as a user setting and passed to the provider.
+    vi.useFakeTimers()
+
+    let historyRequests = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.endsWith('/prompt')) {
+        return new Response(JSON.stringify({ prompt_id: 'slow-job' }), { status: 200 })
+      }
+
+      historyRequests++
+      if (historyRequests < 62)
+        return new Response(JSON.stringify({}), { status: 200 })
+
+      return new Response(JSON.stringify({
+        'slow-job': {
+          outputs: {
+            result: {
+              images: [{ filename: 'result.png', subfolder: '', type: 'output' }],
+            },
+          },
+          status: { completed: true },
+        },
+      }), { status: 200 })
+    }))
+
+    const provider = new ComfyUIProvider()
+    await provider.initialize({
+      comfyuiServerUrl: 'http://comfyui.test:8188',
+      comfyuiGenerationTimeoutMinutes: 10,
+      comfyuiSavedWorkflows: [{
+        id: 'slow-workflow',
+        workflow: {},
+        exposedFields: {},
+      }],
+      comfyuiActiveWorkflow: 'slow-workflow',
+    })
+
+    const job = await provider.generate({ prompt: 'A slow image', extra: {} })
+    await vi.advanceTimersByTimeAsync(310_000)
+
+    await expect(provider.getStatus(job.jobId)).resolves.toMatchObject({
+      status: 'succeeded',
+      imageUrl: 'http://comfyui.test:8188/view?filename=result.png&subfolder=&type=output',
+    })
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.test.ts
@@ -60,4 +60,68 @@ describe('comfyui provider', () => {
       imageUrl: 'http://comfyui.test:8188/view?filename=result.png&subfolder=&type=output',
     })
   })
+
+  // https://github.com/moeru-ai/airi/pull/2083 (Codex review: snapshot the generation timeout per ComfyUI job)
+  it('keeps a running job\'s original timeout when the provider is re-initialized mid-flight (PR #2083 review)', async () => {
+    // ROOT CAUSE:
+    //
+    // The provider is registered as a singleton and pollForResult read the mutable
+    // this.generationTimeoutMs on every poll pass. Re-initializing the provider while
+    // a slow job was still polling (e.g. a second headless generation syncing a
+    // shorter timeout) moved the first job's deadline, so a 10-minute job failed
+    // ~5 minutes after the second initialize().
+    //
+    // We fixed this by snapshotting the timeout in generate() and passing that
+    // snapshot into pollForResult instead of reading the mutable field.
+    vi.useFakeTimers()
+
+    let historyRequests = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.endsWith('/prompt')) {
+        return new Response(JSON.stringify({ prompt_id: 'slow-job' }), { status: 200 })
+      }
+
+      historyRequests++
+      // Complete after ~6 minutes of polling (5s interval -> 72 polls)
+      if (historyRequests < 72)
+        return new Response(JSON.stringify({}), { status: 200 })
+
+      return new Response(JSON.stringify({
+        'slow-job': {
+          outputs: {
+            result: {
+              images: [{ filename: 'result.png', subfolder: '', type: 'output' }],
+            },
+          },
+          status: { completed: true },
+        },
+      }), { status: 200 })
+    }))
+
+    const provider = new ComfyUIProvider()
+    await provider.initialize({
+      comfyuiServerUrl: 'http://comfyui.test:8188',
+      comfyuiGenerationTimeoutMinutes: 10,
+      comfyuiSavedWorkflows: [{
+        id: 'slow-workflow',
+        workflow: {},
+        exposedFields: {},
+      }],
+      comfyuiActiveWorkflow: 'slow-workflow',
+    })
+
+    const job = await provider.generate({ prompt: 'A slow image', extra: {} })
+
+    // A second job syncing different settings re-initializes the singleton provider.
+    await provider.initialize({ comfyuiGenerationTimeoutMinutes: 5 })
+
+    // Past the re-initialized 5-minute deadline but before the original 10-minute
+    // one, and before the provider's 10s post-completion result cleanup runs.
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000 + 5_000)
+
+    await expect(provider.getStatus(job.jobId)).resolves.toMatchObject({
+      status: 'succeeded',
+      imageUrl: 'http://comfyui.test:8188/view?filename=result.png&subfolder=&type=output',
+    })
+  })
 })

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.ts
@@ -7,13 +7,14 @@ import { useLogg } from '@guiiai/logg'
 const log = useLogg('providers-comfyui').useGlobalConfig()
 
 const POLL_INTERVAL_MS = 5000
-const POLL_TIMEOUT_MS = 1000 * 60 * 5 // 5 minutes
+const DEFAULT_GENERATION_TIMEOUT_MINUTES = 10
 
 export class ComfyUIProvider implements ArtistryProvider {
   readonly id = 'comfyui'
   readonly name = 'ComfyUI (Local)'
 
   private serverUrl = 'http://localhost:8188'
+  private generationTimeoutMs = DEFAULT_GENERATION_TIMEOUT_MINUTES * 60 * 1000
   private savedWorkflows: any[] = []
   private activeWorkflowId = ''
 
@@ -55,6 +56,8 @@ export class ComfyUIProvider implements ArtistryProvider {
   async initialize(config: any): Promise<void> {
     if (config?.comfyuiServerUrl)
       this.serverUrl = config.comfyuiServerUrl.replace(/\/+$/, '') // strip trailing slashes
+    if (typeof config?.comfyuiGenerationTimeoutMinutes === 'number')
+      this.generationTimeoutMs = config.comfyuiGenerationTimeoutMinutes * 60 * 1000
     if (config?.comfyuiSavedWorkflows)
       this.savedWorkflows = config.comfyuiSavedWorkflows
     if (config?.comfyuiActiveWorkflow)
@@ -166,8 +169,8 @@ export class ComfyUIProvider implements ArtistryProvider {
         await new Promise(r => setTimeout(r, POLL_INTERVAL_MS))
         attempt++
 
-        if (Date.now() - startTime > POLL_TIMEOUT_MS) {
-          throw new Error('Generation timed out after 5 minutes')
+        if (Date.now() - startTime > this.generationTimeoutMs) {
+          throw new Error(`Generation timed out after ${this.generationTimeoutMs / 60_000} minutes`)
         }
 
         if (attempt % 3 === 0) {

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/comfyui.ts
@@ -80,8 +80,11 @@ export class ComfyUIProvider implements ArtistryProvider {
       return { jobId, providerJobId: jobId }
     }
 
-    // Start async generation
-    this.pollForResult(jobId, template, request)
+    // Start async generation.
+    // NOTICE: Snapshot the timeout for this job. The provider is a shared singleton and
+    // initialize() mutates this.generationTimeoutMs, so a later generation syncing a
+    // different timeout must not move this job's deadline while it is still polling.
+    this.pollForResult(jobId, template, request, this.generationTimeoutMs)
 
     return { jobId, providerJobId: jobId }
   }
@@ -90,6 +93,7 @@ export class ComfyUIProvider implements ArtistryProvider {
     jobId: string,
     template: { workflow: Record<string, any>, exposedFields: Record<string, string[]> },
     request: ArtistryRequest,
+    generationTimeoutMs: number,
   ) {
     this.updateStatus(jobId, { status: 'running', actionLabel: 'Preparing workflow...' })
 
@@ -169,8 +173,8 @@ export class ComfyUIProvider implements ArtistryProvider {
         await new Promise(r => setTimeout(r, POLL_INTERVAL_MS))
         attempt++
 
-        if (Date.now() - startTime > this.generationTimeoutMs) {
-          throw new Error(`Generation timed out after ${this.generationTimeoutMs / 60_000} minutes`)
+        if (Date.now() - startTime > generationTimeoutMs) {
+          throw new Error(`Generation timed out after ${generationTimeoutMs / 60_000} minutes`)
         }
 
         if (attempt % 3 === 0) {

--- a/apps/stage-tamagotchi/src/renderer/stores/tools/builtin/image-journal.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/stores/tools/builtin/image-journal.test.ts
@@ -32,6 +32,7 @@ describe('image_journal config snapshot', () => {
       defaultPromptPrefix: { value: 'anime style' },
       providerOptions: { value: { seed: 42 } },
       comfyuiServerUrl: { value: 'http://localhost:8188' },
+      comfyuiGenerationTimeoutMinutes: { value: 20 },
       comfyuiSavedWorkflows: { value: [{ id: 'wf-1' }] },
       comfyuiActiveWorkflow: { value: 'wf-1' },
       replicateApiKey: { value: 'r8_xxx' },
@@ -50,6 +51,7 @@ describe('image_journal config snapshot', () => {
       options: { seed: 42 },
       globals: {
         comfyuiServerUrl: 'http://localhost:8188',
+        comfyuiGenerationTimeoutMinutes: 20,
         comfyuiSavedWorkflows: [{ id: 'wf-1' }],
         comfyuiActiveWorkflow: 'wf-1',
         replicateApiKey: 'r8_xxx',

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1165,6 +1165,10 @@ pages:
               label: Server URL
               description: The address where ComfyUI is running
               placeholder: http://localhost:8188
+            generation_timeout:
+              label: Generation timeout
+              description: Increase this for slower workflows, integrated GPUs, or low-VRAM systems. AIRI waits for ComfyUI before reporting a result.
+              value: '{minutes} min'
           cors:
             title: CORS Block Detected
             description: ComfyUI blocks requests from other applications by default. To allow AIRI to connect, you must start ComfyUI with the `--enable-cors-header "*"` flag.

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -1112,6 +1112,10 @@ pages:
               label: Server URL
               description: The address where ComfyUI is running
               placeholder: http://localhost:8188
+            generation_timeout:
+              label: 生成超时时间
+              description: 工作流较慢、使用集成显卡或显存不足时请提高此值。AIRI 会在向对话返回结果前等待 ComfyUI 完成。
+              value: '{minutes} 分钟'
           cors:
             title: CORS Block Detected
             description: ComfyUI blocks requests from other applications by default. To allow AIRI to connect, you must start ComfyUI with the `--enable-cors-header "*"` flag.

--- a/packages/stage-pages/src/pages/settings/providers/artistry/comfyui.vue
+++ b/packages/stage-pages/src/pages/settings/providers/artistry/comfyui.vue
@@ -6,7 +6,7 @@ import { createContext } from '@moeru/eventa/adapters/electron/renderer'
 import { errorMessageFrom } from '@moeru/std'
 import { artistryTestComfyUIConnection, isStageTamagotchi } from '@proj-airi/stage-shared'
 import { useArtistryStore } from '@proj-airi/stage-ui/stores/modules/artistry'
-import { Button, FieldInput } from '@proj-airi/ui'
+import { Button, FieldInput, FieldRange } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -16,6 +16,7 @@ const { t } = useI18n()
 
 const {
   comfyuiServerUrl,
+  comfyuiGenerationTimeoutMinutes,
   comfyuiSavedWorkflows,
   comfyuiActiveWorkflow,
 } = storeToRefs(artistryStore)
@@ -321,6 +322,18 @@ function copyToClipboard(text: string) {
       >
         {{ connectionInfo }}
       </div>
+
+      <FieldRange
+        v-model="comfyuiGenerationTimeoutMinutes"
+        :label="t('settings.pages.providers.provider.comfyui.settings.connection.generation_timeout.label')"
+        :description="t('settings.pages.providers.provider.comfyui.settings.connection.generation_timeout.description')"
+        :min="5"
+        :max="60"
+        :step="5"
+        :default-value="10"
+        :format-value="value => t('settings.pages.providers.provider.comfyui.settings.connection.generation_timeout.value', { minutes: value })"
+        as="div"
+      />
 
       <!-- CORS Troubleshooting -->
       <div

--- a/packages/stage-ui/src/stores/modules/artistry.test.ts
+++ b/packages/stage-ui/src/stores/modules/artistry.test.ts
@@ -23,6 +23,7 @@ describe('artistry store', () => {
     expect(artistryStore.globalProvider).toBe('none')
     // @example
     expect(artistryStore.activeProvider).toBe('none')
+    expect(artistryStore.comfyuiGenerationTimeoutMinutes).toBe(10)
     // @example
     expect(artistryStore.configured).toBe(false)
   })

--- a/packages/stage-ui/src/stores/modules/artistry.ts
+++ b/packages/stage-ui/src/stores/modules/artistry.ts
@@ -35,6 +35,10 @@ export const useArtistryStore = defineStore('artistry', () => {
     'artistry-comfyui-server-url',
     'http://localhost:8188',
   )
+  const comfyuiGenerationTimeoutMinutes = useLocalStorageManualReset<number>(
+    'artistry-comfyui-generation-timeout-minutes',
+    10,
+  )
   const comfyuiSavedWorkflows = useLocalStorageManualReset<ComfyUIWorkflowTemplate[]>(
     'artistry-comfyui-saved-workflows',
     [],
@@ -92,6 +96,7 @@ export const useArtistryStore = defineStore('artistry', () => {
     globalProviderOptions.reset()
 
     comfyuiServerUrl.reset()
+    comfyuiGenerationTimeoutMinutes.reset()
     comfyuiSavedWorkflows.reset()
     comfyuiActiveWorkflow.reset()
     replicateApiKey.reset()
@@ -139,6 +144,7 @@ export const useArtistryStore = defineStore('artistry', () => {
 
   const artistryGlobals = computed(() => ({
     comfyuiServerUrl: comfyuiServerUrl.value,
+    comfyuiGenerationTimeoutMinutes: comfyuiGenerationTimeoutMinutes.value,
     comfyuiSavedWorkflows: comfyuiSavedWorkflows.value,
     comfyuiActiveWorkflow: comfyuiActiveWorkflow.value,
     replicateApiKey: replicateApiKey.value,
@@ -167,6 +173,7 @@ export const useArtistryStore = defineStore('artistry', () => {
 
     // ComfyUI provider config
     comfyuiServerUrl,
+    comfyuiGenerationTimeoutMinutes,
     comfyuiSavedWorkflows,
     comfyuiActiveWorkflow,
 
@@ -212,6 +219,7 @@ export function resolveArtistryConfigFromStore(store: any): ResolvedArtistryConf
     options: unwrap(store.providerOptions),
     globals: {
       comfyuiServerUrl: unwrap(store.comfyuiServerUrl),
+      comfyuiGenerationTimeoutMinutes: unwrap(store.comfyuiGenerationTimeoutMinutes),
       comfyuiSavedWorkflows: unwrap(store.comfyuiSavedWorkflows),
       comfyuiActiveWorkflow: unwrap(store.comfyuiActiveWorkflow),
       replicateApiKey: unwrap(store.replicateApiKey),


### PR DESCRIPTION
## Summary
- add a persisted 5–60 minute ComfyUI generation-timeout slider (10-minute default)
- pass the selected timeout through the renderer and main-process configuration to ComfyUI polling
- add Chinese and English settings copy plus a regression test for jobs that exceed five minutes

## Linked issue
Fixes #2084

## Verification
- `pnpm -F @proj-airi/stage-tamagotchi exec vitest run src/main/services/airi/widgets/providers/comfyui.test.ts src/renderer/stores/tools/builtin/image-journal.test.ts`
- `pnpm -F @proj-airi/stage-tamagotchi typecheck`
- `pnpm lint` (passes with 7 existing repository warnings)