### PR TITLE
feat(stage-ui): add full settings backup export and import to the data page

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -430,6 +430,14 @@ pages:
         export: Export chats
         import: Import chats
         delete: Delete all chat sessions
+      settings:
+        title: Settings
+        description: Export or import app settings, module preferences, and provider configurations as a JSON backup.
+        export: Export settings
+        import: Import settings
+        include_secrets: Include API keys and tokens
+        include_secrets_description: Secrets are exported in plain text. Keep the backup file safe.
+        export_secrets_confirm: Export with secrets?
       models:
         title: Models
         description: Remove imported Live2D/VRM models.
@@ -466,6 +474,8 @@ pages:
       imported: Chat sessions imported.
       import_error: Failed to import chat sessions. Please check the file format.
       chats_deleted: Chat sessions deleted.
+      settings_exported: Settings exported.
+      settings_imported: Settings imported. Reloading...
       models_deleted: Models deleted.
       modules_reset: Module settings reset.
       providers_reset: Provider settings reset.

--- a/packages/i18n/src/locales/es/settings.yaml
+++ b/packages/i18n/src/locales/es/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: Exportar conversaciones
         import: Importar conversaciones
         delete: Borrar todas las conversaciones
+      settings:
+        title: Ajustes
+        description: Exporta o importa los ajustes de la aplicación, módulos y proveedores como copia de seguridad JSON.
+        export: Exportar ajustes
+        import: Importar ajustes
+        include_secrets: Incluir claves API y tokens
+        include_secrets_description: Los secretos se exportan en texto plano. Guarda el archivo de copia en un lugar seguro.
+        export_secrets_confirm: ¿Exportar con secretos?
       models:
         title: Modelos
         description: Borrar modelos Live2D/VRM importados.
@@ -447,6 +455,8 @@ pages:
       imported: Sesiones de chat importadas.
       import_error: Error al importar las sesiones de chat. Por favor, compruebe el formato del archivo.
       chats_deleted: Sesiones de chat borradas.
+      settings_exported: Ajustes exportados.
+      settings_imported: Ajustes importados. Recargando…
       models_deleted: Modelo eliminado.
       modules_reset: Ajustes del módulo restablecidos.
       providers_reset: Ajustes del proveedor restablecidos.

--- a/packages/i18n/src/locales/fr/settings.yaml
+++ b/packages/i18n/src/locales/fr/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: Exporter les chats
         import: Importer les chats
         delete: Supprimer toutes les sessions de chat
+      settings:
+        title: Paramètres
+        description: Exportez ou importez les paramètres de l'application, des modules et des fournisseurs sous forme de sauvegarde JSON.
+        export: Exporter les paramètres
+        import: Importer les paramètres
+        include_secrets: Inclure les clés API et jetons
+        include_secrets_description: Les secrets sont exportés en clair. Conservez le fichier de sauvegarde en lieu sûr.
+        export_secrets_confirm: Exporter avec les secrets ?
       models:
         title: Modèles
         description: Supprimer les modèles Live2D/VRM importés.
@@ -447,6 +455,8 @@ pages:
       imported: Sessions de discussion importées.
       import_error: Échec de l'importation des sessions. Veuillez vérifier le format du fichier.
       chats_deleted: Sessions de discussion supprimées.
+      settings_exported: Paramètres exportés.
+      settings_imported: Paramètres importés. Rechargement…
       models_deleted: Modèles supprimés.
       modules_reset: Paramètres du module réinitialisés.
       providers_reset: Paramètres du fournisseur réinitialisés.

--- a/packages/i18n/src/locales/ja/settings.yaml
+++ b/packages/i18n/src/locales/ja/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: チャットをエクスポート
         import: チャットをインポート
         delete: 全てのチャットセッションを削除
+      settings:
+        title: 設定
+        description: アプリ設定、モジュール設定、プロバイダー設定を JSON バックアップとしてエクスポート／インポートします。
+        export: 設定をエクスポート
+        import: 設定をインポート
+        include_secrets: API キーとトークンを含める
+        include_secrets_description: シークレットは平文でエクスポートされます。バックアップファイルは安全に保管してください。
+        export_secrets_confirm: シークレットを含めてエクスポートしますか？
       models:
         title: モデル
         description: インポートされた Live2D/VRM モデルを削除。
@@ -447,6 +455,8 @@ pages:
       imported: チャットセッションをインポートしました。
       import_error: チャットセッションのインポートに失敗しました。ファイルの形式を確認してください。
       chats_deleted: チャットセッションを削除しました。
+      settings_exported: 設定をエクスポートしました。
+      settings_imported: 設定をインポートしました。再読み込みします…
       models_deleted: モデルを削除しました。
       modules_reset: モジュールの設定をリセットしました。
       providers_reset: プロバイダーの設定をリセットしました。

--- a/packages/i18n/src/locales/ko/settings.yaml
+++ b/packages/i18n/src/locales/ko/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: 채팅 내보내기
         import: 채팅 가져오기
         delete: 모든 채팅 세션 삭제
+      settings:
+        title: 설정
+        description: 앱 설정, 모듈 설정, 프로바이더 구성을 JSON 백업으로 내보내거나 가져옵니다.
+        export: 설정 내보내기
+        import: 설정 가져오기
+        include_secrets: API 키 및 토큰 포함
+        include_secrets_description: 시크릿은 평문으로 내보내집니다. 백업 파일을 안전하게 보관하세요.
+        export_secrets_confirm: 시크릿을 포함하여 내보낼까요?
       models:
         title: 모델
         description: 가져온 Live2D/VRM 모델을 삭제합니다.
@@ -447,6 +455,8 @@ pages:
       imported: 채팅 세션을 가져왔습니다.
       import_error: 채팅 세션을 가져오지 못했습니다. 파일 형식을 확인해 주세요.
       chats_deleted: 채팅 세션이 삭제되었습니다.
+      settings_exported: 설정을 내보냈습니다.
+      settings_imported: 설정을 가져왔습니다. 새로고침 중…
       models_deleted: 모델이 삭제되었습니다.
       modules_reset: 모듈 설정이 초기화되었습니다.
       providers_reset: 제공자 설정이 초기화되었습니다.

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: Экспорт чатов
         import: Импорт чатов
         delete: Удалить все сеансы чата
+      settings:
+        title: Настройки
+        description: Экспорт или импорт настроек приложения, модулей и провайдеров в виде JSON-резервной копии.
+        export: Экспорт настроек
+        import: Импорт настроек
+        include_secrets: Включить API-ключи и токены
+        include_secrets_description: Секреты экспортируются в открытом виде. Храните файл резервной копии в безопасности.
+        export_secrets_confirm: Экспортировать с секретами?
       models:
         title: Модели
         description: Удалить импортированные модели Live2D/VRM.
@@ -447,6 +455,8 @@ pages:
       imported: Чат сеансов импортирован.
       import_error: Не удалось импортировать чаты. Проверьте формат файла.
       chats_deleted: Чат сеансы удалены.
+      settings_exported: Настройки экспортированы.
+      settings_imported: Настройки импортированы. Перезагрузка…
       models_deleted: Модели удалены.
       modules_reset: Настройки модуля сброшены.
       providers_reset: Настройки провайдера сброшены.

--- a/packages/i18n/src/locales/vi/settings.yaml
+++ b/packages/i18n/src/locales/vi/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: Xuất hội thoại
         import: Nhập hội thoại
         delete: Xóa tất cả hội thoại
+      settings:
+        title: Cài đặt
+        description: Xuất hoặc nhập cài đặt ứng dụng, mô-đun và nhà cung cấp dưới dạng bản sao lưu JSON.
+        export: Xuất cài đặt
+        import: Nhập cài đặt
+        include_secrets: Bao gồm khóa API và token
+        include_secrets_description: Khóa bí mật được xuất dưới dạng văn bản thuần. Hãy giữ tệp sao lưu an toàn.
+        export_secrets_confirm: Xuất kèm khóa bí mật?
       models:
         title: Mô hình
         description: Xóa các mô hình Live2D/VRM đã nhập.
@@ -447,6 +455,8 @@ pages:
       imported: Đã nhập phiên trò chuyện.
       import_error: Lỗi nhập dữ liệu. Vui lòng kiểm tra định dạng tệp.
       chats_deleted: Đã xóa các phiên trò chuyện.
+      settings_exported: Đã xuất cài đặt.
+      settings_imported: Đã nhập cài đặt. Đang tải lại…
       models_deleted: Đã xóa các mô hình.
       modules_reset: Đã đặt lại cài đặt mô-đun.
       providers_reset: Đã đặt lại cài đặt nhà cung cấp.

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: 导出聊天记录
         import: 导入聊天记录
         delete: 删除所有聊天会话
+      settings:
+        title: 设置
+        description: 将应用设置、模块偏好和提供商配置导出或导入为 JSON 备份。
+        export: 导出设置
+        import: 导入设置
+        include_secrets: 包含 API 密钥和令牌
+        include_secrets_description: 密钥将以明文导出，请妥善保管备份文件。
+        export_secrets_confirm: 确认导出密钥？
       models:
         title: 模型
         description: 删除导入的Live2D/VRM模型。
@@ -447,6 +455,8 @@ pages:
       imported: 聊天会话已导入。
       import_error: 无法导入聊天会话。请检查文件格式。
       chats_deleted: 聊天会话已删除。
+      settings_exported: 设置已导出。
+      settings_imported: 设置已导入，即将刷新…
       models_deleted: 模型已删除。
       modules_reset: 重置模块设置。
       providers_reset: 服务端设置重置。

--- a/packages/i18n/src/locales/zh-Hant/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/settings.yaml
@@ -411,6 +411,14 @@ pages:
         export: 匯出聊天記錄
         import: 匯入聊天記錄
         delete: 刪除所有聊天記錄
+      settings:
+        title: 設定
+        description: 將應用設定、模組偏好和供應商設定匯出或匯入為 JSON 備份。
+        export: 匯出設定
+        import: 匯入設定
+        include_secrets: 包含 API 金鑰和權杖
+        include_secrets_description: 金鑰將以明文匯出，請妥善保管備份檔案。
+        export_secrets_confirm: 確認匯出金鑰？
       models:
         title: 模型
         description: 移除匯入的 Live2D/VRM 模型
@@ -447,6 +455,8 @@ pages:
       imported: 對話階段已匯入。
       import_error: 匯入對話階段失敗，請檢查檔案格式。
       chats_deleted: 對話階段已刪除。
+      settings_exported: 設定已匯出。
+      settings_imported: 設定已匯入，即將重新整理…
       models_deleted: 模型已刪除
       modules_reset: 模組設定已重設
       providers_reset: 服務提供者設定已重設

--- a/packages/stage-pages/src/pages/settings/data/components/settings-section.vue
+++ b/packages/stage-pages/src/pages/settings/data/components/settings-section.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import type { DataSettingsStatusEmits } from '../status'
+
+import { useAnalytics } from '@proj-airi/stage-ui/composables'
+import { applySettingsBackup, collectSettingsBackup, parseSettingsBackup, serializeSettingsBackup } from '@proj-airi/stage-ui/libs/settings-transfer'
+import { Button, DoubleCheckButton, FieldCheckbox } from '@proj-airi/ui'
+import { shallowRef, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { createDataSettingsStatusHelpers } from '../status'
+
+const emit = defineEmits<DataSettingsStatusEmits>()
+const { t } = useI18n()
+const { trackDataAction } = useAnalytics()
+const importFileInput = useTemplateRef<HTMLInputElement>('importFileInput')
+const importError = shallowRef('')
+const includeSecrets = shallowRef(false)
+const { emitStatus, handleActionError } = createDataSettingsStatusHelpers(emit)
+
+function triggerImportPicker() {
+  importFileInput.value?.click()
+}
+
+function triggerExport() {
+  try {
+    const backup = collectSettingsBackup(localStorage, { includeSecrets: includeSecrets.value })
+    const blob = new Blob([serializeSettingsBackup(backup)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `airi-settings-${new Date().toISOString()}.json`
+    anchor.click()
+    URL.revokeObjectURL(url)
+    trackDataAction({ action: 'settings_exported' })
+    emitStatus(t('settings.pages.data.status.settings_exported'))
+  }
+  catch (error) {
+    handleActionError(error)
+  }
+}
+
+async function handleImport(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file)
+    return
+
+  try {
+    const backup = parseSettingsBackup(await file.text())
+    const { appliedCount } = applySettingsBackup(localStorage, backup)
+    if (appliedCount === 0)
+      throw new Error('The backup contains no importable settings.')
+
+    importError.value = ''
+    trackDataAction({ action: 'settings_imported' })
+    emitStatus(t('settings.pages.data.status.settings_imported'))
+
+    // Stores hydrate their useLocalStorage refs at creation, so a reload is
+    // the only reliable way to make every module pick up the imported values.
+    setTimeout(() => location.reload(), 800)
+  }
+  catch (error) {
+    importError.value = t('settings.pages.data.status.import_error')
+    handleActionError(error)
+  }
+  finally {
+    target.value = ''
+  }
+}
+</script>
+
+<template>
+  <div :class="['border-2 border-neutral-200/50 rounded-xl bg-white/70 p-4 shadow-sm', 'dark:border-neutral-800/60 dark:bg-neutral-900/60']">
+    <div :class="['grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(0,1fr)_auto]']">
+      <div :class="['flex flex-col gap-3 md:max-w-[560px]']">
+        <div :class="['flex flex-col gap-1']">
+          <div :class="['text-lg font-medium']">
+            {{ t('settings.pages.data.sections.settings.title') }}
+          </div>
+          <p :class="['text-sm text-neutral-600 dark:text-neutral-400']">
+            {{ t('settings.pages.data.sections.settings.description') }}
+          </p>
+        </div>
+        <FieldCheckbox
+          v-model="includeSecrets"
+          :label="t('settings.pages.data.sections.settings.include_secrets')"
+          :description="t('settings.pages.data.sections.settings.include_secrets_description')"
+        />
+      </div>
+      <div :class="['flex flex-col items-start gap-2 sm:items-end']">
+        <div :class="['flex flex-wrap gap-2']">
+          <!-- Exports containing API keys require a second confirmation (#1254). -->
+          <DoubleCheckButton v-if="includeSecrets" variant="danger" @confirm="triggerExport">
+            {{ t('settings.pages.data.sections.settings.export') }}
+            <template #confirm>
+              {{ t('settings.pages.data.sections.settings.export_secrets_confirm') }}
+            </template>
+            <template #cancel>
+              {{ t('settings.pages.card.cancel') }}
+            </template>
+          </DoubleCheckButton>
+          <Button v-else variant="secondary" @click="triggerExport">
+            {{ t('settings.pages.data.sections.settings.export') }}
+          </Button>
+          <Button variant="primary" @click="triggerImportPicker">
+            {{ t('settings.pages.data.sections.settings.import') }}
+          </Button>
+        </div>
+      </div>
+    </div>
+    <input ref="importFileInput" type="file" accept="application/json,.json" :class="['hidden']" @change="handleImport">
+    <p v-if="importError" :class="['text-sm text-red-500']">
+      {{ importError }}
+    </p>
+  </div>
+</template>

--- a/packages/stage-pages/src/pages/settings/data/index.vue
+++ b/packages/stage-pages/src/pages/settings/data/index.vue
@@ -2,6 +2,7 @@
 import ChatsSection from './components/chats-section.vue'
 import DangerSection from './components/danger-section.vue'
 import ModelsModulesSection from './components/models-modules-section.vue'
+import SettingsSection from './components/settings-section.vue'
 import StatusBanner from './components/status-banner.vue'
 
 import { createDataSettingsStatusState } from './status'
@@ -13,6 +14,7 @@ const { statusMessage, statusTone, handleStatus } = createDataSettingsStatusStat
   <div :class="['flex flex-col gap-4 pb-4']">
     <StatusBanner v-if="statusMessage" :message="statusMessage" :tone="statusTone" />
     <ChatsSection @status="handleStatus" />
+    <SettingsSection @status="handleStatus" />
     <ModelsModulesSection @status="handleStatus" />
     <DangerSection @status="handleStatus" />
   </div>

--- a/packages/stage-ui/src/composables/use-analytics.ts
+++ b/packages/stage-ui/src/composables/use-analytics.ts
@@ -1173,7 +1173,7 @@ export function useAnalytics() {
    * succeeded — a failed wipe is not a churn signal.
    */
   function trackDataAction(properties: {
-    action: 'chats_exported' | 'chats_imported' | 'chats_cleared' | 'app_data_cleared' | 'models_cache_cleared' | 'modules_settings_reset' | 'provider_settings_reset' | 'desktop_state_reset'
+    action: 'chats_exported' | 'chats_imported' | 'chats_cleared' | 'app_data_cleared' | 'models_cache_cleared' | 'modules_settings_reset' | 'provider_settings_reset' | 'desktop_state_reset' | 'settings_exported' | 'settings_imported'
   }) {
     if (!canCapture())
       return

--- a/packages/stage-ui/src/libs/settings-transfer.test.ts
+++ b/packages/stage-ui/src/libs/settings-transfer.test.ts
@@ -1,0 +1,162 @@
+import type { StorageLike } from './settings-transfer'
+
+import { describe, expect, it } from 'vitest'
+
+import { applySettingsBackup, collectSettingsBackup, isSecretSettingsKey, parseSettingsBackup, serializeSettingsBackup } from './settings-transfer'
+
+function fakeStorage(entries: Record<string, string> = {}): StorageLike & { dump: () => Record<string, string> } {
+  const map = new Map(Object.entries(entries))
+  return {
+    get length() {
+      return map.size
+    },
+    key: index => [...map.keys()][index] ?? null,
+    getItem: key => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value)
+    },
+    dump: () => Object.fromEntries(map),
+  }
+}
+
+describe('collectSettingsBackup', () => {
+  it('exports settings keys with raw string values', () => {
+    const storage = fakeStorage({
+      'settings/language': 'en-US',
+      'settings/theme/colors/hue': '220.44',
+      'settings/credentials/providers': '{"openai":{"apiKey":"sk-1"}}',
+    })
+
+    const backup = collectSettingsBackup(storage, { includeSecrets: true })
+
+    expect(backup.kind).toBe('airi-settings-backup')
+    expect(backup.version).toBe(1)
+    // Raw strings preserved exactly — no JSON re-encoding of scalar values.
+    expect(backup.settings['settings/language']).toBe('en-US')
+    expect(backup.settings['settings/theme/colors/hue']).toBe('220.44')
+    expect(backup.settings['settings/credentials/providers']).toBe('{"openai":{"apiKey":"sk-1"}}')
+  })
+
+  it('omits secrets unless explicitly included', () => {
+    const storage = fakeStorage({
+      'settings/language': 'en-US',
+      'settings/credentials/providers': '{"openai":{"apiKey":"sk-1"}}',
+      'settings/discord/token': 'discord-token',
+      'settings/twitter/api-secret': 'twitter-secret',
+      'settings/connection/websocket-auth-token': 'ws-token',
+      'artistry-replicate-api-key': 'replicate-key',
+    })
+
+    const withoutSecrets = collectSettingsBackup(storage, { includeSecrets: false })
+    expect(Object.keys(withoutSecrets.settings)).toEqual(['settings/language'])
+
+    const withSecrets = collectSettingsBackup(storage, { includeSecrets: true })
+    expect(Object.keys(withSecrets.settings)).toHaveLength(6)
+  })
+
+  it('never exports auth or server-owned account state', () => {
+    const storage = fakeStorage({
+      'auth/v1/token': 'session-token',
+      'auth/v1/refresh-token': 'refresh-token',
+      'user/v1/flux': '{"balance":10}',
+      'settings/language': 'en-US',
+    })
+
+    const backup = collectSettingsBackup(storage, { includeSecrets: true })
+
+    expect(Object.keys(backup.settings)).toEqual(['settings/language'])
+  })
+
+  it('ignores unrelated storage keys', () => {
+    const storage = fakeStorage({
+      'some-third-party-lib-cache': 'x',
+      'settings/language': 'en-US',
+      'airi-card-active-id': 'card-1',
+      'onboarding/completed': 'true',
+    })
+
+    const backup = collectSettingsBackup(storage, { includeSecrets: false })
+
+    expect(Object.keys(backup.settings).sort()).toEqual([
+      'airi-card-active-id',
+      'onboarding/completed',
+      'settings/language',
+    ])
+  })
+})
+
+describe('serialize / parse round-trip', () => {
+  it('round-trips a backup through JSON', () => {
+    const storage = fakeStorage({ 'settings/language': 'ja-JP' })
+    const backup = collectSettingsBackup(storage, { includeSecrets: false })
+
+    const parsed = parseSettingsBackup(serializeSettingsBackup(backup))
+
+    expect(parsed).toEqual(backup)
+  })
+
+  it('rejects malformed JSON with a descriptive error', () => {
+    expect(() => parseSettingsBackup('{nope')).toThrow(/Failed to parse settings backup/)
+  })
+
+  it('rejects JSON that is not a settings backup', () => {
+    expect(() => parseSettingsBackup('{"foo":1}')).toThrow(/does not look like an AIRI settings backup/)
+    expect(() => parseSettingsBackup('{"kind":"airi-settings-backup","version":2,"settings":{}}')).toThrow(/does not look like an AIRI settings backup/)
+    expect(() => parseSettingsBackup('{"kind":"airi-settings-backup","version":1,"settings":{"a":1}}')).toThrow(/does not look like an AIRI settings backup/)
+  })
+})
+
+describe('applySettingsBackup', () => {
+  it('writes raw values back and counts applied keys', () => {
+    const storage = fakeStorage()
+
+    const { appliedCount } = applySettingsBackup(storage, {
+      kind: 'airi-settings-backup',
+      version: 1,
+      settings: {
+        'settings/language': 'zh-Hans',
+        'settings/credentials/providers': '{"openai":{"apiKey":"sk-2"}}',
+      },
+    })
+
+    expect(appliedCount).toBe(2)
+    expect(storage.dump()).toEqual({
+      'settings/language': 'zh-Hans',
+      'settings/credentials/providers': '{"openai":{"apiKey":"sk-2"}}',
+    })
+  })
+
+  it('drops keys outside the exportable policy from untrusted files', () => {
+    const storage = fakeStorage()
+
+    const { appliedCount } = applySettingsBackup(storage, {
+      kind: 'airi-settings-backup',
+      version: 1,
+      settings: {
+        'auth/v1/token': 'planted-session',
+        'user/v1/flux': '{"balance":9999}',
+        'totally-unrelated': 'x',
+        'settings/language': 'en-US',
+      },
+    })
+
+    expect(appliedCount).toBe(1)
+    expect(storage.dump()).toEqual({ 'settings/language': 'en-US' })
+  })
+})
+
+describe('isSecretSettingsKey', () => {
+  it('classifies credential keys as secrets', () => {
+    expect(isSecretSettingsKey('settings/credentials/providers')).toBe(true)
+    expect(isSecretSettingsKey('settings/discord/token')).toBe(true)
+    expect(isSecretSettingsKey('settings/twitter/access-token-secret')).toBe(true)
+    expect(isSecretSettingsKey('settings/web-search/api-key')).toBe(true)
+    expect(isSecretSettingsKey('artistry-nanobanana-api-key')).toBe(true)
+  })
+
+  it('does not classify ordinary settings as secrets', () => {
+    expect(isSecretSettingsKey('settings/language')).toBe(false)
+    expect(isSecretSettingsKey('settings/speech/active-provider')).toBe(false)
+    expect(isSecretSettingsKey('onboarding/completed')).toBe(false)
+  })
+})

--- a/packages/stage-ui/src/libs/settings-transfer.ts
+++ b/packages/stage-ui/src/libs/settings-transfer.ts
@@ -1,0 +1,145 @@
+import { errorMessageFrom } from '@moeru/std'
+import { literal, object, record, safeParse, string } from 'valibot'
+
+/**
+ * Minimal Storage surface used by the backup functions, so they can run
+ * against `localStorage` in the app and a plain fake in unit tests without
+ * mocking globals.
+ */
+export interface StorageLike {
+  readonly length: number
+  key: (index: number) => string | null
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+/**
+ * A portable snapshot of AIRI's persisted settings.
+ *
+ * Values are the raw localStorage strings, NOT parsed JSON: vueuse's
+ * useLocalStorage serializes by initial-value type (plain strings stay raw,
+ * objects become JSON), so re-encoding values here would corrupt string
+ * settings on import. Copying raw strings guarantees exact fidelity.
+ */
+export interface SettingsBackup {
+  kind: 'airi-settings-backup'
+  version: 1
+  settings: Record<string, string>
+}
+
+// Keys eligible for export/import. Everything persisted under settings/
+// (including provider credentials), plus a handful of top-level keys that
+// hold user preferences rather than device or account state.
+const EXPORTABLE_PREFIXES = ['settings/', 'artistry-', 'onboarding/']
+const EXPORTABLE_KEYS = new Set(['airi-card-active-id', 'mcp/connected'])
+
+// NOTICE:
+// auth/* (OIDC session and refresh tokens) and user/* (server-owned account
+// state) are deliberately never exported nor imported: session tokens are
+// bound to the signed-in device and expire, and restoring them onto another
+// install is a credential-leak hazard with no migration value. This is a
+// policy decision, not an oversight; remove only if auth intentionally moves
+// to a portable format.
+const BLOCKED_PREFIXES = ['auth/', 'user/']
+
+// Keys whose values are credentials. They are exported only on explicit
+// request (the UI requires a second confirmation, per the request in
+// https://github.com/moeru-ai/airi/issues/1254) but always accepted on
+// import: an import file containing secrets was exported intentionally.
+const SECRET_KEY_PATTERN = /api-key|api-secret|-token|\/token|secret|credentials/
+
+function isBlocked(key: string): boolean {
+  return BLOCKED_PREFIXES.some(prefix => key.startsWith(prefix))
+}
+
+function isExportable(key: string): boolean {
+  if (isBlocked(key))
+    return false
+
+  return EXPORTABLE_KEYS.has(key) || EXPORTABLE_PREFIXES.some(prefix => key.startsWith(prefix))
+}
+
+/** Whether a settings key stores credentials (API keys, tokens, secrets). */
+export function isSecretSettingsKey(key: string): boolean {
+  return SECRET_KEY_PATTERN.test(key)
+}
+
+const settingsBackupSchema = object({
+  kind: literal('airi-settings-backup'),
+  version: literal(1),
+  settings: record(string(), string()),
+})
+
+/**
+ * Collects the exportable settings from storage into a backup snapshot.
+ *
+ * Secrets (API keys, tokens) are omitted unless `includeSecrets` is set —
+ * callers must get explicit user confirmation before requesting them.
+ */
+export function collectSettingsBackup(storage: StorageLike, options: { includeSecrets: boolean }): SettingsBackup {
+  const settings: Record<string, string> = {}
+
+  for (let index = 0; index < storage.length; index++) {
+    const key = storage.key(index)
+    if (!key || !isExportable(key))
+      continue
+
+    if (!options.includeSecrets && isSecretSettingsKey(key))
+      continue
+
+    const value = storage.getItem(key)
+    if (value !== null)
+      settings[key] = value
+  }
+
+  return { kind: 'airi-settings-backup', version: 1, settings }
+}
+
+/** Serializes a backup for file download. */
+export function serializeSettingsBackup(backup: SettingsBackup): string {
+  return `${JSON.stringify(backup, null, 2)}\n`
+}
+
+/**
+ * Parses a previously exported settings backup.
+ *
+ * @throws Error with a user-facing message when the content is not a
+ * version-1 AIRI settings backup.
+ */
+export function parseSettingsBackup(content: string): SettingsBackup {
+  let data: unknown
+  try {
+    data = JSON.parse(content)
+  }
+  catch (error) {
+    throw new Error(`Failed to parse settings backup: ${errorMessageFrom(error) ?? 'unknown error'}`)
+  }
+
+  const result = safeParse(settingsBackupSchema, data)
+  if (!result.success)
+    throw new Error('This file does not look like an AIRI settings backup.')
+
+  return result.output
+}
+
+/**
+ * Writes a backup's settings into storage and reports how many keys were
+ * applied.
+ *
+ * Keys outside the exportable policy are silently dropped: an imported file
+ * is untrusted input and must not be able to plant auth/session tokens or
+ * arbitrary storage entries.
+ */
+export function applySettingsBackup(storage: StorageLike, backup: SettingsBackup): { appliedCount: number } {
+  let appliedCount = 0
+
+  for (const [key, value] of Object.entries(backup.settings)) {
+    if (!isExportable(key))
+      continue
+
+    storage.setItem(key, value)
+    appliedCount++
+  }
+
+  return { appliedCount }
+}


### PR DESCRIPTION
## Description

Adds a **Settings** section to the Data settings page that exports and imports all persisted app settings — appearance, module preferences, and provider configurations — as a JSON backup. Previously only chat sessions were exportable; everything else had reset actions but no backup/migration path.

### How it works

- **`packages/stage-ui/src/libs/settings-transfer.ts`** — the backup policy module:
  - Snapshots **raw localStorage strings** rather than re-parsed values: vueuse's `useLocalStorage` serializes by initial-value type (plain strings stay raw, objects become JSON), so re-encoding would corrupt string settings on import. Raw copies guarantee exact fidelity.
  - **Key policy:** everything under `settings/` plus preference keys (`artistry-*`, `onboarding/*`, `airi-card-active-id`, `mcp/connected`). `auth/*` (OIDC session/refresh tokens) and `user/*` (server-owned account state) are **never** exported *nor* imported — session tokens are device-bound and restoring them elsewhere is a credential-leak hazard with no migration value.
  - **Secrets** (API keys, tokens, `settings/credentials/providers`, …) are excluded by default and exported only on explicit opt-in.
  - Import validates the versioned envelope (Valibot) and **applies only policy-allowed keys**, so a crafted backup file can't plant auth tokens or arbitrary storage entries.
- **`settings-section.vue`** on the Data page: export button, an "Include API keys and tokens" opt-in whose export goes through a **double confirmation** (as the issue requests: 含API秘钥的导出需要二次确认), and import with validation, error surface, and an automatic reload so all stores rehydrate from the imported values.
- i18n entries for the section in all 9 locales.

### Relation to #2074

This complements the devtools-oriented provider config transfer (#2074, approved): that page is a developer tool scoped to provider credentials with YAML/.env formats; this one is the user-facing full-settings backup on the Data page the issue asked for. Both share the same design principles (explicit secret handling, validated imports).

## Linked Issues

Closes #1254

> Note for @luoling8192 — I saw you're assigned to this issue; I hope it was fine to pick up since it had been quiet for a while. Happy to adjust direction or hand over if you had a different design in mind.

## Additional Context

- Chat sessions are intentionally not bundled into this backup — they already have their own export/import on the same page, and mixing multi-megabyte chat data into a settings file would make settings migration clunkier.
- Tested with `pnpm exec vitest run packages/stage-ui/src/libs/settings-transfer.test.ts` (11 tests: key policy, secrets gating both directions, auth exclusion, raw-value fidelity, malicious-file filtering, envelope validation), `vue-tsc` on stage-ui and stage-pages, and ESLint on all touched files.
