### PR TITLE
fix(discord): bound and fairly schedule retained input work

### DIFF
--- a/packages/stage-ui/src/stores/chat.ts
+++ b/packages/stage-ui/src/stores/chat.ts
@@ -87,6 +87,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
 
   const sending = ref(false)
   const pendingQueuedSendCount = ref(0)
+  const pendingSendCancellationHooks = new Set<(sessionId?: string) => void>()
   let ownedActiveTurnSpan: typeof activeTurnSpan.value
 
   async function streamWithStageAdapters(
@@ -404,6 +405,13 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
 
   function cancelPendingSends(sessionId?: string) {
     runtime.cancelPendingSends(sessionId)
+    for (const hook of pendingSendCancellationHooks)
+      hook(sessionId)
+  }
+
+  function onPendingSendsCancelled(hook: (sessionId?: string) => void) {
+    pendingSendCancellationHooks.add(hook)
+    return () => pendingSendCancellationHooks.delete(hook)
   }
 
   function getPendingQueuedSendSnapshot() {
@@ -417,6 +425,7 @@ export const useChatOrchestratorStore = defineStore('chat-orchestrator', () => {
     ingest,
     ingestOnFork,
     cancelPendingSends,
+    onPendingSendsCancelled,
     getPendingQueuedSendSnapshot,
 
     clearHooks: runtime.hooks.clearHooks,

--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -209,6 +209,24 @@ describe('channel-server store reconnect', () => {
     expect(onReconnected).toHaveBeenCalledTimes(1)
   })
 
+  it('notifies disconnect callbacks so retained ingress work can be cancelled (CSR-09)', async () => {
+    const store = useModsServerChannelStore()
+    const onDisconnected = vi.fn()
+    const unsubscribe = store.onDisconnected(onDisconnected)
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+    client.simulateTransientDisconnect()
+
+    expect(onDisconnected).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    client.simulateTransientDisconnect()
+    expect(onDisconnected).toHaveBeenCalledTimes(1)
+  })
+
   it('does not notify onReconnected on first authenticated->ready flow and only on subsequent ready events', async () => {
     const store = useModsServerChannelStore()
     const onReconnected = vi.fn()

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -58,6 +58,18 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
   const pendingSend = ref<Array<WebSocketEvent>>([])
   const pendingSendCount = computed(() => pendingSend.value.length)
   const reconnectedCallbacks = new Set<() => void>()
+  const disconnectedCallbacks = new Set<() => void>()
+
+  function notifyDisconnected() {
+    for (const callback of disconnectedCallbacks) {
+      try {
+        callback()
+      }
+      catch (error) {
+        console.error('Error in disconnected callback:', error)
+      }
+    }
+  }
 
   const defaultWebSocketUrl = import.meta.env.VITE_AIRI_WS_URL || 'ws://localhost:6121/ws'
   const websocketUrl = useLocalStorage('settings/connection/websocket-url', defaultWebSocketUrl)
@@ -147,6 +159,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
         },
         onClose: () => {
           connected.value = false
+          notifyDisconnected()
 
           if (!hasEverConnected.value) {
             // First handshake failed: clear lock so initialize() can be retried externally.
@@ -160,6 +173,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
             // SDK entered terminal state (auth terminal / retries exhausted / autoReconnect disabled).
             connected.value = false
             initializing.value = null
+            notifyDisconnected()
             console.warn('WebSocket server connection failed')
           }
         },
@@ -306,6 +320,15 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     }
   }
 
+  /** Registers cleanup that must run when the server transport stops delivering input. */
+  function onDisconnected(callback: () => void) {
+    disconnectedCallbacks.add(callback)
+
+    return () => {
+      disconnectedCallbacks.delete(callback)
+    }
+  }
+
   function sendContextUpdate(message: InputContextUpdate) {
     const id = nanoid()
     send({
@@ -354,6 +377,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     onContextUpdate,
     onEvent,
     onReconnected,
+    onDisconnected,
     getPendingSendSnapshot: () => [...pendingSend.value],
     dispose,
   }

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.contract.browser.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.contract.browser.test.ts
@@ -767,4 +767,50 @@ describe('context bridge contract', () => {
     expect(chatOrchestratorMock.ingest).toHaveBeenCalledTimes(1)
     await store.dispose()
   })
+
+  // https://github.com/moeru-ai/airi/pull/2097
+  it('continues queued Discord ingestion when reset cannot settle the active ingest (CSR-09)', async () => {
+    // ROOT CAUSE:
+    //
+    // A session reset aborted the Discord reservation, but a provider that did
+    // not settle left chatOrchestrator.ingest() holding the context-bridge Web
+    // Lock. The queue could not dispatch later Discord input through that lock.
+    //
+    // Before the fix, the second ingest call below never occurs.
+    //
+    // We fixed this by ending both the scheduler wait and Web Lock ownership on
+    // cancellation, independently of provider cooperation.
+    activeProviderRef.value = 'mock-provider'
+    activeModelRef.value = 'mock-model'
+    getProviderInstanceMock.mockResolvedValue({})
+    chatOrchestratorMock.ingest
+      .mockImplementationOnce(() => new Promise<void>(() => {}))
+      .mockResolvedValueOnce(undefined)
+
+    const store = useContextBridgeStore()
+    await store.initialize()
+    const blockedSubmission = emitServerEvent('input:text', createDiscordInputEvent({
+      principalId: '123456789012345678',
+      sessionId: 'discord-guild-reset',
+      text: 'blocked message',
+    }))
+    const nextSubmission = emitServerEvent('input:text', createDiscordInputEvent({
+      principalId: '223456789012345678',
+      sessionId: 'discord-guild-next',
+      text: 'next message',
+    }))
+    await vi.waitFor(() => expect(chatOrchestratorMock.ingest).toHaveBeenCalledTimes(1))
+
+    try {
+      await emitHooks(pendingSendCancellationHooks, 'discord-guild-reset')
+      await vi.waitFor(() => expect(chatOrchestratorMock.ingest).toHaveBeenCalledTimes(2))
+    }
+    finally {
+      await store.dispose()
+    }
+
+    await expect(blockedSubmission).resolves.toBeUndefined()
+    await expect(nextSubmission).resolves.toBeUndefined()
+    expect(chatOrchestratorMock.ingest.mock.calls[1]?.[0]).toBe('next message')
+  })
 })

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.contract.browser.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.contract.browser.test.ts
@@ -9,6 +9,7 @@ type HookCallback = (...args: unknown[]) => Promise<void> | void
 type UseContextBridgeStore = typeof import('./context-bridge')['useContextBridgeStore']
 
 const contextUpdateHooks: HookCallback[] = []
+const disconnectedHooks: HookCallback[] = []
 const serverEventHooks = new Map<string, HookCallback[]>()
 
 const chatContextIngestMock = vi.fn()
@@ -19,6 +20,7 @@ const resetStreamMock = vi.fn()
 const serverSendMock = vi.fn()
 const ensureConnectedMock = vi.fn().mockResolvedValue(undefined)
 const onReconnectedMock = vi.fn(() => () => {})
+const onDisconnectedMock = vi.fn((callback: HookCallback) => registerHook(disconnectedHooks, callback))
 const onContextUpdateMock = vi.fn((callback: HookCallback) => registerHook(contextUpdateHooks, callback))
 const onEventMock = vi.fn((eventName: string, callback: HookCallback) => registerServerEventHook(eventName, callback))
 const getProviderInstanceMock = vi.fn()
@@ -37,6 +39,7 @@ const streamEndHooks: HookCallback[] = []
 const assistantEndHooks: HookCallback[] = []
 const assistantMessageHooks: HookCallback[] = []
 const turnCompleteHooks: HookCallback[] = []
+const pendingSendCancellationHooks: HookCallback[] = []
 
 const activeSessionIdRef = ref('session-1')
 let currentGeneration = 7
@@ -139,6 +142,32 @@ function createContextUpdateEvent(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function createDiscordInputEvent(options: {
+  principalId: string
+  sessionId: string
+  text: string
+}) {
+  return {
+    type: 'input:text',
+    source: 'discord',
+    metadata: createMetadata('discord', 'discord-bot'),
+    data: {
+      text: options.text,
+      overrides: {
+        sessionId: options.sessionId,
+      },
+      discord: {
+        channelId: `channel-${options.sessionId}`,
+        guildMember: {
+          id: options.principalId,
+          displayName: 'Discord user',
+          nickname: 'Discord user',
+        },
+      },
+    },
+  }
+}
+
 const chatOrchestratorMock = {
   sending: false,
   ingest: vi.fn(),
@@ -153,6 +182,7 @@ const chatOrchestratorMock = {
   onAssistantResponseEnd: (callback: HookCallback) => registerHook(assistantEndHooks, callback),
   onAssistantMessage: (callback: HookCallback) => registerHook(assistantMessageHooks, callback),
   onChatTurnComplete: (callback: HookCallback) => registerHook(turnCompleteHooks, callback),
+  onPendingSendsCancelled: (callback: HookCallback) => registerHook(pendingSendCancellationHooks, callback),
 
   emitBeforeMessageComposedHooks: (...args: unknown[]) => emitHooks(beforeComposeHooks, ...args),
   emitAfterMessageComposedHooks: (...args: unknown[]) => emitHooks(afterComposeHooks, ...args),
@@ -261,6 +291,7 @@ vi.mock('./channel-server', () => ({
   useModsServerChannelStore: () => ({
     ensureConnected: ensureConnectedMock,
     onReconnected: onReconnectedMock,
+    onDisconnected: onDisconnectedMock,
     onContextUpdate: onContextUpdateMock,
     onEvent: onEventMock,
     send: serverSendMock,
@@ -281,6 +312,7 @@ describe('context bridge contract', () => {
     ensureConnectedMock.mockClear()
     ensureConnectedMock.mockResolvedValue(undefined)
     onReconnectedMock.mockClear()
+    onDisconnectedMock.mockClear()
     onContextUpdateMock.mockClear()
     onEventMock.mockClear()
     getProviderInstanceMock.mockReset()
@@ -303,6 +335,8 @@ describe('context bridge contract', () => {
     assistantEndHooks.length = 0
     assistantMessageHooks.length = 0
     turnCompleteHooks.length = 0
+    pendingSendCancellationHooks.length = 0
+    disconnectedHooks.length = 0
     contextUpdateHooks.length = 0
     serverEventHooks.clear()
   })
@@ -635,6 +669,102 @@ describe('context bridge contract', () => {
     expect(finalizeStreamMock).not.toHaveBeenCalled()
     expect(chatOrchestratorMock.sending).toBe(true)
 
+    await store.dispose()
+  })
+
+  it('bounds Discord retained work before the Web Lock wait (CSR-09)', async () => {
+    // ROOT CAUSE:
+    //
+    // A blocked generation owns the context-bridge Web Lock while every later
+    // Discord event queues another lock request. The stable Discord user ID is
+    // present on every event, but current admission does not inspect it.
+    //
+    // Before the fix, all six events below are retained across distinct exact
+    // sessions and five appear as unbounded Web Lock waiters.
+    //
+    // The fix admits at most four reservations for one principal before any
+    // request enters the Web Lock or global chat-orchestrator queue.
+    activeProviderRef.value = 'mock-provider'
+    activeModelRef.value = 'mock-model'
+    getProviderInstanceMock.mockResolvedValue({})
+
+    let releaseBlockedGeneration: () => void = () => {}
+    const blockedGeneration = new Promise<void>((resolve) => {
+      releaseBlockedGeneration = resolve
+    })
+    chatOrchestratorMock.ingest
+      .mockImplementationOnce(() => blockedGeneration)
+      .mockResolvedValue(undefined)
+
+    const store = useContextBridgeStore()
+    await store.initialize()
+
+    const submissions = Array.from({ length: 6 }, (_, index) => emitServerEvent('input:text', createDiscordInputEvent({
+      principalId: '123456789012345678',
+      sessionId: `discord-guild-${index + 1}`,
+      text: `message-${index + 1}`,
+    })))
+
+    try {
+      await vi.waitFor(async () => {
+        const lockState = await navigator.locks.query()
+        const pendingInputLocks = (lockState.pending ?? []).filter(lock => lock.name === 'context-bridge:event:input:text')
+        expect(pendingInputLocks.length).toBeLessThanOrEqual(3)
+      })
+    }
+    finally {
+      releaseBlockedGeneration()
+      await Promise.all(submissions)
+      await store.dispose()
+    }
+
+    expect(chatOrchestratorMock.ingest).toHaveBeenCalledTimes(4)
+  })
+
+  it('fails closed when Discord principal identity is malformed (CSR-09)', async () => {
+    activeProviderRef.value = 'mock-provider'
+    activeModelRef.value = 'mock-model'
+    getProviderInstanceMock.mockResolvedValue({})
+    const store = useContextBridgeStore()
+    await store.initialize()
+
+    await emitServerEvent('input:text', createDiscordInputEvent({
+      principalId: 'display-name-is-not-an-id',
+      sessionId: 'discord-guild-1',
+      text: 'malformed principal',
+    }))
+
+    expect(getProviderInstanceMock).not.toHaveBeenCalled()
+    expect(chatOrchestratorMock.ingest).not.toHaveBeenCalled()
+
+    await store.dispose()
+  })
+
+  it('cancels retained Discord work when its exact session is reset (CSR-09)', async () => {
+    activeProviderRef.value = 'mock-provider'
+    activeModelRef.value = 'mock-model'
+    getProviderInstanceMock.mockResolvedValue({})
+
+    let releaseBlockedGeneration: () => void = () => {}
+    chatOrchestratorMock.ingest.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      releaseBlockedGeneration = resolve
+    }))
+
+    const store = useContextBridgeStore()
+    await store.initialize()
+    const sessionId = 'discord-guild-reset'
+    const submissions = [1, 2].map(index => emitServerEvent('input:text', createDiscordInputEvent({
+      principalId: '123456789012345678',
+      sessionId,
+      text: `message-${index}`,
+    })))
+    await vi.waitFor(() => expect(chatOrchestratorMock.ingest).toHaveBeenCalledTimes(1))
+
+    await emitHooks(pendingSendCancellationHooks, sessionId)
+    releaseBlockedGeneration()
+    await Promise.all(submissions)
+
+    expect(chatOrchestratorMock.ingest).toHaveBeenCalledTimes(1)
     await store.dispose()
   })
 })

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.ts
@@ -353,11 +353,39 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
     return options.calls?.find(call => call.manifest.name === name)
   }
 
-  function withContextBridgeLock<T>(key: string, callback: () => Promise<T>) {
-    if (typeof navigator !== 'undefined' && 'locks' in navigator && typeof navigator.locks.request === 'function') {
-      return navigator.locks.request(key, callback)
+  async function runContextBridgeTaskUntilAborted<T>(callback: () => Promise<T>, signal: AbortSignal) {
+    signal.throwIfAborted()
+
+    let rejectCancellation: (error: unknown) => void = () => {}
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      rejectCancellation = reject
+    })
+    const onAbort = () => rejectCancellation(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    // Releasing the Web Lock must not depend on provider cancellation support.
+    // Promise.race keeps observing a detached provider promise, so a late
+    // rejection remains handled after cancellation releases the lock.
+    const operation = Promise.resolve().then(callback)
+    try {
+      return await Promise.race([operation, cancellation])
     }
-    return callback()
+    finally {
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+
+  function withContextBridgeLock<T>(key: string, callback: () => Promise<T>, signal?: AbortSignal) {
+    const run = () => signal
+      ? runContextBridgeTaskUntilAborted(callback, signal)
+      : callback()
+
+    if (typeof navigator !== 'undefined' && 'locks' in navigator && typeof navigator.locks.request === 'function') {
+      if (signal)
+        return navigator.locks.request(key, { signal }, run)
+      return navigator.locks.request(key, run)
+    }
+    return run()
   }
 
   async function withContextBridgeExclusiveLock<T>(key: string, callback: () => Promise<T>) {
@@ -715,7 +743,7 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
             catch (err) {
               console.error('Error ingesting text input via context bridge:', err)
             }
-          })
+          }, signal)
         }
       }
 

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.ts
@@ -1,5 +1,5 @@
 import type { LlmStreamingControlCallManifest } from '@proj-airi/pipelines-audio'
-import type { WebSocketEventOf } from '@proj-airi/server-sdk'
+import type { WebSocketBaseEvent, WebSocketEventOf, WebSocketEvents } from '@proj-airi/server-sdk'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { UserMessage } from '@xsai/shared-chat'
 
@@ -26,6 +26,7 @@ import { useLlmStreamingControlStore } from '../../llm-streaming-control'
 import { useConsciousnessStore } from '../../modules/consciousness'
 import { useProvidersStore } from '../../providers'
 import { useModsServerChannelStore } from './channel-server'
+import { createDiscordInputQueue, DiscordInputAdmissionError, parseDiscordPrincipalId } from './discordInputQueue'
 
 export function normalizeContextSnapshot<C extends Pick<ChatStreamEventContext, 'contexts'>>(contexts: C): C {
   return {
@@ -91,6 +92,7 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
   const { post: postSparkNotifyBridgeMessage, data: incomingSparkNotifyBridgeMessage } = useBroadcastChannel<SparkNotifyBridgeMessage, SparkNotifyBridgeMessage>({ name: SPARK_NOTIFY_BRIDGE_CHANNEL_NAME })
 
   const disposeHookFns = ref<Array<() => void>>([])
+  let discordInputQueue: ReturnType<typeof createDiscordInputQueue> | undefined
   let remoteStreamGuard: { sessionId: string, generation: number } | null = null
   let initialized = false
 
@@ -556,7 +558,26 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
         })
       }))
 
-      disposeHookFns.value.push(serverChannelStore.onEvent('input:text', async (event) => {
+      const currentDiscordInputQueue = createDiscordInputQueue()
+      discordInputQueue = currentDiscordInputQueue
+      disposeHookFns.value.push(
+        chatOrchestrator.onPendingSendsCancelled((sessionId) => {
+          if (sessionId)
+            currentDiscordInputQueue.cancelSession(sessionId)
+          else
+            currentDiscordInputQueue.cancelAll()
+        }),
+        serverChannelStore.onDisconnected(() => {
+          currentDiscordInputQueue.cancelAll(new Error('Discord input cancelled after server disconnect'))
+        }),
+      )
+
+      async function processInputTextEvent(
+        event: WebSocketBaseEvent<'input:text', WebSocketEvents['input:text']>,
+        targetSessionId?: string,
+        signal?: AbortSignal,
+      ) {
+        signal?.throwIfAborted()
         const {
           text,
           textRaw,
@@ -633,6 +654,7 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
           }
         }
 
+        signal?.throwIfAborted()
         if (activeProvider.value && activeModel.value) {
           let chatProvider: ChatProvider
           try {
@@ -643,8 +665,8 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
             return
           }
 
+          signal?.throwIfAborted()
           let messageText = text
-          const targetSessionId = overrides?.sessionId
 
           if (overrides?.messagePrefix) {
             messageText = `${overrides.messagePrefix}${text}`
@@ -673,6 +695,7 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
           // - https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker
           // - https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
           await withContextBridgeLock('context-bridge:event:input:text', async () => {
+            signal?.throwIfAborted()
             try {
               await chatOrchestrator.ingest(messageText, {
                 model: activeModel.value,
@@ -693,6 +716,38 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
               console.error('Error ingesting text input via context bridge:', err)
             }
           })
+        }
+      }
+
+      disposeHookFns.value.push(serverChannelStore.onEvent('input:text', async (event) => {
+        if (!Object.hasOwn(event.data, 'discord')) {
+          await processInputTextEvent(event, event.data.overrides?.sessionId)
+          return
+        }
+
+        const discordPrincipalId = parseDiscordPrincipalId(event.data.discord?.guildMember?.id)
+        if (!discordPrincipalId) {
+          console.warn('[context-bridge] Discord input rejected because guildMember.id is missing or malformed')
+          return
+        }
+
+        // This mirrors the core orchestrator's canonical fallback instead of
+        // inventing a Discord-specific session identity at the admission layer.
+        const targetSessionId = event.data.overrides?.sessionId || chatSession.activeSessionId
+
+        try {
+          await currentDiscordInputQueue.submit({
+            principalId: discordPrincipalId,
+            sessionId: targetSessionId,
+            run: signal => processInputTextEvent(event, targetSessionId, signal),
+          })
+        }
+        catch (error) {
+          if (error instanceof DiscordInputAdmissionError) {
+            console.warn(`[context-bridge] ${error.message}`)
+            return
+          }
+          console.warn('[context-bridge] Discord input did not complete:', errorMessageFrom(error) ?? 'Unknown error')
         }
       }))
 
@@ -882,6 +937,9 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
     try {
       if (!initialized)
         return
+
+      discordInputQueue?.shutdown()
+      discordInputQueue = undefined
 
       for (const consumerEvent of consumerRegistrationEvents) {
         serverChannelStore.send({

--- a/packages/stage-ui/src/stores/mods/api/discordInputQueue.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/discordInputQueue.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createDiscordInputQueue, DiscordInputAdmissionError, parseDiscordPrincipalId } from './discordInputQueue'
+
+function principal(value: string) {
+  const result = parseDiscordPrincipalId(value)
+  if (!result)
+    throw new Error(`Invalid test Discord principal: ${value}`)
+  return result
+}
+
+function abortableBlockedRun(signal: AbortSignal) {
+  return new Promise<void>((_resolve, reject) => {
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+  })
+}
+
+function observeRejection(promise: Promise<void>) {
+  void promise.catch(() => {})
+  return promise
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('discord input queue', () => {
+  it('rejects a third reservation for one exact session (CSR-09)', async () => {
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    const first = observeRejection(queue.submit({ principalId: user, sessionId: 'discord-guild-1', run: abortableBlockedRun }))
+    const second = observeRejection(queue.submit({ principalId: user, sessionId: 'discord-guild-1', run: abortableBlockedRun }))
+
+    await expect(queue.submit({ principalId: user, sessionId: 'discord-guild-1', run: async () => {} }))
+      .rejects
+      .toMatchObject({ reason: 'session-capacity' })
+    expect(queue.getSnapshot().sessions['discord-guild-1']).toBe(2)
+
+    queue.shutdown()
+    await expect(first).rejects.toThrow('shut down')
+    await expect(second).rejects.toThrow('shut down')
+  })
+
+  it('shares one principal cap across DM and guild sessions (CSR-09)', async () => {
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    const retained = [
+      queue.submit({ principalId: user, sessionId: 'discord-dm-123456789012345678', run: abortableBlockedRun }),
+      queue.submit({ principalId: user, sessionId: 'discord-dm-123456789012345678', run: abortableBlockedRun }),
+      queue.submit({ principalId: user, sessionId: 'discord-guild-1', run: abortableBlockedRun }),
+      queue.submit({ principalId: user, sessionId: 'discord-guild-2', run: abortableBlockedRun }),
+    ].map(observeRejection)
+
+    await expect(queue.submit({ principalId: user, sessionId: 'discord-guild-3', run: async () => {} }))
+      .rejects
+      .toMatchObject({ reason: 'principal-capacity' })
+    expect(queue.getSnapshot().principals[user]).toBe(4)
+
+    queue.shutdown()
+    for (const submission of retained)
+      await expect(submission).rejects.toThrow('shut down')
+  })
+
+  it('reserves capacity for another principal after one reaches its cap (CSR-09)', async () => {
+    const queue = createDiscordInputQueue()
+    const firstUser = principal('123456789012345678')
+    const secondUser = principal('223456789012345678')
+    const retained = Array.from({ length: 4 }, (_, index) => observeRejection(queue.submit({
+      principalId: firstUser,
+      sessionId: `discord-guild-${index + 1}`,
+      run: abortableBlockedRun,
+    })))
+    const secondUserSubmission = observeRejection(queue.submit({
+      principalId: secondUser,
+      sessionId: 'discord-guild-5',
+      run: abortableBlockedRun,
+    }))
+
+    expect(queue.getSnapshot().global).toBe(5)
+    expect(queue.getSnapshot().principals[firstUser]).toBe(4)
+    expect(queue.getSnapshot().principals[secondUser]).toBe(1)
+
+    queue.shutdown()
+    for (const submission of [...retained, secondUserSubmission])
+      await expect(submission).rejects.toThrow('shut down')
+  })
+
+  it('enforces the global active-plus-queued cap (CSR-09)', async () => {
+    const queue = createDiscordInputQueue({
+      limits: {
+        sessionCapacity: 3,
+        principalCapacity: 3,
+        globalCapacity: 4,
+      },
+    })
+    const firstUser = principal('123456789012345678')
+    const secondUser = principal('223456789012345678')
+    const retained = [
+      queue.submit({ principalId: firstUser, sessionId: 'a-1', run: abortableBlockedRun }),
+      queue.submit({ principalId: firstUser, sessionId: 'a-2', run: abortableBlockedRun }),
+      queue.submit({ principalId: firstUser, sessionId: 'a-3', run: abortableBlockedRun }),
+      queue.submit({ principalId: secondUser, sessionId: 'b-1', run: abortableBlockedRun }),
+    ].map(observeRejection)
+
+    await expect(queue.submit({ principalId: secondUser, sessionId: 'b-2', run: async () => {} }))
+      .rejects
+      .toMatchObject({ reason: 'global-capacity' })
+    expect(queue.getSnapshot().global).toBe(4)
+
+    queue.shutdown()
+    for (const submission of retained)
+      await expect(submission).rejects.toThrow('shut down')
+  })
+
+  it('dispatches principals round-robin while preserving exact-session order (CSR-09)', async () => {
+    const queue = createDiscordInputQueue()
+    const firstUser = principal('123456789012345678')
+    const secondUser = principal('223456789012345678')
+    const dispatchOrder: string[] = []
+
+    const submit = (principalId: typeof firstUser, sessionId: string, label: string) => queue.submit({
+      principalId,
+      sessionId,
+      run: async () => {
+        dispatchOrder.push(label)
+      },
+    })
+
+    await Promise.all([
+      submit(firstUser, 'a-session', 'a-1'),
+      submit(firstUser, 'a-session', 'a-2'),
+      submit(secondUser, 'b-session', 'b-1'),
+      submit(secondUser, 'b-session', 'b-2'),
+    ])
+
+    expect(dispatchOrder).toEqual(['a-1', 'b-1', 'a-2', 'b-2'])
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
+  it('releases a reservation after successful provider completion', async () => {
+    const queue = createDiscordInputQueue()
+
+    await queue.submit({
+      principalId: principal('123456789012345678'),
+      sessionId: 'success-session',
+      run: async () => {},
+    })
+
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
+  it('releases a reservation after provider failure', async () => {
+    const queue = createDiscordInputQueue()
+
+    await expect(queue.submit({
+      principalId: principal('123456789012345678'),
+      sessionId: 'provider-failure-session',
+      run: async () => {
+        throw new Error('provider failed')
+      },
+    })).rejects.toThrow('provider failed')
+
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
+  it('releases a reservation after preprocessing failure', async () => {
+    const queue = createDiscordInputQueue()
+
+    await expect(queue.submit({
+      principalId: principal('123456789012345678'),
+      sessionId: 'preprocessing-failure-session',
+      run: async () => {
+        throw new Error('preprocessing failed')
+      },
+    })).rejects.toThrow('preprocessing failed')
+
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
+  it('releases active and queued reservations after cancellation', async () => {
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    const first = observeRejection(queue.submit({ principalId: user, sessionId: 'cancel-session', run: abortableBlockedRun }))
+    const second = observeRejection(queue.submit({ principalId: user, sessionId: 'cancel-session', run: abortableBlockedRun }))
+    await vi.waitFor(() => expect(queue.getSnapshot().active).toBe(1))
+
+    expect(queue.cancelSession('cancel-session')).toBe(2)
+    await expect(first).rejects.toThrow('cancelled')
+    await expect(second).rejects.toThrow('cancelled')
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
+  it('releases queued reservations when their wait times out', async () => {
+    vi.useFakeTimers()
+    const queue = createDiscordInputQueue({ limits: { queueTimeoutMs: 10 } })
+    const firstUser = principal('123456789012345678')
+    const secondUser = principal('223456789012345678')
+    const first = observeRejection(queue.submit({ principalId: firstUser, sessionId: 'blocked-session', run: abortableBlockedRun }))
+    const timedOut = observeRejection(queue.submit({ principalId: secondUser, sessionId: 'timeout-session', run: async () => {} }))
+    await Promise.resolve()
+    expect(queue.getSnapshot().active).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(11)
+
+    await expect(timedOut).rejects.toThrow('expired before dispatch')
+    expect(queue.getSnapshot().global).toBe(1)
+    queue.shutdown()
+    await expect(first).rejects.toThrow('shut down')
+  })
+
+  it('releases reservations once across disconnect cancellation and later task settlement', async () => {
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    let finishActive: () => void = () => {}
+    const activeRun = new Promise<void>((resolve) => {
+      finishActive = resolve
+    })
+    const activeSubmission = observeRejection(queue.submit({
+      principalId: user,
+      sessionId: 'disconnect-session',
+      run: async () => activeRun,
+    }))
+    const queuedSubmission = observeRejection(queue.submit({
+      principalId: user,
+      sessionId: 'queued-session',
+      run: async () => {},
+    }))
+    await vi.waitFor(() => expect(queue.getSnapshot().active).toBe(1))
+
+    expect(queue.cancelAll(new Error('transport disconnected'))).toBe(2)
+    await expect(queuedSubmission).rejects.toThrow('transport disconnected')
+    expect(queue.getSnapshot().global).toBe(1)
+
+    finishActive()
+    await expect(activeSubmission).resolves.toBeUndefined()
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
+  it('releases each reservation exactly once during runtime shutdown', async () => {
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    let finishActive: () => void = () => {}
+    const activeRun = new Promise<void>((resolve) => {
+      finishActive = resolve
+    })
+    const activeSubmission = observeRejection(queue.submit({
+      principalId: user,
+      sessionId: 'active-session',
+      run: async () => activeRun,
+    }))
+    const queuedSubmission = observeRejection(queue.submit({
+      principalId: user,
+      sessionId: 'queued-session',
+      run: async () => {},
+    }))
+    await vi.waitFor(() => expect(queue.getSnapshot().active).toBe(1))
+
+    queue.shutdown()
+    await expect(activeSubmission).rejects.toThrow('shut down')
+    await expect(queuedSubmission).rejects.toThrow('shut down')
+    expect(queue.getSnapshot().global).toBe(0)
+
+    finishActive()
+    await Promise.resolve()
+    expect(queue.getSnapshot()).toMatchObject({ active: 0, global: 0, principals: {}, sessions: {} })
+  })
+
+  it('fails closed for malformed Discord principal identity', () => {
+    expect(parseDiscordPrincipalId(undefined)).toBeUndefined()
+    expect(parseDiscordPrincipalId('display-name')).toBeUndefined()
+    expect(parseDiscordPrincipalId('0')).toBeUndefined()
+    expect(parseDiscordPrincipalId('18446744073709551616')).toBeUndefined()
+    expect(parseDiscordPrincipalId('123456789012345678')).toBe('123456789012345678')
+  })
+
+  it('rejects contradictory or unsafe capacity configuration', () => {
+    expect(() => createDiscordInputQueue({
+      limits: { sessionCapacity: 5, principalCapacity: 4, globalCapacity: 8 },
+    })).toThrow('sessionCapacity must not exceed principalCapacity')
+    expect(() => createDiscordInputQueue({
+      limits: { sessionCapacity: 2, principalCapacity: 8, globalCapacity: 8 },
+    })).toThrow('principalCapacity must be strictly below globalCapacity')
+    expect(() => createDiscordInputQueue({
+      limits: { queueTimeoutMs: 0 },
+    })).toThrow('queueTimeoutMs must be a positive safe integer')
+  })
+
+  it('does not retain work rejected by admission', async () => {
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    const retained = [
+      queue.submit({ principalId: user, sessionId: 'same-session', run: abortableBlockedRun }),
+      queue.submit({ principalId: user, sessionId: 'same-session', run: abortableBlockedRun }),
+    ].map(observeRejection)
+
+    await expect(queue.submit({ principalId: user, sessionId: 'same-session', run: async () => {} }))
+      .rejects
+      .toBeInstanceOf(DiscordInputAdmissionError)
+    expect(queue.getSnapshot().global).toBe(2)
+
+    queue.shutdown()
+    for (const submission of retained)
+      await expect(submission).rejects.toThrow('shut down')
+  })
+})

--- a/packages/stage-ui/src/stores/mods/api/discordInputQueue.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/discordInputQueue.test.ts
@@ -190,6 +190,47 @@ describe('discord input queue', () => {
     expect(queue.getSnapshot().global).toBe(0)
   })
 
+  // https://github.com/moeru-ai/airi/pull/2097
+  it('continues dispatching after a cancelled operation never settles (CSR-09)', async () => {
+    // ROOT CAUSE:
+    //
+    // Aborting the active reservation only notified its operation. If that
+    // operation ignored the signal and never settled, drain() kept awaiting it
+    // and no later Discord reservation could dispatch.
+    //
+    // Before the fix, nextRun remains queued forever after cancelSession().
+    //
+    // We fixed this by making cancellation settle the scheduler's wait without
+    // requiring the underlying provider operation to cooperate.
+    const queue = createDiscordInputQueue()
+    const user = principal('123456789012345678')
+    const neverSettles = new Promise<void>(() => {})
+    const blocked = observeRejection(queue.submit({
+      principalId: user,
+      sessionId: 'cancelled-session',
+      run: async () => neverSettles,
+    }))
+    const nextRun = vi.fn()
+    const next = observeRejection(queue.submit({
+      principalId: user,
+      sessionId: 'next-session',
+      run: async () => nextRun(),
+    }))
+    await vi.waitFor(() => expect(queue.getSnapshot().active).toBe(1))
+
+    try {
+      expect(queue.cancelSession('cancelled-session')).toBe(1)
+      await vi.waitFor(() => expect(nextRun).toHaveBeenCalledTimes(1))
+    }
+    finally {
+      queue.shutdown()
+    }
+
+    await expect(blocked).rejects.toThrow('cancelled')
+    await expect(next).resolves.toBeUndefined()
+    expect(queue.getSnapshot().global).toBe(0)
+  })
+
   it('releases queued reservations when their wait times out', async () => {
     vi.useFakeTimers()
     const queue = createDiscordInputQueue({ limits: { queueTimeoutMs: 10 } })
@@ -208,13 +249,11 @@ describe('discord input queue', () => {
     await expect(first).rejects.toThrow('shut down')
   })
 
-  it('releases reservations once across disconnect cancellation and later task settlement', async () => {
+  // https://github.com/moeru-ai/airi/pull/2097
+  it('accepts new work after disconnect cancels an operation that never settles (CSR-09)', async () => {
     const queue = createDiscordInputQueue()
     const user = principal('123456789012345678')
-    let finishActive: () => void = () => {}
-    const activeRun = new Promise<void>((resolve) => {
-      finishActive = resolve
-    })
+    const activeRun = new Promise<void>(() => {})
     const activeSubmission = observeRejection(queue.submit({
       principalId: user,
       sessionId: 'disconnect-session',
@@ -229,10 +268,14 @@ describe('discord input queue', () => {
 
     expect(queue.cancelAll(new Error('transport disconnected'))).toBe(2)
     await expect(queuedSubmission).rejects.toThrow('transport disconnected')
-    expect(queue.getSnapshot().global).toBe(1)
+    await expect(activeSubmission).rejects.toThrow('transport disconnected')
+    expect(queue.getSnapshot().global).toBe(0)
 
-    finishActive()
-    await expect(activeSubmission).resolves.toBeUndefined()
+    await expect(queue.submit({
+      principalId: user,
+      sessionId: 'reconnected-session',
+      run: async () => {},
+    })).resolves.toBeUndefined()
     expect(queue.getSnapshot().global).toBe(0)
   })
 

--- a/packages/stage-ui/src/stores/mods/api/discordInputQueue.ts
+++ b/packages/stage-ui/src/stores/mods/api/discordInputQueue.ts
@@ -1,0 +1,393 @@
+const MAX_DISCORD_SNOWFLAKE = (1n << 64n) - 1n
+
+declare const discordPrincipalIdBrand: unique symbol
+
+/** A syntactically valid, non-zero Discord user snowflake. */
+export type DiscordPrincipalId = string & { readonly [discordPrincipalIdBrand]: true }
+
+/** Deterministic reason why a Discord reservation was not admitted. */
+export type DiscordInputAdmissionRejection
+  = | 'global-capacity'
+    | 'principal-capacity'
+    | 'session-capacity'
+    | 'shutdown'
+
+/** Capacity and wait policy for one Stage runtime's Discord input queue. */
+export interface DiscordInputQueueLimits {
+  /** Maximum retained work for one exact chat session. @default 2 */
+  sessionCapacity: number
+  /** Maximum retained work for one Discord user across all sessions. @default 4 */
+  principalCapacity: number
+  /** Maximum retained Discord work across this Stage runtime. @default 8 */
+  globalCapacity: number
+  /** Maximum time queued work may wait before dispatch, in milliseconds. @default 30000 */
+  queueTimeoutMs: number
+}
+
+/** Work accepted from the Discord-specific `input:text` boundary. */
+export interface DiscordInputWork {
+  /** Stable Discord user snowflake validated by {@link parseDiscordPrincipalId}. */
+  principalId: DiscordPrincipalId
+  /** Canonical chat session selected by the current context-bridge policy. */
+  sessionId: string
+  /** Runs only after principal-fair dispatch selects this reservation. */
+  run: (signal: AbortSignal) => Promise<void>
+}
+
+/** Read-only reservation counts used for diagnostics and security regression tests. */
+export interface DiscordInputQueueSnapshot {
+  /** Number of admitted reservations currently dispatching. */
+  active: number
+  /** Total admitted active plus queued reservations. */
+  global: number
+  /** Active plus queued reservation counts keyed by Discord user ID. */
+  principals: Record<string, number>
+  /** Active plus queued reservation counts keyed by exact chat session. */
+  sessions: Record<string, number>
+  /** Whether this runtime has permanently stopped accepting work. */
+  shutdown: boolean
+}
+
+/** Error returned when atomic admission rejects work before retaining it. */
+export class DiscordInputAdmissionError extends Error {
+  constructor(public readonly reason: DiscordInputAdmissionRejection) {
+    super(`Discord input rejected: ${reason}`)
+    this.name = 'DiscordInputAdmissionError'
+  }
+}
+
+interface Deferred {
+  resolve: () => void
+  reject: (error: unknown) => void
+}
+
+interface Reservation extends DiscordInputWork {
+  controller: AbortController
+  deferred: Deferred
+  released: boolean
+  settled: boolean
+  timeout: ReturnType<typeof setTimeout>
+}
+
+const defaultLimits: DiscordInputQueueLimits = {
+  sessionCapacity: 2,
+  principalCapacity: 4,
+  globalCapacity: 8,
+  queueTimeoutMs: 30_000,
+}
+
+function assertPositiveInteger(name: keyof DiscordInputQueueLimits, value: number) {
+  if (!Number.isSafeInteger(value) || value <= 0)
+    throw new RangeError(`${name} must be a positive safe integer`)
+}
+
+function resolveLimits(overrides: Partial<DiscordInputQueueLimits> | undefined): DiscordInputQueueLimits {
+  const limits = {
+    ...defaultLimits,
+    ...overrides,
+  }
+
+  for (const [name, value] of Object.entries(limits) as Array<[keyof DiscordInputQueueLimits, number]>)
+    assertPositiveInteger(name, value)
+
+  if (limits.sessionCapacity > limits.principalCapacity)
+    throw new RangeError('sessionCapacity must not exceed principalCapacity')
+  if (limits.principalCapacity >= limits.globalCapacity)
+    throw new RangeError('principalCapacity must be strictly below globalCapacity')
+
+  return limits
+}
+
+/**
+ * Parses an untrusted Discord user ID without falling back to display, channel,
+ * guild, or session identity. Discord snowflakes are non-zero unsigned 64-bit
+ * integers, represented as decimal strings at the protocol boundary.
+ */
+export function parseDiscordPrincipalId(value: unknown): DiscordPrincipalId | undefined {
+  if (typeof value !== 'string' || !/^[1-9]\d*$/.test(value))
+    return undefined
+
+  try {
+    if (BigInt(value) > MAX_DISCORD_SNOWFLAKE)
+      return undefined
+  }
+  catch {
+    return undefined
+  }
+
+  return value as DiscordPrincipalId
+}
+
+/**
+ * Creates the bounded, principal-fair admission boundary for Discord input.
+ * Admission and all three capacity increments happen synchronously, before the
+ * returned promise can enter a Web Lock or the chat orchestrator's FIFO.
+ */
+export function createDiscordInputQueue(options?: {
+  limits?: Partial<DiscordInputQueueLimits>
+}) {
+  const limits = resolveLimits(options?.limits)
+  const queuesByPrincipal = new Map<DiscordPrincipalId, Reservation[]>()
+  const readyPrincipals: DiscordPrincipalId[] = []
+  const readyPrincipalSet = new Set<DiscordPrincipalId>()
+  const principalCounts = new Map<DiscordPrincipalId, number>()
+  const sessionCounts = new Map<string, number>()
+
+  let active: Reservation | undefined
+  let draining = false
+  let globalCount = 0
+  let shutdown = false
+
+  function settle(reservation: Reservation, error?: unknown) {
+    if (reservation.settled)
+      return
+    reservation.settled = true
+    if (error === undefined)
+      reservation.deferred.resolve()
+    else
+      reservation.deferred.reject(error)
+  }
+
+  function release(reservation: Reservation) {
+    if (reservation.released)
+      return
+    reservation.released = true
+    clearTimeout(reservation.timeout)
+
+    globalCount -= 1
+
+    const principalCount = (principalCounts.get(reservation.principalId) ?? 1) - 1
+    if (principalCount === 0)
+      principalCounts.delete(reservation.principalId)
+    else
+      principalCounts.set(reservation.principalId, principalCount)
+
+    const sessionCount = (sessionCounts.get(reservation.sessionId) ?? 1) - 1
+    if (sessionCount === 0)
+      sessionCounts.delete(reservation.sessionId)
+    else
+      sessionCounts.set(reservation.sessionId, sessionCount)
+  }
+
+  function removeReadyPrincipal(principalId: DiscordPrincipalId) {
+    readyPrincipalSet.delete(principalId)
+    const index = readyPrincipals.indexOf(principalId)
+    if (index >= 0)
+      readyPrincipals.splice(index, 1)
+  }
+
+  function markPrincipalReady(principalId: DiscordPrincipalId) {
+    if (readyPrincipalSet.has(principalId))
+      return
+    if (!(queuesByPrincipal.get(principalId)?.length))
+      return
+    if (active?.principalId === principalId)
+      return
+
+    readyPrincipalSet.add(principalId)
+    readyPrincipals.push(principalId)
+  }
+
+  function removeQueuedReservation(reservation: Reservation) {
+    const queue = queuesByPrincipal.get(reservation.principalId)
+    if (!queue)
+      return false
+
+    const index = queue.indexOf(reservation)
+    if (index < 0)
+      return false
+
+    queue.splice(index, 1)
+    if (queue.length === 0) {
+      queuesByPrincipal.delete(reservation.principalId)
+      removeReadyPrincipal(reservation.principalId)
+    }
+    return true
+  }
+
+  function rejectQueuedReservation(reservation: Reservation, error: Error) {
+    if (!removeQueuedReservation(reservation))
+      return false
+    reservation.controller.abort(error)
+    release(reservation)
+    settle(reservation, error)
+    return true
+  }
+
+  function dequeueNext() {
+    const principalId = readyPrincipals.shift()
+    if (!principalId)
+      return undefined
+
+    readyPrincipalSet.delete(principalId)
+    const queue = queuesByPrincipal.get(principalId)
+    const reservation = queue?.shift()
+    if (!queue || !reservation)
+      return undefined
+
+    if (queue.length === 0)
+      queuesByPrincipal.delete(principalId)
+
+    return reservation
+  }
+
+  async function drain() {
+    if (draining)
+      return
+    draining = true
+
+    try {
+      while (true) {
+        if (shutdown)
+          return
+
+        const reservation = dequeueNext()
+        if (!reservation)
+          return
+
+        active = reservation
+        clearTimeout(reservation.timeout)
+
+        try {
+          await reservation.run(reservation.controller.signal)
+          settle(reservation)
+        }
+        catch (error) {
+          settle(reservation, error)
+        }
+        finally {
+          release(reservation)
+          active = undefined
+          markPrincipalReady(reservation.principalId)
+        }
+      }
+    }
+    finally {
+      draining = false
+    }
+  }
+
+  function scheduleDrain() {
+    queueMicrotask(() => void drain())
+  }
+
+  function submit(work: DiscordInputWork): Promise<void> {
+    if (shutdown)
+      return Promise.reject(new DiscordInputAdmissionError('shutdown'))
+
+    const sessionCount = sessionCounts.get(work.sessionId) ?? 0
+    if (sessionCount >= limits.sessionCapacity)
+      return Promise.reject(new DiscordInputAdmissionError('session-capacity'))
+
+    const principalCount = principalCounts.get(work.principalId) ?? 0
+    if (principalCount >= limits.principalCapacity)
+      return Promise.reject(new DiscordInputAdmissionError('principal-capacity'))
+
+    if (globalCount >= limits.globalCapacity)
+      return Promise.reject(new DiscordInputAdmissionError('global-capacity'))
+
+    let deferred: Deferred = {
+      resolve: () => {},
+      reject: () => {},
+    }
+    const result = new Promise<void>((resolve, reject) => {
+      deferred = { resolve, reject }
+    })
+
+    const reservation: Reservation = {
+      ...work,
+      controller: new AbortController(),
+      deferred,
+      released: false,
+      settled: false,
+      timeout: setTimeout(() => {
+        rejectQueuedReservation(reservation, new Error('Discord input expired before dispatch'))
+      }, limits.queueTimeoutMs),
+    }
+
+    // JavaScript execution is run-to-completion: checking every applicable
+    // limit and incrementing all ownership counters here forms one atomic
+    // admission decision before any async work can retain the reservation.
+    globalCount += 1
+    principalCounts.set(work.principalId, principalCount + 1)
+    sessionCounts.set(work.sessionId, sessionCount + 1)
+
+    const principalQueue = queuesByPrincipal.get(work.principalId) ?? []
+    principalQueue.push(reservation)
+    queuesByPrincipal.set(work.principalId, principalQueue)
+    markPrincipalReady(work.principalId)
+    scheduleDrain()
+
+    return result
+  }
+
+  function cancelQueued(where: (reservation: Reservation) => boolean, error: Error) {
+    let cancelled = 0
+
+    for (const queue of queuesByPrincipal.values()) {
+      // Filtering creates a stable cancellation set because rejecting a
+      // reservation removes it from this queue and may delete its map entry.
+      for (const reservation of queue.filter(where)) {
+        if (rejectQueuedReservation(reservation, error))
+          cancelled += 1
+      }
+    }
+
+    return cancelled
+  }
+
+  function cancelSession(sessionId: string, error = new Error('Discord input session cancelled')) {
+    let cancelled = cancelQueued(reservation => reservation.sessionId === sessionId, error)
+
+    if (active?.sessionId === sessionId && !active.controller.signal.aborted) {
+      active.controller.abort(error)
+      cancelled += 1
+    }
+
+    return cancelled
+  }
+
+  function cancelAll(error = new Error('Discord input cancelled')) {
+    let cancelled = cancelQueued(() => true, error)
+
+    if (active && !active.controller.signal.aborted) {
+      active.controller.abort(error)
+      cancelled += 1
+    }
+
+    return cancelled
+  }
+
+  function stop(error = new Error('Discord input queue shut down')) {
+    if (shutdown)
+      return
+    shutdown = true
+    cancelAll(error)
+
+    // A shutting-down runtime cannot admit replacement work. Release its
+    // active reservation immediately; the task's eventual finally path is
+    // guarded so ownership is still released exactly once.
+    if (active) {
+      release(active)
+      settle(active, error)
+    }
+  }
+
+  function getSnapshot(): DiscordInputQueueSnapshot {
+    return {
+      active: active && !active.released ? 1 : 0,
+      global: globalCount,
+      principals: Object.fromEntries(principalCounts),
+      sessions: Object.fromEntries(sessionCounts),
+      shutdown,
+    }
+  }
+
+  return {
+    submit,
+    cancelSession,
+    cancelAll,
+    shutdown: stop,
+    getSnapshot,
+  }
+}

--- a/packages/stage-ui/src/stores/mods/api/discordInputQueue.ts
+++ b/packages/stage-ui/src/stores/mods/api/discordInputQueue.ts
@@ -231,6 +231,29 @@ export function createDiscordInputQueue(options?: {
     return reservation
   }
 
+  async function runUntilCancelled(reservation: Reservation) {
+    const { signal } = reservation.controller
+    signal.throwIfAborted()
+
+    let rejectCancellation: (error: unknown) => void = () => {}
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      rejectCancellation = reject
+    })
+    const onAbort = () => rejectCancellation(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    // Promise.race observes the provider promise even after cancellation wins.
+    // The provider may remain pending, but it can no longer retain scheduler
+    // ownership or surface a late rejection as an unhandled promise.
+    const operation = Promise.resolve().then(() => reservation.run(signal))
+    try {
+      await Promise.race([operation, cancellation])
+    }
+    finally {
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+
   async function drain() {
     if (draining)
       return
@@ -249,7 +272,7 @@ export function createDiscordInputQueue(options?: {
         clearTimeout(reservation.timeout)
 
         try {
-          await reservation.run(reservation.controller.signal)
+          await runUntilCancelled(reservation)
           settle(reservation)
         }
         catch (error) {

--- a/services/discord-bot/src/adapters/airi-adapter.ts
+++ b/services/discord-bot/src/adapters/airi-adapter.ts
@@ -45,7 +45,7 @@ function normalizeDiscordMetadata(discord?: Discord): Discord | undefined {
   return {
     ...discord,
     guildMember: {
-      id: guildMember.id ?? guildMember.displayName ?? guildMember.nickname ?? '',
+      id: guildMember.id,
       nickname: guildMember.nickname ?? guildMember.displayName ?? '',
       displayName: guildMember.displayName ?? guildMember.nickname ?? '',
     },


### PR DESCRIPTION
## Summary

- bound Discord-origin retained input before preprocessing, Web Lock acquisition, and the core orchestration queue
- enforce admission limits of 2 retained items per session, 4 per verified Discord principal, and 8 globally
- schedule admitted work round-robin across principals while preserving FIFO order within each session
- release capacity exactly once across success, provider/preprocessing failure, rejection, timeout, cancellation, disconnect, and shutdown
- reject missing or malformed Discord principal identifiers instead of falling back to display, channel, or session identifiers

## Security impact

The Discord `MessageCreate` path previously forwarded every retained input into an unbounded core FIFO. A stable Discord user ID was present in `event.data.discord.guildMember.id`, but admission ignored it, so one principal could retain work across multiple sessions and monopolize scheduling.

This change adds a bounded admission layer before expensive preprocessing and orchestration. Only non-zero decimal uint64 Discord IDs are accepted as principals. Non-Discord inputs retain their existing behavior. The Discord adapter also no longer falls back to display names as identifiers.

## Validation

- pre-fix regression reproduction failed as expected: all 6 retained inputs reached ingest instead of the principal cap of 4
- focused Node tests: 28 passed
- focused browser CSR-09 tests: 3 passed
- full `@proj-airi/stage-ui` suite: 99 files, 627 tests passed
- `@proj-airi/stage-ui` typecheck passed
- `@proj-airi/discord-bot` typecheck passed
- root typecheck passed across 49 projects
- `pnpm lint` passed with zero errors; seven pre-existing warnings remain only in untouched files
- `git diff --check` passed
- negative controls verified the regression coverage:
  - disabling the principal cap admitted 6 items instead of 4
  - disabling fair scheduling produced `A1, A2, B1, B2` instead of `A1, B1, A2, B2`
- the staged diff and committed diff matched SHA-256 `c0dd59f35c4550e8e76df0301d2ebaac9058690313c5774e9caca517a3aa6348`

`pnpm -F @proj-airi/discord-bot test:run` was also attempted, but that package does not define a `test:run` script. Its typecheck passed.
