### PR TITLE
feat(stage-ui): speak the native Anthropic Messages API in the Anthropic provider

### DIFF
--- a/packages/stage-ui/src/libs/providers/providers/anthropic/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/index.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { ProviderValidationCheck } from '../../types'
 import { createOpenAICompatibleValidators } from '../../validators'
 import { defineProvider } from '../registry'
+import { createNativeAnthropicFetch } from './native'
 
 const anthropicConfigSchema = z.object({
   apiKey: z
@@ -19,21 +20,16 @@ const anthropicConfigSchema = z.object({
 type AnthropicConfig = z.input<typeof anthropicConfigSchema>
 
 function createAnthropic(apiKey: string, baseURL: string = 'https://api.anthropic.com/v1/') {
-  const anthropicFetch = async (input: any, init: any) => {
-    init.headers ??= {}
-    if (Array.isArray(init.headers))
-      init.headers.push(['anthropic-dangerous-direct-browser-access', 'true'])
-    else if (init.headers instanceof Headers)
-      init.headers.append('anthropic-dangerous-direct-browser-access', 'true')
-    else
-      init.headers['anthropic-dangerous-direct-browser-access'] = 'true'
-
-    return fetch(input, init)
-  }
+  // The translating fetch speaks the native Messages API (`{baseURL}messages`)
+  // while xsai keeps emitting OpenAI-shaped requests — see ./native.ts. This
+  // replaces the previous reliance on Anthropic's OpenAI-compatible endpoint,
+  // which Anthropic documents as a testing-only shim, and makes
+  // `/v1/messages`-only proxies usable via a custom Base URL (Issue #1565).
+  const nativeFetch = createNativeAnthropicFetch({ apiKey })
 
   return merge(
-    createChatProvider({ apiKey, fetch: anthropicFetch, baseURL }),
-    createModelProvider({ apiKey, fetch: anthropicFetch, baseURL }),
+    createChatProvider({ apiKey, fetch: nativeFetch, baseURL }),
+    createModelProvider({ apiKey, fetch: nativeFetch, baseURL }),
   )
 }
 

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.contract.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.contract.test.ts
@@ -1,0 +1,183 @@
+import type { Tool } from '@xsai/shared-chat'
+
+import { generateText } from '@xsai/generate-text'
+import { stepCountAtLeast } from '@xsai/shared-chat'
+import { streamText } from '@xsai/stream-text'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createNativeAnthropicFetch } from './native'
+
+/**
+ * Consumer-contract tests: the REAL xsai pipeline (streamText / generateText,
+ * exactly what `stores/llm.ts` and the provider validators run) is driven
+ * through the adapter, with only the Anthropic upstream stubbed. This locks
+ * the two boundaries a unit test cannot: xsai must be able to parse the
+ * translated stream, and the OpenAI-shaped history xsai builds between tool
+ * rounds must translate back into a valid Messages request.
+ */
+
+const BASE_URL = 'https://api.anthropic.com/v1/'
+
+function sseResponse(frames: string[]): Response {
+  return new Response(frames.join(''), { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+}
+
+const textRoundFrames = [
+  'data: {"type":"message_start","message":{"id":"msg_text","model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":9}}}\n\n',
+  'data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}\n\n',
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"let me think"}}\n\n',
+  'data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+  'data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hel"}}\n\n',
+  'data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"lo"}}\n\n',
+  'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}\n\n',
+  'data: {"type":"message_stop"}\n\n',
+]
+
+const toolRoundFrames = [
+  'data: {"type":"message_start","message":{"id":"msg_tool","model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":20}}}\n\n',
+  'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_w1","name":"get_weather"}}\n\n',
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":"}}\n\n',
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"Tokyo\\"}"}}\n\n',
+  'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":6}}\n\n',
+  'data: {"type":"message_stop"}\n\n',
+]
+
+describe('xsai consumer contract', () => {
+  it('streamText consumes a translated text stream: text, reasoning, finish usage', async () => {
+    const baseFetch = vi.fn().mockResolvedValueOnce(sseResponse(textRoundFrames))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+
+    const events: Array<Record<string, unknown>> = []
+    const result = streamText({
+      apiKey: 'sk-ant-test',
+      baseURL: BASE_URL,
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'hi' }],
+      fetch: nativeFetch,
+      streamOptions: { includeUsage: true },
+      onEvent: event => void events.push(event as Record<string, unknown>),
+    })
+
+    const steps = await result.steps
+    expect(steps).toHaveLength(1)
+    expect(steps[0].text).toBe('Hello')
+    expect(steps[0].finishReason).toBe('stop')
+    expect(steps[0].usage).toEqual({ prompt_tokens: 9, completion_tokens: 4, total_tokens: 13 })
+
+    // Thinking deltas surface on xsai's native reasoning channel.
+    expect(events.some(event => event.type === 'reasoning-delta' && event.text === 'let me think')).toBe(true)
+
+    const messages = await result.messages
+    const assistantTurn = messages[messages.length - 1]
+    expect(assistantTurn.role).toBe('assistant')
+    expect(assistantTurn.content).toBe('Hello')
+  })
+
+  it('streamText drives a full tool loop through both translation directions', async () => {
+    const baseFetch = vi.fn()
+      .mockResolvedValueOnce(sseResponse(toolRoundFrames))
+      .mockResolvedValueOnce(sseResponse([
+        'data: {"type":"message_start","message":{"id":"msg_final","model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":30}}}\n\n',
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Sunny in Tokyo."}}\n\n',
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\n\n',
+        'data: {"type":"message_stop"}\n\n',
+      ]))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+
+    const execute = vi.fn(async (input: { city: string }) => `Sunny in ${input.city}`)
+    const weatherTool = {
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        description: 'Get the weather for a city.',
+        parameters: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'], additionalProperties: false },
+      },
+      execute,
+    } as unknown as Tool
+
+    const result = streamText({
+      apiKey: 'sk-ant-test',
+      baseURL: BASE_URL,
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'weather in Tokyo?' }],
+      fetch: nativeFetch,
+      tools: [weatherTool],
+      // Mirrors stores/llm.ts (streamFrom), which allows multi-step tool rounds.
+      stopWhen: stepCountAtLeast(10),
+      streamOptions: { includeUsage: true },
+    })
+
+    const steps = await result.steps
+    expect(execute).toHaveBeenCalledWith({ city: 'Tokyo' }, expect.objectContaining({ toolCallId: 'toolu_w1' }))
+    expect(steps[steps.length - 1].text).toBe('Sunny in Tokyo.')
+
+    // Round 2 is built from the OpenAI-shaped history xsai accumulated — the
+    // adapter must translate it back into paired tool_use / tool_result
+    // blocks the Messages API accepts.
+    expect(baseFetch).toHaveBeenCalledTimes(2)
+    const secondBody = JSON.parse(String((baseFetch.mock.calls[1] as [string, RequestInit])[1].body)) as Record<string, any>
+    expect(secondBody.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'weather in Tokyo?' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_w1', name: 'get_weather', input: { city: 'Tokyo' } }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_w1', content: 'Sunny in Tokyo' }] },
+    ])
+    expect(secondBody.tools).toHaveLength(1)
+    // claude-sonnet-4-5 is not adaptive-thinking-default: the field must be absent.
+    expect(secondBody.thinking).toBeUndefined()
+    // xsai's runtime-only fields must never leak into the native body.
+    expect(secondBody.stream_options).toBeUndefined()
+    expect(secondBody.stop_when).toBeUndefined()
+  })
+
+  it('streamText surfaces upstream HTTP errors with the Anthropic error payload', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ type: 'error', error: { type: 'authentication_error', message: 'invalid x-api-key' } }),
+      { status: 401 },
+    ))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'bad', fetch: baseFetch })
+
+    const result = streamText({
+      apiKey: 'bad',
+      baseURL: BASE_URL,
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'hi' }],
+      fetch: nativeFetch,
+    })
+
+    await expect(result.steps).rejects.toThrow(/401[\s\S]*invalid x-api-key/)
+    // streamText rejects every deferred on failure; consume them the way
+    // stores/llm.ts does, or they surface as unhandled rejections.
+    await expect(result.messages).rejects.toThrow()
+    await expect(result.usage).rejects.toThrow()
+    await expect(result.totalUsage).rejects.toThrow()
+  })
+
+  it('generateText (the provider validators path) completes non-streaming', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      id: 'msg_ping',
+      model: 'claude-sonnet-4-5-20250929',
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'pong' }],
+      usage: { input_tokens: 3, output_tokens: 1 },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+
+    // Mirrors createOpenAICompatibleValidators' connectivity check, including
+    // its max_tokens: 1 — the Messages API requires the field, so the check
+    // only works if the adapter forwards it.
+    const { text } = await generateText({
+      apiKey: 'sk-ant-test',
+      baseURL: BASE_URL,
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'ping' }],
+      fetch: nativeFetch,
+      max_tokens: 1,
+    } as Parameters<typeof generateText>[0])
+
+    expect(text).toBe('pong')
+    const sent = JSON.parse(String((baseFetch.mock.calls[0] as [string, RequestInit])[1].body)) as Record<string, any>
+    expect(sent.max_tokens).toBe(1)
+    expect((baseFetch.mock.calls[0] as [string])[0]).toBe('https://api.anthropic.com/v1/messages')
+  })
+})

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.contract.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.contract.test.ts
@@ -153,6 +153,61 @@ describe('xsai consumer contract', () => {
     await expect(result.totalUsage).rejects.toThrow()
   })
 
+  // A zero-argument tool (`builtIn_mcpListTools` in src/tools/mcp.ts is one)
+  // makes Anthropic open and close the tool_use block without ever sending an
+  // `input_json_delta`, so the translated tool call carries no argument text.
+  it('runs a zero-argument tool whose tool_use block streams no input deltas', async () => {
+    const baseFetch = vi.fn()
+      .mockResolvedValueOnce(sseResponse([
+        'data: {"type":"message_start","message":{"id":"msg_noargs","model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":11}}}\n\n',
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_list","name":"list_tools"}}\n\n',
+        'data: {"type":"content_block_stop","index":0}\n\n',
+        'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":3}}\n\n',
+        'data: {"type":"message_stop"}\n\n',
+      ]))
+      .mockResolvedValueOnce(sseResponse([
+        'data: {"type":"message_start","message":{"id":"msg_after","model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":19}}}\n\n',
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Two tools."}}\n\n',
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}\n\n',
+        'data: {"type":"message_stop"}\n\n',
+      ]))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+
+    const execute = vi.fn(async () => 'search, weather')
+    const listTool = {
+      type: 'function',
+      function: {
+        name: 'list_tools',
+        description: 'List all available tools.',
+        parameters: { type: 'object', properties: {}, additionalProperties: false },
+      },
+      execute,
+    } as unknown as Tool
+
+    const result = streamText({
+      apiKey: 'sk-ant-test',
+      baseURL: BASE_URL,
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'what tools do you have?' }],
+      fetch: nativeFetch,
+      tools: [listTool],
+      stopWhen: stepCountAtLeast(10),
+    })
+
+    const steps = await result.steps
+    expect(execute).toHaveBeenCalledTimes(1)
+    // Empty argument text must reach the tool as an empty object, not blow up
+    // parsing and abort the call before it runs.
+    expect(execute).toHaveBeenCalledWith({}, expect.objectContaining({ toolCallId: 'toolu_list' }))
+    expect(steps[steps.length - 1].text).toBe('Two tools.')
+
+    // Round 2 must still carry a well-formed tool_use/tool_result pair.
+    const secondBody = JSON.parse(String((baseFetch.mock.calls[1] as [string, RequestInit])[1].body)) as Record<string, any>
+    expect(secondBody.messages[1]).toEqual({ role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_list', name: 'list_tools', input: {} }] })
+    expect(secondBody.messages[2]).toEqual({ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_list', content: 'search, weather' }] })
+  })
+
   it('generateText (the provider validators path) completes non-streaming', async () => {
     const baseFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       id: 'msg_ping',

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.contract.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.contract.test.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@xsai/shared-chat'
+import type { Event, Tool } from '@xsai/shared-chat'
 
 import { generateText } from '@xsai/generate-text'
 import { stepCountAtLeast } from '@xsai/shared-chat'
@@ -47,7 +47,7 @@ describe('xsai consumer contract', () => {
     const baseFetch = vi.fn().mockResolvedValueOnce(sseResponse(textRoundFrames))
     const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
 
-    const events: Array<Record<string, unknown>> = []
+    const events: Event[] = []
     const result = streamText({
       apiKey: 'sk-ant-test',
       baseURL: BASE_URL,
@@ -55,17 +55,17 @@ describe('xsai consumer contract', () => {
       messages: [{ role: 'user', content: 'hi' }],
       fetch: nativeFetch,
       streamOptions: { includeUsage: true },
-      onEvent: event => void events.push(event as Record<string, unknown>),
+      onEvent: event => void events.push(event),
     })
 
     const steps = await result.steps
     expect(steps).toHaveLength(1)
     expect(steps[0].text).toBe('Hello')
     expect(steps[0].finishReason).toBe('stop')
-    expect(steps[0].usage).toEqual({ prompt_tokens: 9, completion_tokens: 4, total_tokens: 13 })
+    expect(steps[0].usage).toEqual({ inputTokens: 9, outputTokens: 4, totalTokens: 13 })
 
     // Thinking deltas surface on xsai's native reasoning channel.
-    expect(events.some(event => event.type === 'reasoning-delta' && event.text === 'let me think')).toBe(true)
+    expect(events.some(event => event.type === 'reasoning.delta' && event.delta === 'let me think')).toBe(true)
 
     const messages = await result.messages
     const assistantTurn = messages[messages.length - 1]

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -567,6 +567,51 @@ describe('fetch wiring', () => {
     expect(sent.tools[0].input_schema).toEqual(parameters)
   })
 
+  it('omits tool_result content when the tool produced nothing', async () => {
+    // `builtIn_mcpListTools` returns '' on its failure path, and the Messages
+    // API represents an empty result by leaving `content` out entirely.
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [
+        { role: 'user', content: 'list them' },
+        { role: 'assistant', tool_calls: [{ id: 'toolu_1', type: 'function', function: { name: 'list_tools', arguments: '{}' } }] },
+        { role: 'tool', tool_call_id: 'toolu_1', content: '' },
+      ],
+    })
+
+    expect(sent.messages[2]).toEqual({
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'toolu_1' }],
+    })
+    expect('content' in sent.messages[2].content[0]).toBe(false)
+  })
+
+  it('omits tool_result content when every content part is empty', async () => {
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [
+        { role: 'user', content: 'list them' },
+        { role: 'assistant', tool_calls: [{ id: 'toolu_1', type: 'function', function: { name: 'list_tools', arguments: '{}' } }] },
+        { role: 'tool', tool_call_id: 'toolu_1', content: [{ type: 'text', text: '' }] },
+      ],
+    })
+
+    expect(sent.messages[2].content[0]).toEqual({ type: 'tool_result', tool_use_id: 'toolu_1' })
+  })
+
+  it('keeps tool_result content when the tool produced output', async () => {
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [
+        { role: 'user', content: 'weather?' },
+        { role: 'assistant', tool_calls: [{ id: 'toolu_1', type: 'function', function: { name: 'get_weather', arguments: '{}' } }] },
+        { role: 'tool', tool_call_id: 'toolu_1', content: 'Sunny' },
+      ],
+    })
+
+    expect(sent.messages[2].content[0]).toEqual({ type: 'tool_result', tool_use_id: 'toolu_1', content: 'Sunny' })
+  })
+
   it('forwards a structured tool result as JSON text instead of throwing', async () => {
     // xsai stringifies structured tool returns before they become message
     // content, so this covers a caller that serializes the object itself: the

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -538,6 +538,42 @@ describe('fetch wiring', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/1565
+  it('keeps bearer auth for custom Base URLs, which /v1/messages proxies commonly require (Issue #1565)', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: 'end_turn' }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'proxy-key', fetch: baseFetch })
+
+    await nativeFetch('https://proxy.example/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer proxy-key' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-5-20250929', messages: [{ role: 'user', content: 'ping' }] }),
+    })
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    // antigravity-claude-proxy (the proxy this issue names) authenticates with
+    // `Authorization: Bearer $API_KEY`; dropping it would 401 before the
+    // rewritten request ever reaches /messages.
+    expect(init.headers.Authorization).toBe('Bearer proxy-key')
+    // Proxies that instead mirror Anthropic's own scheme still get x-api-key.
+    expect(init.headers['x-api-key']).toBe('proxy-key')
+  })
+
+  it('strips bearer auth only on the official host, not on look-alike hosts', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: 'end_turn' }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'k', fetch: baseFetch })
+
+    // A gateway that borrows Anthropic's path layout, or puts the official host
+    // in a subdomain, is still third-party and keeps its bearer header.
+    await nativeFetch('https://api.anthropic.com.gateway.example/v1/chat/completions', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer gateway-token' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+
+    const [, init] = baseFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(init.headers.Authorization).toBe('Bearer gateway-token')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1565
   it('rewrites custom proxy base URLs, keeping the path prefix and query (Issue #1565)', async () => {
     const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: 'end_turn' }))
     const nativeFetch = createNativeAnthropicFetch({ apiKey: 'k', fetch: baseFetch })

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -537,6 +537,37 @@ describe('fetch wiring', () => {
     expect(init.signal).toBe(abortController.signal)
   })
 
+  it('forwards a structured tool result as JSON text instead of throwing', async () => {
+    // xsai stringifies structured tool returns before they become message
+    // content, so this covers a caller that serializes the object itself: the
+    // translation must not blow up mid-request on a non-array content value.
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [
+        { role: 'user', content: 'list them' },
+        { role: 'assistant', tool_calls: [{ id: 'toolu_1', type: 'function', function: { name: 'mcp_call', arguments: '{}' } }] },
+        { role: 'tool', tool_call_id: 'toolu_1', content: { isError: false, structuredContent: { count: 2 } } },
+      ],
+    })
+
+    expect(sent.messages[2]).toEqual({
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: '{"isError":false,"structuredContent":{"count":2}}' }],
+    })
+  })
+
+  it('forwards a structured message content value as JSON text instead of throwing', async () => {
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: { unexpected: 'shape' } }],
+    })
+
+    expect(sent.messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: '{"unexpected":"shape"}' }],
+    })
+  })
+
   // https://github.com/moeru-ai/airi/issues/1565
   it('keeps bearer auth for custom Base URLs, which /v1/messages proxies commonly require (Issue #1565)', async () => {
     const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: 'end_turn' }))

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -537,6 +537,36 @@ describe('fetch wiring', () => {
     expect(init.signal).toBe(abortController.signal)
   })
 
+  it('completes tool schemas that arrive without a type, preserving the rest', async () => {
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [
+        // `rawTool({ parameters: {} })` in @xsai/tool emits exactly this for a
+        // zero-argument tool: no `type`, so the Messages API has no object
+        // schema to validate against.
+        { type: 'function', function: { name: 'zero_args', description: 'no inputs', parameters: { additionalProperties: false } } },
+        { type: 'function', function: { name: 'empty_schema', description: 'no inputs', parameters: {} } },
+      ],
+    })
+
+    expect(sent.tools).toEqual([
+      { name: 'zero_args', description: 'no inputs', input_schema: { additionalProperties: false, type: 'object' } },
+      { name: 'empty_schema', description: 'no inputs', input_schema: { type: 'object' } },
+    ])
+  })
+
+  it('leaves a complete tool schema untouched', async () => {
+    const parameters = { type: 'object', properties: { city: { type: 'string' } }, required: ['city'], additionalProperties: false }
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [{ type: 'function', function: { name: 'get_weather', parameters } }],
+    })
+
+    expect(sent.tools[0].input_schema).toEqual(parameters)
+  })
+
   it('forwards a structured tool result as JSON text instead of throwing', async () => {
     // xsai stringifies structured tool returns before they become message
     // content, so this covers a caller that serializes the object itself: the

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -424,6 +424,42 @@ describe('sse translation', () => {
     expect(chunks[chunks.length - 1].choices[0].finish_reason).toBe('tool_calls')
   })
 
+  it('closes an argument-less tool block with an empty object literal', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_2b","model":"m","usage":{"input_tokens":1}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_0","name":"list_tools"}}\n\n',
+      'data: {"type":"content_block_stop","index":0}\n\n',
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    // A tool registered with an empty schema streams no input_json_delta, so
+    // the argument text must be completed on block stop to stay valid JSON.
+    const toolChunks = chunks.filter(chunk => chunk.choices[0].delta.tool_calls)
+    const args = toolChunks.map(chunk => chunk.choices[0].delta.tool_calls![0].function!.arguments).join('')
+    expect(args).toBe('{}')
+    expect(toolChunks[toolChunks.length - 1].choices[0].delta.tool_calls).toEqual([
+      { index: 0, id: 'toolu_0', type: 'function', function: { name: 'list_tools', arguments: '{}' } },
+    ])
+  })
+
+  it('does not append an empty object when the tool block already streamed arguments', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_2c","model":"m","usage":{"input_tokens":1}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"get_weather"}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":\\"Tokyo\\"}"}}\n\n',
+      'data: {"type":"content_block_stop","index":0}\n\n',
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":2}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    const toolChunks = chunks.filter(chunk => chunk.choices[0].delta.tool_calls)
+    const args = toolChunks.map(chunk => chunk.choices[0].delta.tool_calls![0].function!.arguments).join('')
+    expect(args).toBe('{"city":"Tokyo"}')
+  })
+
   it('maps thinking deltas to reasoning_content and drops signature deltas', async () => {
     const output = await streamThrough([[
       'data: {"type":"message_start","message":{"id":"msg_3","model":"m","usage":{"input_tokens":1}}}\n\n',

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -1,0 +1,643 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createNativeAnthropicFetch } from './native'
+
+interface ChatChunkToolCall {
+  index?: number
+  id?: string
+  type?: string
+  function?: { name?: string, arguments?: string }
+}
+
+interface ChatChunk {
+  id: string
+  object: string
+  created: number
+  model: string
+  choices: Array<{
+    index: number
+    delta: { role?: string, content?: string, reasoning_content?: string, tool_calls?: ChatChunkToolCall[] }
+    finish_reason: string | null
+  }>
+  usage?: { prompt_tokens: number, completion_tokens: number, total_tokens: number }
+  error?: unknown
+}
+
+const CHAT_URL = 'https://api.anthropic.com/v1/chat/completions'
+
+function jsonResponse(payload: unknown, status = 200, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(payload), { status, headers })
+}
+
+/**
+ * Drives the public fetch surface with a stubbed upstream and captures what
+ * was actually POSTed to the Messages endpoint.
+ */
+async function capture(requestBody: Record<string, unknown>, upstream?: Response) {
+  const baseFetch = vi.fn().mockResolvedValue(upstream ?? jsonResponse({ content: [], stop_reason: 'end_turn' }))
+  const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+  const response = await nativeFetch(CHAT_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer sk-ant-test' },
+    body: JSON.stringify(requestBody),
+  })
+  const [url, init] = baseFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+  return { response, url, init, sent: JSON.parse(String(init.body)) as Record<string, any>, baseFetch }
+}
+
+/** Streams Anthropic SSE slices through the adapter and returns the translated SSE text. */
+async function streamThrough(slices: Array<string | Uint8Array>): Promise<string> {
+  const encoder = new TextEncoder()
+  const upstreamBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const slice of slices)
+        controller.enqueue(typeof slice === 'string' ? encoder.encode(slice) : slice)
+      controller.close()
+    },
+  })
+  const baseFetch = vi.fn().mockResolvedValue(new Response(upstreamBody, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }))
+  const nativeFetch = createNativeAnthropicFetch({ apiKey: 'k', fetch: baseFetch })
+  const response = await nativeFetch(CHAT_URL, {
+    method: 'POST',
+    body: JSON.stringify({ stream: true, messages: [{ role: 'user', content: 'hi' }] }),
+  })
+  return response.text()
+}
+
+function parseChunks(sse: string): ChatChunk[] {
+  return sse
+    .split('\n\n')
+    .map(block => block.trim())
+    .filter(block => block.startsWith('data:'))
+    .map(block => block.slice(5).trim())
+    .filter(data => data !== '[DONE]')
+    .map(data => JSON.parse(data) as ChatChunk)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('request translation', () => {
+  it('hoists system and developer messages into a single system prompt', async () => {
+    const { sent } = await capture({
+      model: 'claude-sonnet-4-5-20250929',
+      messages: [
+        { role: 'system', content: 'You are AIRI.' },
+        { role: 'developer', content: 'Stay in character.' },
+        { role: 'user', content: 'hi' },
+      ],
+    })
+
+    expect(sent.system).toBe('You are AIRI.\nStay in character.')
+    expect(sent.messages).toEqual([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }])
+    expect(sent.model).toBe('claude-sonnet-4-5-20250929')
+  })
+
+  it('defaults max_tokens to the all-model-safe floor and honors explicit caps', async () => {
+    expect((await capture({ messages: [{ role: 'user', content: 'hi' }] })).sent.max_tokens).toBe(4096)
+    expect((await capture({ max_tokens: 1, messages: [{ role: 'user', content: 'hi' }] })).sent.max_tokens).toBe(1)
+    expect((await capture({ max_completion_tokens: 42, messages: [{ role: 'user', content: 'hi' }] })).sent.max_tokens).toBe(42)
+  })
+
+  it('clamps temperature into [0, 1] and never sends temperature and top_p together', async () => {
+    const both = (await capture({ messages: [{ role: 'user', content: 'hi' }], temperature: 1.4, top_p: 0.9 })).sent
+    // Claude 4+ rejects requests carrying both sampling params.
+    expect(both.temperature).toBe(1)
+    expect(both.top_p).toBeUndefined()
+
+    expect((await capture({ messages: [{ role: 'user', content: 'hi' }], temperature: -0.3 })).sent.temperature).toBe(0)
+    expect((await capture({ messages: [{ role: 'user', content: 'hi' }], top_p: 0.5 })).sent.top_p).toBe(0.5)
+  })
+
+  it('drops whitespace-only stop sequences the Messages API rejects', async () => {
+    const { sent } = await capture({ messages: [{ role: 'user', content: 'hi' }], stop: ['END', '\n', '  '] })
+    expect(sent.stop_sequences).toEqual(['END'])
+
+    const allBlank = (await capture({ messages: [{ role: 'user', content: 'hi' }], stop: '\n' })).sent
+    expect(allBlank.stop_sequences).toBeUndefined()
+  })
+
+  it('only whitelisted fields reach the native body', async () => {
+    // Runtime-only options that xsai serializes into the wire body must not
+    // leak: the Messages API rejects unknown top-level fields with a 400.
+    const leakedRuntimeOptions = { capture_tool_errors: true, wait_for_tools: true, stream_options: { include_usage: true } }
+    const { sent } = await capture({ messages: [{ role: 'user', content: 'hi' }], ...leakedRuntimeOptions })
+
+    expect(Object.keys(sent).sort()).toEqual(['max_tokens', 'messages', 'model'])
+  })
+
+  it('sets stream only when requested', async () => {
+    expect((await capture({ messages: [{ role: 'user', content: 'hi' }] })).sent.stream).toBeUndefined()
+  })
+
+  it('maps tools and tool_choice variants', async () => {
+    const base = {
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [{ type: 'function', function: { name: 'web_search', description: 'Search.', parameters: { type: 'object', properties: {} } } }],
+    }
+
+    const auto = (await capture({ ...base, tool_choice: 'auto' })).sent
+    expect(auto.tools).toEqual([{ name: 'web_search', description: 'Search.', input_schema: { type: 'object', properties: {} } }])
+    expect(auto.tool_choice).toEqual({ type: 'auto' })
+
+    expect((await capture({ ...base, tool_choice: 'none' })).sent.tool_choice).toEqual({ type: 'none' })
+    expect((await capture({ ...base, tool_choice: 'required' })).sent.tool_choice).toEqual({ type: 'any' })
+    expect((await capture({ ...base, tool_choice: { type: 'function', function: { name: 'web_search' } } })).sent.tool_choice).toEqual({ type: 'tool', name: 'web_search' })
+  })
+
+  it('disables thinking for tool requests only on adaptive-default models', async () => {
+    const tools = [{ type: 'function', function: { name: 't', parameters: {} } }]
+
+    // Sonnet 5 family: adaptive thinking is ON when the field is omitted, and
+    // the OpenAI-shaped history cannot echo signed thinking blocks back — so
+    // tool loops need an explicit off switch.
+    expect((await capture({ model: 'claude-sonnet-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toEqual({ type: 'disabled' })
+    expect((await capture({ model: 'anthropic/claude-sonnet-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toEqual({ type: 'disabled' })
+
+    // Everything else: omitting the field already means off, and older models
+    // may reject the field outright — never send it.
+    expect((await capture({ model: 'claude-sonnet-4-5-20250929', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
+    expect((await capture({ model: 'claude-opus-4-8', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
+    expect((await capture({ model: 'claude-fable-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
+
+    // No tools -> never sent, regardless of model.
+    expect((await capture({ model: 'claude-sonnet-5', messages: [{ role: 'user', content: 'hi' }] })).sent.thinking).toBeUndefined()
+  })
+
+  it('converts assistant tool_calls into tool_use blocks and tolerates malformed arguments', async () => {
+    const { sent } = await capture({
+      messages: [
+        { role: 'user', content: 'weather?' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            { id: 'toolu_1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Tokyo"}' } },
+            { id: 'toolu_2', type: 'function', function: { name: 'get_weather', arguments: '{not json' } },
+          ],
+        },
+      ],
+    })
+
+    expect(sent.messages[1]).toEqual({
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 'toolu_1', name: 'get_weather', input: { city: 'Tokyo' } },
+        { type: 'tool_use', id: 'toolu_2', name: 'get_weather', input: {} },
+      ],
+    })
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1565
+  it('merges consecutive tool results into one user turn for strict alternation (Issue #1565)', async () => {
+    const { sent } = await capture({
+      messages: [
+        { role: 'user', content: 'weather in two cities' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            { id: 'toolu_1', type: 'function', function: { name: 'w', arguments: '{}' } },
+            { id: 'toolu_2', type: 'function', function: { name: 'w', arguments: '{}' } },
+          ],
+        },
+        { role: 'tool', tool_call_id: 'toolu_1', content: 'Sunny' },
+        { role: 'tool', tool_call_id: 'toolu_2', content: [{ type: 'text', text: 'Rainy' }] },
+      ],
+    })
+
+    expect(sent.messages).toHaveLength(3)
+    expect(sent.messages[2]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'toolu_1', content: 'Sunny' },
+        { type: 'tool_result', tool_use_id: 'toolu_2', content: [{ type: 'text', text: 'Rainy' }] },
+      ],
+    })
+  })
+
+  it('drops tool results whose tool_use never reached the translated history', async () => {
+    const { sent } = await capture({
+      messages: [
+        { role: 'user', content: 'hi' },
+        // A nameless tool_call is untranslatable and skipped — its result must
+        // be dropped too, or the Messages API rejects the unpaired
+        // tool_result with a 400.
+        { role: 'assistant', content: '', tool_calls: [{ id: 'toolu_ghost', type: 'function', function: { arguments: '{}' } }] },
+        { role: 'tool', tool_call_id: 'toolu_ghost', content: 'orphaned' },
+        { role: 'user', content: 'and now?' },
+      ],
+    })
+
+    expect(JSON.stringify(sent.messages)).not.toContain('toolu_ghost')
+    expect(JSON.stringify(sent.messages)).not.toContain('orphaned')
+  })
+
+  it('maps image parts to base64 and url sources and drops unsupported parts', async () => {
+    const { sent } = await capture({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'look' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+            { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } },
+            { type: 'input_audio', text: 'ignored' },
+          ],
+        },
+      ],
+    })
+
+    expect(sent.messages[0].content).toEqual([
+      { type: 'text', text: 'look' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+      { type: 'image', source: { type: 'url', url: 'https://example.com/cat.png' } },
+    ])
+  })
+
+  it('drops empty assistant text so the API never sees an empty text block', async () => {
+    const { sent } = await capture({
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'still there?' },
+      ],
+    })
+
+    expect(sent.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }, { type: 'text', text: 'still there?' }] },
+    ])
+  })
+})
+
+describe('response translation', () => {
+  it('maps text, usage (including cache tokens), and stop_reason', async () => {
+    const { response } = await capture({ messages: [{ role: 'user', content: 'hi' }] }, jsonResponse({
+      id: 'msg_01',
+      model: 'claude-sonnet-4-5-20250929',
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'there' }],
+      usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 90, cache_creation_input_tokens: 0 },
+    }))
+
+    const body = await response.json() as Record<string, any>
+    expect(body.id).toBe('msg_01')
+    expect(body.object).toBe('chat.completion')
+    expect(body.choices[0].message.content).toBe('Hello there')
+    expect(body.choices[0].finish_reason).toBe('stop')
+    expect(body.usage).toEqual({ prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 })
+  })
+
+  it('maps tool_use blocks to tool_calls with stringified arguments', async () => {
+    const { response } = await capture({ messages: [{ role: 'user', content: 'hi' }] }, jsonResponse({
+      stop_reason: 'tool_use',
+      content: [
+        { type: 'text', text: 'Let me check.' },
+        { type: 'tool_use', id: 'toolu_9', name: 'get_weather', input: { city: 'Tokyo' } },
+      ],
+    }))
+
+    const body = await response.json() as Record<string, any>
+    expect(body.choices[0].finish_reason).toBe('tool_calls')
+    expect(body.choices[0].message.tool_calls).toEqual([
+      { id: 'toolu_9', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Tokyo"}' } },
+    ])
+  })
+
+  it('surfaces thinking blocks as reasoning_content and maps terminal stop reasons', async () => {
+    const { response } = await capture({ messages: [{ role: 'user', content: 'hi' }] }, jsonResponse({
+      stop_reason: 'max_tokens',
+      content: [{ type: 'thinking', thinking: 'pondering…' }, { type: 'text', text: 'partial' }],
+    }))
+
+    const body = await response.json() as Record<string, any>
+    expect(body.choices[0].message.reasoning_content).toBe('pondering…')
+    expect(body.choices[0].finish_reason).toBe('length')
+
+    const refused = await capture({ messages: [{ role: 'user', content: 'hi' }] }, jsonResponse({ stop_reason: 'refusal', content: [] }))
+    expect(((await refused.response.json()) as Record<string, any>).choices[0].finish_reason).toBe('content_filter')
+  })
+
+  it('keeps upstream diagnostic headers on the translated response', async () => {
+    const { response } = await capture({ messages: [{ role: 'user', content: 'hi' }] }, jsonResponse(
+      { content: [], stop_reason: 'end_turn' },
+      200,
+      { 'request-id': 'req_123', 'anthropic-ratelimit-requests-remaining': '99' },
+    ))
+
+    expect(response.headers.get('request-id')).toBe('req_123')
+    expect(response.headers.get('anthropic-ratelimit-requests-remaining')).toBe('99')
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('returns a 2xx non-JSON body untouched so the real payload surfaces in errors', async () => {
+    const { response } = await capture(
+      { messages: [{ role: 'user', content: 'hi' }] },
+      new Response('<html>proxy speaking html</html>', { status: 200 }),
+    )
+
+    expect(await response.text()).toBe('<html>proxy speaking html</html>')
+  })
+})
+
+describe('sse translation', () => {
+  const textStream = [
+    'event: message_start\n',
+    'data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":12}}}\n\n',
+    'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+    'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}\n\n',
+    'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}\n\n',
+    'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+    'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}\n\n',
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+  ].join('')
+
+  it('translates a text stream into chat.completion chunks with usage and [DONE]', async () => {
+    const output = await streamThrough([textStream])
+    const chunks = parseChunks(output)
+
+    expect(chunks[0].choices[0].delta).toEqual({ role: 'assistant' })
+    expect(chunks[0].id).toBe('msg_1')
+    expect(chunks[0].model).toBe('claude-sonnet-4-5-20250929')
+
+    const text = chunks.map(chunk => chunk.choices[0].delta.content ?? '').join('')
+    expect(text).toBe('Hello')
+
+    const final = chunks[chunks.length - 1]
+    expect(final.choices[0].finish_reason).toBe('stop')
+    expect(final.usage).toEqual({ prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 })
+    expect(output.trimEnd().endsWith('data: [DONE]')).toBe(true)
+  })
+
+  it('is byte-boundary safe: chunked delivery produces identical output', async () => {
+    // Freeze the clock: every chunk embeds a per-translator `created`
+    // timestamp, and the two runs below must serialize identically.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+    const whole = await streamThrough([textStream])
+    const bytewise = await streamThrough([...textStream].map(character => character))
+
+    expect(bytewise).toBe(whole)
+  })
+
+  it('reassembles multi-byte UTF-8 characters split across chunks', async () => {
+    const frames = [
+      'data: {"type":"message_start","message":{"id":"msg_utf8","model":"m","usage":{"input_tokens":1}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"你好🎉"}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ].join('')
+    const encoded = new TextEncoder().encode(frames)
+    // Slice the raw bytes into 3-byte chunks, guaranteed to cut through the
+    // middle of the CJK and emoji code points.
+    const slices: Uint8Array[] = []
+    for (let offset = 0; offset < encoded.length; offset += 3)
+      slices.push(encoded.slice(offset, offset + 3))
+
+    const output = await streamThrough(slices)
+    const chunks = parseChunks(output)
+
+    expect(chunks.map(chunk => chunk.choices[0].delta.content ?? '').join('')).toBe('你好🎉')
+  })
+
+  it('translates tool_use blocks into indexed tool_call deltas', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_2","model":"m","usage":{"input_tokens":1}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"get_weather"}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":"}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"Tokyo\\"}"}}\n\n',
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":2}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    const toolChunks = chunks.filter(chunk => chunk.choices[0].delta.tool_calls)
+    expect(toolChunks[0].choices[0].delta.tool_calls).toEqual([
+      { index: 0, id: 'toolu_1', type: 'function', function: { name: 'get_weather', arguments: '' } },
+    ])
+    const args = toolChunks.slice(1).map(chunk => chunk.choices[0].delta.tool_calls![0].function!.arguments).join('')
+    expect(args).toBe('{"city":"Tokyo"}')
+
+    expect(chunks[chunks.length - 1].choices[0].finish_reason).toBe('tool_calls')
+  })
+
+  it('maps thinking deltas to reasoning_content and drops signature deltas', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_3","model":"m","usage":{"input_tokens":1}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}\n\n',
+      'data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+      'data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hi"}}\n\n',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    expect(chunks.some(chunk => chunk.choices[0].delta.reasoning_content === 'hmm')).toBe(true)
+    expect(output).not.toContain('sig')
+    expect(chunks.map(chunk => chunk.choices[0].delta.content ?? '').join('')).toBe('hi')
+  })
+
+  it('forwards provider error events on the error channel xsai raises on', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_4","model":"m","usage":{"input_tokens":1}}}\n\n',
+      'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+    ].join('')])
+
+    expect(output).toContain('"error":{"type":"overloaded_error"')
+  })
+
+  it('preserves finish_reason and usage when the upstream closes without message_stop', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_5","model":"m","usage":{"input_tokens":3}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"cut"}}\n\n',
+      'data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":7}}\n\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    const final = chunks[chunks.length - 1]
+    expect(final.choices[0].finish_reason).toBe('length')
+    expect(final.usage).toEqual({ prompt_tokens: 3, completion_tokens: 7, total_tokens: 10 })
+    expect(output.trimEnd().endsWith('data: [DONE]')).toBe(true)
+  })
+
+  it('handles CRLF-delimited SSE frames', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_6","model":"m","usage":{"input_tokens":1}}}\r\n\r\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\r\n\r\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"crlf"}}\r\n\r\n',
+      'data: {"type":"message_stop"}\r\n\r\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    expect(chunks.map(chunk => chunk.choices[0].delta.content ?? '').join('')).toBe('crlf')
+  })
+})
+
+describe('fetch wiring', () => {
+  it('rewrites chat/completions to messages with Anthropic auth headers and forwards the abort signal', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [{ type: 'text', text: 'pong' }], stop_reason: 'end_turn' }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+    const abortController = new AbortController()
+
+    await nativeFetch(CHAT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer sk-ant-test' },
+      body: JSON.stringify({ model: 'claude-sonnet-4-5-20250929', messages: [{ role: 'user', content: 'ping' }], max_tokens: 1 }),
+      signal: abortController.signal,
+    })
+
+    const [url, init] = baseFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(url).toBe('https://api.anthropic.com/v1/messages')
+    expect(init.headers['x-api-key']).toBe('sk-ant-test')
+    expect(init.headers['anthropic-version']).toBe('2023-06-01')
+    expect(init.headers['anthropic-dangerous-direct-browser-access']).toBe('true')
+    expect(Object.keys(init.headers).some(key => key.toLowerCase() === 'authorization')).toBe(false)
+    expect(init.signal).toBe(abortController.signal)
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1565
+  it('rewrites custom proxy base URLs, keeping the path prefix and query (Issue #1565)', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: 'end_turn' }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'k', fetch: baseFetch })
+
+    await nativeFetch('https://proxy.example/anthropic/v1/chat/completions?key=abc', {
+      method: 'POST',
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+
+    expect((baseFetch.mock.calls[0] as [string])[0]).toBe('https://proxy.example/anthropic/v1/messages?key=abc')
+  })
+
+  it('translates streaming responses into chat.completion.chunk SSE', async () => {
+    const output = await streamThrough([[
+      'data: {"type":"message_start","message":{"id":"msg_8","model":"m","usage":{"input_tokens":2}}}\n\n',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hey"}}\n\n',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+      'data: {"type":"message_stop"}\n\n',
+    ].join('')])
+    const chunks = parseChunks(output)
+
+    expect(chunks.map(chunk => chunk.choices[0].delta.content ?? '').join('')).toBe('hey')
+    expect(output.trimEnd().endsWith('data: [DONE]')).toBe(true)
+  })
+
+  it('passes non-2xx responses through untouched for xsai error handling', async () => {
+    const errorBody = JSON.stringify({ type: 'error', error: { type: 'authentication_error', message: 'invalid x-api-key' } })
+    const baseFetch = vi.fn().mockResolvedValue(new Response(errorBody, { status: 401 }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'bad', fetch: baseFetch })
+
+    const response = await nativeFetch(CHAT_URL, {
+      method: 'POST',
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.text()).toBe(errorBody)
+  })
+
+  it('forwards an unparseable request body verbatim so the provider names the real error', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(new Response('{"type":"error"}', { status: 400 }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'k', fetch: baseFetch })
+
+    await nativeFetch(CHAT_URL, { method: 'POST', body: '{not json' })
+
+    const [url, init] = baseFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.anthropic.com/v1/messages')
+    expect(String(init.body)).toBe('{not json')
+  })
+
+  it('honors Request-object input per fetch semantics', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ content: [], stop_reason: 'end_turn' }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'k', fetch: baseFetch })
+
+    await nativeFetch(new Request(CHAT_URL, {
+      method: 'POST',
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'from-request' }] }),
+    }))
+
+    const [url, init] = baseFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.anthropic.com/v1/messages')
+    const sent = JSON.parse(String(init.body)) as Record<string, any>
+    expect(sent.messages).toEqual([{ role: 'user', content: [{ type: 'text', text: 'from-request' }] }])
+  })
+
+  it('passes non-chat requests through with swapped auth headers', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse({ data: [{ id: 'claude-sonnet-4-5-20250929' }] }))
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: 'sk-ant-test', fetch: baseFetch })
+
+    await nativeFetch('https://api.anthropic.com/v1/models', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer sk-ant-test' },
+    })
+
+    const [url, init] = baseFetch.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(url).toBe('https://api.anthropic.com/v1/models')
+    expect(init.headers['x-api-key']).toBe('sk-ant-test')
+    expect(Object.keys(init.headers).some(key => key.toLowerCase() === 'authorization')).toBe(false)
+  })
+})
+
+// Env-gated integration coverage against a real native Messages endpoint
+// (official API or a /v1/messages proxy — the Issue #1565 scenario). Gated on
+// a DEDICATED opt-in variable so a developer's ambient ANTHROPIC_API_KEY (or
+// one picked up from .env by vitest's loadEnv) never triggers network calls.
+// Set ANTHROPIC_NATIVE_SMOKE_KEY (+ optional ANTHROPIC_NATIVE_SMOKE_BASE_URL
+// without /v1, and ANTHROPIC_NATIVE_SMOKE_MODEL) to enable.
+const smokeKey = process.env.ANTHROPIC_NATIVE_SMOKE_KEY
+
+describe.skipIf(!smokeKey)('createNativeAnthropicFetch (integration)', () => {
+  const base = (process.env.ANTHROPIC_NATIVE_SMOKE_BASE_URL ?? 'https://api.anthropic.com').replace(/\/$/, '')
+  const model = process.env.ANTHROPIC_NATIVE_SMOKE_MODEL ?? 'claude-haiku-4-5-20251001'
+  const chatCompletionsURL = `${base}/v1/chat/completions`
+
+  // https://github.com/moeru-ai/airi/issues/1565
+  it('completes a non-streaming round trip (Issue #1565)', async () => {
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: smokeKey! })
+    const response = await nativeFetch(chatCompletionsURL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'Reply with exactly: pong' }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json() as Record<string, any>
+    expect(body.object).toBe('chat.completion')
+    expect(typeof body.choices[0].message.content).toBe('string')
+    expect(body.choices[0].message.content.length).toBeGreaterThan(0)
+    expect(body.usage.prompt_tokens).toBeGreaterThan(0)
+  }, 60_000)
+
+  // https://github.com/moeru-ai/airi/issues/1565
+  it('completes a streaming round trip ending in [DONE] (Issue #1565)', async () => {
+    const nativeFetch = createNativeAnthropicFetch({ apiKey: smokeKey! })
+    const response = await nativeFetch(chatCompletionsURL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        stream: true,
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'Reply with exactly: pong' }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const output = await response.text()
+    const chunks = parseChunks(output)
+    expect(chunks[0].choices[0].delta.role).toBe('assistant')
+    expect(chunks.map(chunk => chunk.choices[0].delta.content ?? '').join('').length).toBeGreaterThan(0)
+    expect(chunks[chunks.length - 1].usage!.completion_tokens).toBeGreaterThan(0)
+    expect(output.trimEnd().endsWith('data: [DONE]')).toBe(true)
+  }, 60_000)
+})

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.test.ts
@@ -150,17 +150,23 @@ describe('request translation', () => {
   it('disables thinking for tool requests only on adaptive-default models', async () => {
     const tools = [{ type: 'function', function: { name: 't', parameters: {} } }]
 
-    // Sonnet 5 family: adaptive thinking is ON when the field is omitted, and
-    // the OpenAI-shaped history cannot echo signed thinking blocks back — so
-    // tool loops need an explicit off switch.
+    // Sonnet 5 and Opus 5 think when the field is omitted, and the
+    // OpenAI-shaped history cannot echo signed thinking blocks back — so tool
+    // loops need an explicit off switch.
     expect((await capture({ model: 'claude-sonnet-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toEqual({ type: 'disabled' })
     expect((await capture({ model: 'anthropic/claude-sonnet-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toEqual({ type: 'disabled' })
+    expect((await capture({ model: 'claude-opus-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toEqual({ type: 'disabled' })
+    expect((await capture({ model: 'anthropic/claude-opus-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toEqual({ type: 'disabled' })
 
     // Everything else: omitting the field already means off, and older models
-    // may reject the field outright — never send it.
+    // may reject the field outright — never send it. Opus 4.x in particular is
+    // thinking-off by default, so it must not be caught by the Opus 5 match.
     expect((await capture({ model: 'claude-sonnet-4-5-20250929', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
     expect((await capture({ model: 'claude-opus-4-8', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
+    expect((await capture({ model: 'claude-opus-4-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
+    // Fable and Mythos think by default but reject `disabled` outright.
     expect((await capture({ model: 'claude-fable-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
+    expect((await capture({ model: 'claude-mythos-5', messages: [{ role: 'user', content: 'hi' }], tools })).sent.thinking).toBeUndefined()
 
     // No tools -> never sent, regardless of model.
     expect((await capture({ model: 'claude-sonnet-5', messages: [{ role: 'user', content: 'hi' }] })).sent.thinking).toBeUndefined()

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -1,0 +1,770 @@
+/**
+ * Native Anthropic Messages API adapter.
+ *
+ * The xsai runtime speaks the OpenAI Chat Completions wire protocol. Anthropic
+ * documents its OpenAI-compatible endpoint as a testing shim ("not considered a
+ * long-term or production-ready solution") that drops prompt caching, thinking
+ * output, and strict tool schemas, and it is absent from `/v1/messages`-only
+ * proxies (https://github.com/moeru-ai/airi/issues/1565).
+ *
+ * This module bridges the two protocols at the `fetch` boundary instead: xsai
+ * still emits an OpenAI-shaped request to `{baseURL}chat/completions`, and
+ * {@link createNativeAnthropicFetch} rewrites it into a native
+ * `{baseURL}messages` call, then rewrites the JSON (or SSE) response back into
+ * the Chat Completions shape xsai parses. No other layer of the app changes.
+ *
+ * Envelope ownership: the OpenAI-wire and Anthropic-wire types below describe
+ * exactly the subset of both protocols this adapter translates. They are owned
+ * here — xsai only types the pre-serialization camelCase options, and pulling
+ * in an Anthropic SDK for types alone would add a runtime dependency.
+ */
+
+/** Protocol revision sent as `anthropic-version` on every native request. */
+const ANTHROPIC_VERSION = '2023-06-01'
+
+/**
+ * Fallback `max_tokens` when the caller does not set one. The Messages API
+ * requires the field while Chat Completions treats it as optional, and AIRI's
+ * chat path never sets it. 4096 is the floor across every Claude model still
+ * served (older ones like claude-3-haiku cap there, and the API rejects —
+ * not clamps — an over-cap value), so the default can never 400 a model a
+ * proxy exposes; callers wanting longer replies pass `max_tokens` explicitly.
+ */
+const DEFAULT_MAX_TOKENS = 4096
+
+interface OpenAIContentPart {
+  type: string
+  text?: string
+  image_url?: { url?: string }
+}
+
+interface OpenAIToolCall {
+  id?: string
+  type?: string
+  function?: { name?: string, arguments?: string }
+}
+
+interface OpenAIWireMessage {
+  role: string
+  content?: string | OpenAIContentPart[] | null
+  tool_calls?: OpenAIToolCall[]
+  tool_call_id?: string
+}
+
+/** The subset of the Chat Completions request body this adapter translates. */
+interface OpenAIWireRequest {
+  model?: string
+  messages?: OpenAIWireMessage[]
+  stream?: boolean
+  max_tokens?: number
+  max_completion_tokens?: number
+  temperature?: number
+  top_p?: number
+  stop?: string | string[]
+  tools?: Array<{ type?: string, function?: { name?: string, description?: string, parameters?: Record<string, unknown> } }>
+  tool_choice?: string | { type?: string, function?: { name?: string }, name?: string }
+}
+
+type AnthropicImageSource
+  = | { type: 'base64', media_type: string, data: string }
+    | { type: 'url', url: string }
+
+type AnthropicToolResultContent = string | Array<{ type: 'text', text: string } | { type: 'image', source: AnthropicImageSource }>
+
+type AnthropicContentBlock
+  = | { type: 'text', text: string }
+    | { type: 'image', source: AnthropicImageSource }
+    | { type: 'tool_use', id: string, name: string, input: Record<string, unknown> }
+    | { type: 'tool_result', tool_use_id: string, content: AnthropicToolResultContent }
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant'
+  content: AnthropicContentBlock[]
+}
+
+interface AnthropicRequestBody {
+  model: string
+  messages: AnthropicMessage[]
+  max_tokens: number
+  system?: string
+  stream?: boolean
+  temperature?: number
+  top_p?: number
+  stop_sequences?: string[]
+  tools?: Array<{ name: string, description?: string, input_schema: Record<string, unknown> }>
+  tool_choice?: { type: 'auto' | 'any' | 'none' } | { type: 'tool', name: string }
+  thinking?: { type: 'disabled' }
+}
+
+interface AnthropicUsage {
+  input_tokens?: number
+  output_tokens?: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+}
+
+interface AnthropicResponseMessage {
+  id?: string
+  model?: string
+  stop_reason?: string | null
+  content?: Array<{ type: string, text?: string, thinking?: string, id?: string, name?: string, input?: Record<string, unknown> }>
+  usage?: AnthropicUsage
+}
+
+/**
+ * One parsed frame of the Messages API SSE stream. Every field is optional
+ * because frames are provider input — the handler guards each access.
+ */
+interface AnthropicSSEEvent {
+  type?: string
+  index?: number
+  message?: { id?: string, model?: string, usage?: AnthropicUsage }
+  content_block?: { type?: string, id?: string, name?: string, text?: string }
+  delta?: { type?: string, text?: string, thinking?: string, partial_json?: string, stop_reason?: string | null }
+  usage?: AnthropicUsage
+  error?: unknown
+}
+
+/**
+ * Models where adaptive thinking is ON when the `thinking` field is omitted
+ * (the Claude Sonnet 5 family). Matched non-anchored so gateway-prefixed ids
+ * like `anthropic/claude-sonnet-5` are recognized too.
+ */
+function isAdaptiveThinkingDefaultModel(model: string): boolean {
+  return /claude-sonnet-5/.test(model)
+}
+
+function mapStopReason(stopReason: string | null | undefined): string {
+  switch (stopReason) {
+    case 'tool_use':
+      return 'tool_calls'
+    case 'max_tokens':
+    case 'model_context_window_exceeded':
+      return 'length'
+    case 'refusal':
+      return 'content_filter'
+    // end_turn, stop_sequence, pause_turn, and unknown future reasons all mean
+    // "the model stopped normally" as far as the Chat Completions shape goes.
+    default:
+      return 'stop'
+  }
+}
+
+function mapImagePart(url: string): { type: 'image', source: AnthropicImageSource } | undefined {
+  const dataUri = /^data:([^;,]+);base64,(.*)$/.exec(url)
+  if (dataUri)
+    return { type: 'image', source: { type: 'base64', media_type: dataUri[1], data: dataUri[2] } }
+  if (/^https?:\/\//.test(url))
+    return { type: 'image', source: { type: 'url', url } }
+  return undefined
+}
+
+function mapContentParts(content: string | OpenAIContentPart[] | null | undefined): AnthropicContentBlock[] {
+  if (content == null)
+    return []
+  // The Messages API rejects empty text blocks, and xsai appends an assistant
+  // turn with `content: ''` after every tool round — skip empties everywhere.
+  if (typeof content === 'string')
+    return content.length > 0 ? [{ type: 'text', text: content }] : []
+
+  const blocks: AnthropicContentBlock[] = []
+  for (const part of content) {
+    if (part.type === 'text' && part.text) {
+      blocks.push({ type: 'text', text: part.text })
+    }
+    else if (part.type === 'image_url' && part.image_url?.url) {
+      const image = mapImagePart(part.image_url.url)
+      if (image)
+        blocks.push(image)
+    }
+    // input_audio / file parts are dropped, matching the behavior Anthropic's
+    // own OpenAI-compatible endpoint documents for unsupported content.
+  }
+  return blocks
+}
+
+function mapToolResultContent(content: string | OpenAIContentPart[] | null | undefined): AnthropicToolResultContent {
+  if (typeof content === 'string' || content == null)
+    return content ?? ''
+
+  const blocks: Array<{ type: 'text', text: string } | { type: 'image', source: AnthropicImageSource }> = []
+  for (const part of content) {
+    if (part.type === 'text' && part.text != null) {
+      blocks.push({ type: 'text', text: part.text })
+    }
+    else if (part.type === 'image_url' && part.image_url?.url) {
+      const image = mapImagePart(part.image_url.url)
+      if (image)
+        blocks.push(image)
+    }
+  }
+  return blocks.length > 0 ? blocks : ''
+}
+
+function mapToolChoice(toolChoice: OpenAIWireRequest['tool_choice']): AnthropicRequestBody['tool_choice'] | undefined {
+  if (toolChoice == null)
+    return undefined
+  if (typeof toolChoice === 'string') {
+    if (toolChoice === 'auto')
+      return { type: 'auto' }
+    if (toolChoice === 'none')
+      return { type: 'none' }
+    if (toolChoice === 'required')
+      return { type: 'any' }
+    return undefined
+  }
+  if (toolChoice.type === 'function' && toolChoice.function?.name)
+    return { type: 'tool', name: toolChoice.function.name }
+  if (toolChoice.type === 'tool' && toolChoice.name)
+    return { type: 'tool', name: toolChoice.name }
+  if (toolChoice.type === 'auto' || toolChoice.type === 'any' || toolChoice.type === 'none')
+    return { type: toolChoice.type }
+  return undefined
+}
+
+/**
+ * Translates a Chat Completions request body into a Messages API body.
+ *
+ * Before:
+ * - `{ model, messages: [{role:'system'},...], tools: [{type:'function',function:{...}}], stream: true }`
+ *
+ * After:
+ * - `{ model, system, messages: [...blocks], max_tokens, tools: [{name,input_schema}], stream: true }`
+ *
+ * Translation is whitelist-based: xsai serializes every leftover runtime
+ * option into the wire body (snake_cased), and the Messages API rejects
+ * unknown top-level fields with a 400 — so only fields this adapter
+ * understands are carried over.
+ */
+function translateChatRequest(request: OpenAIWireRequest): AnthropicRequestBody {
+  const model = request.model ?? ''
+  const systemTexts: string[] = []
+  const messages: AnthropicMessage[] = []
+  // tool_result blocks must reference a tool_use the model actually saw;
+  // orphans (e.g. a result for a skipped nameless tool_call) would 400.
+  const emittedToolUseIds = new Set<string>()
+
+  const appendBlocks = (role: 'user' | 'assistant', blocks: AnthropicContentBlock[]) => {
+    if (blocks.length === 0)
+      return
+    const last = messages[messages.length - 1]
+    // Merge consecutive same-role turns: the OpenAI shape emits one message
+    // per tool result, while stricter Messages API implementations (the
+    // proxies issue #1565 targets) expect alternating roles.
+    if (last?.role === role)
+      last.content.push(...blocks)
+    else
+      messages.push({ role, content: blocks })
+  }
+
+  for (const message of request.messages ?? []) {
+    switch (message.role) {
+      // Anthropic accepts a single top-level system prompt, so system and
+      // developer turns are hoisted and joined — the same behavior Anthropic's
+      // OpenAI-compatible endpoint documents.
+      case 'system':
+      case 'developer': {
+        if (typeof message.content === 'string' && message.content.length > 0)
+          systemTexts.push(message.content)
+        else if (Array.isArray(message.content))
+          systemTexts.push(...message.content.filter(part => part.type === 'text' && part.text).map(part => part.text!))
+        break
+      }
+      case 'user': {
+        appendBlocks('user', mapContentParts(message.content))
+        break
+      }
+      case 'assistant': {
+        const blocks = mapContentParts(message.content)
+        for (const toolCall of message.tool_calls ?? []) {
+          if (!toolCall.function?.name)
+            continue
+          let input: Record<string, unknown> = {}
+          try {
+            input = JSON.parse(toolCall.function.arguments?.trim() || '{}') as Record<string, unknown>
+          }
+          catch {
+            // A malformed argument payload still has to round-trip so the
+            // paired tool_result keeps its target; the model sees `{}`.
+            input = {}
+          }
+          const id = toolCall.id ?? `toolu_${blocks.length}`
+          emittedToolUseIds.add(id)
+          blocks.push({ type: 'tool_use', id, name: toolCall.function.name, input })
+        }
+        appendBlocks('assistant', blocks)
+        break
+      }
+      case 'tool': {
+        // Results whose tool_use never made it into the translated history
+        // are dropped for the same pairing rule.
+        if (!message.tool_call_id || !emittedToolUseIds.has(message.tool_call_id))
+          break
+        appendBlocks('user', [{ type: 'tool_result', tool_use_id: message.tool_call_id, content: mapToolResultContent(message.content) }])
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  const body: AnthropicRequestBody = {
+    model,
+    messages,
+    max_tokens: request.max_tokens ?? request.max_completion_tokens ?? DEFAULT_MAX_TOKENS,
+  }
+
+  if (systemTexts.length > 0)
+    body.system = systemTexts.join('\n')
+  if (request.stream === true)
+    body.stream = true
+
+  // Claude 4+ rejects requests carrying BOTH temperature and top_p, and the
+  // Messages API bounds temperature to [0, 1] — clamp and prefer temperature
+  // when a caller (legally, on the OpenAI protocol) sends both.
+  if (typeof request.temperature === 'number')
+    body.temperature = Math.min(Math.max(request.temperature, 0), 1)
+  else if (typeof request.top_p === 'number')
+    body.top_p = request.top_p
+
+  if (request.stop != null) {
+    // The Messages API rejects empty or whitespace-only stop sequences that
+    // the OpenAI protocol allows (e.g. the common "\n").
+    const stopSequences = (Array.isArray(request.stop) ? request.stop : [request.stop]).filter(stop => stop.trim().length > 0)
+    if (stopSequences.length > 0)
+      body.stop_sequences = stopSequences
+  }
+
+  const tools = (request.tools ?? [])
+    .filter(tool => tool.function?.name)
+    .map(tool => ({
+      name: tool.function!.name!,
+      description: tool.function!.description,
+      input_schema: tool.function!.parameters ?? { type: 'object' },
+    }))
+  if (tools.length > 0) {
+    body.tools = tools
+    const toolChoice = mapToolChoice(request.tool_choice)
+    if (toolChoice)
+      body.tool_choice = toolChoice
+
+    // NOTICE:
+    // Tool loops need thinking OFF on models where adaptive thinking is the
+    // default when the field is omitted (Claude Sonnet 5 family): with
+    // thinking on, the Messages API requires the previous assistant turn's
+    // signed thinking blocks to be echoed before its tool_use blocks, but the
+    // OpenAI-shaped history xsai maintains cannot carry them, so round 2 of
+    // any tool call would 400. The field is sent ONLY to that allowlist —
+    // older models may reject the `thinking` field outright, and on everything
+    // else omitting it already means "off". Always-thinking models
+    // (Fable/Mythos) reject `disabled` and remain a documented tool-use
+    // limitation of this adapter.
+    // Source: platform.claude.com/docs/en/build-with-claude/extended-thinking
+    // (tool-use echo requirement); removal condition: xsai history preserving
+    // thinking blocks + signatures end-to-end.
+    if (isAdaptiveThinkingDefaultModel(model))
+      body.thinking = { type: 'disabled' }
+  }
+
+  return body
+}
+
+function toOpenAIUsage(usage: AnthropicUsage | undefined) {
+  // Cache reads/writes are still input the provider processed; fold them into
+  // prompt_tokens so cost dashboards see the full input size.
+  const promptTokens = (usage?.input_tokens ?? 0) + (usage?.cache_creation_input_tokens ?? 0) + (usage?.cache_read_input_tokens ?? 0)
+  const completionTokens = usage?.output_tokens ?? 0
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+  }
+}
+
+/**
+ * Translates a non-streaming Messages API response into a Chat Completions
+ * response.
+ *
+ * Before:
+ * - `{ content: [{type:'text',text:'hi'},{type:'tool_use',...}], stop_reason: 'tool_use' }`
+ *
+ * After:
+ * - `{ choices: [{ message: { content: 'hi', tool_calls: [...] }, finish_reason: 'tool_calls' }] }`
+ */
+function translateChatResponse(response: AnthropicResponseMessage): Record<string, unknown> {
+  const textParts: string[] = []
+  const reasoningParts: string[] = []
+  const toolCalls: Array<{ id: string, type: 'function', function: { name: string, arguments: string } }> = []
+
+  for (const block of response.content ?? []) {
+    if (block.type === 'text' && block.text != null)
+      textParts.push(block.text)
+    else if (block.type === 'thinking' && block.thinking)
+      reasoningParts.push(block.thinking)
+    else if (block.type === 'tool_use' && block.name)
+      toolCalls.push({ id: block.id ?? `toolu_${toolCalls.length}`, type: 'function', function: { name: block.name, arguments: JSON.stringify(block.input ?? {}) } })
+  }
+
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    content: textParts.length > 0 ? textParts.join('') : null,
+  }
+  if (reasoningParts.length > 0)
+    message.reasoning_content = reasoningParts.join('')
+  if (toolCalls.length > 0)
+    message.tool_calls = toolCalls
+
+  return {
+    id: response.id ?? 'chatcmpl-anthropic',
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: response.model ?? '',
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: mapStopReason(response.stop_reason),
+      logprobs: null,
+    }],
+    usage: toOpenAIUsage(response.usage),
+  }
+}
+
+interface SSEBlockState {
+  kind: 'text' | 'thinking' | 'tool' | 'ignored'
+  toolIndex?: number
+  toolId?: string
+  toolName?: string
+}
+
+/**
+ * Translates an Anthropic Messages SSE stream into a Chat Completions
+ * `chat.completion.chunk` SSE stream.
+ *
+ * Event mapping:
+ * - `message_start`            -> role-priming chunk (captures id/model/input usage)
+ * - `content_block_delta`      -> `delta.content` (text_delta),
+ *                                 `delta.reasoning_content` (thinking_delta),
+ *                                 `delta.tool_calls[].function.arguments` (input_json_delta)
+ * - `content_block_start` (tool_use) -> tool_calls entry carrying id + name
+ * - `message_delta`            -> stop reason + output usage (buffered)
+ * - `message_stop`             -> final chunk with finish_reason + usage, then `[DONE]`
+ * - `error`                    -> `data: {"error": ...}` (xsai's SSE parser raises it)
+ * - `ping` / signature deltas / unknown events -> dropped
+ */
+function createAnthropicSSETranslator(): TransformStream<Uint8Array, Uint8Array> {
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  const created = Math.floor(Date.now() / 1000)
+
+  let buffer = ''
+  let chunkId = 'chatcmpl-anthropic'
+  let model = ''
+  let roleEmitted = false
+  let doneEmitted = false
+  let stopReason: string | null | undefined
+  let usage: AnthropicUsage = {}
+  let toolCount = 0
+  const blocks = new Map<number, SSEBlockState>()
+
+  const emit = (controller: TransformStreamDefaultController<Uint8Array>, payload: unknown) => {
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`))
+  }
+
+  const chunkOf = (delta: Record<string, unknown>, finishReason: string | null = null) => ({
+    id: chunkId,
+    object: 'chat.completion.chunk',
+    created,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason, logprobs: null }],
+  })
+
+  const emitRoleOnce = (controller: TransformStreamDefaultController<Uint8Array>) => {
+    if (roleEmitted)
+      return
+    roleEmitted = true
+    emit(controller, chunkOf({ role: 'assistant' }))
+  }
+
+  const emitFinal = (controller: TransformStreamDefaultController<Uint8Array>) => {
+    if (doneEmitted)
+      return
+    doneEmitted = true
+    emit(controller, {
+      ...chunkOf({}, mapStopReason(stopReason)),
+      usage: toOpenAIUsage(usage),
+    })
+    controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+  }
+
+  const handleEvent = (event: AnthropicSSEEvent, controller: TransformStreamDefaultController<Uint8Array>) => {
+    switch (event.type) {
+      case 'message_start': {
+        chunkId = event.message?.id ?? chunkId
+        model = event.message?.model ?? model
+        usage = { ...usage, ...event.message?.usage }
+        emitRoleOnce(controller)
+        break
+      }
+      case 'content_block_start': {
+        if (typeof event.index !== 'number')
+          break
+        const block = event.content_block ?? {}
+        if (block.type === 'tool_use') {
+          const toolIndex = toolCount++
+          blocks.set(event.index, { kind: 'tool', toolIndex, toolId: block.id, toolName: block.name })
+          emitRoleOnce(controller)
+          emit(controller, chunkOf({
+            tool_calls: [{ index: toolIndex, id: block.id, type: 'function', function: { name: block.name, arguments: '' } }],
+          }))
+        }
+        else if (block.type === 'text') {
+          blocks.set(event.index, { kind: 'text' })
+          // Anthropic may seed the block with initial text.
+          if (typeof block.text === 'string' && block.text.length > 0) {
+            emitRoleOnce(controller)
+            emit(controller, chunkOf({ content: block.text }))
+          }
+        }
+        else if (block.type === 'thinking') {
+          blocks.set(event.index, { kind: 'thinking' })
+        }
+        else {
+          // redacted_thinking, server tool blocks, and future block types have
+          // no Chat Completions representation.
+          blocks.set(event.index, { kind: 'ignored' })
+        }
+        break
+      }
+      case 'content_block_delta': {
+        const state = typeof event.index === 'number' ? blocks.get(event.index) : undefined
+        const delta = event.delta ?? {}
+        if (delta.type === 'text_delta' && typeof delta.text === 'string') {
+          emitRoleOnce(controller)
+          emit(controller, chunkOf({ content: delta.text }))
+        }
+        else if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+          emitRoleOnce(controller)
+          emit(controller, chunkOf({ reasoning_content: delta.thinking }))
+        }
+        else if (delta.type === 'input_json_delta' && state?.kind === 'tool' && typeof delta.partial_json === 'string') {
+          emit(controller, chunkOf({
+            tool_calls: [{ index: state.toolIndex, id: state.toolId, type: 'function', function: { name: state.toolName, arguments: delta.partial_json } }],
+          }))
+        }
+        // signature_delta carries the thinking signature, which cannot cross
+        // the OpenAI-shaped boundary — dropped.
+        break
+      }
+      case 'message_delta': {
+        if (event.delta?.stop_reason != null)
+          stopReason = event.delta.stop_reason
+        usage = { ...usage, ...event.usage }
+        break
+      }
+      case 'message_stop': {
+        emitRoleOnce(controller)
+        emitFinal(controller)
+        break
+      }
+      case 'error': {
+        // xsai's JsonMessageTransformStream throws RemoteAPIError for any SSE
+        // payload carrying an `error` key — forward it verbatim to reuse that
+        // channel instead of inventing a side-band.
+        emit(controller, { error: event.error ?? event })
+        break
+      }
+      default:
+        // ping / content_block_stop / unknown future events carry no state.
+        break
+    }
+  }
+
+  const processBuffer = (controller: TransformStreamDefaultController<Uint8Array>, flushing: boolean) => {
+    // SSE events are separated by a blank line; the tail may be incomplete
+    // unless the upstream closed.
+    const events = buffer.split(/\r?\n\r?\n/)
+    buffer = flushing ? '' : (events.pop() ?? '')
+    for (const rawEvent of events) {
+      let data = ''
+      for (const line of rawEvent.split(/\r?\n/)) {
+        if (line.startsWith('data:'))
+          data += (data.length > 0 ? '\n' : '') + line.slice(5).trimStart()
+      }
+      if (!data)
+        continue
+      try {
+        handleEvent(JSON.parse(data) as AnthropicSSEEvent, controller)
+      }
+      catch {
+        // A malformed frame is dropped rather than poisoning the stream; the
+        // terminal message_stop (or upstream close) still ends the response.
+      }
+    }
+  }
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true })
+      processBuffer(controller, false)
+    },
+    flush(controller) {
+      buffer += decoder.decode()
+      if (buffer.length > 0)
+        processBuffer(controller, true)
+      // An upstream that closed without message_stop (abort, proxy hiccup)
+      // still gets the terminal chunk: any stop reason and usage received via
+      // message_delta are preserved instead of silently discarded, and the
+      // OpenAI [DONE] terminator lets downstream parsers finish.
+      if (roleEmitted)
+        emitFinal(controller)
+    },
+  })
+}
+
+function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string> {
+  const record: Record<string, string> = {}
+  if (!headers)
+    return record
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      record[key] = value
+    })
+    return record
+  }
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers)
+      record[key] = value
+    return record
+  }
+  return { ...headers }
+}
+
+function toAnthropicHeaders(headers: HeadersInit | undefined, apiKey: string): Record<string, string> {
+  const record = toHeaderRecord(headers)
+  // The Messages API authenticates via x-api-key; sending the Bearer header
+  // xsai injects alongside it is rejected by api.anthropic.com.
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() === 'authorization')
+      delete record[key]
+  }
+  record['x-api-key'] = apiKey
+  record['anthropic-version'] = ANTHROPIC_VERSION
+  // Anthropic requires this opt-in header for direct browser (CORS) calls;
+  // the renderer is exactly that environment.
+  record['anthropic-dangerous-direct-browser-access'] = 'true'
+  return record
+}
+
+/**
+ * Rewrites a Chat Completions endpoint URL to its Messages sibling.
+ *
+ * Before:
+ * - `https://proxy.example/anthropic/v1/chat/completions?key=1`
+ *
+ * After:
+ * - `https://proxy.example/anthropic/v1/messages?key=1`
+ */
+function toMessagesURL(url: string): string {
+  return url.replace(/chat\/completions\/?(\?|$)/, 'messages$1')
+}
+
+/**
+ * Options for {@link createNativeAnthropicFetch}.
+ */
+export interface NativeAnthropicFetchOptions {
+  /** Anthropic API key, sent as `x-api-key` on every rewritten request. */
+  apiKey: string
+  /**
+   * Underlying fetch implementation.
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: typeof globalThis.fetch
+}
+
+/**
+ * Creates a `fetch` that transparently bridges xsai's OpenAI-protocol requests
+ * onto the native Anthropic Messages API.
+ *
+ * `POST …/chat/completions` is rewritten to `POST …/messages` with a
+ * translated body, and the JSON or SSE response is translated back. Every
+ * other request (e.g. `GET …/models`, which the native API also serves) passes
+ * through with only the auth headers swapped to Anthropic's scheme.
+ */
+export function createNativeAnthropicFetch(options: NativeAnthropicFetchOptions): typeof globalThis.fetch {
+  const baseFetch = options.fetch ?? globalThis.fetch
+
+  return async (input, init) => {
+    // Normalize per fetch semantics: init fields override the Request's own.
+    const request = input instanceof Request ? input : undefined
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const method = (init?.method ?? request?.method ?? 'GET').toUpperCase()
+    const headers = init?.headers ?? request?.headers
+    const signal = init?.signal ?? request?.signal
+    const isChatCompletions = method === 'POST' && /\/chat\/completions\/?$/.test(url.split('?')[0])
+
+    if (!isChatCompletions) {
+      return baseFetch(url, {
+        ...init,
+        method,
+        headers: toAnthropicHeaders(headers, options.apiKey),
+        signal,
+      })
+    }
+
+    const rawBody = init?.body != null ? String(init.body) : request != null ? await request.text() : ''
+    let wireRequest: OpenAIWireRequest | undefined
+    try {
+      wireRequest = JSON.parse(rawBody || '{}') as OpenAIWireRequest
+    }
+    catch {
+      // A body this adapter cannot parse cannot be translated either — forward
+      // it verbatim so the provider's own "invalid JSON" error names the real
+      // cause instead of a synthetic empty-model complaint.
+      wireRequest = undefined
+    }
+
+    const response = await baseFetch(toMessagesURL(url), {
+      method: 'POST',
+      headers: toAnthropicHeaders(headers, options.apiKey),
+      body: wireRequest != null ? JSON.stringify(translateChatRequest(wireRequest)) : rawBody,
+      signal,
+    })
+
+    // Non-2xx responses pass through untouched: xsai's responseCatch surfaces
+    // the status plus Anthropic's error JSON, which is what the app's
+    // provider-error classifiers already parse.
+    if (!response.ok)
+      return response
+
+    // Keep upstream diagnostics (request-id, anthropic-ratelimit-*) on the
+    // translated response; only the content type is ours.
+    const translatedHeaders = new Headers(response.headers)
+
+    if (wireRequest?.stream === true && response.body != null) {
+      translatedHeaders.set('Content-Type', 'text/event-stream')
+      return new Response(response.body.pipeThrough(createAnthropicSSETranslator()), {
+        status: response.status,
+        headers: translatedHeaders,
+      })
+    }
+
+    const text = await response.text()
+    let json: AnthropicResponseMessage
+    try {
+      json = JSON.parse(text) as AnthropicResponseMessage
+    }
+    catch {
+      // A 2xx with a non-JSON body (misbehaving proxy) is returned as-is so
+      // xsai's responseJSON reports the actual payload instead of this
+      // adapter masking it with a bare SyntaxError.
+      return new Response(text, { status: response.status, headers: translatedHeaders })
+    }
+
+    translatedHeaders.set('Content-Type', 'application/json')
+    return new Response(JSON.stringify(translateChatResponse(json)), {
+      status: response.status,
+      headers: translatedHeaders,
+    })
+  }
+}

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -662,14 +662,45 @@ function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string
   return { ...headers }
 }
 
-function toAnthropicHeaders(headers: HeadersInit | undefined, apiKey: string): Record<string, string> {
-  const record = toHeaderRecord(headers)
-  // The Messages API authenticates via x-api-key; sending the Bearer header
-  // xsai injects alongside it is rejected by api.anthropic.com.
-  for (const key of Object.keys(record)) {
-    if (key.toLowerCase() === 'authorization')
-      delete record[key]
+/**
+ * Whether a request targets Anthropic's own API rather than a user-configured
+ * proxy. Matched on the exact host so a gateway that merely borrows the path
+ * layout is still treated as third-party.
+ */
+function isOfficialAnthropicHost(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'api.anthropic.com'
   }
+  catch {
+    // An unparseable URL cannot be the official endpoint, whose Base URL is a
+    // fixed absolute default.
+    return false
+  }
+}
+
+function toAnthropicHeaders(headers: HeadersInit | undefined, apiKey: string, url: string): Record<string, string> {
+  const record = toHeaderRecord(headers)
+
+  // xsai authenticates by putting the configured key in `Authorization: Bearer`.
+  // Anthropic accepts either `x-api-key` or `Authorization`, but its bearer
+  // path expects a short-lived Workload Identity Federation token rather than a
+  // static `sk-ant-` key, and the precedence when both headers arrive is
+  // undocumented — so on the official host the bearer header is dropped and
+  // only the documented `x-api-key` method is used.
+  //
+  // Custom Base URLs keep it: `/v1/messages` proxies are commonly protected by
+  // bearer auth instead (antigravity-claude-proxy, the proxy Issue #1565 names,
+  // requires `Authorization: Bearer $API_KEY` once `API_KEY` is configured), and
+  // dropping it would 401 exactly the deployments this provider exists to
+  // support. `x-api-key` is still set alongside, so proxies that mirror
+  // Anthropic's own scheme keep working.
+  if (isOfficialAnthropicHost(url)) {
+    for (const key of Object.keys(record)) {
+      if (key.toLowerCase() === 'authorization')
+        delete record[key]
+    }
+  }
+
   record['x-api-key'] = apiKey
   record['anthropic-version'] = ANTHROPIC_VERSION
   // Anthropic requires this opt-in header for direct browser (CORS) calls;
@@ -730,7 +761,7 @@ export function createNativeAnthropicFetch(options: NativeAnthropicFetchOptions)
       return baseFetch(url, {
         ...init,
         method,
-        headers: toAnthropicHeaders(headers, options.apiKey),
+        headers: toAnthropicHeaders(headers, options.apiKey, url),
         signal,
       })
     }
@@ -749,7 +780,7 @@ export function createNativeAnthropicFetch(options: NativeAnthropicFetchOptions)
 
     const response = await baseFetch(toMessagesURL(url), {
       method: 'POST',
-      headers: toAnthropicHeaders(headers, options.apiKey),
+      headers: toAnthropicHeaders(headers, options.apiKey, url),
       body: wireRequest != null ? JSON.stringify(translateChatRequest(wireRequest)) : rawBody,
       signal,
     })

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -46,7 +46,12 @@ interface OpenAIToolCall {
 
 interface OpenAIWireMessage {
   role: string
-  content?: string | OpenAIContentPart[] | null
+  /**
+   * Parsed straight out of the caller's serialized body, so the array shape is
+   * what a well-behaved client sends rather than something this adapter can
+   * rely on — the mappers below narrow before iterating.
+   */
+  content?: string | OpenAIContentPart[] | Record<string, unknown> | null
   tool_calls?: OpenAIToolCall[]
   tool_call_id?: string
 }
@@ -159,13 +164,18 @@ function mapImagePart(url: string): { type: 'image', source: AnthropicImageSourc
   return undefined
 }
 
-function mapContentParts(content: string | OpenAIContentPart[] | null | undefined): AnthropicContentBlock[] {
+function mapContentParts(content: OpenAIWireMessage['content'] | undefined): AnthropicContentBlock[] {
   if (content == null)
     return []
   // The Messages API rejects empty text blocks, and xsai appends an assistant
   // turn with `content: ''` after every tool round — skip empties everywhere.
   if (typeof content === 'string')
     return content.length > 0 ? [{ type: 'text', text: content }] : []
+  // Anything that is neither text nor a parts array is carried through as its
+  // JSON text: the model still sees the value, and the adapter does not throw
+  // a bare TypeError out of `fetch` where the app expects a provider error.
+  if (!Array.isArray(content))
+    return [{ type: 'text', text: JSON.stringify(content) }]
 
   const blocks: AnthropicContentBlock[] = []
   for (const part of content) {
@@ -183,9 +193,15 @@ function mapContentParts(content: string | OpenAIContentPart[] | null | undefine
   return blocks
 }
 
-function mapToolResultContent(content: string | OpenAIContentPart[] | null | undefined): AnthropicToolResultContent {
+function mapToolResultContent(content: OpenAIWireMessage['content'] | undefined): AnthropicToolResultContent {
   if (typeof content === 'string' || content == null)
     return content ?? ''
+  // xsai already stringifies a structured tool return before it becomes message
+  // content (`wrapToolResult` in `@xsai/shared-chat`), so this guards the wire
+  // shape rather than that path: a caller that serializes the object itself
+  // gets its JSON forwarded instead of crashing the translation.
+  if (!Array.isArray(content))
+    return JSON.stringify(content)
 
   const blocks: Array<{ type: 'text', text: string } | { type: 'image', source: AnthropicImageSource }> = []
   for (const part of content) {

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -434,6 +434,13 @@ interface SSEBlockState {
   toolIndex?: number
   toolId?: string
   toolName?: string
+  /**
+   * Whether the tool block has carried any `input_json_delta`. A tool with an
+   * empty schema produces none, and the accumulated argument text would then
+   * stay empty rather than becoming an object literal — see the
+   * `content_block_stop` handler.
+   */
+  receivedArgumentDelta?: boolean
 }
 
 /**
@@ -547,6 +554,7 @@ function createAnthropicSSETranslator(): TransformStream<Uint8Array, Uint8Array>
           emit(controller, chunkOf({ reasoning_content: delta.thinking }))
         }
         else if (delta.type === 'input_json_delta' && state?.kind === 'tool' && typeof delta.partial_json === 'string') {
+          state.receivedArgumentDelta = true
           emit(controller, chunkOf({
             tool_calls: [{ index: state.toolIndex, id: state.toolId, type: 'function', function: { name: state.toolName, arguments: delta.partial_json } }],
           }))
@@ -566,6 +574,21 @@ function createAnthropicSSETranslator(): TransformStream<Uint8Array, Uint8Array>
         emitFinal(controller)
         break
       }
+      case 'content_block_stop': {
+        // A tool whose schema takes no arguments closes without a single
+        // `input_json_delta`, leaving the accumulated argument text empty.
+        // Emit the object literal the non-streaming path already produces
+        // (`JSON.stringify(block.input ?? {})`) so both directions put the same
+        // valid JSON on the wire, rather than leaning on the consumer to read
+        // empty text as an empty object.
+        const state = typeof event.index === 'number' ? blocks.get(event.index) : undefined
+        if (state?.kind === 'tool' && !state.receivedArgumentDelta) {
+          emit(controller, chunkOf({
+            tool_calls: [{ index: state.toolIndex, id: state.toolId, type: 'function', function: { name: state.toolName, arguments: '{}' } }],
+          }))
+        }
+        break
+      }
       case 'error': {
         // xsai's JsonMessageTransformStream throws RemoteAPIError for any SSE
         // payload carrying an `error` key — forward it verbatim to reuse that
@@ -574,7 +597,7 @@ function createAnthropicSSETranslator(): TransformStream<Uint8Array, Uint8Array>
         break
       }
       default:
-        // ping / content_block_stop / unknown future events carry no state.
+        // ping / unknown future events carry no state.
         break
     }
   }

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -80,7 +80,9 @@ type AnthropicContentBlock
   = | { type: 'text', text: string }
     | { type: 'image', source: AnthropicImageSource }
     | { type: 'tool_use', id: string, name: string, input: Record<string, unknown> }
-    | { type: 'tool_result', tool_use_id: string, content: AnthropicToolResultContent }
+    // `content` is optional on the Messages API, and omitting it is how the
+    // docs represent a tool that produced no output.
+    | { type: 'tool_result', tool_use_id: string, content?: AnthropicToolResultContent }
 
 interface AnthropicMessage {
   role: 'user' | 'assistant'
@@ -193,9 +195,20 @@ function mapContentParts(content: OpenAIWireMessage['content'] | undefined): Ant
   return blocks
 }
 
-function mapToolResultContent(content: OpenAIWireMessage['content'] | undefined): AnthropicToolResultContent {
+/**
+ * Maps a `tool` message's content onto a `tool_result` block's `content`.
+ *
+ * Returns `undefined` when the tool produced nothing: a tool legitimately
+ * returns `''` (`builtIn_mcpListTools` does so on its failure path), and the
+ * Messages API represents an empty result by omitting the field rather than by
+ * sending an empty string, which would otherwise ride along as empty content in
+ * the next round of the tool loop — after the tool has already run. A
+ * placeholder is deliberately not substituted; inventing output the tool never
+ * produced would misinform the model.
+ */
+function mapToolResultContent(content: OpenAIWireMessage['content'] | undefined): AnthropicToolResultContent | undefined {
   if (typeof content === 'string' || content == null)
-    return content ?? ''
+    return content == null || content.length === 0 ? undefined : content
   // xsai already stringifies a structured tool return before it becomes message
   // content (`wrapToolResult` in `@xsai/shared-chat`), so this guards the wire
   // shape rather than that path: a caller that serializes the object itself
@@ -205,7 +218,9 @@ function mapToolResultContent(content: OpenAIWireMessage['content'] | undefined)
 
   const blocks: Array<{ type: 'text', text: string } | { type: 'image', source: AnthropicImageSource }> = []
   for (const part of content) {
-    if (part.type === 'text' && part.text != null) {
+    // The API rejects empty text blocks, so a part carrying no text is dropped
+    // rather than forwarded.
+    if (part.type === 'text' && part.text) {
       blocks.push({ type: 'text', text: part.text })
     }
     else if (part.type === 'image_url' && part.image_url?.url) {
@@ -214,7 +229,7 @@ function mapToolResultContent(content: OpenAIWireMessage['content'] | undefined)
         blocks.push(image)
     }
   }
-  return blocks.length > 0 ? blocks : ''
+  return blocks.length > 0 ? blocks : undefined
 }
 
 /**

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -217,6 +217,33 @@ function mapToolResultContent(content: OpenAIWireMessage['content'] | undefined)
   return blocks.length > 0 ? blocks : ''
 }
 
+/**
+ * Completes a tool's JSON Schema into the object schema the Messages API
+ * describes for `input_schema`.
+ *
+ * Before:
+ * - `undefined` / `{}` / `{ additionalProperties: false }`
+ *
+ * After:
+ * - `{ type: 'object' }` / `{ type: 'object' }` / `{ type: 'object', additionalProperties: false }`
+ *
+ * A declared `type` is never overwritten: a caller that means something other
+ * than an object should get the provider's own error rather than a silently
+ * rewritten schema.
+ */
+function toInputSchema(parameters: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (parameters == null)
+    return { type: 'object' }
+  // A schema can arrive without `type` even when it is not empty — `rawTool`
+  // in `@xsai/tool` forwards `parameters` as given, so `rawTool({parameters: {}})`
+  // yields `{ additionalProperties: false }`. Filling the field in keeps a
+  // zero-argument tool from taking the whole `tools` array down with it, and
+  // matches the repo rule that schemas carry an explicit `type: object`.
+  if (parameters.type == null)
+    return { ...parameters, type: 'object' }
+  return parameters
+}
+
 function mapToolChoice(toolChoice: OpenAIWireRequest['tool_choice']): AnthropicRequestBody['tool_choice'] | undefined {
   if (toolChoice == null)
     return undefined
@@ -356,7 +383,7 @@ function translateChatRequest(request: OpenAIWireRequest): AnthropicRequestBody 
     .map(tool => ({
       name: tool.function!.name!,
       description: tool.function!.description,
-      input_schema: tool.function!.parameters ?? { type: 'object' },
+      input_schema: toInputSchema(tool.function!.parameters),
     }))
   if (tools.length > 0) {
     body.tools = tools

--- a/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
+++ b/packages/stage-ui/src/libs/providers/providers/anthropic/native.ts
@@ -133,12 +133,22 @@ interface AnthropicSSEEvent {
 }
 
 /**
- * Models where adaptive thinking is ON when the `thinking` field is omitted
- * (the Claude Sonnet 5 family). Matched non-anchored so gateway-prefixed ids
+ * Models that think by default when the `thinking` field is omitted AND accept
+ * `thinking: {type: 'disabled'}`. Matched non-anchored so gateway-prefixed ids
  * like `anthropic/claude-sonnet-5` are recognized too.
+ *
+ * Fable and Mythos also think by default but reject `disabled` outright, so
+ * they are deliberately absent — see the NOTICE at the `thinking` call site.
+ *
+ * NOTICE:
+ * Claude Opus 5 only accepts `disabled` at effort `high` or below; combining it
+ * with `xhigh` or `max` returns 400. This adapter never sends `effort`, so the
+ * account default applies and the field is safe to send today. Revisit this if
+ * `effort` is ever added to the translated request.
+ * https://platform.claude.com/docs/en/build-with-claude/thinking
  */
 function isAdaptiveThinkingDefaultModel(model: string): boolean {
-  return /claude-sonnet-5/.test(model)
+  return /claude-(?:sonnet|opus)-5/.test(model)
 }
 
 function mapStopReason(stopReason: string | null | undefined): string {

--- a/packages/stage-ui/src/libs/providers/types.ts
+++ b/packages/stage-ui/src/libs/providers/types.ts
@@ -35,6 +35,14 @@ export function isModelProvider(providerInstance: ProviderInstance): providerIns
   return false
 }
 
+export function isChatProvider(providerInstance: ProviderInstance): providerInstance is ChatProvider | ChatProviderWithExtraOptions {
+  if ('chat' in providerInstance && typeof providerInstance.chat === 'function') {
+    return true
+  }
+
+  return false
+}
+
 export interface ProviderOnboardingField {
   key: string
   type: 'text' | 'password'

--- a/packages/stage-ui/src/libs/providers/types.ts
+++ b/packages/stage-ui/src/libs/providers/types.ts
@@ -50,6 +50,14 @@ export function isModelProvider(providerInstance: ProviderInstance): providerIns
   return false
 }
 
+export function isChatProvider(providerInstance: ProviderInstance): providerInstance is ChatProvider | ChatProviderWithExtraOptions {
+  if ('chat' in providerInstance && typeof providerInstance.chat === 'function') {
+    return true
+  }
+
+  return false
+}
+
 export interface ProviderOnboardingField {
   key: string
   type: 'text' | 'password'

--- a/packages/stage-ui/src/libs/providers/validators/openai-compatible.test.ts
+++ b/packages/stage-ui/src/libs/providers/validators/openai-compatible.test.ts
@@ -145,4 +145,61 @@ describe('createOpenAICompatibleValidators', () => {
       model: 'seed-2-0-pro-260328',
     }))
   })
+
+  // https://github.com/moeru-ai/airi/issues/1565
+  it('chat probing goes through the provider\'s own fetch so translating providers are checked on their real transport (Issue #1565)', async () => {
+    listModelsMock.mockResolvedValue([
+      { id: 'claude-sonnet-4-5-20250929' },
+    ])
+
+    // Mirrors the Anthropic provider, which rewrites Chat Completions requests
+    // onto the native Messages API inside its fetch. Probing without it would
+    // hit `{baseUrl}chat/completions`, which /v1/messages-only proxies do not serve.
+    const translatingFetch = vi.fn()
+    const translatingProvider: ProviderInstance = {
+      chat: (model: string) => ({
+        apiKey: config.apiKey,
+        baseURL: config.baseUrl,
+        fetch: translatingFetch,
+        model,
+      }),
+      model: () => ({
+        apiKey: config.apiKey,
+        baseURL: config.baseUrl,
+        fetch: translatingFetch,
+      }),
+    } as ProviderInstance
+
+    const [, chatValidator] = getProviderValidators({
+      checks: [ProviderValidationCheck.Connectivity, ProviderValidationCheck.ChatCompletions],
+    })
+
+    const result = await chatValidator.validator(config, translatingProvider, providerExtra, { t: mockT })
+
+    expect(result.valid).toBe(true)
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      fetch: translatingFetch,
+      model: 'claude-sonnet-4-5-20250929',
+    }))
+  })
+
+  it('leaves fetch unset for providers that do not supply one', async () => {
+    listModelsMock.mockResolvedValue([
+      { id: 'gpt-4o' },
+    ])
+
+    const [, chatValidator] = getProviderValidators({
+      checks: [ProviderValidationCheck.Connectivity, ProviderValidationCheck.ChatCompletions],
+    })
+
+    // `provider` exposes only `model()`, so there is no transport to inherit.
+    const result = await chatValidator.validator(config, provider, providerExtra, { t: mockT })
+
+    expect(result.valid).toBe(true)
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      fetch: undefined,
+      baseURL: config.baseUrl,
+      apiKey: config.apiKey,
+    }))
+  })
 })

--- a/packages/stage-ui/src/libs/providers/validators/openai-compatible.ts
+++ b/packages/stage-ui/src/libs/providers/validators/openai-compatible.ts
@@ -8,7 +8,7 @@ import { listModels } from '@xsai/model'
 import { message } from '@xsai/utils-chat'
 import { Mutex } from 'es-toolkit'
 
-import { isModelProvider, ProviderValidationCheck } from '../types'
+import { isChatProvider, isModelProvider, ProviderValidationCheck } from '../types'
 
 interface OpenAICompatibleValidationOptions<TConfig extends { apiKey?: string, baseUrl?: string }> {
   checks?: ProviderValidationCheck[]
@@ -133,12 +133,31 @@ export function createOpenAICompatibleValidators<TConfig extends { apiKey?: stri
       }
     }
 
+    // A provider may reach its API through a translating `fetch` rather than by
+    // POSTing Chat Completions directly — the Anthropic provider rewrites
+    // requests onto the native Messages API that way. Checking with a
+    // hand-built request would then probe `{baseUrl}chat/completions`, an
+    // endpoint the provider itself never uses and `/v1/messages`-only proxies
+    // do not serve, so the check fails while real chat traffic succeeds.
+    //
+    // Only the transport is inherited; apiKey/baseURL/headers stay caller-owned
+    // so this stays a check of the configuration under validation. Providers
+    // created without a custom `fetch` resolve to `undefined` and are unchanged.
+    //
+    // NOTICE: `chat()` returns the provider's own options object and assigns
+    // `model` onto it (`Object.assign(options, { model })` in
+    // `@xsai-ext/providers/dist/utils/index.js`). That write is harmless — every
+    // real call sets `model` the same way — but it is why this reads the options
+    // through a call instead of a property.
+    const providerFetch = isChatProvider(provider) ? provider.chat(normalizedModel).fetch : undefined
+
     try {
       await generateText({
         apiKey: config.apiKey,
         baseURL: config.baseUrl!,
         headers: additionalHeaders,
         model: normalizedModel,
+        fetch: providerFetch,
         messages: message.messages(message.user('ping')),
         max_tokens: 1,
       })


### PR DESCRIPTION
Closes #1565

## What this does

Adds a protocol adapter at the `fetch` boundary of the Anthropic provider. xsai keeps emitting OpenAI Chat Completions requests exactly as before — the provider's fetch translates each `POST {baseURL}chat/completions` into a native `POST {baseURL}messages` call, and translates the JSON / SSE response back into the Chat Completions shape xsai parses. **No other layer of the app changes**: `stores/llm.ts`, the chat orchestrator, tool resolution, and the provider validators all run unmodified.

```
xsai (OpenAI wire) ──► createNativeAnthropicFetch ──► Anthropic /v1/messages
                 ◄── chat.completion / SSE chunks ◄── Messages JSON / SSE events
```

Three files: the adapter (`native.ts`), its test suite, and a ~15-line change wiring it into the provider definition.

## Why

**1. The proxy gap (#1565).** Proxies that implement only the native `/v1/messages` endpoint (e.g. antigravity-claude-proxy) currently cannot be used at all — the provider only ever speaks `/v1/chat/completions`. With this change they work by just setting the Base URL.

**2. The compatibility layer is a documented dead end for production.** The official API does serve both formats — but Anthropic's own documentation is explicit about what the OpenAI-compatible endpoint is for:

> "This compatibility layer is primarily intended to **test and compare model capabilities**, and is **not considered a long-term or production-ready solution** for most use cases."
> — [OpenAI SDK compatibility](https://platform.claude.com/docs/en/api/openai-sdk)

Concretely, staying on it costs us (all from that same page):

- **Prompt caching is not supported** — for a companion app that resends a large stable prefix (character card + toolset prompts) on every single turn, this forfeits the single biggest cost/latency lever the Messages API offers (`cache_control` breakpoints, ~90% input-cost reduction on cache reads).
- **Thinking output is never returned** — `thinking` can be enabled via `extra_body`, but the compat layer discards the model's reasoning stream, so AIRI can never display it.
- **`strict` tool schemas are silently ignored** — no guaranteed schema conformance for tool calls, undermining the provider-safe schema work elsewhere in the codebase.
- `response_format` ignored, system/developer messages flattened by concatenation, audio/file parts stripped.

**3. Field experience.** I maintain [Luna-ts](https://github.com/Alan-Yu-2077/Luna-ts), a TypeScript companion agent that has been running against the native Messages API (official endpoint and `/v1/messages` proxies) in production for months — streaming, tool loops, thinking, and prompt caching included. This adapter distills the protocol handling that implementation converged on, adapted to xsai's wire contracts (which I verified against the installed `@xsai/*` dists rather than assuming).

## What lands immediately / what staying costs

| | native (this PR) | compat layer (status quo) |
|---|---|---|
| `/v1/messages`-only proxies | ✅ work via Base URL | ❌ unusable (#1565) |
| Thinking display | ✅ `thinking_delta` → xsai's `reasoning_content` channel (existing `reasoning-delta` events consume it) | ❌ discarded by the endpoint |
| Usage accounting | ✅ exact, incl. `cache_read/creation_input_tokens` folded into `prompt_tokens` | partial |
| Prompt caching | groundwork laid (native protocol is the prerequisite for `cache_control`) | ❌ impossible |
| Provider diagnostics | `request-id` / `anthropic-ratelimit-*` headers preserved on translated responses | n/a |
| Anthropic's support posture | production path | "test and compare" shim |

## Protocol notes (for review)

The translation is deliberately **whitelist-based**: xsai serializes leftover runtime options into the wire body, and the Messages API 400s on unknown top-level fields — so only understood fields cross the boundary. Decisions reviewers may want to check:

- **Pairing invariant**: every `tool_result` must reference a `tool_use` in the immediately preceding assistant turn. The adapter merges consecutive same-role turns (strict-alternation proxies), and drops orphaned results (e.g. after an untranslatable nameless `tool_call`) rather than letting the API reject the request.
- **`max_tokens` is required** on Messages (optional on Chat Completions), and the API *rejects* — not clamps — values above a model's output cap. Default is 4096, the floor across every Claude model still served; callers passing `max_tokens` explicitly are honored (the validators' `max_tokens: 1` connectivity probe included).
- **Sampling params**: `temperature` is clamped to the Messages range `[0, 1]`; `temperature` and `top_p` are never sent together (rejected on Claude 4+ — when a caller legally sends both on the OpenAI protocol, `temperature` wins).
- **`stop_sequences`**: whitespace-only entries (the common OpenAI `"\n"` idiom) are rejected by the Messages API and filtered out.
- **Thinking policy**: on models where adaptive thinking defaults ON when the field is omitted (Claude Sonnet 5 family), tool requests send `thinking: {type: "disabled"}` — the Messages API requires the previous assistant turn's *signed* thinking blocks to be echoed ahead of its `tool_use` blocks, and an OpenAI-shaped history cannot carry signatures, so round 2 of any tool loop would 400. The field is sent **only** to that allowlist: older models may reject `thinking` outright, and everywhere else omission already means off. Always-thinking models (Fable/Mythos) reject `disabled` and are a documented tool-loop limitation (`// NOTICE` in the code).
- **SSE grammar**: `message_start` / `content_block_start|delta|stop` / `message_delta` / `message_stop` / `ping` / `error` are all handled; `text_delta` → `delta.content`, `thinking_delta` → `delta.reasoning_content`, `input_json_delta` → indexed `tool_calls` argument deltas (first chunk per index carries `id` + `name`, matching xsai's accumulator contract), `signature_delta` and unknown block types are dropped. Provider `error` frames are forwarded on the SSE `{"error": …}` channel that xsai's parser already raises on. If the upstream closes without `message_stop`, an already-received `stop_reason`/usage from `message_delta` is still emitted before `[DONE]`.
- **`stop_reason` taxonomy**: `end_turn`/`stop_sequence`/`pause_turn` → `stop`, `tool_use` → `tool_calls`, `max_tokens`/`model_context_window_exceeded` → `length`, `refusal` → `content_filter`.
- Non-2xx responses and 2xx non-JSON bodies pass through untouched so xsai's error path reports Anthropic's real payload.

## Behavior change (honest note)

Users who pointed this provider's Base URL at a gateway that only implements the **OpenAI** protocol will need to move that endpoint to the **OpenAI Compatible** provider — which is exactly what that provider exists for. Official `api.anthropic.com` users are unaffected (the native endpoint is the first-class path there). If maintainers prefer, an opt-in protocol toggle on the provider config is a straightforward follow-up — happy to adjust.

## How tested

```sh
pnpm -F @proj-airi/stage-ui exec vitest run src/libs/providers/providers/anthropic/
pnpm -F @proj-airi/stage-ui exec vitest run --project node   # full suite: 628 passed, 2 gated-skipped
pnpm -F @proj-airi/stage-ui typecheck && pnpm -F @proj-airi/stage-web typecheck && pnpm -F @proj-airi/stage-tamagotchi typecheck
```

- **33 unit tests** exercising the public fetch surface only (request translation, response translation, SSE state machine incl. byte-boundary and split multi-byte UTF-8 delivery, CRLF frames, abort propagation, URL rewriting with query strings, header swapping).
- **4 consumer-contract tests** driving the **real** `@xsai/stream-text` / `@xsai/generate-text` through the adapter with only the upstream stubbed — including a full two-round tool loop asserting the round-2 Messages body byte-for-byte, and the validators' `generateText` connectivity path.
- **2 env-gated live integration tests** (`ANTHROPIC_NATIVE_SMOKE_KEY` / `_BASE_URL` / `_MODEL`), which I ran against a real `/v1/messages` endpoint: streaming and non-streaming round trips both pass.

## Follow-ups

- **Prompt caching**: with the native protocol in place, `cache_control` breakpoints on the stable system prefix become possible — the largest cost/latency win available to AIRI's chat loop. I'd like to take this as a follow-up PR.
- Optional protocol toggle on the provider config, if maintainers want the compat path selectable.
