### PR TITLE
fix(stage-ui): repair dangling character card selection

### DIFF
--- a/packages/stage-ui/src/stores/modules/airi-card.test.ts
+++ b/packages/stage-ui/src/stores/modules/airi-card.test.ts
@@ -311,4 +311,29 @@ describe('airi-card store', () => {
     expect(cardStore.cards.has('default')).toBe(true)
     expect(cardStore.activeCardId).toBe('default')
   })
+
+  it('preserves a valid persisted active card during initialization', () => {
+    const cardStore = useAiriCardStore()
+    const cardId = cardStore.addCard({
+      name: 'Persisted active card',
+      version: '1.0.0',
+      description: 'Keep this selection.',
+    }, 'scratch')
+    cardStore.activeCardId = cardId
+
+    cardStore.initialize()
+
+    expect(cardStore.activeCardId).toBe(cardId)
+    expect(cardStore.activeCard?.name).toBe('Persisted active card')
+  })
+
+  it('repairs a dangling persisted active card during initialization', () => {
+    const cardStore = useAiriCardStore()
+    cardStore.activeCardId = 'missing-card'
+
+    cardStore.initialize()
+
+    expect(cardStore.activeCardId).toBe('default')
+    expect(cardStore.activeCard?.name).toBe('ReLU')
+  })
 })

--- a/packages/stage-ui/src/stores/modules/airi-card.ts
+++ b/packages/stage-ui/src/stores/modules/airi-card.ts
@@ -296,19 +296,20 @@ export const useAiriCardStore = defineStore('airi-card', () => {
   }
 
   function initialize() {
-    if (cards.value.has('default')) {
-      applyActiveCardSettings()
-      return
+    if (!cards.value.has('default')) {
+      cards.value.set('default', newAiriCard({
+        name: 'ReLU',
+        version: '1.0.0',
+        description: SystemPromptV2(
+          t('base.prompt.prefix'),
+          t('base.prompt.suffix'),
+        ).content,
+      }))
     }
-    cards.value.set('default', newAiriCard({
-      name: 'ReLU',
-      version: '1.0.0',
-      description: SystemPromptV2(
-        t('base.prompt.prefix'),
-        t('base.prompt.suffix'),
-      ).content,
-    }))
-    if (!activeCardId.value)
+
+    // The active id and card map are persisted separately. Older versions
+    // could delete the selected card without repairing its stored id.
+    if (!cards.value.has(activeCardId.value))
       activeCardId.value = 'default'
 
     applyActiveCardSettings()


### PR DESCRIPTION
## Description

- repair a persisted active card ID that points to a missing card by falling back to the built-in `default` card
- preserve the selected card when its persisted ID still resolves successfully
- add regression coverage for both initialization paths

## Linked Issues

None.

## Additional Context

Before #2110, deleting the active card could remove it from the persisted card map without repairing the separately persisted `airi-card-active-id`. #2110 prevents new dangling selections; this PR repairs data already left behind by older versions.

The `airi-cards` key, `airi-card-active-id` key, VueUse Map serialization, and persisted `AiriCard` shape are unchanged. No storage migration is required.

This remains the base for #2119 and #2120, while runtime compilation and editor work stay outside this fix.

### Validation

- `pnpm -F @proj-airi/stage-ui exec vitest run src/stores/modules/airi-card.test.ts` — 10 tests passed
- `pnpm exec eslint packages/stage-ui/src/stores/modules/airi-card.ts packages/stage-ui/src/stores/modules/airi-card.test.ts` — passed
- `git diff --check` — passed
