### PR TITLE
feat(stage): persist speech mute and desktop window bounds

### DIFF
--- a/apps/stage-tamagotchi/src/main/libs/electron/persistence.test.ts
+++ b/apps/stage-tamagotchi/src/main/libs/electron/persistence.test.ts
@@ -77,7 +77,10 @@ describe('createConfig', () => {
       app: appMock,
     }))
     vi.doMock('es-toolkit', () => ({
-      throttle: (handler: (...args: unknown[]) => unknown) => handler,
+      throttle: (handler: (...args: unknown[]) => unknown) => Object.assign(handler, {
+        cancel: vi.fn(),
+        flush: vi.fn(),
+      }),
     }))
     vi.doMock('node:fs', () => ({
       existsSync: () => false,
@@ -112,5 +115,74 @@ describe('createConfig', () => {
     expect(saveErrorSpy).not.toHaveBeenCalledWith('Failed to save config', expect.anything())
     expect(new Set(renameMock.mock.calls.map(([from]) => from)).size).toBe(2)
     saveErrorSpy.mockRestore()
+  })
+
+  it('flushes the latest throttled config before the Electron main process exits', async () => {
+    const writeFileMock = vi.fn(async () => {})
+    const renameMock = vi.fn(async () => {})
+
+    vi.doMock('electron', () => ({
+      app: {
+        getPath: vi.fn(() => '/tmp/airi-user-data'),
+      },
+    }))
+    vi.doMock('es-toolkit', () => ({
+      throttle: (handler: () => void) => {
+        let pending = false
+        return Object.assign(
+          () => {
+            pending = true
+          },
+          {
+            cancel: vi.fn(),
+            flush: () => {
+              if (!pending)
+                return
+              pending = false
+              handler()
+            },
+          },
+        )
+      },
+    }))
+    vi.doMock('node:fs', () => ({
+      existsSync: () => false,
+      readFileSync: () => '',
+    }))
+    vi.doMock('node:fs/promises', () => ({
+      copyFile: vi.fn(async () => {}),
+      mkdir: vi.fn(async () => {}),
+      rename: renameMock,
+      writeFile: writeFileMock,
+    }))
+
+    const { createConfig } = await import('./persistence')
+    const config = createConfig('app', 'config.json', object({ value: number() }), {
+      default: { value: 0 },
+    })
+
+    config.setup()
+    config.update({ value: 42 })
+
+    expect(writeFileMock).not.toHaveBeenCalled()
+
+    // ROOT CAUSE:
+    //
+    // If Electron restarts while a throttled bounds update is pending, the
+    // process exits before the async config write starts.
+    //
+    // Before the patch, createConfig exposed no lifecycle operation that could
+    // force and await this pending save.
+    //
+    // We fixed this by cancelling the delayed call, awaiting active writes, and
+    // persisting the latest in-memory value as the authoritative final write.
+    await config.flush()
+
+    expect(writeFileMock).toHaveBeenCalledOnce()
+    expect(writeFileMock).toHaveBeenCalledWith(
+      expect.stringMatching(/app-config\.json\..+\.tmp$/),
+      JSON.stringify({ value: 42 }),
+    )
+    expect(renameMock).toHaveBeenCalledOnce()
   })
 })

--- a/apps/stage-tamagotchi/src/main/libs/electron/persistence.ts
+++ b/apps/stage-tamagotchi/src/main/libs/electron/persistence.ts
@@ -58,6 +58,8 @@ export interface Config<TSchema extends PersistedSchema> {
   setup: () => ConfigDiagnostics<InferOutput<TSchema>>
   get: () => InferOutput<TSchema> | undefined
   update: (newData: InferOutput<TSchema>) => void
+  /** Persists the latest value and waits for active writes to finish. */
+  flush: () => Promise<void>
   getDiagnostics: () => ConfigDiagnostics<InferOutput<TSchema>> | undefined
 }
 
@@ -77,7 +79,7 @@ export function createConfig<TSchema extends PersistedSchema>(
     return diagnostics
   }
 
-  const save = throttle(async () => {
+  async function persist() {
     try {
       const path = configPath()
       await ensureConfigDirectory(path)
@@ -88,6 +90,13 @@ export function createConfig<TSchema extends PersistedSchema>(
     catch (error) {
       console.error('Failed to save config', error)
     }
+  }
+
+  const pendingSaves = new Set<Promise<void>>()
+  const save = throttle(() => {
+    const pendingSave = persist()
+    pendingSaves.add(pendingSave)
+    void pendingSave.finally(() => pendingSaves.delete(pendingSave))
   }, 250)
 
   const writeHealingConfig = async (value: InferOutput<TSchema>) => {
@@ -170,6 +179,22 @@ export function createConfig<TSchema extends PersistedSchema>(
     save()
   }
 
+  /**
+   * Persists the latest in-memory value before a lifecycle boundary completes.
+   *
+   * Callers should await this during application shutdown so a throttled update
+   * cannot be dropped when Electron restarts the main process.
+   */
+  let flushQueue = Promise.resolve()
+  const flush = () => {
+    flushQueue = flushQueue.then(async () => {
+      save.cancel()
+      await Promise.all(pendingSaves)
+      await persist()
+    })
+    return flushQueue
+  }
+
   const get = () => persistenceMap.get(key) as InferOutput<TSchema> | undefined
 
   const getDiagnostics = () => diagnosticsMap.get(key) as ConfigDiagnostics<InferOutput<TSchema>> | undefined
@@ -178,6 +203,7 @@ export function createConfig<TSchema extends PersistedSchema>(
     setup,
     get,
     update,
+    flush,
     getDiagnostics,
   }
 }

--- a/apps/stage-tamagotchi/src/main/windows/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/main/index.ts
@@ -67,6 +67,7 @@ export async function setupMainWindow(params: {
     setup: setupConfig,
     get: getConfigRaw,
     update: updateConfig,
+    flush: flushConfig,
   } = createConfig('app', 'config.json', appConfigSchema, {
     default: { windows: [] },
     autoHeal: true,
@@ -102,8 +103,20 @@ export async function setupMainWindow(params: {
   }
 
   let allowClose = false
-  onAppBeforeQuit(() => {
+  onAppBeforeQuit(async () => {
     allowClose = true
+
+    // NOTICE:
+    // Capture native bounds because the macOS click-drag bridge can finish
+    // without a final Electron `move` event reaching this process.
+    // The bridge calls `performWindowDragWithEvent:` outside Electron's normal
+    // drag region path; see https://github.com/Wargraphs/electron-click-drag-plugin.
+    // Remove this fallback only when the drag path guarantees a final bounds
+    // notification and config shutdown flushing remains covered separately.
+    if (!window.isDestroyed()) {
+      handleNewBounds(window.getBounds())
+    }
+    await flushConfig()
   })
 
   // NOTICE: in development mode, open devtools by default
@@ -150,6 +163,21 @@ export async function setupMainWindow(params: {
 
   window.on('resize', () => handleNewBounds(window.getBounds()))
   window.on('move', () => handleNewBounds(window.getBounds()))
+  if (isMacOS) {
+    // NOTICE:
+    // Electron documents `moved`/`resized` as the completed native gesture
+    // events on supported platforms. Persist immediately here because
+    // electron-vite terminates the old main process directly during HMR.
+    // https://www.electronjs.org/docs/latest/api/base-window#event-moved-macos-windows
+    // Remove the immediate flush only when the development supervisor awaits
+    // graceful app shutdown before replacing the main process.
+    const persistFinalBounds = () => {
+      handleNewBounds(window.getBounds())
+      void flushConfig()
+    }
+    window.on('moved', persistFinalBounds)
+    window.on('resized', persistFinalBounds)
+  }
   window.on('close', (event) => {
     if (allowClose) {
       return

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.vue
@@ -65,7 +65,7 @@ const {
   trackChatMessageRetried,
   trackChatMessagesCleared,
 } = useAnalytics()
-const { showStopSpeakingButton, stopSpeakingFromChat } = useStopSpeakingButton()
+const { showStopSpeakingButton, speechMuted, stopSpeakingFromChat, toggleSpeechMuted } = useStopSpeakingButton()
 
 const latestImageEntries = computed(() => {
   if (!activeCardId.value)
@@ -387,6 +387,24 @@ async function handleCleanupMessages() {
           </DropdownMenuContent>
         </DropdownMenuPortal>
       </DropdownMenuRoot>
+
+      <button
+        data-testid="speech-mute-button"
+        :class="[
+          'max-h-[10lh] min-h-[1lh] flex items-center justify-center rounded-md p-2 outline-none',
+          'text-lg transition-colors transition-transform active:scale-95',
+          speechMuted
+            ? 'bg-primary-100 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300'
+            : 'bg-neutral-100 text-neutral-500 hover:text-primary-500 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:text-primary-400',
+        ]"
+        :title="speechMuted ? t('stage.speech-output.unmute') : t('stage.speech-output.mute')"
+        :aria-label="speechMuted ? t('stage.speech-output.unmute') : t('stage.speech-output.mute')"
+        :aria-pressed="speechMuted"
+        @click="toggleSpeechMuted"
+      >
+        <div v-if="speechMuted" class="i-solar:volume-cross-bold-duotone" />
+        <div v-else class="i-solar:volume-loud-bold-duotone" />
+      </button>
 
       <button
         v-if="showStopSpeakingButton"

--- a/packages/i18n/src/locales/en/stage.yaml
+++ b/packages/i18n/src/locales/en/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Enter
   ctrl-enter: Ctrl + Enter
   double-enter: Double Enter
+speech-output:
+  mute: Mute voice
+  unmute: Unmute voice
 operations:
   load-models: Load Models
   load-models-status:

--- a/packages/i18n/src/locales/es/stage.yaml
+++ b/packages/i18n/src/locales/es/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Intro
   ctrl-enter: Ctrl + Intro
   double-enter: Entrada doble
+speech-output:
+  mute: Silenciar voz
+  unmute: Activar voz
 operations:
   load-models: Cargar Modelos
   load-models-status:

--- a/packages/i18n/src/locales/fr/stage.yaml
+++ b/packages/i18n/src/locales/fr/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Entrée
   ctrl-enter: Ctrl + Entrée
   double-enter: Double Entrée
+speech-output:
+  mute: Couper la voix
+  unmute: Réactiver la voix
 operations:
   load-models: Charger les modèles
   load-models-status:

--- a/packages/i18n/src/locales/ja/stage.yaml
+++ b/packages/i18n/src/locales/ja/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Enter
   ctrl-enter: Ctrl + Enter
   double-enter: Enter二回
+speech-output:
+  mute: 音声をミュート
+  unmute: ミュートを解除
 operations:
   load-models: モデルの読み込み
   load-models-status:

--- a/packages/i18n/src/locales/ko/stage.yaml
+++ b/packages/i18n/src/locales/ko/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: 엔터
   ctrl-enter: Ctrl + Enter
   double-enter: Double Enter
+speech-output:
+  mute: 음성 음소거
+  unmute: 음소거 해제
 operations:
   load-models: 모델 불러오기
   load-models-status:

--- a/packages/i18n/src/locales/ru/stage.yaml
+++ b/packages/i18n/src/locales/ru/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Enter
   ctrl-enter: Ctrl + Enter
   double-enter: Двойной Enter
+speech-output:
+  mute: Отключить озвучивание
+  unmute: Включить озвучивание
 operations:
   load-models: Загрузить модели
   load-models-status:

--- a/packages/i18n/src/locales/vi/stage.yaml
+++ b/packages/i18n/src/locales/vi/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Nhập
   ctrl-enter: Ctrl + Enter
   double-enter: Nhập hai lần
+speech-output:
+  mute: Tắt tiếng nói
+  unmute: Bật tiếng nói
 operations:
   load-models: Tải mô hình
   load-models-status:

--- a/packages/i18n/src/locales/zh-Hans/stage.yaml
+++ b/packages/i18n/src/locales/zh-Hans/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Enter
   ctrl-enter: Ctrl + Enter
   double-enter: 双击Enter
+speech-output:
+  mute: 静音语音
+  unmute: 恢复语音
 operations:
   load-models: 加载模型
   load-models-status:

--- a/packages/i18n/src/locales/zh-Hant/stage.yaml
+++ b/packages/i18n/src/locales/zh-Hant/stage.yaml
@@ -20,6 +20,9 @@ send-mode:
   enter: Enter
   ctrl-enter: Ctrl + Enter
   double-enter: Enter + Enter
+speech-output:
+  mute: 靜音語音
+  unmute: 恢復語音
 operations:
   load-models: 載入模型
   load-models-status:

--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -94,7 +94,7 @@ const { isListening, startStreamingTranscription, stopStreamingTranscription } =
     isStageTamagotchi,
   },
 )
-const { showStopSpeakingButton, stopSpeakingFromChat } = useStopSpeakingButton()
+const { showStopSpeakingButton, speechMuted, stopSpeakingFromChat, toggleSpeechMuted } = useStopSpeakingButton()
 const toggleTranscription = () => isListening.value ? stopStreamingTranscription() : startStreamingTranscription()
 
 async function handleSubmit() {
@@ -273,6 +273,23 @@ onMounted(() => {
           @compositionstart="isComposing = true"
           @compositionend="isComposing = false"
         />
+        <button
+          data-testid="speech-mute-button"
+          :class="[
+            'h-[calc(1lh+4px+4px)] w-[calc(1lh+4px+4px)] flex items-center justify-center self-end rounded-md outline-none',
+            'text-lg transition-all duration-200 active:scale-95',
+            speechMuted
+              ? 'bg-primary-100/60 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300'
+              : 'text-neutral-500 hover:bg-primary-100/60 hover:text-primary-600 dark:text-neutral-400 dark:hover:bg-primary-900/40 dark:hover:text-primary-300',
+          ]"
+          :title="speechMuted ? t('stage.speech-output.unmute') : t('stage.speech-output.mute')"
+          :aria-label="speechMuted ? t('stage.speech-output.unmute') : t('stage.speech-output.mute')"
+          :aria-pressed="speechMuted"
+          @click="toggleSpeechMuted"
+        >
+          <div v-if="speechMuted" class="i-solar:volume-cross-bold-duotone h-5 w-5" />
+          <div v-else class="i-solar:volume-loud-bold-duotone h-5 w-5" />
+        </button>
         <button
           v-if="showStopSpeakingButton"
           data-testid="stop-speaking-button"

--- a/packages/stage-layouts/src/components/Widgets/ChatArea.vue
+++ b/packages/stage-layouts/src/components/Widgets/ChatArea.vue
@@ -60,7 +60,7 @@ const { isListening, startStreamingTranscription, stopStreamingTranscription, au
     isStageTamagotchi,
   },
 )
-const { showStopSpeakingButton, stopSpeakingFromChat } = useStopSpeakingButton()
+const { showStopSpeakingButton, speechMuted, stopSpeakingFromChat, toggleSpeechMuted } = useStopSpeakingButton()
 
 async function handleSend() {
   if (!messageInput.value.trim() || isComposing.value) {
@@ -302,8 +302,26 @@ watch(sendMode, () => {
       </div>
 
       <div
-        absolute bottom-2 right-2 z-10 flex items-center
+        absolute bottom-2 right-2 z-10 flex items-center gap-1
       >
+        <button
+          data-testid="speech-mute-button"
+          :class="[
+            'h-8 w-8 flex items-center justify-center rounded-md outline-none',
+            'text-lg transition-all duration-200 active:scale-95',
+            speechMuted
+              ? 'bg-primary-100/60 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300'
+              : 'text-neutral-500 hover:bg-primary-100/60 hover:text-primary-600 dark:text-neutral-400 dark:hover:bg-primary-900/40 dark:hover:text-primary-300',
+          ]"
+          :title="speechMuted ? t('stage.speech-output.unmute') : t('stage.speech-output.mute')"
+          :aria-label="speechMuted ? t('stage.speech-output.unmute') : t('stage.speech-output.mute')"
+          :aria-pressed="speechMuted"
+          @click="toggleSpeechMuted"
+        >
+          <div v-if="speechMuted" class="i-solar:volume-cross-bold-duotone h-5 w-5" />
+          <div v-else class="i-solar:volume-loud-bold-duotone h-5 w-5" />
+        </button>
+
         <button
           v-if="showStopSpeakingButton"
           data-testid="stop-speaking-button"

--- a/packages/stage-layouts/src/composables/useStopSpeakingButton.test.ts
+++ b/packages/stage-layouts/src/composables/useStopSpeakingButton.test.ts
@@ -4,7 +4,9 @@ import { ref } from 'vue'
 import { useStopSpeakingButton } from './useStopSpeakingButton'
 
 const nowSpeaking = ref(false)
+const speechMuted = ref(false)
 const requestStopSpeakingMock = vi.fn()
+const toggleSpeechMutedMock = vi.fn()
 const trackTtsStopClickedMock = vi.fn()
 
 vi.mock('@proj-airi/stage-ui/stores/audio', () => ({
@@ -16,6 +18,8 @@ vi.mock('@proj-airi/stage-ui/stores/audio', () => ({
 vi.mock('@proj-airi/stage-ui/stores/speech-output-control', () => ({
   useSpeechOutputControlStore: () => ({
     requestStopSpeaking: requestStopSpeakingMock,
+    speechMuted,
+    toggleSpeechMuted: toggleSpeechMutedMock,
   }),
 }))
 
@@ -68,5 +72,18 @@ describe('useStopSpeakingButton', () => {
     expect(trackTtsStopClickedMock).toHaveBeenCalledWith({
       reason: 'manual-all',
     })
+  })
+
+  it('exposes persisted mute state and toggles it through the shared output store', () => {
+    speechMuted.value = true
+    toggleSpeechMutedMock.mockClear()
+
+    const controls = useStopSpeakingButton()
+
+    expect(controls.speechMuted.value).toBe(true)
+
+    controls.toggleSpeechMuted()
+
+    expect(toggleSpeechMutedMock).toHaveBeenCalledOnce()
   })
 })

--- a/packages/stage-layouts/src/composables/useStopSpeakingButton.ts
+++ b/packages/stage-layouts/src/composables/useStopSpeakingButton.ts
@@ -5,20 +5,15 @@ import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 
 /**
- * Connects chat UI stop-speaking controls to the active stage speech output host.
+ * Connects chat speech controls to the active Stage output host.
  *
- * Use when:
- * - Chat input UI needs to stop assistant TTS playback without cancelling text generation.
- *
- * Expects:
- * - A Stage instance is mounted and consumes speech output stop requests.
- *
- * Returns:
- * - Visibility state for the button and click handlers for manual stops.
+ * Manual stops affect current playback without cancelling text generation.
+ * Mute is persisted by the shared store and also blocks future TTS sessions.
  */
 export function useStopSpeakingButton() {
   const { nowSpeaking } = storeToRefs(useSpeakingStore())
   const speechOutputControlStore = useSpeechOutputControlStore()
+  const { speechMuted } = storeToRefs(speechOutputControlStore)
   const { trackTtsStopClicked } = useAnalytics()
 
   const showStopSpeakingButton = computed(() => nowSpeaking.value)
@@ -35,7 +30,9 @@ export function useStopSpeakingButton() {
 
   return {
     showStopSpeakingButton,
+    speechMuted,
     stopSpeakingFromChat,
     stopAllSpeaking,
+    toggleSpeechMuted: speechOutputControlStore.toggleSpeechMuted,
   }
 }

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -93,7 +93,8 @@ const {
 const { mouthOpenSize, nowSpeaking } = storeToRefs(useSpeakingStore())
 const { audioContext } = useAudioContext()
 const currentAudioSource = ref<AudioBufferSourceNode>()
-const { latestStopRequest } = storeToRefs(useSpeechOutputControlStore())
+const speechOutputControlStore = useSpeechOutputControlStore()
+const { latestStopRequest, speechMuted } = storeToRefs(speechOutputControlStore)
 const lastVrmInteractionAt = new Map<VrmInteractionTarget, number>()
 const VRM_INTERACTION_COOLDOWN_MS = 450
 
@@ -389,6 +390,9 @@ function trackOfficialAutoTtsForTurn(modelId: string) {
 const speechPipeline = createSpeechPipeline<AudioBuffer>({
   tts: async (request, signal) => {
     if (signal.aborted)
+      return null
+
+    if (speechMuted.value)
       return null
 
     if (activeSpeechProvider.value === 'speech-noop')
@@ -693,6 +697,9 @@ function resolveStreamingSessionModel(): string | null {
 }
 
 function buildStreamingSnapshot(): StreamingSessionSnapshot | null {
+  if (speechMuted.value)
+    return null
+
   // Snapshotted once per session, so a mid-session provider/voice swap
   // does not corrupt an in-flight session — the watcher below detects
   // changes and tears down explicitly. Returns `null` when streaming
@@ -790,15 +797,24 @@ watch(latestStopRequest, (request) => {
   stopSpeechOutput(request.reason)
 })
 
+watch(speechMuted, (muted) => {
+  if (muted)
+    stopSpeechOutput('muted')
+}, { immediate: true })
+
 chatHookCleanups.push(onBeforeMessageComposed(async () => {
   officialAutoTtsTrackedForTurn = false
   playbackManager.stopAll('new-message')
-
-  setupAnalyser()
-  await setupLipSync()
   resetAssistantSpeechSurface('new-message')
 
   currentSession?.cancel('new-message')
+  currentSession = null
+
+  if (speechMuted.value)
+    return
+
+  setupAnalyser()
+  await setupLipSync()
   currentSession = openTtsSession()
 }))
 
@@ -811,6 +827,13 @@ chatHookCleanups.push(onTokenLiteral(async (literal) => {
 }))
 
 chatHookCleanups.push(onTokenSpecial(async (special) => {
+  // Muting speech must not suppress non-audio signals such as emotion, motion,
+  // delay, or plugin calls that normally travel through the TTS session.
+  if (speechMuted.value) {
+    await playSpecialToken(special)
+    return
+  }
+
   currentSession?.appendSpecial(special)
 }))
 

--- a/packages/stage-ui/src/stores/speech-output-control.test.ts
+++ b/packages/stage-ui/src/stores/speech-output-control.test.ts
@@ -1,11 +1,59 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import { useSpeechOutputControlStore } from './speech-output-control'
 
+class MemoryStorage implements Storage {
+  readonly values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  clear() {
+    this.values.clear()
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
 describe('speech output control store', () => {
   beforeEach(() => {
+    const localStorage = new MemoryStorage()
+    vi.stubGlobal('Storage', MemoryStorage)
+    vi.stubGlobal('StorageEvent', class {
+      constructor(
+        readonly type: string,
+        readonly init: StorageEventInit,
+      ) {}
+    })
+    vi.stubGlobal('localStorage', localStorage)
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => true),
+      localStorage,
+      removeEventListener: vi.fn(),
+    })
     setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('records manual chat stop-speaking requests with monotonic sequence numbers', () => {
@@ -36,6 +84,39 @@ describe('speech output control store', () => {
     expect(store.latestStopRequest).toEqual({
       id: 1,
       reason: 'manual-all',
+    })
+  })
+
+  it('persists mute state and requests an immediate stop when mute is enabled', async () => {
+    const store = useSpeechOutputControlStore()
+
+    expect(store.speechMuted).toBe(false)
+
+    store.setSpeechMuted(true)
+
+    expect(store.speechMuted).toBe(true)
+    expect(store.latestStopRequest).toEqual({
+      id: 1,
+      reason: 'muted',
+    })
+
+    await nextTick()
+    setActivePinia(createPinia())
+    const restoredStore = useSpeechOutputControlStore()
+
+    expect(restoredStore.speechMuted).toBe(true)
+  })
+
+  it('does not publish another stop request when speech output is unmuted', () => {
+    const store = useSpeechOutputControlStore()
+    store.setSpeechMuted(true)
+
+    store.setSpeechMuted(false)
+
+    expect(store.speechMuted).toBe(false)
+    expect(store.latestStopRequest).toEqual({
+      id: 1,
+      reason: 'muted',
     })
   })
 })

--- a/packages/stage-ui/src/stores/speech-output-control.ts
+++ b/packages/stage-ui/src/stores/speech-output-control.ts
@@ -1,7 +1,8 @@
+import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-export type SpeechOutputStopReason = 'manual-chat' | 'manual-all'
+export type SpeechOutputStopReason = 'manual-chat' | 'manual-all' | 'muted'
 
 /**
  * Represents a user-requested stop-speaking command for the stage output host.
@@ -14,6 +15,9 @@ export interface SpeechOutputStopRequest {
 }
 
 export const useSpeechOutputControlStore = defineStore('speech-output-control', () => {
+  const speechMuted = useLocalStorage('settings/speech/output-muted', false, {
+    window: typeof window === 'undefined' ? undefined : window,
+  })
   const latestStopRequest = ref<SpeechOutputStopRequest>()
   let nextRequestId = 1
 
@@ -36,8 +40,30 @@ export const useSpeechOutputControlStore = defineStore('speech-output-control', 
     }
   }
 
+  /**
+   * Enables or disables automatic assistant speech output.
+   *
+   * Enabling mute also publishes a stop request so an active Stage host can
+   * cancel synthesis, streaming transport, queued audio, and current playback.
+   */
+  function setSpeechMuted(muted: boolean) {
+    if (speechMuted.value === muted)
+      return
+
+    speechMuted.value = muted
+    if (muted)
+      requestStopSpeaking('muted')
+  }
+
+  function toggleSpeechMuted() {
+    setSpeechMuted(!speechMuted.value)
+  }
+
   return {
     latestStopRequest,
+    speechMuted,
     requestStopSpeaking,
+    setSpeechMuted,
+    toggleSpeechMuted,
   }
 })


### PR DESCRIPTION
## Summary

- add a persistent speech mute control to the Web, Pocket, and Electron chat surfaces
- stop active synthesis, streaming, queued playback, and current audio when mute is enabled
- prevent new TTS sessions while muted without suppressing emotion, motion, delay, or plugin signals
- persist the final Electron main-window bounds after native move/resize gestures and flush pending config writes during shutdown
- add localized mute/unmute labels for all current stage locales

## Root cause

The existing speech output control only exposed one-shot stop commands, so it could not persist a user preference or gate future TTS sessions.

For the desktop position issue, bounds updates were throttled. Electron main-process HMR terminates the old process directly, so the latest bounds could remain queued and the next process would restore an older saved position. The macOS native click-drag bridge also required an explicit completed-gesture persistence point.

## Validation

- `pnpm exec vitest run apps/stage-tamagotchi/src/main/libs/electron/persistence.test.ts` — 2 tests passed
- `pnpm exec vitest run --config packages/stage-ui/vitest.config.ts packages/stage-ui/src/stores/speech-output-control.test.ts` — 4 tests passed
- `pnpm exec vitest run --config vitest.config.ts src/composables/useStopSpeakingButton.test.ts` from `packages/stage-layouts` — 4 tests passed
- `pnpm run typecheck` — all 49 selected workspaces passed
- `pnpm lint` — 0 errors; 7 existing warnings outside this change
- Electron runtime check — mute state, accessible button state, and local persistence survived a chat renderer reload; test state was restored afterward

## Remaining verification

A physical macOS window drag followed by a real main-process HMR was not manually performed. The behavior is covered by completed native move/resize event handling, shutdown flushing, and the persistence regression test.