### PR TITLE
fix(stage-pages): make browser-local transcription settings usable

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1072,7 +1072,7 @@ pages:
         description: https://github.com/moeru-ai/xsai-transformers
       browser-local-audio-transcription:
         title: Browser (Local)
-        description: https://github.com/moeru-ai/xsai-transformers
+        description: In-browser Whisper via Transformers.js (no API key)
       browser-local-audio-speech:
         title: Browser (Local)
         description: https://github.com/moeru-ai/xsai-transformers

--- a/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/browser-local-audio-transcription.vue
@@ -1,9 +1,274 @@
 <script setup lang="ts">
-import { WIP } from '@proj-airi/stage-ui/components'
+import type { RemovableRef } from '@vueuse/core'
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import { errorMessageFromValue } from '@proj-airi/stage-shared'
+import {
+  Alert,
+  ErrorContainer,
+  ProviderBasicSettings,
+  ProviderSettingsContainer,
+  ProviderSettingsLayout,
+  TranscriptionPlayground,
+} from '@proj-airi/stage-ui/components'
+import { MODEL_IDS, MODEL_NAMES } from '@proj-airi/stage-ui/libs/inference'
+import { getWhisperAdapter } from '@proj-airi/stage-ui/libs/inference/adapters/whisper'
+import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { Button, FieldCombobox } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+
+const providerId = 'browser-local-audio-transcription'
+const defaultModel = MODEL_NAMES.WHISPER
+const { t } = useI18n()
+const router = useRouter()
+
+const hearingStore = useHearingStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore) as { providers: RemovableRef<Record<string, any>> }
+
+providersStore.initializeProvider(providerId)
+
+const providerMetadata = computed(() => providersStore.getProviderMetadata(providerId))
+
+const model = computed({
+  get: () => providers.value[providerId]?.model || defaultModel,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].model = value
+  },
+})
+
+const language = computed({
+  get: () => providers.value[providerId]?.language || 'en',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].language = value
+  },
+})
+
+const languageOptions = [
+  { label: 'English', value: 'en' },
+  { label: 'Chinese', value: 'zh' },
+  { label: 'Japanese', value: 'ja' },
+  { label: 'Korean', value: 'ko' },
+  { label: 'Spanish', value: 'es' },
+  { label: 'French', value: 'fr' },
+  { label: 'German', value: 'de' },
+  { label: 'Italian', value: 'it' },
+  { label: 'Portuguese', value: 'pt' },
+  { label: 'Russian', value: 'ru' },
+]
+
+const modelOptions = computed(() => {
+  return providersStore.getModelsForProvider(providerId).map(item => ({
+    label: item.name,
+    value: item.id,
+  }))
+})
+
+const isLoadingModel = ref(false)
+const modelReady = ref(false)
+const modelError = ref('')
+const loadProgressLabel = ref('')
+const loadProgressPercent = ref(0)
+let unsubscribeWhisper: (() => void) | undefined
+
+function handleResetSettings() {
+  providers.value[providerId] = {
+    model: defaultModel,
+    language: 'en',
+  }
+  modelError.value = ''
+  loadProgressLabel.value = ''
+  loadProgressPercent.value = 0
+}
+
+async function ensureDefaults() {
+  if (!providers.value[providerId]) {
+    providers.value[providerId] = {
+      model: defaultModel,
+      language: 'en',
+    }
+  }
+  if (!providers.value[providerId].model)
+    providers.value[providerId].model = defaultModel
+  if (!providers.value[providerId].language)
+    providers.value[providerId].language = 'en'
+}
+
+async function loadLocalModel() {
+  isLoadingModel.value = true
+  modelError.value = ''
+  loadProgressLabel.value = 'Preparing Whisper model...'
+  loadProgressPercent.value = 0
+
+  try {
+    const metadata = providersStore.getProviderMetadata(providerId)
+    const config = providersStore.getProviderConfig(providerId)
+    const validation = await metadata.validators.validateProviderConfig(config)
+    if (!validation.valid) {
+      throw new Error(validation.reason || 'Browser local transcription is not available on this device.')
+    }
+
+    if (metadata.capabilities.loadModel) {
+      await metadata.capabilities.loadModel(config, {
+        onProgress: async (progress) => {
+          const payload = progress as { file?: string, name?: string, progress?: number }
+          loadProgressLabel.value = payload.file || payload.name || 'Downloading / compiling model...'
+          loadProgressPercent.value = typeof payload.progress === 'number' ? Math.round(payload.progress) : 0
+        },
+      })
+    }
+
+    modelReady.value = true
+    loadProgressLabel.value = 'Model ready'
+    loadProgressPercent.value = 100
+    providersStore.forceProviderConfigured(providerId)
+  }
+  catch (error) {
+    modelReady.value = false
+    modelError.value = errorMessageFromValue(error)
+    loadProgressLabel.value = ''
+  }
+  finally {
+    isLoadingModel.value = false
+  }
+}
+
+async function handleGenerateTranscription(file: File) {
+  if (!modelReady.value)
+    await loadLocalModel()
+
+  const provider = await providersStore.getProviderInstance<TranscriptionProviderWithExtraOptions<string, any>>(providerId)
+  if (!provider)
+    throw new Error('Failed to initialize browser local transcription provider')
+
+  const providerConfig = providersStore.getProviderConfig(providerId)
+  const modelToUse = (providerConfig.model as string | undefined) || model.value || defaultModel
+
+  return hearingStore.transcription(
+    providerId,
+    provider,
+    modelToUse,
+    file,
+    'json',
+    {
+      providerOptions: {
+        language: language.value,
+      },
+    },
+  )
+}
+
+onMounted(async () => {
+  await ensureDefaults()
+  await providersStore.fetchModelsForProvider(providerId)
+
+  const adapter = await getWhisperAdapter()
+  modelReady.value = adapter.state === 'ready'
+  unsubscribeWhisper = adapter.onMessage((event) => {
+    if (event.type === 'model-ready')
+      modelReady.value = true
+    if (event.type === 'error')
+      modelError.value = event.payload.message
+  })
+
+  const metadata = providersStore.getProviderMetadata(providerId)
+  const validation = await metadata.validators.validateProviderConfig(providersStore.getProviderConfig(providerId))
+  if (validation.valid)
+    providersStore.forceProviderConfigured(providerId)
+})
+
+onUnmounted(() => {
+  unsubscribeWhisper?.()
+})
+
+watch(language, () => {
+  // Rebuild provider instance so subsequent transcriptions pick up the new language default.
+  void providersStore.disposeProviderInstance(providerId)
+})
 </script>
 
 <template>
-  <WIP />
+  <ProviderSettingsLayout
+    :provider-name="providerMetadata?.localizedName || 'Browser (Local)'"
+    :provider-icon="providerMetadata?.icon"
+    :provider-icon-color="providerMetadata?.iconColor"
+    :on-back="() => router.back()"
+  >
+    <div flex="~ col md:row gap-6">
+      <ProviderSettingsContainer class="w-full md:w-[40%] space-y-6">
+        <Alert type="info">
+          <template #title>
+            Free in-browser Whisper
+          </template>
+          <template #content>
+            Runs Whisper locally in your browser via Transformers.js. No API key or remote base URL is required. First use downloads the model ({{ MODEL_IDS.WHISPER }}).
+          </template>
+        </Alert>
+
+        <ProviderBasicSettings
+          :title="t('settings.pages.providers.common.section.basic.title')"
+          :description="t('settings.pages.providers.common.section.basic.description')"
+          :on-reset="handleResetSettings"
+        >
+          <div class="space-y-4">
+            <FieldCombobox
+              v-model="model"
+              label="Model"
+              description="Local Whisper ONNX model used for speech-to-text"
+              :options="modelOptions.length > 0 ? modelOptions : [{ label: 'Whisper Large V3 Turbo (ONNX)', value: defaultModel }]"
+              layout="vertical"
+            />
+
+            <FieldCombobox
+              v-model="language"
+              label="Recognition Language"
+              description="Language hint passed to Whisper"
+              :options="languageOptions"
+              layout="vertical"
+            />
+
+            <Button
+              class="w-full"
+              :disabled="isLoadingModel"
+              @click="loadLocalModel()"
+            >
+              <div v-if="isLoadingModel" class="mr-2 animate-spin">
+                <div i-solar:spinner-line-duotone text-lg />
+              </div>
+              {{ isLoadingModel ? 'Loading model...' : modelReady ? 'Reload model' : 'Load model' }}
+            </Button>
+
+            <div v-if="loadProgressLabel" class="text-xs text-neutral-500 dark:text-neutral-400">
+              {{ loadProgressLabel }}
+              <span v-if="loadProgressPercent > 0"> ({{ loadProgressPercent }}%)</span>
+            </div>
+
+            <div v-if="modelReady" class="flex items-center gap-2 text-green-600 dark:text-green-400">
+              <div i-solar:check-circle-bold-duotone class="text-sm" />
+              <span class="text-sm">Model ready for transcription</span>
+            </div>
+
+            <ErrorContainer v-if="modelError" title="Model error" :error="modelError" />
+          </div>
+        </ProviderBasicSettings>
+      </ProviderSettingsContainer>
+
+      <div flex="~ col gap-6" class="w-full md:w-[60%]">
+        <TranscriptionPlayground
+          :generate-transcription="handleGenerateTranscription"
+          :api-key-configured="true"
+        />
+      </div>
+    </div>
+  </ProviderSettingsLayout>
 </template>
 
 <route lang="yaml">

--- a/packages/stage-ui/src/libs/audio/decode-audio-file.test.ts
+++ b/packages/stage-ui/src/libs/audio/decode-audio-file.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { resampleMonoLinear } from './decode-audio-file'
+
+describe('resampleMonoLinear', () => {
+  // https://github.com/moeru-ai/airi/issues/1342
+  it('issue #1342 keeps identical samples when rates match so local STT can reuse decoded PCM', () => {
+    const samples = new Float32Array([0, 0.5, -0.5, 1])
+    expect(resampleMonoLinear(samples, 16_000, 16_000)).toBe(samples)
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1342
+  it('issue #1342 downsamples mono PCM for Whisper 16 kHz input', () => {
+    // ROOT CAUSE:
+    //
+    // Browser-local transcription settings were a WIP stub, and even a naive
+    // OpenAI-compatible local page still required a base URL. Real in-browser
+    // Whisper needs decoded mono PCM at 16 kHz from arbitrary uploaded files.
+    //
+    // We fixed this by decoding the FormData file client-side and resampling
+    // before calling the Whisper adapter.
+    const samples = new Float32Array(4)
+    samples[0] = 0
+    samples[1] = 1
+    samples[2] = 0
+    samples[3] = -1
+
+    const resampled = resampleMonoLinear(samples, 32_000, 16_000)
+    expect(resampled).toHaveLength(2)
+    expect(resampled[0]).toBeCloseTo(0, 5)
+    expect(resampled[1]).toBeCloseTo(0, 5)
+  })
+})

--- a/packages/stage-ui/src/libs/audio/decode-audio-file.ts
+++ b/packages/stage-ui/src/libs/audio/decode-audio-file.ts
@@ -1,0 +1,66 @@
+const WHISPER_SAMPLE_RATE = 16_000
+
+/**
+ * Linearly resamples a mono PCM buffer.
+ *
+ * Before:
+ * - Float32 samples at `fromRate`
+ *
+ * After:
+ * - Float32 samples at `toRate`
+ */
+export function resampleMonoLinear(samples: Float32Array, fromRate: number, toRate: number): Float32Array {
+  if (fromRate === toRate || samples.length === 0)
+    return samples
+
+  const ratio = fromRate / toRate
+  const newLength = Math.max(1, Math.round(samples.length / ratio))
+  const output = new Float32Array(newLength)
+
+  for (let i = 0; i < newLength; i++) {
+    const srcIndex = i * ratio
+    const left = Math.floor(srcIndex)
+    const right = Math.min(left + 1, samples.length - 1)
+    const frac = srcIndex - left
+    output[i] = samples[left]! * (1 - frac) + samples[right]! * frac
+  }
+
+  return output
+}
+
+/**
+ * Decodes an audio file into mono Float32 PCM for Whisper.
+ *
+ * Before:
+ * - Encoded audio `File` / `Blob` (wav/mp3/webm/…)
+ *
+ * After:
+ * - Mono Float32Array at 16 kHz suitable for `audioFloat32` Whisper input
+ */
+export async function decodeAudioFileToMonoFloat32(
+  file: Blob,
+  targetSampleRate = WHISPER_SAMPLE_RATE,
+): Promise<Float32Array> {
+  const audioContext = new AudioContext()
+  try {
+    const arrayBuffer = await file.arrayBuffer()
+    // decodeAudioData detaches the buffer in some engines; pass a copy.
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0))
+    const length = audioBuffer.length
+    const channelCount = audioBuffer.numberOfChannels
+    const mono = new Float32Array(length)
+
+    for (let channel = 0; channel < channelCount; channel++) {
+      const data = audioBuffer.getChannelData(channel)
+      for (let i = 0; i < length; i++)
+        mono[i]! += data[i]! / channelCount
+    }
+
+    return resampleMonoLinear(mono, audioBuffer.sampleRate, targetSampleRate)
+  }
+  finally {
+    await audioContext.close()
+  }
+}
+
+export { WHISPER_SAMPLE_RATE }

--- a/packages/stage-ui/src/libs/inference/adapters/whisper.test.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/whisper.test.ts
@@ -36,11 +36,12 @@ vi.mock('../../../composables/use-inference-status', () => ({
 
 const enqueueMock = vi.fn((_id: string, _p: number, loader: () => Promise<unknown>) => loader())
 const recordDeviceLoss = vi.fn()
+const releaseAllocation = vi.fn()
 
 vi.mock('../coordinator', () => ({
   getGPUCoordinator: () => ({
     recordDeviceLoss,
-    release: vi.fn(),
+    release: releaseAllocation,
     requestAllocation: vi.fn(() => ({ estimatedBytes: 0, modelId: 'whisper' })),
   }),
   getLoadQueue: () => ({
@@ -67,6 +68,7 @@ describe('whisper adapter worker failure handling', () => {
     enqueueMock.mockClear()
     enqueueMock.mockImplementation((_id: string, _p: number, loader: () => Promise<unknown>) => loader())
     recordDeviceLoss.mockClear()
+    releaseAllocation.mockClear()
   })
 
   afterEach(() => {
@@ -122,5 +124,64 @@ describe('whisper adapter worker failure handling', () => {
 
     await expect(transcribing).rejects.toThrow('Whisper worker crashed during transcription')
     expect(adapter.state).toBe('error')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1342
+  // https://github.com/moeru-ai/airi/pull/2130
+  it('issue #1342 terminates errored singleton adapters before replacing them', async () => {
+    // ROOT CAUSE:
+    //
+    // getWhisperAdapter() replaced `error` / `terminated` singletons with a new
+    // createWhisperAdapter() without calling terminate(). Errored adapters can
+    // still hold a Worker and GPU allocation token after abort/timeout/worker
+    // failure, so repeated retries leaked ~800MB allocations.
+    //
+    // We fixed this by terminating the previous singleton before assigning the
+    // replacement.
+    vi.resetModules()
+    MockWorker.instances.length = 0
+
+    const { getWhisperAdapter } = await import('./whisper')
+    const first = await getWhisperAdapter()
+
+    const loading = first.load()
+    await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalled())
+    const worker = MockWorker.instances.at(-1)!
+    const loadRequest = worker.postMessage.mock.calls.find(([message]) => message.type === 'load-model')?.[0]
+    expect(loadRequest).toBeDefined()
+
+    worker.dispatch('message', {
+      data: {
+        device: 'webgpu',
+        modelId: 'whisper',
+        requestId: loadRequest!.requestId,
+        type: 'model-ready',
+      },
+    })
+    await loading
+    expect(first.state).toBe('ready')
+
+    const transcribing = first.transcribe({ audio: 'data:audio/wav;base64,test', language: 'en' })
+    await vi.waitFor(() => {
+      expect(worker.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'run-inference' }))
+    })
+
+    // Simulate a transcription timeout / abort path that marks state=error without
+    // going through handleWorkerError's destroyWorker().
+    worker.dispatch('message', {
+      data: {
+        type: 'error',
+        requestId: worker.postMessage.mock.calls.find(([message]) => message.type === 'run-inference')?.[0].requestId,
+        payload: { message: 'transcription failed', code: 'TIMEOUT' },
+      },
+    })
+    await expect(transcribing).rejects.toThrow('transcription failed')
+    expect(first.state).toBe('error')
+
+    const second = await getWhisperAdapter()
+    expect(second).not.toBe(first)
+    expect(first.state).toBe('terminated')
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(releaseAllocation).toHaveBeenCalled()
   })
 })

--- a/packages/stage-ui/src/libs/inference/adapters/whisper.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/whisper.ts
@@ -103,7 +103,7 @@ interface PendingWaiter {
 // Factory
 // ---------------------------------------------------------------------------
 
-export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
+export function createWhisperAdapter(workerUrl: string | URL = new URL('../../workers/worker.ts', import.meta.url)): WhisperAdapter {
   let worker: Worker | null = null
   let state: WhisperState = 'idle'
   let allocationToken: AllocationToken | null = null
@@ -441,4 +441,30 @@ export function createWhisperAdapter(workerUrl: string | URL): WhisperAdapter {
     get manifest() { return lastManifest },
     get deviceLossCount() { return deviceLossCount },
   }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let globalAdapter: WhisperAdapter | null = null
+const singletonMutex = new Mutex()
+
+/**
+ * Get the global Whisper adapter instance.
+ * Creates and starts the worker on first call.
+ * Automatically re-creates the adapter if it has entered a terminal state
+ * ('terminated' or 'error' after max restarts exhausted).
+ */
+export async function getWhisperAdapter(): Promise<WhisperAdapter> {
+  return singletonMutex.runExclusive(async () => {
+    if (
+      !globalAdapter
+      || globalAdapter.state === 'terminated'
+      || globalAdapter.state === 'error'
+    ) {
+      globalAdapter = createWhisperAdapter()
+    }
+    return globalAdapter
+  })
 }

--- a/packages/stage-ui/src/libs/inference/adapters/whisper.ts
+++ b/packages/stage-ui/src/libs/inference/adapters/whisper.ts
@@ -108,6 +108,7 @@ export function createWhisperAdapter(workerUrl: string | URL = new URL('../../wo
   let state: WhisperState = 'idle'
   let allocationToken: AllocationToken | null = null
   let restartAttempts = 0
+  let restartTimeoutId: ReturnType<typeof setTimeout> | null = null
   let messageListener: ((event: MessageEvent) => void) | null = null
   let errorListener: ((event: ErrorEvent) => void) | null = null
   const messageHandlers = new Set<(event: WhisperEvent) => void>()
@@ -184,7 +185,14 @@ export function createWhisperAdapter(workerUrl: string | URL = new URL('../../wo
     const delay = RESTART_DELAY_MS * restartAttempts
     console.warn(`[WhisperAdapter] Restarting in ${delay}ms (attempt ${restartAttempts}/${MAX_RESTARTS})`)
 
-    setTimeout(() => {
+    if (restartTimeoutId !== null)
+      clearTimeout(restartTimeoutId)
+
+    restartTimeoutId = setTimeout(() => {
+      restartTimeoutId = null
+      // Skip recreating a worker after an intentional terminate()/singleton replace.
+      if (state === 'terminated')
+        return
       ensureWorker()
     }, delay)
   }
@@ -415,6 +423,10 @@ export function createWhisperAdapter(workerUrl: string | URL = new URL('../../wo
   }
 
   function terminateAdapter(): void {
+    if (restartTimeoutId !== null) {
+      clearTimeout(restartTimeoutId)
+      restartTimeoutId = null
+    }
     operationMutex.cancel()
     rejectPendingWaiters(new InferenceAbortError('Whisper adapter terminated.'))
     destroyWorker()
@@ -463,6 +475,13 @@ export async function getWhisperAdapter(): Promise<WhisperAdapter> {
       || globalAdapter.state === 'terminated'
       || globalAdapter.state === 'error'
     ) {
+      // NOTICE:
+      // Aborted / timed-out / worker-failed transcriptions leave the singleton in
+      // `error` while the Worker and GPU allocation token may still be held.
+      // Replacing without terminate() leaks roughly one Whisper VRAM estimate per
+      // failure and can exhaust browser resources after repeated retries.
+      // https://github.com/moeru-ai/airi/pull/2130
+      globalAdapter?.terminate()
       globalAdapter = createWhisperAdapter()
     }
     return globalAdapter

--- a/packages/stage-ui/src/stores/providers.ts
+++ b/packages/stage-ui/src/stores/providers.ts
@@ -52,12 +52,15 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { getKokoroAdapter } from '../libs/inference/adapters/kokoro'
+import { getWhisperAdapter } from '../libs/inference/adapters/whisper'
+import { MODEL_IDS, MODEL_NAMES } from '../libs/inference/constants'
 import { getProviderValidationIntervalMs, listProviders as listDefinedProviders, ProviderValidationCheck } from '../libs/providers'
 import { resolveProviderSourceMetadata } from '../libs/providers/source-metadata'
 import { getDefaultKokoroModel, KOKORO_MODELS, kokoroModelsToModelInfo } from '../workers/kokoro/constants'
 import { capturePosthogEvent, ensurePosthogInitialized, isPosthogAvailableInBuild } from './analytics/posthog'
 import { useAuthStore } from './auth'
 import { createAliyunNLSProvider as createAliyunNlsStreamProvider } from './providers/aliyun/stream-transcription'
+import { createBrowserLocalTranscriptionProvider } from './providers/browser-local-transcription'
 import { convertProviderDefinitionsToMetadata } from './providers/converters'
 import { models as elevenLabsModels } from './providers/elevenlabs/list-models'
 import { buildGoogleGeminiSpeechProvider } from './providers/google-gemini-speech'
@@ -473,25 +476,66 @@ export const useProvidersStore = defineStore('providers', () => {
         },
       },
     }),
-    'browser-local-audio-transcription': buildOpenAICompatibleProvider({
+    'browser-local-audio-transcription': {
       id: 'browser-local-audio-transcription',
-      name: 'Browser (Local)',
-      nameKey: 'settings.pages.providers.provider.browser-local-audio-transcription.title',
-      descriptionKey: 'settings.pages.providers.provider.browser-local-audio-transcription.description',
-      icon: 'i-lobe-icons:huggingface',
-      description: 'https://github.com/moeru-ai/xsai-transformers',
       category: 'transcription',
       tasks: ['speech-to-text', 'automatic-speech-recognition', 'asr', 'stt'],
+      nameKey: 'settings.pages.providers.provider.browser-local-audio-transcription.title',
+      name: 'Browser (Local)',
+      descriptionKey: 'settings.pages.providers.provider.browser-local-audio-transcription.description',
+      description: 'In-browser Whisper transcription via Transformers.js. No API keys.',
+      icon: 'i-lobe-icons:huggingface',
+      requiresCredentials: false,
+      transcriptionFeatures: {
+        supportsGenerate: true,
+        supportsStreamOutput: false,
+        supportsStreamInput: false,
+      },
       isAvailableBy: isBrowserAndMemoryEnough,
-      creator: createOpenAI,
-      validation: [],
+      defaultOptions: () => ({
+        model: MODEL_NAMES.WHISPER,
+        language: 'en',
+      }),
+      createProvider: async (config) => {
+        return createBrowserLocalTranscriptionProvider({
+          language: typeof config.language === 'string' ? config.language : 'en',
+        })
+      },
+      capabilities: {
+        listModels: async () => {
+          return [
+            {
+              id: MODEL_NAMES.WHISPER,
+              name: 'Whisper Large V3 Turbo (ONNX)',
+              provider: 'browser-local-audio-transcription',
+              description: MODEL_IDS.WHISPER,
+              contextLength: 0,
+              deprecated: false,
+            },
+          ]
+        },
+        loadModel: async (_config, hooks) => {
+          const adapter = await getWhisperAdapter()
+          await adapter.load((progress) => {
+            void hooks?.onProgress?.({
+              name: progress.file ?? '',
+              file: progress.file ?? '',
+              progress: progress.percent >= 0 ? progress.percent : 0,
+              status: 'progress',
+              loaded: progress.loaded ?? 0,
+              total: progress.total ?? 0,
+            } as ProgressInfo)
+          })
+        },
+      },
       validators: {
         chatPingCheckAvailable: false,
-        validateProviderConfig: (config) => {
-          if (!config.baseUrl) {
+        validateProviderConfig: async () => {
+          const available = await isBrowserAndMemoryEnough()
+          if (!available) {
             return {
-              errors: [new Error('Base URL is required.')],
-              reason: 'Base URL is required. This is likely a bug, report to developers on https://github.com/moeru-ai/airi/issues.',
+              errors: [new Error('Browser local transcription requires WebGPU or at least 8 GB of device memory, and is only available in the web app.')],
+              reason: 'This device or runtime cannot run in-browser Whisper.',
               valid: false,
             }
           }
@@ -503,7 +547,7 @@ export const useProvidersStore = defineStore('providers', () => {
           }
         },
       },
-    }),
+    },
     'openai-audio-speech': buildOpenAICompatibleProvider({
       id: 'openai-audio-speech',
       name: 'OpenAI',
@@ -2416,15 +2460,15 @@ export const useProvidersStore = defineStore('providers', () => {
     if (!metadata)
       return false
 
-    // Web Speech API doesn't require credentials - use empty config if not present
-    if (providerId === 'browser-web-speech-api') {
+    // Credential-free browser providers use empty/default config if not present
+    if (providerId === 'browser-web-speech-api' || providerId === 'browser-local-audio-transcription') {
       if (!providerCredentials.value[providerId]) {
         providerCredentials.value[providerId] = getDefaultProviderConfig(providerId)
       }
     }
 
     const config = providerCredentials.value[providerId]
-    if (!config && providerId !== 'browser-web-speech-api')
+    if (!config && providerId !== 'browser-web-speech-api' && providerId !== 'browser-local-audio-transcription')
       return false
 
     const configString = JSON.stringify(config || {})
@@ -2454,7 +2498,7 @@ export const useProvidersStore = defineStore('providers', () => {
         providerRuntimeState.value[providerId].isConfigured = validationResult.valid
         providerRuntimeState.value[providerId].validatedCredentialHash = configString
         // Auto-mark Web Speech API as added if valid and available
-        if (validationResult.valid && ['browser-web-speech-api', 'player2'].includes(providerId)) {
+        if (validationResult.valid && ['browser-web-speech-api', 'browser-local-audio-transcription', 'player2'].includes(providerId)) {
           markProviderAdded(providerId)
         }
       }
@@ -2837,7 +2881,9 @@ export const useProvidersStore = defineStore('providers', () => {
 
     // Providers that don't require credentials use empty config
     let config = providerCredentials.value[providerId]
-    const noCredentials = metadata.requiresCredentials === false || providerId === 'browser-web-speech-api'
+    const noCredentials = metadata.requiresCredentials === false
+      || providerId === 'browser-web-speech-api'
+      || providerId === 'browser-local-audio-transcription'
     if (!config && noCredentials) {
       config = getDefaultProviderConfig(providerId) || {}
       providerCredentials.value[providerId] = config

--- a/packages/stage-ui/src/stores/providers/browser-local-transcription/index.test.ts
+++ b/packages/stage-ui/src/stores/providers/browser-local-transcription/index.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const whisperMock = vi.hoisted(() => ({
+  load: vi.fn(async () => {}),
+  transcribe: vi.fn(async () => 'hello local whisper'),
+  state: 'ready' as string,
+}))
+
+vi.mock('../../../libs/inference/adapters/whisper', () => ({
+  getWhisperAdapter: vi.fn(async () => whisperMock),
+}))
+
+vi.mock('../../../libs/audio/decode-audio-file', () => ({
+  decodeAudioFileToMonoFloat32: vi.fn(async () => new Float32Array([0.1, -0.1])),
+}))
+
+describe('createBrowserLocalTranscriptionProvider', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    whisperMock.state = 'ready'
+    whisperMock.transcribe.mockResolvedValue('hello local whisper')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1342
+  it('issue #1342 transcribes FormData audio through the local Whisper adapter without a base URL', async () => {
+    // ROOT CAUSE:
+    //
+    // Navigating to browser-local transcription opened a WIP placeholder, so
+    // users could not configure or exercise the provider. The registered
+    // metadata also required a base URL as if it were a remote OpenAI-compatible
+    // endpoint, which blocked configuration for true in-browser Whisper.
+    //
+    // We fixed this by implementing a credential-free provider that decodes the
+    // uploaded file and calls the existing Whisper adapter.
+    const { createBrowserLocalTranscriptionProvider } = await import('./index')
+    const { decodeAudioFileToMonoFloat32 } = await import('../../../libs/audio/decode-audio-file')
+
+    const provider = createBrowserLocalTranscriptionProvider({ language: 'en' })
+    const request = provider.transcription('whisper-large-v3-turbo', { language: 'zh' })
+
+    const form = new FormData()
+    form.append('file', new File([new Uint8Array([1, 2, 3])], 'clip.wav', { type: 'audio/wav' }))
+    form.append('model', 'whisper-large-v3-turbo')
+
+    const response = await request.fetch!(new URL('http://browser-local-audio-transcription/v1/audio/transcriptions'), {
+      method: 'POST',
+      body: form,
+    })
+
+    expect(response.ok).toBe(true)
+    await expect(response.json()).resolves.toEqual({ text: 'hello local whisper' })
+    expect(decodeAudioFileToMonoFloat32).toHaveBeenCalledOnce()
+    expect(whisperMock.transcribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: 'zh',
+        audioFloat32: expect.any(Float32Array),
+      }),
+      expect.any(Object),
+    )
+  })
+
+  // https://github.com/moeru-ai/airi/issues/1342
+  it('issue #1342 loads the Whisper model when the adapter is not ready yet', async () => {
+    whisperMock.state = 'idle'
+
+    const { createBrowserLocalTranscriptionProvider } = await import('./index')
+    const provider = createBrowserLocalTranscriptionProvider()
+    const request = provider.transcription('whisper-large-v3-turbo')
+
+    const form = new FormData()
+    form.append('file', new Blob([new Uint8Array([9])], { type: 'audio/wav' }))
+
+    await request.fetch!(new URL('http://browser-local/v1/audio/transcriptions'), {
+      method: 'POST',
+      body: form,
+    })
+
+    expect(whisperMock.load).toHaveBeenCalledOnce()
+    expect(whisperMock.transcribe).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/stage-ui/src/stores/providers/browser-local-transcription/index.ts
+++ b/packages/stage-ui/src/stores/providers/browser-local-transcription/index.ts
@@ -1,0 +1,78 @@
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import { errorMessageFromValue } from '@proj-airi/stage-shared'
+
+import { decodeAudioFileToMonoFloat32 } from '../../../libs/audio/decode-audio-file'
+import { getWhisperAdapter } from '../../../libs/inference/adapters/whisper'
+import { MODEL_NAMES } from '../../../libs/inference/constants'
+
+export interface BrowserLocalTranscriptionExtraOptions {
+  language?: string
+  abortSignal?: AbortSignal
+}
+
+/**
+ * In-browser Whisper transcription provider (no API key / base URL).
+ *
+ * Implements the OpenAI-compatible FormData transcription contract expected by
+ * `@xsai/generate-transcription`, then runs inference through the local Whisper
+ * worker instead of a remote endpoint.
+ */
+export function createBrowserLocalTranscriptionProvider(
+  config: { language?: string } = {},
+): TranscriptionProviderWithExtraOptions<string, BrowserLocalTranscriptionExtraOptions> {
+  return {
+    transcription: (model: string, extraOptions?: BrowserLocalTranscriptionExtraOptions) => {
+      return {
+        baseURL: 'http://browser-local-audio-transcription/v1/',
+        model: model || MODEL_NAMES.WHISPER,
+        fetch: async (_request: RequestInfo | URL, init?: RequestInit) => {
+          try {
+            const body = init?.body
+            if (!(body instanceof FormData)) {
+              throw new TypeError('Browser local transcription expects a FormData body with an audio file.')
+            }
+
+            const fileEntry = body.get('file')
+            if (!(fileEntry instanceof Blob)) {
+              throw new TypeError('Browser local transcription requires an audio file in the FormData body.')
+            }
+
+            const languageFromForm = body.get('language')
+            const language = (
+              typeof languageFromForm === 'string' && languageFromForm.trim()
+                ? languageFromForm.trim()
+                : extraOptions?.language || config.language || 'en'
+            )
+
+            const adapter = await getWhisperAdapter()
+            if (adapter.state !== 'ready')
+              await adapter.load(undefined, { signal: extraOptions?.abortSignal ?? init?.signal ?? undefined })
+
+            const audioFloat32 = await decodeAudioFileToMonoFloat32(fileEntry)
+            const text = await adapter.transcribe(
+              { audioFloat32, language },
+              { signal: extraOptions?.abortSignal ?? init?.signal ?? undefined },
+            )
+
+            return new Response(JSON.stringify({ text }), {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            })
+          }
+          catch (error) {
+            const message = errorMessageFromValue(error)
+            return new Response(JSON.stringify({ error: { message } }), {
+              status: 500,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            })
+          }
+        },
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the WIP placeholder on `/settings/providers/transcription/browser-local-audio-transcription` with a real settings page (model + language + load progress + playground).
- Replaces the OpenAI-compatible stub that required a remote `baseUrl` with a credential-free in-browser Whisper provider wired to the existing Whisper adapter/worker.
- Adds audio decode/resample helpers and Issue #1342 regression coverage for FormData → local Whisper transcription.
- Terminates errored Whisper singleton adapters before replacement so Worker/GPU allocations are not leaked across retries.

Closes #1342

## Root cause

Navigating to Browser (Local) transcription only rendered a WIP callout, so users could not configure or exercise the provider. The registered metadata also validated like a remote OpenAI-compatible endpoint (`baseUrl` required), which does not match the documented in-browser Whisper flow.

## Review follow-ups

- `getWhisperAdapter()` now calls `terminate()` on `error` / `terminated` singletons before creating a replacement, and clears pending restart timers so abandoned workers cannot respawn after dispose.

## Test plan

- [x] `vitest` for Whisper adapter (including singleton terminate-before-replace)
- [x] `vitest` for decode helpers + browser-local transcription provider
- [ ] Manual (web): open `/settings/providers/transcription/browser-local-audio-transcription`
- [ ] Confirm page is not WIP, Load model works (or shows a clear device unsupported error)
- [ ] Record/upload in the playground and verify transcription text returns
- [ ] Enable the provider under Settings → Hearing and send a short voice input