### PR TITLE
fix(docs): restore characters pages

### DIFF
--- a/docs/.vitepress/components/DocTopbar.vue
+++ b/docs/.vitepress/components/DocTopbar.vue
@@ -6,7 +6,6 @@ import { useScroll } from '@vueuse/core'
 import { DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, DialogTrigger } from 'reka-ui'
 import { useData, useRoute, withBase } from 'vitepress'
 import { computed, ref, toRefs, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import DocSidebarItem from '../components/DocSidebarItem.vue'
 
@@ -14,7 +13,6 @@ import { flatten } from '../utils/flatten'
 
 const { path } = toRefs(useRoute())
 const { page, theme } = useData()
-const { t } = useI18n()
 
 const isSidebarOpen = ref(false)
 const sidebar = computed(() => (theme.value.sidebar as (DefaultTheme.SidebarItem & { icon?: string })[]))
@@ -143,7 +141,9 @@ watch(path, () => {
 
       <div class="h-full flex items-center">
         <a
-          href="/characters/"
+          v-for="tab in sectionTabs.filter(i => isCharacterPage(i.link))"
+          :key="tab.label"
+          :href="tab.link"
           :class="{ '!border-b-primary !font-semibold !text-foreground': withBase(page.relativePath).includes('characters') }"
           class="mx-4 h-full inline-flex items-center gap-2 border-b border-b-transparent py-2 text-sm text-muted-foreground font-medium hover:border-b-muted hover:text-foreground"
         >
@@ -151,7 +151,7 @@ watch(path, () => {
             icon="lucide:scan-face"
             class="text-lg"
           />
-          {{ t('docs.theme.pages.characters.title') }}
+          {{ tab.label }}
         </a>
       </div>
     </div>

--- a/docs/content/en/characters/index.md
+++ b/docs/content/en/characters/index.md
@@ -1,0 +1,20 @@
+---
+title: Characters
+description: Create, import, and switch the characters you use with Project AIRI.
+sidebar: false
+outline: false
+---
+
+Character cards define who AIRI is: a character's name, description, personality, scenario, greeting, and character-specific modules.
+
+## Create or switch a character
+
+Open **Settings → AIRI Character Card** to create, import, edit, or activate a character. Newly created cards must be activated before AIRI will use them.
+
+[Open the character card guide](../docs/manual/tamagotchi/setup-and-use/#chapter-4-airi-card)
+
+## Start from a template
+
+Use the minimal Character Card V3 template when you want to create a card as JSON or share it with another AIRI user.
+
+[Open the character card template](../docs/manual/tamagotchi/character-card-template)

--- a/docs/content/ja/characters/index.md
+++ b/docs/content/ja/characters/index.md
@@ -1,0 +1,20 @@
+---
+title: キャラクター
+description: Project AIRI で使用するキャラクターを作成、インポート、切り替えできます。
+sidebar: false
+outline: false
+---
+
+キャラクターカードは、AIRI の名前、説明、性格、シナリオ、最初のメッセージ、キャラクター固有のモジュールを定義します。
+
+## キャラクターを作成または切り替える
+
+**設定 → AIRI キャラクターカード** を開くと、キャラクターを作成、インポート、編集、または有効化できます。新しく作成したカードは、AIRI で使用する前に有効化してください。
+
+[AIRI のマニュアルを開く](../docs/manual/tamagotchi/)
+
+## テンプレートから始める
+
+JSON でカードを作成したり、ほかの AIRI ユーザーと共有したりする場合は、最小構成の Character Card V3 テンプレートを使用できます。
+
+[キャラクターカードテンプレートを開く](../docs/manual/tamagotchi/character-card-template)

--- a/docs/content/zh-Hans/characters/index.md
+++ b/docs/content/zh-Hans/characters/index.md
@@ -1,0 +1,20 @@
+---
+title: 角色
+description: 创建、导入和切换你在 Project AIRI 中使用的角色。
+sidebar: false
+outline: false
+---
+
+角色卡用于定义 AIRI 的身份，包括角色名称、描述、性格、场景、开场白和角色专属模块。
+
+## 创建或切换角色
+
+打开 **设置 → AIRI 角色卡**，即可创建、导入、编辑或启用角色。新建的角色卡必须先手动启用，AIRI 才会使用它。
+
+[打开角色卡指南](../docs/manual/tamagotchi/setup-and-use/#chapter-4-airi-card)
+
+## 从模板开始
+
+如果你想用 JSON 创建角色卡，或把角色卡分享给其他 AIRI 用户，可以从最小可用的 Character Card V3 模板开始。
+
+[打开角色卡模板](../docs/manual/tamagotchi/character-card-template)


### PR DESCRIPTION
## Description

Restores the missing Characters landing pages for English, Simplified Chinese, and Japanese. The navigation has linked to these routes since the VitePress migration, but no source pages existed, so every locale returned a 404.

Also updates the mobile Characters link to reuse the locale-aware sidebar URL instead of hardcoding `/characters/`, which bypassed the deployed `/docs/` base path.

## Linked Issues

None.

## Additional Context

Verified with:

- `pnpm --filter @proj-airi/docs typecheck`
- `pnpm --filter @proj-airi/docs build:base`
- Browser checks for all three `/docs/<locale>/characters/` routes and both English guide links (HTTP 200, no console errors)