### PR TITLE
fix(electron): stop opening remote inspector

### DIFF
--- a/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
+++ b/apps/stage-tamagotchi/scripts/desktop-overlay-live-window-smoke.ts
@@ -398,7 +398,6 @@ function startStage(debugPort: number, heartbeatLines: string[]): ChildProcessWi
       ...env,
       APP_REMOTE_DEBUG: 'true',
       APP_REMOTE_DEBUG_PORT: String(debugPort),
-      APP_REMOTE_DEBUG_NO_OPEN: 'true',
       APP_USER_DATA_PATH: userDataDir,
       AIRI_DESKTOP_OVERLAY: '1',
       AIRI_DESKTOP_OVERLAY_POLL_HEARTBEAT: '1',

--- a/apps/stage-tamagotchi/src/main/app/debugger.test.ts
+++ b/apps/stage-tamagotchi/src/main/app/debugger.test.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from 'node:events'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { announceDebuggerEndpoint } from './debugger'
+
+const electronMocks = vi.hoisted(() => ({
+  appendSwitch: vi.fn(),
+  openExternal: vi.fn(),
+}))
+
+const httpMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: {
+      appendSwitch: electronMocks.appendSwitch,
+    },
+  },
+  shell: {
+    openExternal: electronMocks.openExternal,
+  },
+}))
+
+vi.mock('node:http', () => ({
+  default: {
+    get: httpMocks.get,
+  },
+}))
+
+describe('announceDebuggerEndpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.APP_REMOTE_DEBUG = 'true'
+    process.env.APP_REMOTE_DEBUG_PORT = '9250'
+  })
+
+  afterEach(() => {
+    delete process.env.APP_REMOTE_DEBUG
+    delete process.env.APP_REMOTE_DEBUG_PORT
+  })
+
+  it('does not open the remote inspector in the system browser', () => {
+    const response = new EventEmitter()
+    const request = new EventEmitter()
+
+    httpMocks.get.mockImplementation((_url, handleResponse) => {
+      handleResponse(response)
+      return request
+    })
+
+    announceDebuggerEndpoint()
+
+    response.emit('data', JSON.stringify([{
+      webSocketDebuggerUrl: 'ws://localhost:9250/devtools/page/renderer',
+    }]))
+    response.emit('end')
+
+    // ROOT CAUSE:
+    //
+    // Enabling the CDP endpoint also called shell.openExternal, so every
+    // development launch forced the inspector into the system browser.
+    //
+    // Remote inspection should remain available through the logged URL
+    // without taking focus away from the Electron app.
+    expect(electronMocks.openExternal).not.toHaveBeenCalled()
+  })
+})

--- a/apps/stage-tamagotchi/src/main/app/debugger.ts
+++ b/apps/stage-tamagotchi/src/main/app/debugger.ts
@@ -2,8 +2,9 @@ import http from 'node:http'
 
 import { env } from 'node:process'
 
-import { app, shell } from 'electron'
+import { app } from 'electron'
 
+/** Enables Electron's CDP endpoint before the app ready event. */
 export function setupDebugger() {
   if (/^true$/i.test(env.APP_REMOTE_DEBUG || '')) {
     const remoteDebugPort = Number(env.APP_REMOTE_DEBUG_PORT || '9222')
@@ -16,7 +17,13 @@ export function setupDebugger() {
   }
 }
 
-export function openDebugger() {
+/**
+ * Logs an inspector URL for the first available Electron renderer target.
+ *
+ * The URL stays opt-in: developers and automation can connect to CDP without
+ * every development launch taking focus by opening the system browser.
+ */
+export function announceDebuggerEndpoint() {
   if (/^true$/i.test(env.APP_REMOTE_DEBUG || '')) {
     const remoteDebugEndpoint = `http://localhost:${env.APP_REMOTE_DEBUG_PORT || '9222'}`
 
@@ -39,7 +46,6 @@ export function openDebugger() {
 
           wsUrl = wsUrl.substring(5)
           console.info(`Inspect remotely: ${remoteDebugEndpoint}/devtools/inspector.html?ws=${wsUrl}`)
-          shell.openExternal(`${remoteDebugEndpoint}/devtools/inspector.html?ws=${wsUrl}`)
         }
         catch (err) {
           console.error('[Remote Debugging] Failed to parse metadata from /json:', err)

--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -20,7 +20,7 @@ import { isLinux } from 'std-env'
 
 import icon from '../../resources/icon.png?asset'
 
-import { openDebugger, setupDebugger } from './app/debugger'
+import { announceDebuggerEndpoint, setupDebugger } from './app/debugger'
 import { nullFileLoggerHandle, setupFileLogger } from './app/file-logger'
 import { installSingleInstanceGuard } from './app/single-instance'
 import { createArtistryConfig } from './configs/artistry'
@@ -275,7 +275,7 @@ app.whenReady().then(async () => {
   emitAppReady()
 
   // Extra
-  openDebugger()
+  announceDebuggerEndpoint()
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.

--- a/services/computer-use-mcp/src/bin/e2e-airi-chat-observable.ts
+++ b/services/computer-use-mcp/src/bin/e2e-airi-chat-observable.ts
@@ -501,7 +501,6 @@ async function main() {
         ...env,
         APP_REMOTE_DEBUG: 'true',
         APP_REMOTE_DEBUG_PORT: String(debugPort),
-        APP_REMOTE_DEBUG_NO_OPEN: 'true',
       },
       stdio: 'pipe',
     })

--- a/services/computer-use-mcp/src/bin/e2e-airi-chat-terminal-self-acquire.ts
+++ b/services/computer-use-mcp/src/bin/e2e-airi-chat-terminal-self-acquire.ts
@@ -666,7 +666,6 @@ async function main() {
         ...env,
         APP_REMOTE_DEBUG: 'true',
         APP_REMOTE_DEBUG_PORT: String(debugPort),
-        APP_REMOTE_DEBUG_NO_OPEN: 'true',
         APP_USER_DATA_PATH: userDataDir,
       },
       stdio: 'pipe',

--- a/services/computer-use-mcp/src/bin/e2e-airi-discord-agentic.ts
+++ b/services/computer-use-mcp/src/bin/e2e-airi-discord-agentic.ts
@@ -658,7 +658,6 @@ async function main() {
         ...env,
         APP_REMOTE_DEBUG: 'true',
         APP_REMOTE_DEBUG_PORT: String(debugPort),
-        APP_REMOTE_DEBUG_NO_OPEN: 'true',
       },
       stdio: 'pipe',
     })

--- a/services/computer-use-mcp/src/bin/e2e-airi-discord-observable.ts
+++ b/services/computer-use-mcp/src/bin/e2e-airi-discord-observable.ts
@@ -554,7 +554,6 @@ async function main() {
         ...env,
         APP_REMOTE_DEBUG: 'true',
         APP_REMOTE_DEBUG_PORT: String(debugPort),
-        APP_REMOTE_DEBUG_NO_OPEN: 'true',
       },
       stdio: 'pipe',
     })


### PR DESCRIPTION
## Summary

- keep Electron remote debugging available during development but only log the inspector endpoint
- stop calling shell.openExternal on every dev launch, which caused the browser inspector page to open or steal focus
- rename the helper around its remaining responsibility and add focused regression coverage
- remove APP_REMOTE_DEBUG_NO_OPEN from automation launchers because the application never read it and the new default behavior makes the flag obsolete

## Verification

- pnpm build:packages
- pnpm -F @proj-airi/stage-tamagotchi typecheck
- targeted ESLint on all changed TypeScript files
- 1 targeted Vitest regression assertion