### PR TITLE
fix: deliver X / Twitter configuration to its service

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -786,7 +786,8 @@ pages:
       access-token-secret: Access Token Secret
       access-token-secret-description: Your X / Twitter access token secret
       access-token-secret-placeholder: Enter your X / Twitter access token secret
-      configured: X / Twitter is properly configured!
+      service-online: X / Twitter service is online. Credentials are sent when saved.
+      service-offline: X / Twitter service is unavailable. Start it before saving credentials.
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/es/settings.yaml
+++ b/packages/i18n/src/locales/es/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: Secreto de token de acceso
       access-token-secret-description: Su secreto de token de acceso de X / Twitter
       access-token-secret-placeholder: Ingrese su secreto de token de acceso de X / Twitter
-      configured: '¡X / Twitter está configurado correctamente!'
+      service-online: El servicio de X / Twitter está en línea. Las credenciales se enviarán al guardar.
+      service-offline: El servicio de X / Twitter no está disponible. Inícialo antes de guardar las credenciales.
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/fr/settings.yaml
+++ b/packages/i18n/src/locales/fr/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: Secret du jeton d'accès
       access-token-secret-description: Votre secret de jeton d'accès X / Twitter
       access-token-secret-placeholder: Entrez votre secret de jeton d'accès X / Twitter
-      configured: X / Twitter est correctement configuré !
+      service-online: Le service X / Twitter est en ligne. Les identifiants seront envoyés lors de l’enregistrement.
+      service-offline: Le service X / Twitter n’est pas disponible. Démarrez-le avant d’enregistrer les identifiants.
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/ja/settings.yaml
+++ b/packages/i18n/src/locales/ja/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: アクセストークンシークレット
       access-token-secret-description: あなたのX / Twitterアクセストークンシークレット
       access-token-secret-placeholder: あなたのX / Twitterアクセストークンシークレットを入力
-      configured: X / Twitterは適切に設定されています！
+      service-online: X / Twitterサービスはオンラインです。保存すると認証情報が送信されます。
+      service-offline: X / Twitterサービスを利用できません。認証情報を保存する前に起動してください。
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/ko/settings.yaml
+++ b/packages/i18n/src/locales/ko/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: 액세스 토큰 시크릿
       access-token-secret-description: X / 트위터의 액세스 토큰 시크릿
       access-token-secret-placeholder: X / 트위터의 액세스 토큰 시크릿을 입력해주세요
-      configured: X / 트위터 구성 완료!
+      service-online: X / Twitter 서비스가 온라인 상태입니다. 저장하면 자격 증명이 전송됩니다.
+      service-offline: X / Twitter 서비스를 사용할 수 없습니다. 자격 증명을 저장하기 전에 서비스를 시작하세요.
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/ru/settings.yaml
+++ b/packages/i18n/src/locales/ru/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: Секрет токена доступа
       access-token-secret-description: Ваш секрет токена доступа X / Twitter
       access-token-secret-placeholder: Введите ваш секрет токена доступа X / Twitter
-      configured: X / Twitter настроен правильно!
+      service-online: Сервис X / Twitter работает. Учётные данные будут отправлены после сохранения.
+      service-offline: Сервис X / Twitter недоступен. Запустите его перед сохранением учётных данных.
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/vi/settings.yaml
+++ b/packages/i18n/src/locales/vi/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: Bí mật mã truy cập
       access-token-secret-description: Bí mật mã truy cập X / Twitter của bạn
       access-token-secret-placeholder: Nhập bí mật mã truy cập X / Twitter của bạn
-      configured: Đã cấu hình X / Twitter thành công!
+      service-online: Dịch vụ X / Twitter đang trực tuyến. Thông tin xác thực sẽ được gửi khi lưu.
+      service-offline: Dịch vụ X / Twitter không khả dụng. Hãy khởi động dịch vụ trước khi lưu thông tin xác thực.
     web-search:
       title: Web Search
       description: Let AIRI search the web for current information

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: 访问令牌密文
       access-token-secret-description: 您的X / Twitter访问令牌密文
       access-token-secret-placeholder: 输入您的X / Twitter访问令牌密文
-      configured: X / Twitter已正确配置！
+      service-online: X / Twitter 服务已上线。保存时会发送凭据。
+      service-offline: X / Twitter 服务不可用。请先启动服务，再保存凭据。
     web-search:
       title: 网络搜索
       description: 让 AIRI 联网搜索最新信息

--- a/packages/i18n/src/locales/zh-Hant/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hant/settings.yaml
@@ -749,7 +749,8 @@ pages:
       access-token-secret: 存取權杖密文
       access-token-secret-description: 您的 X / Twitter 存取權杖密文
       access-token-secret-placeholder: 輸入您的 X / Twitter 存取權杖密文
-      configured: X / Twitter 已正確設定！
+      service-online: X / Twitter 服務已上線。儲存時會傳送憑證。
+      service-offline: X / Twitter 服務無法使用。請先啟動服務，再儲存憑證。
     web-search:
       title: 網路搜尋
       description: 讓 AIRI 連網搜尋最新資訊

--- a/packages/server-runtime/src/setupApp.liveness.test.ts
+++ b/packages/server-runtime/src/setupApp.liveness.test.ts
@@ -95,11 +95,11 @@ function decodeEvents(sent: string[]) {
   return sent.map(message => parse<WebSocketEvent>(message))
 }
 
-function createExtensionModuleAnnounceEvent(): WebSocketEvent {
+function createExtensionModuleAnnounceEvent(name = 'memory'): WebSocketEvent {
   return {
     type: 'extension:module:announce',
     data: {
-      name: 'memory',
+      name,
       possibleEvents: [],
       identity: {
         id: 'memory-module-1',
@@ -231,5 +231,67 @@ describe('setupApp websocket liveness', () => {
     runtime.dispose()
 
     expect(peer.peer.close).toHaveBeenCalledOnce()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2154
+  // ROOT CAUSE:
+  //
+  // The X settings UI sent `ui:configure` with a module name that did not
+  // match the announced service, and the service subscribed to `ui:configure`
+  // instead of the server-routed `module:configure` event.
+  //
+  // The runtime forwards UI configuration to the announced X module as
+  // `module:configure`, so the service can validate and apply its credentials.
+  it('routes Issue #2154 X configuration to the announced module', () => {
+    const runtime = setupApp()
+    const handler = wsHandler()
+    const stage = createPeer('stage')
+    const xService = createPeer('x-service')
+
+    handler.open?.(stage.peer)
+    handler.open?.(xService.peer)
+    sendEvent(handler, xService.peer, createExtensionModuleAnnounceEvent('x'))
+    xService.sent.length = 0
+
+    sendEvent(handler, stage.peer, {
+      type: 'ui:configure',
+      data: {
+        moduleName: 'x',
+        config: {
+          apiKey: 'api-key',
+          apiSecret: 'api-secret',
+          accessToken: 'access-token',
+          accessTokenSecret: 'access-token-secret',
+        },
+      },
+      metadata: {
+        source: {
+          kind: 'plugin',
+          id: 'stage',
+          plugin: {
+            id: 'stage-web',
+          },
+        },
+        event: {
+          id: 'x-configure-1',
+        },
+      },
+    })
+
+    expect(decodeEvents(xService.sent)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'module:configure',
+        data: {
+          config: {
+            apiKey: 'api-key',
+            apiSecret: 'api-secret',
+            accessToken: 'access-token',
+            accessTokenSecret: 'access-token-secret',
+          },
+        },
+      }),
+    ]))
+
+    runtime.dispose()
   })
 })

--- a/packages/stage-ui/src/components/modules/X.vue
+++ b/packages/stage-ui/src/components/modules/X.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Button, FieldCheckbox, FieldInput } from '@proj-airi/ui'
+import { Button, Callout, FieldCheckbox, FieldInput } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
+import { computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { useTwitterStore } from '../../stores/modules/twitter'
@@ -9,13 +10,26 @@ const { t } = useI18n()
 const twitterStore = useTwitterStore()
 const { enabled, apiKey, apiSecret, accessToken, accessTokenSecret, configured } = storeToRefs(twitterStore)
 
+const statusTheme = computed(() => configured.value ? 'lime' : 'orange')
+const statusLabel = computed(() => {
+  return configured.value
+    ? t('settings.pages.modules.x.service-online')
+    : t('settings.pages.modules.x.service-offline')
+})
+
 function saveSettings() {
   twitterStore.saveSettings()
 }
+
+onMounted(() => {
+  twitterStore.initialize()
+})
 </script>
 
 <template>
-  <div flex="~ col gap-6">
+  <div :class="['flex flex-col gap-6']">
+    <Callout :theme="statusTheme" :label="statusLabel" />
+
     <FieldCheckbox
       v-model="enabled"
       :label="t('settings.pages.modules.x.enable')"
@@ -60,10 +74,6 @@ function saveSettings() {
         variant="primary"
         @click="saveSettings"
       />
-    </div>
-
-    <div v-if="configured" class="mt-4 rounded-lg bg-green-100 p-4 text-green-800">
-      {{ t('settings.pages.modules.x.configured') }}
     </div>
   </div>
 </template>

--- a/packages/stage-ui/src/composables/use-modules-list.ts
+++ b/packages/stage-ui/src/composables/use-modules-list.ts
@@ -46,6 +46,7 @@ export function useModulesList() {
   const beatSyncState = ref<BeatSyncDetectorState>()
 
   minecraftStore.initialize()
+  twitterStore.initialize()
 
   const modulesList = computed<Module[]>(() => [
     {

--- a/packages/stage-ui/src/stores/modules/twitter.ts
+++ b/packages/stage-ui/src/stores/modules/twitter.ts
@@ -1,22 +1,103 @@
+import type { MetadataEventSource, WebSocketBaseEvent, WebSocketEvents } from '@proj-airi/server-sdk'
+
 import { useLocalStorageManualReset } from '@proj-airi/stage-shared/composables'
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import { useConfiguratorByModsChannelServer } from '../configurator'
+import { useModsServerChannelStore } from '../mods/api/channel-server'
 
+const X_MODULE_NAME = 'x'
+
+function isXModuleIdentity(value: { name?: string, identity?: MetadataEventSource }) {
+  return value.name === X_MODULE_NAME || value.identity?.id === X_MODULE_NAME
+}
+
+/** Tracks X service availability and delivers its credential configuration. */
 export const useTwitterStore = defineStore('twitter', () => {
   const configurator = useConfiguratorByModsChannelServer()
+  const serverChannelStore = useModsServerChannelStore()
 
   const enabled = useLocalStorageManualReset<boolean>('settings/twitter/enabled', false)
   const apiKey = useLocalStorageManualReset<string>('settings/twitter/api-key', '')
   const apiSecret = useLocalStorageManualReset<string>('settings/twitter/api-secret', '')
   const accessToken = useLocalStorageManualReset<string>('settings/twitter/access-token', '')
   const accessTokenSecret = useLocalStorageManualReset<string>('settings/twitter/access-token-secret', '')
+  const initialized = ref(false)
+  const servicePresent = ref(false)
+  const serviceHealthy = ref(false)
+
+  let disposeRegistrySync: (() => void) | null = null
+  let disposeRegistryHealthy: (() => void) | null = null
+  let disposeRegistryUnhealthy: (() => void) | null = null
+  let disposeModuleDeAnnounced: (() => void) | null = null
+
+  const configured = computed(() => servicePresent.value && serviceHealthy.value)
+
+  function handleRegistrySync(event: WebSocketBaseEvent<'registry:modules:sync', WebSocketEvents['registry:modules:sync']>) {
+    const wasPresent = servicePresent.value
+    servicePresent.value = event.data.modules.some(isXModuleIdentity)
+
+    if (!servicePresent.value) {
+      serviceHealthy.value = false
+      return
+    }
+
+    if (!wasPresent)
+      serviceHealthy.value = true
+  }
+
+  function handleRegistryHealthy(event: WebSocketBaseEvent<'registry:modules:health:healthy', WebSocketEvents['registry:modules:health:healthy']>) {
+    if (!isXModuleIdentity(event.data))
+      return
+
+    servicePresent.value = true
+    serviceHealthy.value = true
+  }
+
+  function handleRegistryUnhealthy(event: WebSocketBaseEvent<'registry:modules:health:unhealthy', WebSocketEvents['registry:modules:health:unhealthy']>) {
+    if (!isXModuleIdentity(event.data))
+      return
+
+    servicePresent.value = true
+    serviceHealthy.value = false
+  }
+
+  function handleModuleDeAnnounced(event: WebSocketBaseEvent<'module:de-announced', WebSocketEvents['module:de-announced']>) {
+    if (!isXModuleIdentity(event.data))
+      return
+
+    servicePresent.value = false
+    serviceHealthy.value = false
+  }
+
+  function initialize() {
+    if (initialized.value)
+      return
+
+    initialized.value = true
+    disposeRegistrySync = serverChannelStore.onEvent('registry:modules:sync', handleRegistrySync)
+    disposeRegistryHealthy = serverChannelStore.onEvent('registry:modules:health:healthy', handleRegistryHealthy)
+    disposeRegistryUnhealthy = serverChannelStore.onEvent('registry:modules:health:unhealthy', handleRegistryUnhealthy)
+    disposeModuleDeAnnounced = serverChannelStore.onEvent('module:de-announced', handleModuleDeAnnounced)
+  }
+
+  function dispose() {
+    disposeRegistrySync?.()
+    disposeRegistryHealthy?.()
+    disposeRegistryUnhealthy?.()
+    disposeModuleDeAnnounced?.()
+    disposeRegistrySync = null
+    disposeRegistryHealthy = null
+    disposeRegistryUnhealthy = null
+    disposeModuleDeAnnounced = null
+    initialized.value = false
+  }
 
   function saveSettings() {
     // Data is automatically saved to localStorage via useLocalStorage
     // Also broadcast configuration to backend
-    configurator.updateFor('twitter', {
+    configurator.updateFor(X_MODULE_NAME, {
       enabled: enabled.value,
       apiKey: apiKey.value,
       apiSecret: apiSecret.value,
@@ -24,10 +105,6 @@ export const useTwitterStore = defineStore('twitter', () => {
       accessTokenSecret: accessTokenSecret.value,
     })
   }
-
-  const configured = computed(() => {
-    return !!(apiKey.value.trim() && apiSecret.value.trim() && accessToken.value.trim() && accessTokenSecret.value.trim())
-  })
 
   function resetState() {
     enabled.reset()
@@ -45,6 +122,8 @@ export const useTwitterStore = defineStore('twitter', () => {
     accessToken,
     accessTokenSecret,
     configured,
+    initialize,
+    dispose,
     saveSettings,
     resetState,
   }

--- a/services/twitter-services/src/adapters/airi-adapter.ts
+++ b/services/twitter-services/src/adapters/airi-adapter.ts
@@ -54,7 +54,7 @@ export class AiriAdapter {
         'module:authenticate',
         'module:authenticated',
         'module:announce',
-        'ui:configure',
+        'module:configure',
         'input:text',
       ],
     })
@@ -71,8 +71,8 @@ export class AiriAdapter {
 
   private setupEventHandlers(): void {
     // Handle configuration from UI
-    this.client.onEvent('ui:configure', async (event) => {
-      if (event.data && event.data.moduleName === 'x' && event.data.config && isXConfig(event.data.config)) {
+    this.client.onEvent('module:configure', async (event) => {
+      if (event.data.config && isXConfig(event.data.config)) {
         logger.main.log('Received configuration from UI for X module')
         logger.main.log('Twitter configuration received:', event.data.config)
 
@@ -106,8 +106,7 @@ export class AiriAdapter {
           }
         }
       }
-      else if (event.data && event.data.moduleName === 'x') {
-        // Log error if config is not valid
+      else {
         logger.main.error('Invalid configuration received for X module')
       }
     })


### PR DESCRIPTION
Closes #2154

## Summary
- Route X settings through the consistent `x` module identifier and server-delivered `module:configure` contract.
- Report live X service availability instead of treating locally populated credentials as a working integration.
- Add the configuration-routing regression test and localized status messages.

## Root cause
The UI targeted `twitter`, while the service expected `x`; additionally, the service listened for `ui:configure` although the runtime forwards the event as `module:configure`.

## Validation
- `pnpm exec vitest run packages/server-runtime/src/setupApp.liveness.test.ts`
- `pnpm -F @proj-airi/stage-ui typecheck`
- `pnpm -F @proj-airi/server-runtime typecheck`
- `pnpm lint`

`pnpm -F @proj-airi/twitter-services typecheck` remains blocked by existing unused variables in `src/parsers/profile-parser.ts` and `src/parsers/tweet-parser.ts`.