### PR TITLE
fix(auth-ui): remove unavailable analytics script

### DIFF
--- a/apps/ui-server-auth/index.html
+++ b/apps/ui-server-auth/index.html
@@ -40,14 +40,6 @@
           document.documentElement.classList.toggle('dark', true)
       })()
     </script>
-    <!-- Privacy-friendly analytics by Plausible -->
-    <script async src="https://moeru-ai-airi-helper.kwaa.workers.dev/remote-assets/page-external-data/js/script.js"></script>
-    <script>
-      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-      plausible.init({
-        endpoint: "https://moeru-ai-airi-helper.kwaa.workers.dev/api/v1/page-external-data/submit"
-      })
-    </script>
   </head>
   <body class="font-sans">
     <div id="app"></div>


### PR DESCRIPTION
## Summary

Removes the obsolete Plausible helper script from the hosted auth UI.

## Root cause

The helper endpoint returns 404 on the sign-in page, creating a failed `script.js` request. The auth UI already uses PostHog, so the unused Plausible bootstrap can be removed safely.

Fixes #2165.

## Validation

- `pnpm -F @proj-airi/ui-server-auth typecheck`
- `pnpm -F @proj-airi/ui-server-auth lint`
- `pnpm -F @proj-airi/ui-server-auth build`
- `pnpm typecheck`

Deployment is needed to verify the end-to-end hosted sign-in result, because the local server requires a database configuration that is not available in this checkout.
