### PR TITLE
fix(ci): pin Node to 24 in CI and autofix workflows

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
 
     # Setup .NET for Godot C# linting
@@ -78,7 +78,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
 
       # Setup .NET and Godot
@@ -127,7 +127,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
 
       # # Setup .NET and Godot
@@ -164,7 +164,7 @@ jobs:
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Pin `actions/setup-node@v6` to Node 24 in `ci.yml` and `autofix.yaml`, replacing `lts/*`.

## Why
Peeled off from #1966 (Steam desktop sign-in) at maintainer request, since it's orthogonal to Steam auth.

Two failures were observed on that branch while `lts/*` was in use:
- `lts/*` intermittently failed `setup-node@v6` with `manifest.filter is not a function`, cancelling PR builds.
- Node 22 (an earlier attempted pin) lacks `CloseEvent`, which breaks `better-ws` unit tests.

Node 24 is the current LTS and has both issues fixed.

## Test plan
- [ ] CI green on this PR (lint/typecheck/unit/build across all four `setup-node` jobs).

Made with [Cursor](https://cursor.com)