### PR TITLE
fix(ui-server-auth): preserve apiServerUrl across SPA verify-email navigation

### DIFF
--- a/apps/ui-server-auth/src/modules/server-auth-context.test.ts
+++ b/apps/ui-server-auth/src/modules/server-auth-context.test.ts
@@ -58,4 +58,34 @@ describe('ui-server-auth bootstrap context', () => {
 
     expect(getServerAuthBootstrapContext()?.apiServerUrl).toBe('https://airi-server-dev.up.railway.app')
   })
+
+  // ROOT CAUSE:
+  //
+  // This standalone auth UI is a client-side SPA: vue-router navigates from
+  // /sign-in to /verify-email via pushState, changing window.location.href
+  // without a page reload. getServerAuthBootstrapContext() used to cache its
+  // result in a single module-level variable on first call, so every later
+  // call on the same page load reused the FIRST visited route's resolved
+  // apiServerUrl (or null) regardless of the current URL's query string.
+  //
+  // Concretely: a user lands on /sign-in with no api_server_url (context is
+  // cached as null), signs up, and gets redirected to
+  // /verify-email?api_server_url=http://localhost:3000 — but the stale cached
+  // `null` is returned, so verify-email silently falls back to the production
+  // SERVER_URL instead of the local dev server that created the account.
+  //
+  // Fixed by keying the cache on window.location.href so each SPA route
+  // re-resolves its own context.
+  it('re-resolves the bootstrap context after an in-page SPA navigation changes the URL', () => {
+    document.body.innerHTML = ''
+    window.history.replaceState(null, '', '/ui/sign-in')
+    expect(getServerAuthBootstrapContext()).toBeNull()
+
+    window.history.pushState(
+      null,
+      '',
+      '/ui/verify-email?api_server_url=http%3A%2F%2Flocalhost%3A3000',
+    )
+    expect(getServerAuthBootstrapContext()?.apiServerUrl).toBe('http://localhost:3000')
+  })
 })

--- a/apps/ui-server-auth/src/modules/server-auth-context.ts
+++ b/apps/ui-server-auth/src/modules/server-auth-context.ts
@@ -12,7 +12,7 @@ export interface ServerAuthBootstrapContext {
 }
 
 const SCRIPT_ID = 'airi-server-auth-context'
-const API_SERVER_URL_QUERY_PARAM = 'api_server_url'
+export const API_SERVER_URL_QUERY_PARAM = 'api_server_url'
 
 const TRUSTED_STANDALONE_API_SERVER_ORIGINS = [
   'https://api.airi.build',
@@ -34,31 +34,42 @@ const TRUSTED_LOCAL_API_SERVER_ORIGIN_PATTERNS = [
   /^https:\/\/127\.0\.0\.1(:\d+)?$/,
 ]
 
-let cachedContext: ServerAuthBootstrapContext | null | undefined
+// NOTICE:
+// Keyed by current href because this standalone auth UI is a client-side SPA:
+// vue-router changes `window.location.search` (and thus the `api_server_url`
+// query param) without a page reload. A single module-level cache pinned to the
+// first visited route would freeze every later route onto the first route's
+// apiServerUrl (e.g. landing on /sign-in with no param cached null, then
+// /verify-email?api_server_url=http://localhost:3000 wrongly reusing null and
+// falling back to the production SERVER_URL). See debug session 474385.
+let cachedContextForUrl: { url: string, context: ServerAuthBootstrapContext | null } | undefined
 
 export function getServerAuthBootstrapContext(): ServerAuthBootstrapContext | null {
-  if (cachedContext !== undefined)
-    return cachedContext
+  const currentHref = window.location.href
+  if (cachedContextForUrl !== undefined && cachedContextForUrl.url === currentHref)
+    return cachedContextForUrl.context
 
   const element = document.getElementById(SCRIPT_ID)
+  let context: ServerAuthBootstrapContext | null
   if (!element) {
-    cachedContext = resolveStandaloneServerAuthContext(window.location.href, SERVER_URL)
-    return cachedContext
+    context = resolveStandaloneServerAuthContext(currentHref, SERVER_URL)
+  }
+  else {
+    try {
+      const parsed = JSON.parse(element.textContent ?? '') as Partial<ServerAuthBootstrapContext>
+      context = {
+        apiServerUrl: parsed.apiServerUrl ?? SERVER_URL,
+        currentUrl: parsed.currentUrl ?? currentHref,
+        oidcCallback: parsed.oidcCallback,
+      }
+    }
+    catch {
+      context = resolveStandaloneServerAuthContext(currentHref, SERVER_URL)
+    }
   }
 
-  try {
-    const parsed = JSON.parse(element.textContent ?? '') as Partial<ServerAuthBootstrapContext>
-    cachedContext = {
-      apiServerUrl: parsed.apiServerUrl ?? SERVER_URL,
-      currentUrl: parsed.currentUrl ?? window.location.href,
-      oidcCallback: parsed.oidcCallback,
-    }
-    return cachedContext
-  }
-  catch {
-    cachedContext = resolveStandaloneServerAuthContext(window.location.href, SERVER_URL)
-    return cachedContext
-  }
+  cachedContextForUrl = { url: currentHref, context }
+  return context
 }
 
 /**

--- a/apps/ui-server-auth/src/pages/sign-in.vue
+++ b/apps/ui-server-auth/src/pages/sign-in.vue
@@ -21,7 +21,7 @@ import {
   signInWithEmail,
   signUpWithEmail,
 } from '../modules/email-password'
-import { getServerAuthBootstrapContext } from '../modules/server-auth-context'
+import { API_SERVER_URL_QUERY_PARAM, getServerAuthBootstrapContext } from '../modules/server-auth-context'
 import { createServerSignInContext, requestSocialSignInRedirect } from '../modules/sign-in'
 
 type Step = 'identify' | 'password' | 'create'
@@ -201,6 +201,7 @@ async function handleEmailSignIn(event: Event) {
         path: '/verify-email',
         query: {
           email: credentials.email.trim(),
+          [API_SERVER_URL_QUERY_PARAM]: apiServerUrl,
           ...(oidcContinueURL.value ? { continueURL: oidcContinueURL.value } : {}),
         },
       })
@@ -252,6 +253,7 @@ async function handleEmailSignUp(event: Event) {
         path: '/verify-email',
         query: {
           email,
+          [API_SERVER_URL_QUERY_PARAM]: apiServerUrl,
           ...(oidcContinueURL.value ? { continueURL: oidcContinueURL.value } : {}),
         },
       })


### PR DESCRIPTION
## Summary
- Carry `api_server_url` on the `/sign-in` -> `/verify-email` router push so the verification page resolves the same API server that created the account.
- Key `getServerAuthBootstrapContext()`'s cache by `window.location.href` instead of a single module-level value, so each SPA route re-resolves its own context.

## Why
Peeled off from #1966 (Steam desktop sign-in) at maintainer request, since it's an independent bug unrelated to Steam.

This auth UI is a client-side SPA: vue-router navigates from `/sign-in` to `/verify-email` via `pushState`, changing `window.location.href` without a page reload. The bootstrap context used a single module-level cache populated on first call, so every later call on the same page load reused the *first* visited route's resolved `apiServerUrl` (or `null`) regardless of the current URL's query string.

Concretely: a user lands on `/sign-in` with no `api_server_url` (cached as `null`), signs up against a local dev server, and gets redirected to `/verify-email?api_server_url=http://localhost:3000` — but the stale cached `null` was returned, so verify-email silently fell back to the production `SERVER_URL` instead of the local server that created the account.

Reproduced via an instrumented debug session before this fix; confirmed resolved after.

## Test plan
- [x] `pnpm exec vitest run apps/ui-server-auth/src/modules/server-auth-context.test.ts` — 7/7 passing, including a new regression test for the SPA-navigation cache staleness.
- [x] `pnpm eslint` on changed files — clean.
- [ ] CI green.

Made with [Cursor](https://cursor.com)