### PR TITLE
feat(stage-ui): add continuous emotion state so expressions persist and decay

### DIFF
--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -23,6 +23,8 @@ const props = withDefaults(defineProps<{
   nowSpeaking?: boolean
   themeColorsHue?: number
   themeColorsHueDynamic?: boolean
+  /** Forwarded to the model; see `Model.vue`. */
+  emotion?: { valence: number, arousal: number, dominance: number }
 }>(), {
   paused: false,
   mouthOpenSize: 0,
@@ -119,6 +121,7 @@ defineExpose({
         :eye-focus-source-active="!!activeCursorPosition"
         :theme-colors-hue="themeColorsHue"
         :theme-colors-hue-dynamic="themeColorsHueDynamic"
+        :emotion="emotion"
         :live2d-idle-animation-enabled="live2dIdleAnimationEnabled"
         :live2d-force-idle-eye-animation="live2dForceIdleEyeAnimation"
         :live2d-auto-blink-enabled="live2dAutoBlinkEnabled"

--- a/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/Live2D.vue
@@ -23,6 +23,8 @@ const props = withDefaults(defineProps<{
   nowSpeaking?: boolean
   themeColorsHue?: number
   themeColorsHueDynamic?: boolean
+  /** Forwarded to the model; see `Model.vue`. */
+  emotion?: { valence: number, arousal: number, dominance: number }
 }>(), {
   paused: false,
   mouthOpenSize: 0,
@@ -124,6 +126,7 @@ defineExpose({
         :eye-focus-source-active="!!activeCursorPosition"
         :theme-colors-hue="themeColorsHue"
         :theme-colors-hue-dynamic="themeColorsHueDynamic"
+        :emotion="emotion"
         :live2d-idle-animation-enabled="live2dIdleAnimationEnabled"
         :live2d-force-idle-eye-animation="live2dForceIdleEyeAnimation"
         :live2d-auto-blink-enabled="live2dAutoBlinkEnabled"

--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
@@ -16,6 +16,7 @@ import { computed, onMounted, onUnmounted, ref, shallowRef, toRef, watch } from 
 
 import {
   createBeatSyncController,
+  createEmotionOverlayPlugins,
   useExpressionController,
   useLive2DMotionManagerUpdate,
   useMotionUpdatePluginAutoEyeBlink,
@@ -50,6 +51,12 @@ const props = withDefaults(defineProps<{
   live2dForceAutoBlinkEnabled?: boolean
   live2dExpressionEnabled?: boolean
   live2dShadowEnabled?: boolean
+  /**
+   * Continuous emotional reading, layered onto the rig as small additive
+   * offsets. Typed structurally rather than imported from the package that owns
+   * it, which already depends on this one.
+   */
+  emotion?: { valence: number, arousal: number, dominance: number }
 }>(), {
   mouthOpenSize: 0,
   nowSpeaking: false,
@@ -350,6 +357,15 @@ async function loadModel() {
       lastUpdateTime,
     })
 
+    const emotionOverlay = createEmotionOverlayPlugins({
+      reading: () => props.emotion ?? { valence: 0, arousal: 0, dominance: 0 },
+      enabled: () => props.live2dExpressionEnabled !== false,
+    })
+
+    // Must be the first 'pre' plugin: the stage stops at the first plugin that
+    // marks the frame handled, and the overlay needs its previous contribution
+    // undone before anything else reads or writes these parameters.
+    motionManagerUpdate.register(emotionOverlay.restore, 'pre')
     motionManagerUpdate.register(useMotionUpdatePluginBeatSync(beatSync), 'pre')
     motionManagerUpdate.register(useMotionUpdatePluginIdleDisable(), 'pre')
     motionManagerUpdate.register(useMotionUpdatePluginIdleFocus(), 'post')
@@ -360,6 +376,8 @@ async function loadModel() {
     motionManagerUpdate.register(useMotionUpdatePluginExpression(expressionController), 'final')
     motionManagerUpdate.register(useMotionUpdatePluginAutoEyeBlink(live2dExpressionEnabled), 'final')
     motionManagerUpdate.register(useMotionUpdatePluginLipSync(mouthOpenSize, nowSpeaking), 'final')
+    // Last: the mood layer colours whatever the frame already produced.
+    motionManagerUpdate.register(emotionOverlay.apply, 'final')
 
     const hookedUpdate = motionManager.update as (model: PixiLive2DInternalModel['coreModel'], now: number) => boolean
     motionManager.update = function (model: PixiLive2DInternalModel['coreModel'], now: number) {

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
@@ -167,6 +167,50 @@ describe('createEmotionOverlayPlugins', () => {
     expect(values.get('ParamEyeLOpen')).toBeCloseTo(0.95, 6)
   })
 
+  // https://github.com/moeru-ai/airi/pull/2193#discussion_r3688677911
+  //
+  // ROOT CAUSE:
+  //
+  // `restore` wrote its recorded base back unconditionally. The model-settings
+  // sliders write these same parameter ids from Vue watchers, which run outside
+  // the frame loop, so a manual change made between two frames was overwritten
+  // by the previous frame's base before the next frame even started — and for a
+  // parameter no motion keys, nothing put it back.
+  //
+  // Restoring only when the parameter still holds the overlay's own last write
+  // keeps that manual value. The question is only answerable in `pre`, where no
+  // plugin, motion, expression or blink has run yet, so an out-of-band write is
+  // the only thing a difference can mean.
+  it('should keep a value written from outside the frame loop', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.1 })
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value })
+    const offset = resolveEmotionOffsets(vad.value).ParamMouthForm
+
+    runFrame(overlay, model)
+
+    // A settings slider moves between frames.
+    model.values.set('ParamMouthForm', 0.8)
+    runFrame(overlay, model)
+
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.8 + offset, 6)
+  })
+
+  it('should not strand the outside value once the state goes neutral', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.1 })
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value })
+
+    runFrame(overlay, model)
+    model.values.set('ParamMouthForm', 0.8)
+    runFrame(overlay, model)
+
+    vad.value = { ...NEUTRAL }
+    runFrame(overlay, model)
+
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.8, 6)
+  })
+
   it('should skip parameters the model does not declare', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
     const vad = ref({ valence: 0.5, arousal: 0.5, dominance: 0.5 })

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
@@ -211,6 +211,48 @@ describe('createEmotionOverlayPlugins', () => {
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.8, 6)
   })
 
+  // https://github.com/moeru-ai/airi/pull/2193#discussion_r3689112594
+  //
+  // ROOT CAUSE:
+  //
+  // The eye offset was added flat. `apply` is registered after the expression
+  // and auto-blink plugins on 'final', so a frame that deliberately wrote the
+  // eyes to 0 — a blink apex, or a closed-eye expression — was reopened to the
+  // offset. Everything else in this package modulates eye openness
+  // multiplicatively (auto-blink writes `blinkFactor * base`) precisely so that
+  // a deliberate zero survives; the overlay now does the same.
+  it('should leave eyes closed by a blink or expression closed', () => {
+    const model = createModel(['ParamEyeLOpen', 'ParamEyeROpen'], { ParamEyeLOpen: 0, ParamEyeROpen: 0 })
+    const vad = ref({ ...NEUTRAL, arousal: 0.85 })
+
+    createEmotionOverlayPlugins({ reading: () => vad.value }).apply(createContext(model))
+
+    expect(model.values.get('ParamEyeLOpen')).toBe(0)
+    expect(model.values.get('ParamEyeROpen')).toBe(0)
+  })
+
+  it('should still widen eyes that are open', () => {
+    const model = createModel(['ParamEyeLOpen'], { ParamEyeLOpen: 1 })
+    const vad = ref({ ...NEUTRAL, arousal: 0.85 })
+
+    createEmotionOverlayPlugins({ reading: () => vad.value }).apply(createContext(model))
+
+    expect(model.values.get('ParamEyeLOpen')).toBeGreaterThan(1)
+  })
+
+  it('should scale the eye offset with how open the eye already is', () => {
+    const half = createModel(['ParamEyeLOpen'], { ParamEyeLOpen: 0.5 })
+    const full = createModel(['ParamEyeLOpen'], { ParamEyeLOpen: 1 })
+    const vad = ref({ ...NEUTRAL, arousal: 0.85 })
+
+    createEmotionOverlayPlugins({ reading: () => vad.value }).apply(createContext(half))
+    createEmotionOverlayPlugins({ reading: () => vad.value }).apply(createContext(full))
+
+    const halfDelta = half.values.get('ParamEyeLOpen')! - 0.5
+    const fullDelta = full.values.get('ParamEyeLOpen')! - 1
+    expect(halfDelta).toBeCloseTo(fullDelta / 2, 6)
+  })
+
   it('should skip parameters the model does not declare', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
     const vad = ref({ valence: 0.5, arousal: 0.5, dominance: 0.5 })

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
@@ -1,0 +1,129 @@
+import type { MotionManagerPluginContext } from './motion-manager'
+
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { createEmotionOverlayPlugin, resolveEmotionOffsets } from './emotion-overlay'
+
+const NEUTRAL = { valence: 0, arousal: 0, dominance: 0 }
+
+function createModel(declared: string[], initial: Record<string, number> = {}) {
+  const values = new Map(Object.entries(initial))
+  return {
+    getParameterIndex: vi.fn((id: string) => declared.indexOf(id)),
+    getParameterValueById: vi.fn((id: string) => values.get(id) ?? 0),
+    setParameterValueById: vi.fn((id: string, value: number) => {
+      values.set(id, value)
+    }),
+    values,
+  }
+}
+
+function createContext(model: ReturnType<typeof createModel>): MotionManagerPluginContext {
+  return { model, now: 1000, timeDelta: 16 } as unknown as MotionManagerPluginContext
+}
+
+describe('resolveEmotionOffsets', () => {
+  it('should produce no offsets for a neutral state', () => {
+    expect(resolveEmotionOffsets(NEUTRAL)).toEqual({})
+  })
+
+  it('should turn positive valence into a positive mouth form', () => {
+    const offsets = resolveEmotionOffsets({ ...NEUTRAL, valence: 0.5 })
+    expect(offsets.ParamMouthForm).toBeGreaterThan(0)
+  })
+
+  it('should flip the mouth form sign with valence', () => {
+    const happy = resolveEmotionOffsets({ ...NEUTRAL, valence: 0.5 })
+    const sad = resolveEmotionOffsets({ ...NEUTRAL, valence: -0.5 })
+    expect(sad.ParamMouthForm).toBeCloseTo(-happy.ParamMouthForm, 6)
+  })
+
+  it('should widen the eyes with arousal', () => {
+    const offsets = resolveEmotionOffsets({ ...NEUTRAL, arousal: 1 })
+    expect(offsets.ParamEyeLOpen).toBeGreaterThan(0)
+    expect(offsets.ParamEyeROpen).toBeCloseTo(offsets.ParamEyeLOpen, 6)
+  })
+
+  it('should raise the chin with dominance and lower it without', () => {
+    expect(resolveEmotionOffsets({ ...NEUTRAL, dominance: 1 }).ParamAngleY).toBeGreaterThan(0)
+    expect(resolveEmotionOffsets({ ...NEUTRAL, dominance: -1 }).ParamAngleY).toBeLessThan(0)
+  })
+
+  // Mouth aperture belongs to lipsync; anything written here would fight it.
+  it('should never emit a mouth aperture offset', () => {
+    const extreme = { valence: 1, arousal: 1, dominance: 1 }
+    expect(Object.keys(resolveEmotionOffsets(extreme))).not.toContain('ParamMouthOpenY')
+  })
+
+  // This layer is a mood floor, not a performance — it must not be able to
+  // overpower an authored expression even at a saturated state.
+  it('should keep every offset within its ceiling', () => {
+    const extreme = { valence: 1, arousal: 1, dominance: 1 }
+
+    for (const [id, value] of Object.entries(resolveEmotionOffsets(extreme))) {
+      const limit = id.startsWith('ParamAngle') ? 8 : 0.25
+      expect(Math.abs(value)).toBeLessThanOrEqual(limit)
+    }
+  })
+})
+
+describe('createEmotionOverlayPlugin', () => {
+  it('should add its offset to the value the frame already produced', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.4 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+
+    createEmotionOverlayPlugin({ snapshot })(createContext(model))
+
+    const expected = 0.4 + resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(expected, 6)
+  })
+
+  // A rig without brow parameters should lose the brow contribution, not throw
+  // or have a wrong baseline baked into an undeclared parameter.
+  it('should skip parameters the model does not declare', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
+    const snapshot = ref({ current: { valence: 0.5, arousal: 0.5, dominance: 0.5 } })
+
+    createEmotionOverlayPlugin({ snapshot })(createContext(model))
+
+    expect(model.setParameterValueById).toHaveBeenCalledTimes(1)
+    expect(model.setParameterValueById).toHaveBeenCalledWith('ParamMouthForm', expect.any(Number))
+  })
+
+  it('should write nothing while the state is neutral', () => {
+    const model = createModel(['ParamMouthForm', 'ParamAngleY'])
+    const snapshot = ref({ current: { ...NEUTRAL } })
+
+    createEmotionOverlayPlugin({ snapshot })(createContext(model))
+
+    expect(model.setParameterValueById).not.toHaveBeenCalled()
+  })
+
+  it('should write nothing while disabled', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.9 } })
+
+    createEmotionOverlayPlugin({ snapshot, enabled: ref(false) })(createContext(model))
+
+    expect(model.setParameterValueById).not.toHaveBeenCalled()
+  })
+
+  it('should accumulate over frames only through the value it reads back', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const plugin = createEmotionOverlayPlugin({ snapshot })
+    const offset = resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
+
+    plugin(createContext(model))
+    const afterFirst = model.values.get('ParamMouthForm')
+
+    // A fresh frame resets the parameter before plugins run, so a real second
+    // frame starts from the model default rather than from the previous write.
+    model.values.set('ParamMouthForm', 0)
+    plugin(createContext(model))
+
+    expect(afterFirst).toBeCloseTo(offset, 6)
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(offset, 6)
+  })
+})

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
@@ -109,21 +109,80 @@ describe('createEmotionOverlayPlugin', () => {
     expect(model.setParameterValueById).not.toHaveBeenCalled()
   })
 
-  it('should accumulate over frames only through the value it reads back', () => {
+  // A parameter no motion keys is not reset between frames, so reading it back
+  // returns this overlay's own previous output. Without a record of what was
+  // written the offset compounds every frame — 0.11 becomes 6.6 within a
+  // second at 60fps.
+  it('should hold steady over many frames when nothing else touches the parameter', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const plugin = createEmotionOverlayPlugin({ snapshot })
+    const offset = resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
+
+    const ctx = createContext(model)
+    for (let frame = 0; frame < 60; frame++)
+      plugin(ctx)
+
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(offset, 6)
+  })
+
+  it('should layer onto the value a motion produced this frame', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
     const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
     const plugin = createEmotionOverlayPlugin({ snapshot })
     const offset = resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
 
     plugin(createContext(model))
-    const afterFirst = model.values.get('ParamMouthForm')
-
-    // A fresh frame resets the parameter before plugins run, so a real second
-    // frame starts from the model default rather than from the previous write.
-    model.values.set('ParamMouthForm', 0)
+    // A motion keys the parameter on the next frame.
+    model.values.set('ParamMouthForm', 0.6)
     plugin(createContext(model))
 
-    expect(afterFirst).toBeCloseTo(offset, 6)
-    expect(model.values.get('ParamMouthForm')).toBeCloseTo(offset, 6)
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.6 + offset, 6)
+  })
+
+  // Same transition the expression controller handles: a parameter written
+  // last frame and not written this frame has to be put back, or the last mood
+  // stays frozen on the model forever.
+  it('should restore the parameter when the state returns to neutral', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.2 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const plugin = createEmotionOverlayPlugin({ snapshot })
+
+    plugin(createContext(model))
+    expect(model.values.get('ParamMouthForm')).not.toBeCloseTo(0.2, 6)
+
+    snapshot.value = { current: { ...NEUTRAL } }
+    plugin(createContext(model))
+
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.2, 6)
+  })
+
+  it('should restore the parameter when it is switched off', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.2 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const enabled = ref(true)
+    const plugin = createEmotionOverlayPlugin({ snapshot, enabled })
+
+    plugin(createContext(model))
+    enabled.value = false
+    plugin(createContext(model))
+
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.2, 6)
+  })
+
+  // If something else claimed the parameter after our write, that newer value
+  // is the one that should stand — undoing our contribution would clobber it.
+  it('should not undo its contribution once another writer has claimed the parameter', () => {
+    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
+    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const plugin = createEmotionOverlayPlugin({ snapshot })
+
+    plugin(createContext(model))
+    model.values.set('ParamMouthForm', 0.9)
+
+    snapshot.value = { current: { ...NEUTRAL } }
+    plugin(createContext(model))
+
+    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.9, 6)
   })
 })

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
@@ -170,6 +170,32 @@ describe('createEmotionOverlayPlugin', () => {
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.2, 6)
   })
 
+  // Cubism clamps to a parameter's declared range, so the model may not hold
+  // the number that was written. Recording the unclamped value would make the
+  // next frame read it as someone else's change and leave the parameter stuck
+  // at the ceiling.
+  it('should restore the base even when the model clamped the write', () => {
+    const values = new Map([['ParamEyeLOpen', 0.95]])
+    const model = {
+      getParameterIndex: vi.fn(() => 0),
+      getParameterValueById: vi.fn((id: string) => values.get(id) ?? 0),
+      setParameterValueById: vi.fn((id: string, value: number) => {
+        values.set(id, Math.min(Math.max(value, 0), 1))
+      }),
+      values,
+    }
+    const snapshot = ref({ current: { ...NEUTRAL, arousal: 0.8 } })
+    const plugin = createEmotionOverlayPlugin({ snapshot })
+
+    plugin(createContext(model as unknown as ReturnType<typeof createModel>))
+    expect(values.get('ParamEyeLOpen')).toBe(1)
+
+    snapshot.value = { current: { ...NEUTRAL } }
+    plugin(createContext(model as unknown as ReturnType<typeof createModel>))
+
+    expect(values.get('ParamEyeLOpen')).toBeCloseTo(0.95, 6)
+  })
+
   // If something else claimed the parameter after our write, that newer value
   // is the one that should stand — undoing our contribution would clobber it.
   it('should not undo its contribution once another writer has claimed the parameter', () => {

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.test.ts
@@ -3,7 +3,7 @@ import type { MotionManagerPluginContext } from './motion-manager'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
-import { createEmotionOverlayPlugin, resolveEmotionOffsets } from './emotion-overlay'
+import { createEmotionOverlayPlugins, resolveEmotionOffsets } from './emotion-overlay'
 
 const NEUTRAL = { valence: 0, arousal: 0, dominance: 0 }
 
@@ -68,113 +68,84 @@ describe('resolveEmotionOffsets', () => {
   })
 })
 
-describe('createEmotionOverlayPlugin', () => {
-  it('should add its offset to the value the frame already produced', () => {
+describe('createEmotionOverlayPlugins', () => {
+  function runFrame(
+    overlay: ReturnType<typeof createEmotionOverlayPlugins>,
+    model: ReturnType<typeof createModel>,
+  ) {
+    overlay.restore(createContext(model))
+    overlay.apply(createContext(model))
+  }
+
+  it('should layer its offset onto the value the frame produced', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.4 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
 
-    createEmotionOverlayPlugin({ snapshot })(createContext(model))
+    runFrame(createEmotionOverlayPlugins({ reading: () => vad.value }), model)
 
-    const expected = 0.4 + resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
+    const expected = 0.4 + resolveEmotionOffsets(vad.value).ParamMouthForm
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(expected, 6)
   })
 
-  // A rig without brow parameters should lose the brow contribution, not throw
-  // or have a wrong baseline baked into an undeclared parameter.
-  it('should skip parameters the model does not declare', () => {
-    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
-    const snapshot = ref({ current: { valence: 0.5, arousal: 0.5, dominance: 0.5 } })
-
-    createEmotionOverlayPlugin({ snapshot })(createContext(model))
-
-    expect(model.setParameterValueById).toHaveBeenCalledTimes(1)
-    expect(model.setParameterValueById).toHaveBeenCalledWith('ParamMouthForm', expect.any(Number))
-  })
-
-  it('should write nothing while the state is neutral', () => {
-    const model = createModel(['ParamMouthForm', 'ParamAngleY'])
-    const snapshot = ref({ current: { ...NEUTRAL } })
-
-    createEmotionOverlayPlugin({ snapshot })(createContext(model))
-
-    expect(model.setParameterValueById).not.toHaveBeenCalled()
-  })
-
-  it('should write nothing while disabled', () => {
-    const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.9 } })
-
-    createEmotionOverlayPlugin({ snapshot, enabled: ref(false) })(createContext(model))
-
-    expect(model.setParameterValueById).not.toHaveBeenCalled()
-  })
-
-  // A parameter no motion keys is not reset between frames, so reading it back
-  // returns this overlay's own previous output. Without a record of what was
-  // written the offset compounds every frame — 0.11 becomes 6.6 within a
-  // second at 60fps.
+  // A parameter no motion keys is not reset between frames. Without the restore
+  // stage the overlay would read back its own output and compound: a 0.11
+  // offset reaches 6.6 within a second at 60fps.
   it('should hold steady over many frames when nothing else touches the parameter', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
-    const plugin = createEmotionOverlayPlugin({ snapshot })
-    const offset = resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value })
+    const offset = resolveEmotionOffsets(vad.value).ParamMouthForm
 
-    const ctx = createContext(model)
     for (let frame = 0; frame < 60; frame++)
-      plugin(ctx)
+      runFrame(overlay, model)
 
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(offset, 6)
   })
 
-  it('should layer onto the value a motion produced this frame', () => {
+  it('should follow a motion that rewrites the parameter each frame', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
-    const plugin = createEmotionOverlayPlugin({ snapshot })
-    const offset = resolveEmotionOffsets(snapshot.value.current).ParamMouthForm
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value })
+    const offset = resolveEmotionOffsets(vad.value).ParamMouthForm
 
-    plugin(createContext(model))
-    // A motion keys the parameter on the next frame.
+    overlay.restore(createContext(model))
     model.values.set('ParamMouthForm', 0.6)
-    plugin(createContext(model))
+    overlay.apply(createContext(model))
 
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.6 + offset, 6)
   })
 
-  // Same transition the expression controller handles: a parameter written
-  // last frame and not written this frame has to be put back, or the last mood
-  // stays frozen on the model forever.
-  it('should restore the parameter when the state returns to neutral', () => {
+  it('should give the parameter back when the state returns to neutral', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.2 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
-    const plugin = createEmotionOverlayPlugin({ snapshot })
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value })
 
-    plugin(createContext(model))
+    runFrame(overlay, model)
     expect(model.values.get('ParamMouthForm')).not.toBeCloseTo(0.2, 6)
 
-    snapshot.value = { current: { ...NEUTRAL } }
-    plugin(createContext(model))
+    vad.value = { ...NEUTRAL }
+    runFrame(overlay, model)
 
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.2, 6)
   })
 
-  it('should restore the parameter when it is switched off', () => {
+  it('should give the parameter back when it is switched off', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0.2 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
+    const vad = ref({ ...NEUTRAL, valence: 0.5 })
     const enabled = ref(true)
-    const plugin = createEmotionOverlayPlugin({ snapshot, enabled })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value, enabled: () => enabled.value })
 
-    plugin(createContext(model))
+    runFrame(overlay, model)
     enabled.value = false
-    plugin(createContext(model))
+    runFrame(overlay, model)
 
     expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.2, 6)
   })
 
-  // Cubism clamps to a parameter's declared range, so the model may not hold
-  // the number that was written. Recording the unclamped value would make the
-  // next frame read it as someone else's change and leave the parameter stuck
-  // at the ceiling.
-  it('should restore the base even when the model clamped the write', () => {
+  // The model clamps to a parameter's declared range, so the value it keeps is
+  // not always the one written. Restoring from the recorded base rather than
+  // from a readback means the clamp cannot strand the parameter at its ceiling.
+  it('should give the parameter back even when the model clamped the write', () => {
     const values = new Map([['ParamEyeLOpen', 0.95]])
     const model = {
       getParameterIndex: vi.fn(() => 0),
@@ -183,32 +154,35 @@ describe('createEmotionOverlayPlugin', () => {
         values.set(id, Math.min(Math.max(value, 0), 1))
       }),
       values,
-    }
-    const snapshot = ref({ current: { ...NEUTRAL, arousal: 0.8 } })
-    const plugin = createEmotionOverlayPlugin({ snapshot })
+    } as unknown as ReturnType<typeof createModel>
+    const vad = ref({ ...NEUTRAL, arousal: 0.8 })
+    const overlay = createEmotionOverlayPlugins({ reading: () => vad.value })
 
-    plugin(createContext(model as unknown as ReturnType<typeof createModel>))
+    runFrame(overlay, model)
     expect(values.get('ParamEyeLOpen')).toBe(1)
 
-    snapshot.value = { current: { ...NEUTRAL } }
-    plugin(createContext(model as unknown as ReturnType<typeof createModel>))
+    vad.value = { ...NEUTRAL }
+    runFrame(overlay, model)
 
     expect(values.get('ParamEyeLOpen')).toBeCloseTo(0.95, 6)
   })
 
-  // If something else claimed the parameter after our write, that newer value
-  // is the one that should stand — undoing our contribution would clobber it.
-  it('should not undo its contribution once another writer has claimed the parameter', () => {
+  it('should skip parameters the model does not declare', () => {
     const model = createModel(['ParamMouthForm'], { ParamMouthForm: 0 })
-    const snapshot = ref({ current: { ...NEUTRAL, valence: 0.5 } })
-    const plugin = createEmotionOverlayPlugin({ snapshot })
+    const vad = ref({ valence: 0.5, arousal: 0.5, dominance: 0.5 })
 
-    plugin(createContext(model))
-    model.values.set('ParamMouthForm', 0.9)
+    createEmotionOverlayPlugins({ reading: () => vad.value }).apply(createContext(model))
 
-    snapshot.value = { current: { ...NEUTRAL } }
-    plugin(createContext(model))
+    expect(model.setParameterValueById).toHaveBeenCalledTimes(1)
+    expect(model.setParameterValueById).toHaveBeenCalledWith('ParamMouthForm', expect.any(Number))
+  })
 
-    expect(model.values.get('ParamMouthForm')).toBeCloseTo(0.9, 6)
+  it('should write nothing while the state is neutral', () => {
+    const model = createModel(['ParamMouthForm', 'ParamAngleY'])
+    const vad = ref({ ...NEUTRAL })
+
+    createEmotionOverlayPlugins({ reading: () => vad.value }).apply(createContext(model))
+
+    expect(model.setParameterValueById).not.toHaveBeenCalled()
   })
 })

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
@@ -25,6 +25,16 @@ interface OverlayBinding {
   valence?: number
   arousal?: number
   dominance?: number
+  /**
+   * Scale the offset by the parameter's current value instead of adding it flat.
+   *
+   * Eye openness is modulated multiplicatively everywhere else in this package —
+   * auto-blink writes `blinkFactor * base` — so that a deliberate zero survives:
+   * a blink apex, or an expression that closes the eyes, must stay closed. This
+   * overlay runs after both, so adding a flat offset there would prise them
+   * back open.
+   */
+  relativeToCurrent?: boolean
 }
 
 /**
@@ -45,13 +55,21 @@ const OVERLAY_BINDINGS: readonly OverlayBinding[] = [
   // inner brow on negative valence is what makes sadness legible at all.
   { parameterId: 'ParamBrowLY', valence: 0.12, arousal: 0.08 },
   { parameterId: 'ParamBrowRY', valence: 0.12, arousal: 0.08 },
-  // Arousal widens the eyes slightly. Small, because auto-blink also writes
-  // here and a large offset would visibly fight it.
-  { parameterId: 'ParamEyeLOpen', arousal: 0.10 },
-  { parameterId: 'ParamEyeROpen', arousal: 0.10 },
+  // Arousal widens the eyes slightly, in proportion to how open they already
+  // are, so a closed eye stays closed.
+  { parameterId: 'ParamEyeLOpen', arousal: 0.10, relativeToCurrent: true },
+  { parameterId: 'ParamEyeROpen', arousal: 0.10, relativeToCurrent: true },
   // Dominance rides the head: chin up when in control, down when withdrawing.
   { parameterId: 'ParamAngleY', dominance: 6 },
 ] as const
+
+/**
+ * Parameters whose offset is a gain on the current value rather than an amount
+ * added to it. Derived from the table so the two cannot drift apart.
+ */
+const RELATIVE_PARAMETERS = new Set(
+  OVERLAY_BINDINGS.filter(binding => binding.relativeToCurrent).map(binding => binding.parameterId),
+)
 
 /** Ceiling on any single parameter's offset, in that parameter's own units. */
 const MAX_ABS_OFFSET = 0.25
@@ -71,8 +89,9 @@ function clamp(value: number, limit: number): number {
  * After:
  * - `{ ParamMouthForm: 0.11, ParamBrowLY: 0.06, ParamBrowRY: 0.06 }`
  *
- * Offsets are additive, so a parameter absent from the result simply means the
- * state has no opinion about it this frame.
+ * A parameter absent from the result simply means the state has no opinion about
+ * it this frame. Whether a value is added to the parameter or multiplied through
+ * it is a property of the binding, not of this result — see `relativeToCurrent`.
  */
 export function resolveEmotionOffsets(vad: EmotionOverlayInput): Record<string, number> {
   const offsets: Record<string, number> = {}
@@ -203,14 +222,20 @@ export function createEmotionOverlayPlugins(options: EmotionOverlayOptions): Emo
       if (!Number.isFinite(base))
         continue
 
-      coreModel.setParameterValueById(parameterId, base + offset)
+      // A relative parameter multiplies through the current value, so a zero
+      // written by a blink or a closed-eye expression stays zero.
+      const amount = RELATIVE_PARAMETERS.has(parameterId) ? offset * base : offset
+      if (amount === 0)
+        continue
+
+      coreModel.setParameterValueById(parameterId, base + amount)
 
       // Read back rather than storing `base + offset`: the model clamps to the
       // parameter's declared range, so what it kept is what `restore` has to
       // recognise next frame. Nothing has run in between, so this readback is
       // unambiguously the overlay's own write.
       const written = coreModel.getParameterValueById(parameterId) as number
-      applied.set(parameterId, { base, written: Number.isFinite(written) ? written : base + offset })
+      applied.set(parameterId, { base, written: Number.isFinite(written) ? written : base + amount })
     }
   }
 

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
@@ -188,7 +188,19 @@ export function createEmotionOverlayPlugin(options: EmotionOverlayOptions): Moti
 
       const next = base + offset
       coreModel.setParameterValueById(parameterId, next)
-      applied.set(parameterId, { written: next, base })
+
+      // NOTICE:
+      // Cubism clamps to the parameter's declared range, so the model may not
+      // hold the value that was just written — `ParamEyeLOpen` tops out at 1
+      // and an arousal offset pushes past it. Recording the unclamped number
+      // would make the next frame's comparison fail, the record be dropped as
+      // "someone else changed it", and the parameter stay stuck at the ceiling
+      // instead of returning to base. Store what the model actually kept.
+      const effective = coreModel.getParameterValueById(parameterId) as number
+      applied.set(parameterId, {
+        written: Number.isFinite(effective) ? effective : next,
+        base,
+      })
     }
   }
 }

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
@@ -127,7 +127,9 @@ export interface EmotionOverlayPlugins {
  * Undoing the contribution in `pre` removes the question. Nothing else has run
  * yet that frame, so the value there is unambiguously the previous frame's
  * output, and by the time `apply` reads it in `final` the model holds only
- * what this frame produced.
+ * what this frame produced. It also narrows the one comparison that remains —
+ * "is this still what I left here?" — down to a single possible other writer,
+ * the parameter watchers that run outside the frame loop.
  *
  * @example
  * ```ts
@@ -139,8 +141,12 @@ export interface EmotionOverlayPlugins {
 export function createEmotionOverlayPlugins(options: EmotionOverlayOptions): EmotionOverlayPlugins {
   const { reading, enabled } = options
 
-  /** Value each touched parameter held before this overlay contributed to it. */
-  const bases = new Map<string, number>()
+  /**
+   * Per touched parameter: the value it held before the overlay contributed
+   * (`base`), and the value the model actually kept afterwards (`written`,
+   * which differs from `base + offset` whenever the model clamped the write).
+   */
+  const applied = new Map<string, { base: number, written: number }>()
 
   function declaresParameter(coreModel: MotionManagerPluginContext['model'], parameterId: string): boolean {
     // NOTICE:
@@ -158,12 +164,28 @@ export function createEmotionOverlayPlugins(options: EmotionOverlayOptions): Emo
     if (!coreModel)
       return
 
-    for (const [parameterId, base] of bases)
-      coreModel.setParameterValueById(parameterId, base)
+    for (const [parameterId, record] of applied) {
+      const current = coreModel.getParameterValueById(parameterId) as number
+      if (!Number.isFinite(current))
+        continue
 
-    // Writing the base back here is safe even for a parameter a motion will
-    // key: the motion runs after this stage and overwrites it anyway.
-    bases.clear()
+      // Still holding what the overlay left there, so its contribution is what
+      // needs to come out. A different value can only have come from outside
+      // the frame loop — the parameter watchers behind the model-settings
+      // sliders write these same ids — and that write is now the base.
+      //
+      // Asking this here rather than in `apply` is what makes the answer
+      // trustworthy: no plugin, motion, expression or blink has run yet this
+      // frame, so an out-of-band write is the only thing the difference can
+      // mean. The residual case, an outside writer landing on exactly the
+      // overlay's last output, restores and re-adds the same offset and so is
+      // invisible unless the reading also changed in that frame, where it is
+      // bounded by MAX_ABS_OFFSET.
+      if (Object.is(current, record.written))
+        coreModel.setParameterValueById(parameterId, record.base)
+    }
+
+    applied.clear()
   }
 
   const apply: MotionManagerPlugin = (ctx: MotionManagerPluginContext) => {
@@ -182,7 +204,13 @@ export function createEmotionOverlayPlugins(options: EmotionOverlayOptions): Emo
         continue
 
       coreModel.setParameterValueById(parameterId, base + offset)
-      bases.set(parameterId, base)
+
+      // Read back rather than storing `base + offset`: the model clamps to the
+      // parameter's declared range, so what it kept is what `restore` has to
+      // recognise next frame. Nothing has run in between, so this readback is
+      // unambiguously the overlay's own write.
+      const written = coreModel.getParameterValueById(parameterId) as number
+      applied.set(parameterId, { base, written: Number.isFinite(written) ? written : base + offset })
     }
   }
 

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
@@ -122,15 +122,47 @@ export interface EmotionOverlayOptions {
 export function createEmotionOverlayPlugin(options: EmotionOverlayOptions): MotionManagerPlugin {
   const { snapshot, enabled } = options
 
-  return (ctx: MotionManagerPluginContext) => {
-    if (enabled && !enabled.value)
-      return
+  /**
+   * What this overlay wrote last frame, and the value it was built on.
+   *
+   * NOTICE:
+   * A parameter no motion keys is not reset between frames — the expression
+   * controller documents the same behaviour and solves it by writing from a
+   * stored default. Without this record, reading the parameter back would
+   * return this overlay's own previous output and the offset would compound
+   * every frame: a 0.11 mouth offset reaches 6.6 within a second at 60fps.
+   *
+   * So the readback is only trusted when something else has changed it. If it
+   * still equals what was written, the frame has no opinion of its own and the
+   * recorded base is used instead.
+   */
+  const applied = new Map<string, { written: number, base: number }>()
 
+  return (ctx: MotionManagerPluginContext) => {
     const coreModel = ctx.model
     if (!coreModel)
       return
 
-    const offsets = resolveEmotionOffsets(snapshot.value.current)
+    // Disabled produces an empty set rather than returning early, so the
+    // restore pass below still runs and the last offset does not stay stuck on
+    // the model.
+    const offsets = enabled && !enabled.value
+      ? {}
+      : resolveEmotionOffsets(snapshot.value.current)
+
+    for (const parameterId of [...applied.keys()]) {
+      if (parameterId in offsets)
+        continue
+
+      const prev = applied.get(parameterId)!
+      const currentValue = coreModel.getParameterValueById(parameterId) as number
+      // Only undo the contribution if nothing else has claimed the parameter
+      // since; otherwise the newer value is the one that should stand.
+      if (Number.isFinite(currentValue) && Object.is(currentValue, prev.written))
+        coreModel.setParameterValueById(parameterId, prev.base)
+
+      applied.delete(parameterId)
+    }
 
     for (const [parameterId, offset] of Object.entries(offsets)) {
       // NOTICE:
@@ -149,7 +181,14 @@ export function createEmotionOverlayPlugin(options: EmotionOverlayOptions): Moti
       if (!Number.isFinite(currentValue))
         continue
 
-      coreModel.setParameterValueById(parameterId, currentValue + offset)
+      const prev = applied.get(parameterId)
+      const base = prev !== undefined && Object.is(currentValue, prev.written)
+        ? prev.base
+        : currentValue
+
+      const next = base + offset
+      coreModel.setParameterValueById(parameterId, next)
+      applied.set(parameterId, { written: next, base })
     }
   }
 }

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
@@ -1,0 +1,155 @@
+import type { Ref } from 'vue'
+
+import type { MotionManagerPlugin, MotionManagerPluginContext } from './motion-manager'
+
+/**
+ * The reading this overlay consumes.
+ *
+ * Declared structurally rather than imported from `@proj-airi/stage-ui`, which
+ * already depends on this package — taking the dependency the other way would
+ * close a cycle. Any producer of these three axes fits, which is also what
+ * keeps the emotional state renderer-agnostic.
+ */
+export interface EmotionOverlayInput {
+  valence: number
+  arousal: number
+  dominance: number
+}
+
+/**
+ * Per-axis contribution to one Cubism parameter.
+ *
+ * Kept as data so the whole mapping is readable in one place, and so it can be
+ * tested without a model.
+ */
+interface OverlayBinding {
+  parameterId: string
+  valence?: number
+  arousal?: number
+  dominance?: number
+}
+
+/**
+ * How the continuous state reaches the rig.
+ *
+ * Every gain is small on purpose. This layer is a mood floor that colours
+ * whatever the motion is already doing — it is not a performance, and it must
+ * never be able to overpower an authored expression.
+ *
+ * `ParamMouthOpenY` is deliberately absent: mouth aperture belongs to lipsync,
+ * which runs later and would fight anything written here. Only mouth *shape*
+ * is touched.
+ */
+const OVERLAY_BINDINGS: readonly OverlayBinding[] = [
+  // Pleasantness reads mostly at the mouth corners.
+  { parameterId: 'ParamMouthForm', valence: 0.22 },
+  // Brows carry both how pleasant and how activated the state is; a raised
+  // inner brow on negative valence is what makes sadness legible at all.
+  { parameterId: 'ParamBrowLY', valence: 0.12, arousal: 0.08 },
+  { parameterId: 'ParamBrowRY', valence: 0.12, arousal: 0.08 },
+  // Arousal widens the eyes slightly. Small, because auto-blink also writes
+  // here and a large offset would visibly fight it.
+  { parameterId: 'ParamEyeLOpen', arousal: 0.10 },
+  { parameterId: 'ParamEyeROpen', arousal: 0.10 },
+  // Dominance rides the head: chin up when in control, down when withdrawing.
+  { parameterId: 'ParamAngleY', dominance: 6 },
+] as const
+
+/** Ceiling on any single parameter's offset, in that parameter's own units. */
+const MAX_ABS_OFFSET = 0.25
+/** `ParamAngle*` is in degrees, so it needs its own, larger ceiling. */
+const MAX_ABS_ANGLE_OFFSET = 8
+
+function clamp(value: number, limit: number): number {
+  return Math.min(Math.max(value, -limit), limit)
+}
+
+/**
+ * Turns one emotional state into additive parameter offsets.
+ *
+ * Before:
+ * - `{ valence: 0.5, arousal: 0, dominance: 0 }`
+ *
+ * After:
+ * - `{ ParamMouthForm: 0.11, ParamBrowLY: 0.06, ParamBrowRY: 0.06 }`
+ *
+ * Offsets are additive, so a parameter absent from the result simply means the
+ * state has no opinion about it this frame.
+ */
+export function resolveEmotionOffsets(vad: EmotionOverlayInput): Record<string, number> {
+  const offsets: Record<string, number> = {}
+
+  for (const binding of OVERLAY_BINDINGS) {
+    const raw
+      = vad.valence * (binding.valence ?? 0)
+        + vad.arousal * (binding.arousal ?? 0)
+        + vad.dominance * (binding.dominance ?? 0)
+
+    if (raw === 0)
+      continue
+
+    const limit = binding.parameterId.startsWith('ParamAngle') ? MAX_ABS_ANGLE_OFFSET : MAX_ABS_OFFSET
+    offsets[binding.parameterId] = clamp(raw, limit)
+  }
+
+  return offsets
+}
+
+export interface EmotionOverlayOptions {
+  snapshot: Ref<{ current: EmotionOverlayInput }>
+  /** Lets the overlay be switched off without unregistering it. @default always on */
+  enabled?: Ref<boolean>
+}
+
+/**
+ * Applies the continuous emotional state to the model as small additive
+ * offsets, on top of whatever motion and expressions produced this frame.
+ *
+ * Register on the `final` stage: those run unconditionally, so the mood floor
+ * survives a frame that another plugin has marked handled, and it lands after
+ * the native motion update rather than being overwritten by it.
+ *
+ * A parameter the model does not declare is skipped rather than written, so a
+ * rig missing brow parameters degrades to no brow contribution instead of
+ * throwing.
+ *
+ * @example
+ * ```ts
+ * const state = createEmotionState()
+ * register(createEmotionOverlayPlugin({ snapshot: state.snapshot }), 'final')
+ * ```
+ */
+export function createEmotionOverlayPlugin(options: EmotionOverlayOptions): MotionManagerPlugin {
+  const { snapshot, enabled } = options
+
+  return (ctx: MotionManagerPluginContext) => {
+    if (enabled && !enabled.value)
+      return
+
+    const coreModel = ctx.model
+    if (!coreModel)
+      return
+
+    const offsets = resolveEmotionOffsets(snapshot.value.current)
+
+    for (const [parameterId, offset] of Object.entries(offsets)) {
+      // NOTICE:
+      // Cubism returns 0 and warns for an unknown parameter id rather than
+      // throwing, which would silently bake a wrong baseline into the model.
+      // `getParameterIndex` is the cheap way to ask whether the rig actually
+      // declares this parameter; guarded because the mock models used in tests
+      // do not implement it.
+      const index = typeof coreModel.getParameterIndex === 'function'
+        ? coreModel.getParameterIndex(parameterId)
+        : 0
+      if (index < 0)
+        continue
+
+      const currentValue = coreModel.getParameterValueById(parameterId) as number
+      if (!Number.isFinite(currentValue))
+        continue
+
+      coreModel.setParameterValueById(parameterId, currentValue + offset)
+    }
+  }
+}

--- a/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/emotion-overlay.ts
@@ -1,5 +1,3 @@
-import type { Ref } from 'vue'
-
 import type { MotionManagerPlugin, MotionManagerPluginContext } from './motion-manager'
 
 /**
@@ -96,111 +94,97 @@ export function resolveEmotionOffsets(vad: EmotionOverlayInput): Record<string, 
 }
 
 export interface EmotionOverlayOptions {
-  snapshot: Ref<{ current: EmotionOverlayInput }>
+  /** Reads the state for the current frame. Called once per frame, in `apply`. */
+  reading: () => EmotionOverlayInput
   /** Lets the overlay be switched off without unregistering it. @default always on */
-  enabled?: Ref<boolean>
+  enabled?: () => boolean
+}
+
+/**
+ * The two halves of the overlay. Both must be registered, and `restore` must be
+ * the first `pre` plugin — a `pre` plugin that marks the frame handled stops
+ * the ones after it, and skipping the restore would leave the previous frame's
+ * offset baked into the base.
+ */
+export interface EmotionOverlayPlugins {
+  /** Register on `pre`, before any other pre plugin. */
+  restore: MotionManagerPlugin
+  /** Register on `final`. */
+  apply: MotionManagerPlugin
 }
 
 /**
  * Applies the continuous emotional state to the model as small additive
- * offsets, on top of whatever motion and expressions produced this frame.
+ * offsets, layered on whatever motion and expressions produced this frame.
  *
- * Register on the `final` stage: those run unconditionally, so the mood floor
- * survives a frame that another plugin has marked handled, and it lands after
- * the native motion update rather than being overwritten by it.
+ * Split across two stages on purpose. A parameter no motion keys is not reset
+ * between frames, so a single-stage overlay would read back its own previous
+ * output and compound the offset every frame. Comparing the readback against
+ * what was written cannot fix that reliably either: the model clamps, and two
+ * writers can land on the same value, so equality answers neither "did anyone
+ * else write this" nor "is this still mine".
  *
- * A parameter the model does not declare is skipped rather than written, so a
- * rig missing brow parameters degrades to no brow contribution instead of
- * throwing.
+ * Undoing the contribution in `pre` removes the question. Nothing else has run
+ * yet that frame, so the value there is unambiguously the previous frame's
+ * output, and by the time `apply` reads it in `final` the model holds only
+ * what this frame produced.
  *
  * @example
  * ```ts
- * const state = createEmotionState()
- * register(createEmotionOverlayPlugin({ snapshot: state.snapshot }), 'final')
+ * const overlay = createEmotionOverlayPlugins({ reading: () => state.snapshot.value.current })
+ * register(overlay.restore, 'pre')   // must come first
+ * register(overlay.apply, 'final')
  * ```
  */
-export function createEmotionOverlayPlugin(options: EmotionOverlayOptions): MotionManagerPlugin {
-  const { snapshot, enabled } = options
+export function createEmotionOverlayPlugins(options: EmotionOverlayOptions): EmotionOverlayPlugins {
+  const { reading, enabled } = options
 
-  /**
-   * What this overlay wrote last frame, and the value it was built on.
-   *
-   * NOTICE:
-   * A parameter no motion keys is not reset between frames — the expression
-   * controller documents the same behaviour and solves it by writing from a
-   * stored default. Without this record, reading the parameter back would
-   * return this overlay's own previous output and the offset would compound
-   * every frame: a 0.11 mouth offset reaches 6.6 within a second at 60fps.
-   *
-   * So the readback is only trusted when something else has changed it. If it
-   * still equals what was written, the frame has no opinion of its own and the
-   * recorded base is used instead.
-   */
-  const applied = new Map<string, { written: number, base: number }>()
+  /** Value each touched parameter held before this overlay contributed to it. */
+  const bases = new Map<string, number>()
 
-  return (ctx: MotionManagerPluginContext) => {
+  function declaresParameter(coreModel: MotionManagerPluginContext['model'], parameterId: string): boolean {
+    // NOTICE:
+    // Cubism answers an unknown parameter id with 0 and a warning rather than
+    // an error, which would silently bake a wrong baseline into the model.
+    // Guarded because the mock models used in tests do not implement it.
+    if (typeof coreModel.getParameterIndex !== 'function')
+      return true
+
+    return coreModel.getParameterIndex(parameterId) >= 0
+  }
+
+  const restore: MotionManagerPlugin = (ctx: MotionManagerPluginContext) => {
     const coreModel = ctx.model
     if (!coreModel)
       return
 
-    // Disabled produces an empty set rather than returning early, so the
-    // restore pass below still runs and the last offset does not stay stuck on
-    // the model.
-    const offsets = enabled && !enabled.value
-      ? {}
-      : resolveEmotionOffsets(snapshot.value.current)
+    for (const [parameterId, base] of bases)
+      coreModel.setParameterValueById(parameterId, base)
 
-    for (const parameterId of [...applied.keys()]) {
-      if (parameterId in offsets)
+    // Writing the base back here is safe even for a parameter a motion will
+    // key: the motion runs after this stage and overwrites it anyway.
+    bases.clear()
+  }
+
+  const apply: MotionManagerPlugin = (ctx: MotionManagerPluginContext) => {
+    const coreModel = ctx.model
+    if (!coreModel)
+      return
+    if (enabled && !enabled())
+      return
+
+    for (const [parameterId, offset] of Object.entries(resolveEmotionOffsets(reading()))) {
+      if (!declaresParameter(coreModel, parameterId))
         continue
 
-      const prev = applied.get(parameterId)!
-      const currentValue = coreModel.getParameterValueById(parameterId) as number
-      // Only undo the contribution if nothing else has claimed the parameter
-      // since; otherwise the newer value is the one that should stand.
-      if (Number.isFinite(currentValue) && Object.is(currentValue, prev.written))
-        coreModel.setParameterValueById(parameterId, prev.base)
-
-      applied.delete(parameterId)
-    }
-
-    for (const [parameterId, offset] of Object.entries(offsets)) {
-      // NOTICE:
-      // Cubism returns 0 and warns for an unknown parameter id rather than
-      // throwing, which would silently bake a wrong baseline into the model.
-      // `getParameterIndex` is the cheap way to ask whether the rig actually
-      // declares this parameter; guarded because the mock models used in tests
-      // do not implement it.
-      const index = typeof coreModel.getParameterIndex === 'function'
-        ? coreModel.getParameterIndex(parameterId)
-        : 0
-      if (index < 0)
+      const base = coreModel.getParameterValueById(parameterId) as number
+      if (!Number.isFinite(base))
         continue
 
-      const currentValue = coreModel.getParameterValueById(parameterId) as number
-      if (!Number.isFinite(currentValue))
-        continue
-
-      const prev = applied.get(parameterId)
-      const base = prev !== undefined && Object.is(currentValue, prev.written)
-        ? prev.base
-        : currentValue
-
-      const next = base + offset
-      coreModel.setParameterValueById(parameterId, next)
-
-      // NOTICE:
-      // Cubism clamps to the parameter's declared range, so the model may not
-      // hold the value that was just written — `ParamEyeLOpen` tops out at 1
-      // and an arousal offset pushes past it. Recording the unclamped number
-      // would make the next frame's comparison fail, the record be dropped as
-      // "someone else changed it", and the parameter stay stuck at the ceiling
-      // instead of returning to base. Store what the model actually kept.
-      const effective = coreModel.getParameterValueById(parameterId) as number
-      applied.set(parameterId, {
-        written: Number.isFinite(effective) ? effective : next,
-        base,
-      })
+      coreModel.setParameterValueById(parameterId, base + offset)
+      bases.set(parameterId, base)
     }
   }
+
+  return { restore, apply }
 }

--- a/packages/stage-ui-live2d/src/composables/live2d/index.ts
+++ b/packages/stage-ui-live2d/src/composables/live2d/index.ts
@@ -1,5 +1,6 @@
 export * from './animation'
 export * from './beat-sync'
+export * from './emotion-overlay'
 export * from './expression-controller'
 export * from './eye-tracking'
 export * from './live2d'

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -22,7 +22,7 @@ import { ThreeScene } from '@proj-airi/stage-ui-three'
 import { animations } from '@proj-airi/stage-ui-three/assets/vrm'
 import { createQueue } from '@proj-airi/stream-kit'
 import { Callout } from '@proj-airi/ui'
-import { useBroadcastChannel } from '@vueuse/core'
+import { useBroadcastChannel, useRafFn } from '@vueuse/core'
 // import { createTransformers } from '@xsai-transformers/embed'
 // import embedWorkerURL from '@xsai-transformers/embed/worker?worker&url'
 // import { embed } from '@xsai/embed'
@@ -47,6 +47,7 @@ import { useLlmStreamingControlStore } from '../../stores/ai/chat-llm/streaming-
 import { useAudioContext, useSpeakingStore } from '../../stores/audio'
 import { useBackgroundStore } from '../../stores/background'
 import { useChatStore } from '../../stores/chat'
+import { createEmotionState } from '../../stores/emotion-state'
 import { useAiriCardStore } from '../../stores/modules'
 import { useSpeechStore } from '../../stores/modules/speech'
 import { useProviderConfigStore } from '../../stores/providers/config'
@@ -211,6 +212,14 @@ const { activeBackgroundUrl } = storeToRefs(backgroundStore)
 
 const { currentMotion } = storeToRefs(useLive2dParams())
 
+// Continuous mood floor. Motions are discrete and end; this keeps a reading
+// that decays back to baseline between them, so the model does not snap to
+// perfectly neutral the moment a motion finishes.
+const emotionState = createEmotionState()
+const emotionReading = computed(() => emotionState.snapshot.value.current)
+
+useRafFn(({ delta }) => emotionState.update(delta / 1000))
+
 const emotionsQueue = createQueue<EmotionPayload>({
   handlers: [
     async (ctx) => {
@@ -224,6 +233,8 @@ const emotionsQueue = createQueue<EmotionPayload>({
       }
       else if (stageModelRenderer.value === 'live2d') {
         currentMotion.value = { group: EMOTION_EmotionMotionName_value[ctx.data.name] }
+        // The motion plays once; the reading outlives it and fades on its own.
+        emotionState.nudge(ctx.data.name, ctx.data.intensity)
       }
       else if (stageModelRenderer.value === 'spine') {
         spineSceneRef.value?.setEmotion(ctx.data.name, ctx.data.intensity)
@@ -1087,6 +1098,7 @@ defineExpose({
         :live2d-shadow-enabled="live2dShadowEnabled"
         :live2d-max-fps="live2dMaxFps"
         :live2d-render-scale="live2dRenderScale"
+        :emotion="emotionReading"
         @error="handleStageRenderError"
       />
       <ThreeScene

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -281,6 +281,15 @@ chatHookCleanups.push(streamingControl.onSignal(async (signal) => {
     const act = normalizeActPayload(signal.payload)
     if (act.motion && stageModelRenderer.value === 'live2d') {
       currentMotion.value = { group: act.motion }
+
+      // A payload may name both, and the custom motion wins — it is more
+      // specific than the one the emotion would have picked. The mood is
+      // orthogonal to which motion plays, though, so it still moves rather
+      // than being dropped along with the emotion's motion.
+      const emotion = act.emotion ? toStageEmotionPayload(act.emotion) : undefined
+      if (emotion)
+        emotionState.nudge(emotion.name, emotion.intensity)
+
       return
     }
     if (act.emotion) {

--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -19,7 +19,7 @@ import { ThreeScene } from '@proj-airi/stage-ui-three'
 import { animations } from '@proj-airi/stage-ui-three/assets/vrm'
 import { createQueue } from '@proj-airi/stream-kit'
 import { Callout } from '@proj-airi/ui'
-import { useBroadcastChannel } from '@vueuse/core'
+import { useBroadcastChannel, useRafFn } from '@vueuse/core'
 // import { createTransformers } from '@xsai-transformers/embed'
 // import embedWorkerURL from '@xsai-transformers/embed/worker?worker&url'
 // import { embed } from '@xsai/embed'
@@ -41,6 +41,7 @@ import { createStageTtsSession } from '../../libs/speech/tts-session'
 import { useAudioContext, useSpeakingStore } from '../../stores/audio'
 import { useBackgroundStore } from '../../stores/background'
 import { useChatOrchestratorStore } from '../../stores/chat'
+import { createEmotionState } from '../../stores/emotion-state'
 import { useLlmStreamingControlStore } from '../../stores/llm-streaming-control'
 import { useAiriCardStore } from '../../stores/modules'
 import { useSpeechStore } from '../../stores/modules/speech'
@@ -183,6 +184,14 @@ const { activeBackgroundUrl } = storeToRefs(backgroundStore)
 
 const { currentMotion } = storeToRefs(useLive2dParams())
 
+// Continuous mood floor. Motions are discrete and end; this keeps a reading
+// that decays back to baseline between them, so the model does not snap to
+// perfectly neutral the moment a motion finishes.
+const emotionState = createEmotionState()
+const emotionReading = computed(() => emotionState.snapshot.value.current)
+
+useRafFn(({ delta }) => emotionState.update(delta / 1000))
+
 const emotionsQueue = createQueue<EmotionPayload>({
   handlers: [
     async (ctx) => {
@@ -196,6 +205,8 @@ const emotionsQueue = createQueue<EmotionPayload>({
       }
       else if (stageModelRenderer.value === 'live2d') {
         currentMotion.value = { group: EMOTION_EmotionMotionName_value[ctx.data.name] }
+        // The motion plays once; the reading outlives it and fades on its own.
+        emotionState.nudge(ctx.data.name, ctx.data.intensity)
       }
       else if (stageModelRenderer.value === 'spine') {
         spineSceneRef.value?.setEmotion(ctx.data.name, ctx.data.intensity)
@@ -1028,6 +1039,7 @@ defineExpose({
         :live2d-shadow-enabled="live2dShadowEnabled"
         :live2d-max-fps="live2dMaxFps"
         :live2d-render-scale="live2dRenderScale"
+        :emotion="emotionReading"
       />
       <ThreeScene
         v-if="stageModelRenderer === 'vrm' && showStage"

--- a/packages/stage-ui/src/constants/emotions.ts
+++ b/packages/stage-ui/src/constants/emotions.ts
@@ -62,3 +62,43 @@ export interface EmotionPayload {
   name: Emotion
   intensity: number
 }
+
+/**
+ * A point in the valence-arousal-dominance space, each axis in `[-1, 1]`.
+ *
+ * Valence is how pleasant the state is, arousal how activated, and dominance
+ * how in-control. Dominance is what separates otherwise similar states: anger
+ * and anxiety share negative valence and high arousal, and only dominance
+ * tells them apart.
+ */
+export interface VADVector {
+  valence: number
+  arousal: number
+  dominance: number
+}
+
+/**
+ * Where each discrete emotion sits in continuous space.
+ *
+ * The enum stays the wire format between the model and the app; this table is
+ * only the entry point into the continuous layer, so a consumer that reads VAD
+ * and one that reads the enum never disagree about what the character feels.
+ *
+ * Values are authored, not derived: they place each emotion relative to the
+ * others rather than claiming any absolute scale.
+ */
+export const EMOTION_VAD_value = {
+  [Emotion.Happy]: { valence: 0.72, arousal: 0.45, dominance: 0.35 },
+  [Emotion.Sad]: { valence: -0.65, arousal: -0.35, dominance: -0.42 },
+  // High dominance is what keeps anger distinguishable from anxiety, which
+  // shares its negative valence and high arousal.
+  [Emotion.Angry]: { valence: -0.70, arousal: 0.75, dominance: 0.55 },
+  [Emotion.Think]: { valence: 0.05, arousal: -0.20, dominance: 0.15 },
+  [Emotion.Surprise]: { valence: 0.18, arousal: 0.85, dominance: -0.15 },
+  // Negative valence with *low* dominance — the withdrawing kind of unpleasant,
+  // as opposed to anger's assertive kind.
+  [Emotion.Awkward]: { valence: -0.35, arousal: 0.30, dominance: -0.50 },
+  [Emotion.Question]: { valence: 0.05, arousal: 0.25, dominance: -0.10 },
+  [Emotion.Curious]: { valence: 0.40, arousal: 0.42, dominance: 0.12 },
+  [Emotion.Neutral]: { valence: 0, arousal: 0, dominance: 0 },
+} satisfies Record<Emotion, VADVector>

--- a/packages/stage-ui/src/stores/emotion-state.test.ts
+++ b/packages/stage-ui/src/stores/emotion-state.test.ts
@@ -126,6 +126,22 @@ describe('createEmotionState', () => {
       expect(state.snapshot.value.target.valence).toBeLessThan(0)
     })
 
+    // A backgrounded tab resumes with a multi-second delta. Charging that whole
+    // frame to the hold would skip every second of decay that actually elapsed
+    // after the hold ended, so the emotion would outlive its own timer.
+    it('should decay for the part of a long frame that falls after the hold', () => {
+      const coarse = createEmotionState({ seed: 9 })
+      const fine = createEmotionState({ seed: 9 })
+
+      coarse.nudge(Emotion.Angry, 0)
+      fine.nudge(Emotion.Angry, 0)
+
+      coarse.update(60)
+      run(fine, 60, 0.1)
+
+      expect(coarse.snapshot.value.target.valence).toBeCloseTo(fine.snapshot.value.target.valence, 2)
+    })
+
     it('should scale the hold with intensity', () => {
       const weak = createEmotionState()
       const strong = createEmotionState()

--- a/packages/stage-ui/src/stores/emotion-state.test.ts
+++ b/packages/stage-ui/src/stores/emotion-state.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import { Emotion, EMOTION_VAD_value } from '../constants/emotions'
+import { createEmotionState } from './emotion-state'
+
+/** Drive the simulation for `seconds` in fixed steps. */
+function run(state: ReturnType<typeof createEmotionState>, seconds: number, step = 1 / 60): void {
+  for (let elapsed = 0; elapsed < seconds; elapsed += step)
+    state.update(step)
+}
+
+describe('createEmotionState', () => {
+  describe('nudge', () => {
+    it('should move the target toward the emotion', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Angry, 0.78)
+
+      const { target } = state.snapshot.value
+      expect(target.valence).toBeLessThan(0)
+      expect(target.arousal).toBeGreaterThan(0)
+      expect(target.dominance).toBeGreaterThan(0)
+    })
+
+    // A single message must not be able to overwrite the state outright, or
+    // the character has no memory of what it already felt.
+    it('should blend toward the preset rather than replacing it', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Angry, 0.78)
+
+      const { target } = state.snapshot.value
+      const preset = EMOTION_VAD_value[Emotion.Angry]
+
+      expect(target.valence).not.toBeCloseTo(preset.valence, 5)
+      expect(Math.abs(target.valence)).toBeLessThan(Math.abs(preset.valence))
+    })
+
+    it('should accumulate across repeated nudges of the same emotion', () => {
+      const state = createEmotionState()
+
+      state.nudge(Emotion.Happy, 0.5)
+      const afterFirst = state.snapshot.value.target.valence
+      state.nudge(Emotion.Happy, 0.5)
+      const afterSecond = state.snapshot.value.target.valence
+
+      expect(afterSecond).toBeGreaterThan(afterFirst)
+    })
+
+    it('should default the intensity when the payload omits it', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Happy)
+
+      const { target, holdRemaining } = state.snapshot.value
+      expect(Number.isNaN(target.valence)).toBe(false)
+      expect(target.valence).toBeGreaterThan(0)
+      expect(holdRemaining).toBeGreaterThan(0)
+    })
+  })
+
+  describe('integration', () => {
+    it('should carry the current value toward the target over time', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Happy, 0.9)
+
+      const start = state.snapshot.value.current.valence
+      run(state, 1)
+      const later = state.snapshot.value.current.valence
+
+      expect(later).toBeGreaterThan(start)
+      expect(later).toBeLessThan(state.snapshot.value.target.valence + 0.05)
+    })
+
+    // The integrator is exponential precisely so that the result does not
+    // depend on how the elapsed time was chopped up. A rate-times-dt
+    // integrator fails this.
+    it('should reach the same state regardless of how the frames are sliced', () => {
+      const coarse = createEmotionState({ seed: 42 })
+      const fine = createEmotionState({ seed: 42 })
+
+      coarse.nudge(Emotion.Angry, 0.7)
+      fine.nudge(Emotion.Angry, 0.7)
+
+      coarse.update(1)
+      for (let i = 0; i < 10; i++)
+        fine.update(0.1)
+
+      expect(coarse.snapshot.value.current.valence).toBeCloseTo(fine.snapshot.value.current.valence, 2)
+      expect(coarse.snapshot.value.current.arousal).toBeCloseTo(fine.snapshot.value.current.arousal, 2)
+    })
+
+    it('should ignore non-advancing time steps', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Happy, 0.6)
+      const before = state.snapshot.value.current
+
+      state.update(0)
+      state.update(-1)
+      state.update(Number.NaN)
+
+      expect(state.snapshot.value.current).toEqual(before)
+    })
+  })
+
+  describe('hold and decay', () => {
+    // This gate is the mechanism that stops an expression from collapsing back
+    // to neutral the moment its triggering motion ends.
+    it('should not decay the target while the hold is active', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Angry, 1)
+
+      const held = state.snapshot.value.target.valence
+      run(state, 5)
+
+      expect(state.snapshot.value.holdRemaining).toBeGreaterThan(0)
+      expect(state.snapshot.value.target.valence).toBeCloseTo(held, 5)
+    })
+
+    it('should decay the target toward baseline once the hold expires', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Angry, 0)
+
+      const peak = state.snapshot.value.target.valence
+      run(state, 60)
+
+      expect(state.snapshot.value.holdRemaining).toBe(0)
+      expect(state.snapshot.value.target.valence).toBeGreaterThan(peak)
+      expect(state.snapshot.value.target.valence).toBeLessThan(0)
+    })
+
+    it('should scale the hold with intensity', () => {
+      const weak = createEmotionState()
+      const strong = createEmotionState()
+
+      weak.nudge(Emotion.Sad, 0.1)
+      strong.nudge(Emotion.Sad, 0.9)
+
+      expect(strong.snapshot.value.holdRemaining).toBeGreaterThan(weak.snapshot.value.holdRemaining)
+    })
+
+    it('should decay toward a non-neutral baseline when one is configured', () => {
+      const cheerful = { valence: 0.3, arousal: 0.1, dominance: 0.1 }
+      const state = createEmotionState({ baseline: cheerful })
+
+      state.nudge(Emotion.Sad, 0)
+      run(state, 400)
+
+      expect(state.snapshot.value.target.valence).toBeGreaterThan(0)
+    })
+  })
+
+  describe('ambient drift', () => {
+    it('should keep moving when no emotion is active', () => {
+      const state = createEmotionState({ seed: 7 })
+
+      run(state, 5)
+      const first = state.snapshot.value.current.valence
+      run(state, 5)
+      const second = state.snapshot.value.current.valence
+
+      expect(first).not.toBe(second)
+      // Drift is a floor of liveliness, not a performance.
+      expect(Math.abs(second)).toBeLessThan(0.1)
+    })
+
+    it('should be reproducible for a given seed', () => {
+      const a = createEmotionState({ seed: 777 })
+      const b = createEmotionState({ seed: 777 })
+
+      run(a, 10)
+      run(b, 10)
+
+      expect(a.snapshot.value.current).toEqual(b.snapshot.value.current)
+    })
+
+    it('should differ between seeds', () => {
+      const a = createEmotionState({ seed: 1 })
+      const b = createEmotionState({ seed: 2 })
+
+      run(a, 10)
+      run(b, 10)
+
+      expect(a.snapshot.value.current).not.toEqual(b.snapshot.value.current)
+    })
+  })
+
+  describe('magnitude', () => {
+    it('should report a stronger reading for a stronger nudge', () => {
+      const weak = createEmotionState({ seed: 5 })
+      const strong = createEmotionState({ seed: 5 })
+
+      weak.nudge(Emotion.Angry, 0.2)
+      strong.nudge(Emotion.Angry, 1)
+      run(weak, 3)
+      run(strong, 3)
+
+      expect(strong.snapshot.value.magnitude).toBeGreaterThan(weak.snapshot.value.magnitude)
+    })
+
+    it('should stay within the unit range', () => {
+      const state = createEmotionState()
+      for (let i = 0; i < 20; i++)
+        state.nudge(Emotion.Angry, 1)
+      run(state, 10)
+
+      expect(state.snapshot.value.magnitude).toBeGreaterThanOrEqual(0)
+      expect(state.snapshot.value.magnitude).toBeLessThanOrEqual(1)
+    })
+  })
+
+  describe('reset', () => {
+    // The very first snapshot is published before any frame has run, so it is
+    // the one place magnitude could be written rather than derived — and with a
+    // non-neutral baseline that would make reset() silently change the reading.
+    it('should report the same magnitude before and after a no-op reset', () => {
+      const state = createEmotionState({ baseline: { valence: 0.3, arousal: 0.1, dominance: 0.1 } })
+
+      const initial = state.snapshot.value.magnitude
+      state.reset()
+
+      expect(initial).toBeGreaterThan(0)
+      expect(state.snapshot.value.magnitude).toBe(initial)
+    })
+
+    it('should return every axis to the baseline', () => {
+      const state = createEmotionState()
+      state.nudge(Emotion.Angry, 1)
+      run(state, 3)
+      state.reset()
+
+      expect(state.snapshot.value.current).toEqual({ valence: 0, arousal: 0, dominance: 0 })
+      expect(state.snapshot.value.target).toEqual({ valence: 0, arousal: 0, dominance: 0 })
+      expect(state.snapshot.value.holdRemaining).toBe(0)
+    })
+  })
+})

--- a/packages/stage-ui/src/stores/emotion-state.ts
+++ b/packages/stage-ui/src/stores/emotion-state.ts
@@ -1,0 +1,252 @@
+import type { Ref } from 'vue'
+
+import type { Emotion, VADVector } from '../constants/emotions'
+
+import { readonly, ref } from 'vue'
+
+import { EMOTION_VAD_value } from '../constants/emotions'
+
+/**
+ * How fast `current` chases `target`, as a rate in reciprocal seconds.
+ * ~1.35 puts the time constant near 0.74s, so an emotion reads as arriving
+ * rather than snapping, and is most of the way there within two seconds.
+ */
+const APPROACH_RATE = 1.35
+
+/**
+ * How fast `target` returns to baseline once the hold expires. Two orders of
+ * magnitude slower than the approach (time constant ~50s) so a state fades
+ * over a conversation rather than over a breath.
+ */
+const DECAY_RATE = 0.02
+
+/** Seconds a state is protected from decay, before and per unit of intensity. */
+const HOLD_BASE_SECONDS = 6
+const HOLD_INTENSITY_SECONDS = 18
+
+/**
+ * How much of the incoming emotion a nudge mixes in, before and per unit of
+ * intensity. Capped below 1 so a single message can never fully overwrite the
+ * state — what the character already felt always survives in some measure.
+ */
+const NUDGE_BASE = 0.28
+const NUDGE_INTENSITY = 0.58
+const NUDGE_CEILING = 0.96
+
+/**
+ * Used when a payload carries no intensity. Producers frequently omit it, and
+ * letting `undefined` reach the arithmetic would poison the state with NaN.
+ */
+const DEFAULT_INTENSITY = 0.65
+
+/** Peak displacement of the ambient drift, per axis. */
+const DRIFT_AMPLITUDE = 0.04
+/** Bounds on how long the drift keeps heading toward one point. */
+const DRIFT_MIN_SECONDS = 1.7
+const DRIFT_SPAN_SECONDS = 4.2
+/** Rate at which the drift eases toward its current point. */
+const DRIFT_RATE = 0.55
+
+const ZERO: VADVector = { valence: 0, arousal: 0, dominance: 0 }
+
+/**
+ * Fraction of the remaining distance to cover this frame.
+ *
+ * Framerate independence is the whole point: integrating `rate * dt` directly
+ * would make the same emotion settle at a visibly different speed on a 30Hz
+ * versus a 120Hz display, and would overshoot outright on a long frame.
+ */
+function approach(dt: number, rate: number): number {
+  return 1 - Math.exp(-dt * rate)
+}
+
+function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t
+}
+
+function lerpVAD(from: VADVector, to: VADVector, t: number): VADVector {
+  return {
+    valence: lerp(from.valence, to.valence, t),
+    arousal: lerp(from.arousal, to.arousal, t),
+    dominance: lerp(from.dominance, to.dominance, t),
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Deterministic 0..1 generator.
+ *
+ * Seeded rather than `Math.random` so idle drift is reproducible: a test can
+ * assert the character keeps moving without asserting where it moved to.
+ */
+function createRandom(seed: number): () => number {
+  let state = seed >>> 0 || 1
+
+  return () => {
+    // xorshift32 — small, dependency-free, and good enough for drift.
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    state >>>= 0
+    return state / 0x100000000
+  }
+}
+
+/** A reading of the emotional state at one instant. */
+export interface VADSnapshot {
+  /** Drift included. This is the value renderers should consume. */
+  current: VADVector
+  /** Where the state is heading, before drift. */
+  target: VADVector
+  /** Length of `current`, normalized to 0..1 — how strongly anything is felt. */
+  magnitude: number
+  /** Seconds before decay resumes; 0 once the state is already decaying. */
+  holdRemaining: number
+}
+
+export interface CreateEmotionStateOptions {
+  /**
+   * The state decays toward this rather than toward zero, which is what makes
+   * a character read as habitually cheerful or habitually reserved.
+   * @default neutral
+   */
+  baseline?: VADVector
+  /** @default 1 */
+  seed?: number
+}
+
+export interface EmotionState {
+  snapshot: Readonly<Ref<VADSnapshot>>
+  /**
+   * Mix an emotion into the target. Deliberately a blend rather than an
+   * assignment: consecutive messages accumulate instead of overwriting, which
+   * is where the sense of momentum comes from.
+   */
+  nudge: (emotion: Emotion, intensity?: number) => void
+  /** Advance the simulation by `dtSeconds`. The caller owns the clock. */
+  update: (dtSeconds: number) => void
+  reset: () => void
+}
+
+/**
+ * Continuous emotional state, independent of any renderer.
+ *
+ * Discrete emotions enter only through {@link EmotionState.nudge}; everything
+ * downstream reads a continuous value. Keeping the quantized step at the entry
+ * and nowhere else is what prevents the character from visibly snapping
+ * between states as a label flips.
+ *
+ * The clock is injected rather than read from `performance.now()`, so the
+ * caller decides the tick and tests can drive it exactly.
+ *
+ * @example
+ * ```ts
+ * const state = createEmotionState()
+ * state.nudge(Emotion.Happy, 0.8)
+ * state.update(1 / 60)
+ * state.snapshot.value.current // → drifts toward happy, then decays back
+ * ```
+ */
+export function createEmotionState(options?: CreateEmotionStateOptions): EmotionState {
+  const baseline = options?.baseline ?? ZERO
+  const random = createRandom(options?.seed ?? 1)
+
+  let target: VADVector = { ...baseline }
+  let current: VADVector = { ...baseline }
+  let ambient: VADVector = { ...ZERO }
+  let driftGoal: VADVector = { ...ZERO }
+  let driftCountdown = 0
+  let holdRemaining = 0
+
+  // Derived rather than written as 0: with a non-neutral baseline the state
+  // starts out already displaced, and a literal would make the very first read
+  // disagree with every later one.
+  const snapshot = ref<VADSnapshot>({
+    current: { ...current },
+    target: { ...target },
+    magnitude: magnitudeOf(current),
+    holdRemaining: 0,
+  })
+
+  function magnitudeOf(vad: VADVector): number {
+    // Normalized by √3 so a corner of the unit cube reads as 1 rather than 1.73.
+    const raw = Math.hypot(vad.valence, vad.arousal, vad.dominance)
+    return clamp(raw / Math.sqrt(3), 0, 1)
+  }
+
+  function publish(): void {
+    snapshot.value = {
+      current: { ...current },
+      target: { ...target },
+      magnitude: magnitudeOf(current),
+      holdRemaining,
+    }
+  }
+
+  function retargetDrift(): void {
+    driftGoal = {
+      valence: (random() * 2 - 1) * DRIFT_AMPLITUDE,
+      arousal: (random() * 2 - 1) * DRIFT_AMPLITUDE,
+      dominance: (random() * 2 - 1) * DRIFT_AMPLITUDE,
+    }
+    driftCountdown = DRIFT_MIN_SECONDS + random() * DRIFT_SPAN_SECONDS
+  }
+
+  function nudge(emotion: Emotion, intensity?: number): void {
+    const strength = clamp(
+      typeof intensity === 'number' && Number.isFinite(intensity) ? intensity : DEFAULT_INTENSITY,
+      0,
+      1,
+    )
+    const amount = clamp(NUDGE_BASE + strength * NUDGE_INTENSITY, 0, NUDGE_CEILING)
+
+    target = lerpVAD(target, EMOTION_VAD_value[emotion], amount)
+    holdRemaining = HOLD_BASE_SECONDS + strength * HOLD_INTENSITY_SECONDS
+    publish()
+  }
+
+  function update(dtSeconds: number): void {
+    if (!Number.isFinite(dtSeconds) || dtSeconds <= 0)
+      return
+
+    // Hold gates the decay and nothing else: the state still approaches and
+    // still drifts while held, it just is not yet being pulled back to
+    // baseline. This is what stops an expression from collapsing the instant
+    // its triggering motion finishes.
+    if (holdRemaining > 0)
+      holdRemaining = Math.max(0, holdRemaining - dtSeconds)
+    else
+      target = lerpVAD(target, baseline, approach(dtSeconds, DECAY_RATE))
+
+    driftCountdown -= dtSeconds
+    if (driftCountdown <= 0)
+      retargetDrift()
+    ambient = lerpVAD(ambient, driftGoal, approach(dtSeconds, DRIFT_RATE))
+
+    const destination: VADVector = {
+      valence: target.valence + ambient.valence,
+      arousal: target.arousal + ambient.arousal,
+      dominance: target.dominance + ambient.dominance,
+    }
+    current = lerpVAD(current, destination, approach(dtSeconds, APPROACH_RATE))
+
+    publish()
+  }
+
+  function reset(): void {
+    target = { ...baseline }
+    current = { ...baseline }
+    ambient = { ...ZERO }
+    driftGoal = { ...ZERO }
+    driftCountdown = 0
+    holdRemaining = 0
+    publish()
+  }
+
+  retargetDrift()
+
+  return { snapshot: readonly(snapshot) as Readonly<Ref<VADSnapshot>>, nudge, update, reset }
+}

--- a/packages/stage-ui/src/stores/emotion-state.ts
+++ b/packages/stage-ui/src/stores/emotion-state.ts
@@ -216,10 +216,17 @@ export function createEmotionState(options?: CreateEmotionStateOptions): Emotion
     // still drifts while held, it just is not yet being pulled back to
     // baseline. This is what stops an expression from collapsing the instant
     // its triggering motion finishes.
-    if (holdRemaining > 0)
-      holdRemaining = Math.max(0, holdRemaining - dtSeconds)
-    else
-      target = lerpVAD(target, baseline, approach(dtSeconds, DECAY_RATE))
+    //
+    // The frame is split at the moment the hold expires rather than being
+    // charged wholly to one side. A tab that was backgrounded and resumes with
+    // a multi-second delta would otherwise consume the whole frame clearing the
+    // hold and decay for none of the time that actually elapsed after it.
+    const heldFor = Math.min(holdRemaining, dtSeconds)
+    holdRemaining -= heldFor
+
+    const decayFor = dtSeconds - heldFor
+    if (decayFor > 0)
+      target = lerpVAD(target, baseline, approach(decayFor, DECAY_RATE))
 
     driftCountdown -= dtSeconds
     if (driftCountdown <= 0)


### PR DESCRIPTION
## The problem

An emotion in AIRI lasts exactly as long as the motion that carries it. `emotionsQueue` delivers `{ name, intensity }`, a motion group plays, and when it ends the character is back at Idle — with nothing left over. Ask it something that lands badly and it is neutral again before you have finished reading the reply.

That reads as a character that forgets, because between two sentences there is no state at all. `intensity` is already on the payload and is currently almost inert.

## What this adds

A continuous valence/arousal/dominance state that sits *behind* the discrete emotions rather than replacing them.

```ts
const state = createEmotionState()

state.nudge(Emotion.Angry, 0.78)  // blends toward anger, holds ~20s
state.update(1 / 60)              // caller owns the clock
state.snapshot.value.current      // → drifts in, holds, then decays back
```

Three axes, three behaviours:

- **`nudge` blends, it does not assign.** A message mixes toward its emotion by `0.28 + intensity·0.58`, capped below 1. Consecutive messages accumulate, so what the character already felt always survives in some measure.
- **The hold gates decay, and only decay.** For `6 + intensity·18` seconds the target is not pulled back to baseline — the state still approaches and still drifts, it simply is not yet fading. This is the mechanism that stops an expression collapsing the instant its motion finishes.
- **A small seeded drift keeps idle alive.** ±0.04 per axis, retargeted every 1.7–5.9s. Enough that a resting character is not frozen, small enough that it never reads as a performance.

## Why the discrete enum still enters at the top

`EMOTION_VAD_value` maps each of the nine `Emotion` values to a point in the continuous space, and that mapping is the *only* place a discrete label is consumed. Everything downstream reads a continuous value.

That ordering is deliberate. Putting a nearest-label lookup in the middle of a continuous pipeline is what makes a character visibly twitch as the state wanders across a boundary between two similar emotions — several channels jump at once on the frame the label flips. Quantising once, at the entry, avoids it entirely.

The anchors are authored rather than derived, and placed relative to each other rather than on any absolute scale. Dominance carries real weight: it is what keeps anger (negative valence, high arousal, **high** dominance) distinguishable from awkwardness (negative valence, moderate arousal, **low** dominance), which otherwise sit almost on top of each other.

## Frame-rate independence

The integrator is `1 - exp(-dt·k)`, not `k·dt`. The same emotion therefore settles at the same speed whether the display is 30Hz or 120Hz, and a long frame cannot overshoot — `alpha` approaches 1 asymptotically and never exceeds it.

There is a test for exactly this: `update(1.0)` once and `update(0.1)` ten times land in the same place. Swapping in the naive integrator turns it red.

## Boundaries

Deliberately not in this change:

- **Nothing is wired into a renderer.** This is the state layer only; the Live2D adapter is a follow-up. Keeping them apart means this can be reviewed as pure logic, and means the VAD state does not end up living inside the Live2D package when it needs to serve VRM, MMD and Spine too.
- **`EmotionPayload` is untouched.** The wire format between the model and the app is unchanged, so the `<|EMOTE_*|>` token contract and `emotionsQueue` keep working exactly as they do today.
- **No action-unit / FACS layer.** A FACS intermediate is a natural-looking idea here and it does not earn its place: in the reference implementation this design draws on, deleting the AU projection leaves the rendered parameters bit-identical. It is vocabulary, not machinery.
- **No new dependencies**, and no changes to `expression-controller`, the wlipsync path, or the three existing `EMOTION_*_value` backend tables.

## Follow-ups

1. A Live2D adapter registered on the existing `MotionManagerPlugin` `'pre'` stage, writing small additive offsets. It must never touch `ParamMouthOpenY` — that belongs to lipsync.
2. Per-character baselines, so a character can decay toward habitually cheerful rather than toward neutral. The store already takes `baseline`; nothing surfaces it yet.
3. VRM / MMD / Spine adapters. Spine is the constraint worth designing against early: it has no morphs at all, so the state layer must keep emitting continuous VAD and let each adapter decide how to consume it.

## Base

Branched from `ce65bcd7f` rather than the tip of `main`, because `main` does not currently build:

```
packages/stage-ui/src/components/scenes/Stage.vue(831,43): error TS2339:
  Property 'turnId' does not exist on type 'Omit<ChatStreamEventContext, "composedMessage">'.
packages/stage-ui/src/components/scenes/Stage.vue(846,55): error TS2339:
  Property 'turnId' does not exist on type 'ChatStreamEventContext'.
```

and `stores/chat.contract.test.ts > emits special tokens with a stable turn id` fails with it. Both reproduce on a clean detached checkout of `main` with none of this branch's commits, so they are not from this PR. Happy to rebase once that is sorted.

## How tested

```sh
pnpm -F @proj-airi/stage-ui exec vitest run src/stores/emotion-state.test.ts   # 17 passed
pnpm -F @proj-airi/stage-ui exec vitest run --project node                     # 625 passed (608 on this base)
pnpm exec eslint packages/stage-ui/src/stores/ packages/stage-ui/src/constants/
pnpm -F @proj-airi/stage-ui typecheck && pnpm -F @proj-airi/stage-web typecheck && pnpm -F @proj-airi/stage-tamagotchi typecheck
```

17 tests covering the blend, the hold gate, decay toward baseline (including a non-neutral one), frame-slicing equivalence, drift reproducibility across seeds, magnitude bounds, and the nudge-without-intensity default.

Each of the three load-bearing behaviours was reverse-verified — replacing the exponential integrator with `k·dt`, removing the hold gate, and making `nudge` assign instead of blend each turn the matching test red.
