### PR TITLE
fix(ui-server-auth): bust poisoned asset caches

### DIFF
--- a/apps/ui-server-auth/README.md
+++ b/apps/ui-server-auth/README.md
@@ -23,7 +23,7 @@ pnpm -F @proj-airi/ui-server-auth build
 
 ## Deployment
 
-`pnpm -F @proj-airi/ui-server-auth build` writes to `apps/ui-server-auth/dist`. Vue Router owns `/ui/*`, while Vite assets are served from root `/assets/*` so Cloudflare Pages can serve static files without rewriting nested asset paths. `public/_redirects` scopes the SPA rewrite to `/ui/*`, and the top-level `public/404.html` keeps missing assets and other unknown paths as HTTP 404 responses.
+`pnpm -F @proj-airi/ui-server-auth build` writes to `apps/ui-server-auth/dist`. Vue Router owns `/ui/*`, while Vite assets are served from root `/assets-v2/*` so Cloudflare Pages can serve static files without rewriting nested asset paths. The versioned namespace moves existing clients away from previously poisoned `/assets/*` browser cache entries. Both namespaces use `Cache-Control: public, no-cache`, allowing browsers to retain files only when Pages revalidates them. `public/_redirects` scopes the SPA rewrite to `/ui/*`, and the top-level `public/404.html` keeps missing assets and other unknown paths as HTTP 404 responses.
 
 The production GitHub Actions workflow deploys this app to the Cloudflare Pages project `moeru-ai-airi-auth` with separate auth-account credentials:
 

--- a/apps/ui-server-auth/public/_headers
+++ b/apps/ui-server-auth/public/_headers
@@ -1,4 +1,5 @@
 /assets/*
-  cache-control: max-age=31536000
-  cache-control: immutable
+  cache-control: public, no-cache
 
+/assets-v2/*
+  cache-control: public, no-cache

--- a/apps/ui-server-auth/src/cloudflare-pages-routing.test.ts
+++ b/apps/ui-server-auth/src/cloudflare-pages-routing.test.ts
@@ -23,4 +23,12 @@ describe('cloudflare Pages routing', () => {
     expect(notFoundPage).toContain('<title>Page not found</title>')
     expect(redirects).toContain('/ui/* / 200')
   })
+
+  it('requires old and current asset namespaces to revalidate cached responses', async () => {
+    const headers = await readFile(resolve(publicDirectory, '_headers'), 'utf8')
+
+    expect(headers).toContain('/assets/*\n  cache-control: public, no-cache')
+    expect(headers).toContain('/assets-v2/*\n  cache-control: public, no-cache')
+    expect(headers).not.toContain('immutable')
+  })
 })

--- a/apps/ui-server-auth/vite.config.ts
+++ b/apps/ui-server-auth/vite.config.ts
@@ -12,6 +12,16 @@ import VueRouter from 'vue-router/vite'
 
 import { defineConfig } from 'vite'
 
+// NOTICE:
+// Keep this namespace distinct from `/assets/`, where an earlier Pages SPA
+// fallback allowed missing JavaScript URLs to cache index.html as immutable.
+// Root cause: the old asset cache policy outlived the deployment that restored
+// those files, so affected browsers cannot observe corrected response headers.
+// Source/context: `apps/ui-server-auth/public/_headers` and `public/404.html`.
+// Removal condition: keep the namespace permanently; reusing `/assets/` can
+// reactivate poisoned browser entries that remain fresh for up to one year.
+const assetsDirectory = 'assets-v2'
+
 export default defineConfig({
   base: '/',
   optimizeDeps: {
@@ -44,6 +54,7 @@ export default defineConfig({
     },
   },
   build: {
+    assetsDir: assetsDirectory,
     emptyOutDir: true,
     manifest: true,
     outDir: resolve(join(import.meta.dirname, 'dist')),
@@ -58,8 +69,8 @@ export default defineConfig({
           // Keep analytics as the source-domain name, but explicitly map its
           // public URL to a neutral chunk name that filter lists cannot infer.
           return containsAnalyticsModule
-            ? 'assets/chunk-[hash].js'
-            : 'assets/[name]-[hash].js'
+            ? `${assetsDirectory}/chunk-[hash].js`
+            : `${assetsDirectory}/[name]-[hash].js`
         },
       },
     },


### PR DESCRIPTION
## Summary

- move auth UI build assets from `/assets/*` to the permanent `/assets-v2/*` namespace
- replace one-year immutable browser caching with `Cache-Control: public, no-cache` for both old and new asset paths
- add a regression test for the Pages routing and cache policy
- document the cache-bust namespace and revalidation behavior

## Root cause

A temporary chunk filename change made previously referenced hashed assets disappear while Cloudflare Pages still treated missing paths as SPA navigations. Those requests returned `index.html` with `200 text/html`, and the broad `/assets/*` header cached that response for one year as immutable.

Even after the asset was restored, affected browsers could keep using the poisoned HTML response under the JavaScript URL. The new namespace forces those clients onto URLs that have never carried the poisoned response, while `no-cache` requires Pages revalidation before future reuse.

## User impact

After this reaches production, current HTML references `/assets-v2/*`, so affected users recover without manually clearing their browser cache. Missing assets remain `404 no-store` instead of receiving the SPA document.

## Validation

- `pnpm exec vitest run apps/ui-server-auth/src/cloudflare-pages-routing.test.ts` — 2 tests passed
- `pnpm -F @proj-airi/ui-server-auth typecheck` — passed
- `pnpm -F @proj-airi/ui-server-auth build` — passed; HTML and manifest only reference `/assets-v2/*`
- `pnpm typecheck` — passed across 50 workspaces
- `pnpm lint` — passed with 0 errors and 7 unrelated existing warnings
- `git diff --check` — passed
- local Wrangler Pages verification:
  - `/ui/profile` → `200 text/html`
  - generated Vue asset → `200 application/javascript`, `Cache-Control: public, no-cache`
  - missing `/assets-v2/*` and `/assets/*` → `404`, `Cache-Control: no-store`

## Deployment note

This PR does not deploy production by itself. After the Pages deployment completes, purge the Cloudflare cache once and verify `accounts.airi.build` serves the new namespace and headers.