### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-yLxJY/vGscG3ljgr+wDI0dKrjH5tjfs/8/hsG1cAyTo=
+sha256-WuBHey8y7UwLzA9DJbNXiIGkus+pzUxu82ZI3gV/PZ4=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.