### PR TITLE
fix(server): honor mobile analytics consent

### DIFF
--- a/server/apps/api/src/routes/openai/v1/analytics.ts
+++ b/server/apps/api/src/routes/openai/v1/analytics.ts
@@ -3,6 +3,7 @@ import type { AiGenerationAppSurface } from '../../../services/domain/product-ev
 export const AIRI_CHAT_SESSION_ID_HEADER = 'x-airi-session-id'
 export const AIRI_CHAT_ROUND_ID_HEADER = 'x-airi-round-id'
 export const AIRI_CHAT_APP_SURFACE_HEADER = 'x-airi-app-surface'
+export const AIRI_ANALYTICS_CONSENT_HEADER = 'x-airi-analytics-consent'
 
 const CLIENT_CHAT_ANALYTICS_SURFACES = new Set<AiGenerationAppSurface>(['web', 'mobile', 'electron'])
 
@@ -18,4 +19,24 @@ export function resolveChatAnalyticsSurface(value: string | undefined): AiGenera
     return value as AiGenerationAppSurface
 
   return undefined
+}
+
+/**
+ * Resolves whether optional chat analytics may leave the API process.
+ *
+ * Mobile is fail-closed because its in-app switch is the consent boundary.
+ * Existing web and Electron clients remain enabled until they send an explicit
+ * denial, so adding the mobile contract does not silently change their current
+ * analytics behavior.
+ */
+export function resolveAnalyticsConsent(
+  value: string | undefined,
+  appSurface: AiGenerationAppSurface | undefined,
+): boolean {
+  if (value === 'denied')
+    return false
+  if (value === 'granted')
+    return true
+
+  return appSurface !== 'mobile'
 }

--- a/server/apps/api/src/routes/openai/v1/index.ts
+++ b/server/apps/api/src/routes/openai/v1/index.ts
@@ -6,9 +6,11 @@ import type { LlmTracingDeps, V1RouteDeps } from './types'
 import { authGuard } from '../../../middlewares/auth'
 import { configGuard } from '../../../middlewares/config-guard'
 import {
+  AIRI_ANALYTICS_CONSENT_HEADER,
   AIRI_CHAT_APP_SURFACE_HEADER,
   AIRI_CHAT_ROUND_ID_HEADER,
   AIRI_CHAT_SESSION_ID_HEADER,
+  resolveAnalyticsConsent,
   resolveChatAnalyticsSurface,
 } from './analytics'
 import { createV1Gateway } from './gateway'
@@ -43,13 +45,15 @@ export function createV1Routes(input: CreateV1RoutesDeps) {
       async (c) => {
         const user = c.get('user')!
         const body = await c.req.json() as Record<string, unknown>
+        const appSurface = resolveChatAnalyticsSurface(c.req.header(AIRI_CHAT_APP_SURFACE_HEADER))
 
         return {
           userId: user.id,
           body,
           sessionId: c.req.header(AIRI_CHAT_SESSION_ID_HEADER),
           roundId: c.req.header(AIRI_CHAT_ROUND_ID_HEADER),
-          appSurface: resolveChatAnalyticsSurface(c.req.header(AIRI_CHAT_APP_SURFACE_HEADER)),
+          appSurface,
+          analyticsEnabled: resolveAnalyticsConsent(c.req.header(AIRI_ANALYTICS_CONSENT_HEADER), appSurface),
           abortSignal: c.req.raw.signal,
         }
       },
@@ -70,11 +74,14 @@ export function createV1Routes(input: CreateV1RoutesDeps) {
       async (c) => {
         const user = c.get('user')!
         const body = await c.req.json() as Record<string, unknown>
+        const appSurface = resolveChatAnalyticsSurface(c.req.header(AIRI_CHAT_APP_SURFACE_HEADER))
 
         return {
           userId: user.id,
           body,
           sessionId: c.req.header(AIRI_CHAT_SESSION_ID_HEADER),
+          analyticsEnabled: resolveAnalyticsConsent(c.req.header(AIRI_ANALYTICS_CONSENT_HEADER), appSurface),
+          contentCaptureAllowed: appSurface !== 'mobile',
           abortSignal: c.req.raw.signal,
         }
       },

--- a/server/apps/api/src/routes/openai/v1/operations/chat-completions/index.ts
+++ b/server/apps/api/src/routes/openai/v1/operations/chat-completions/index.ts
@@ -23,6 +23,7 @@ export interface ChatCompletionsOperationRequest {
   sessionId?: string
   roundId?: string
   appSurface?: AiGenerationAppSurface
+  analyticsEnabled: boolean
   abortSignal?: AbortSignal
 }
 
@@ -71,18 +72,20 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
       stream,
       messageCount: Array.isArray(body.messages) ? body.messages.length : undefined,
     }).log('chat completion request')
-    void deps.productEventService.track({
-      userId: input.userId,
-      feature: 'gen_ai_chat',
-      action: 'completion_requested',
-      status: 'started',
-      source: 'openai.chat.completions',
-      model: requestModel,
-      metadata: {
-        stream,
-        message_count: Array.isArray(body.messages) ? body.messages.length : null,
-      },
-    })
+    if (input.analyticsEnabled) {
+      void deps.productEventService.track({
+        userId: input.userId,
+        feature: 'gen_ai_chat',
+        action: 'completion_requested',
+        status: 'started',
+        source: 'openai.chat.completions',
+        model: requestModel,
+        metadata: {
+          stream,
+          message_count: Array.isArray(body.messages) ? body.messages.length : null,
+        },
+      })
+    }
 
     // Server-connection attrs come from the router (which knows the actual
     // upstream baseURL it dispatched to) — it enriches the active span with
@@ -118,6 +121,7 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
     catch (err) {
       telemetry.failSpan(span, 'Router exhausted or unknown model')
       deps.llmTracing.startChatGeneration({
+        contentCaptureAllowed: input.analyticsEnabled && input.appSurface !== 'mobile',
         input: body.messages,
         model: routeCtx.upstreamModel ?? requestModel,
         requestId,
@@ -126,20 +130,22 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
         sessionId: input.sessionId,
       }).fail('Router exhausted or unknown model')
       telemetry.recordMetrics({ model: requestModel, status: 502, type: 'chat', provider: routeCtx.provider, durationMs: Date.now() - startedAt, fluxConsumed: 0 })
-      void deps.productEventService.track({
-        userId: input.userId,
-        feature: 'gen_ai_chat',
-        action: 'completion_failed',
-        status: 'failed',
-        source: 'openai.chat.completions',
-        model: requestModel,
-        provider: routeCtx.provider,
-        reason: 'router_exhausted',
-        metadata: {
-          duration_ms: Date.now() - startedAt,
-          stream,
-        },
-      })
+      if (input.analyticsEnabled) {
+        void deps.productEventService.track({
+          userId: input.userId,
+          feature: 'gen_ai_chat',
+          action: 'completion_failed',
+          status: 'failed',
+          source: 'openai.chat.completions',
+          model: requestModel,
+          provider: routeCtx.provider,
+          reason: 'router_exhausted',
+          metadata: {
+            duration_ms: Date.now() - startedAt,
+            stream,
+          },
+        })
+      }
       throw err
     }
 
@@ -153,6 +159,7 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
     // alias (`auto` / `chat-auto`), so Langfuse model-cost grouping matches the
     // provider model that actually generated the tokens.
     const generationTrace = deps.llmTracing.startChatGeneration({
+      contentCaptureAllowed: input.analyticsEnabled && input.appSurface !== 'mobile',
       input: body.messages,
       model: langfuseModel,
       requestId,
@@ -165,21 +172,23 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
       telemetry.failSpan(span, `Gateway ${response.status}`)
       generationTrace.fail(`Gateway ${response.status}`)
       telemetry.recordMetrics({ model: requestModel, status: response.status, type: 'chat', provider: routeCtx.provider, durationMs, fluxConsumed: 0 })
-      void deps.productEventService.track({
-        userId: input.userId,
-        feature: 'gen_ai_chat',
-        action: 'completion_failed',
-        status: 'failed',
-        source: 'openai.chat.completions',
-        model: requestModel,
-        provider: routeCtx.provider,
-        reason: 'upstream_error',
-        metadata: {
-          http_status: response.status,
-          duration_ms: durationMs,
-          stream,
-        },
-      })
+      if (input.analyticsEnabled) {
+        void deps.productEventService.track({
+          userId: input.userId,
+          feature: 'gen_ai_chat',
+          action: 'completion_failed',
+          status: 'failed',
+          source: 'openai.chat.completions',
+          model: requestModel,
+          provider: routeCtx.provider,
+          reason: 'upstream_error',
+          metadata: {
+            http_status: response.status,
+            duration_ms: durationMs,
+            stream,
+          },
+        })
+      }
       logger.withFields({ requestId, userId: input.userId, model: requestModel, status: response.status, durationMs })
         .warn('chat completion delivered with upstream error status')
 
@@ -202,6 +211,7 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
         sessionId: input.sessionId,
         roundId: input.roundId,
         appSurface: input.appSurface,
+        analyticsEnabled: input.analyticsEnabled,
         requestModel,
         generationModel: langfuseModel,
         routeCtxProvider: routeCtx.provider,
@@ -223,6 +233,7 @@ export function chatCompletions(deps: V1RouteDeps): GatewayCallback<'chat.comple
       sessionId: input.sessionId,
       roundId: input.roundId,
       appSurface: input.appSurface,
+      analyticsEnabled: input.analyticsEnabled,
       requestModel,
       generationModel: langfuseModel,
       routeCtxProvider: routeCtx.provider,
@@ -361,6 +372,7 @@ function streamChatCompletion(input: {
   sessionId?: string
   roundId?: string
   appSurface?: AiGenerationAppSurface
+  analyticsEnabled: boolean
   requestModel: string
   generationModel: string
   routeCtxProvider: string
@@ -433,21 +445,23 @@ function streamChatCompletion(input: {
         input.telemetry.endSpan(input.span)
         input.generationTrace.fail('Gateway stream interrupted')
         input.telemetry.recordMetrics({ model: input.requestModel, status: input.response.status, type: 'chat', provider: input.routeCtxProvider, durationMs: input.durationMs, fluxConsumed: 0 })
-        void input.deps.productEventService.track({
-          userId: input.userId,
-          feature: 'gen_ai_chat',
-          action: 'completion_failed',
-          status: 'failed',
-          source: 'openai.chat.completions',
-          model: input.requestModel,
-          provider: input.routeCtxProvider,
-          reason: 'stream_interrupted',
-          metadata: {
-            http_status: input.response.status,
-            duration_ms: input.durationMs,
-            stream: true,
-          },
-        })
+        if (input.analyticsEnabled) {
+          void input.deps.productEventService.track({
+            userId: input.userId,
+            feature: 'gen_ai_chat',
+            action: 'completion_failed',
+            status: 'failed',
+            source: 'openai.chat.completions',
+            model: input.requestModel,
+            provider: input.routeCtxProvider,
+            reason: 'stream_interrupted',
+            metadata: {
+              http_status: input.response.status,
+              duration_ms: input.durationMs,
+              stream: true,
+            },
+          })
+        }
       }
       else if (streamCompleted) {
         try {
@@ -481,19 +495,21 @@ function streamChatCompletion(input: {
         })
         input.telemetry.recordMetrics({ model: input.requestModel, status: input.response.status, type: 'chat', provider: input.routeCtxProvider, durationMs: input.durationMs, fluxConsumed, ...usage })
 
-        captureGeneration({
-          deps: input.deps,
-          userId: input.userId,
-          requestId: input.requestId,
-          sessionId: input.sessionId,
-          roundId: input.roundId,
-          appSurface: input.appSurface,
-          generationModel: input.generationModel,
-          routeCtxProvider: input.routeCtxProvider,
-          usage,
-          durationMs: input.durationMs,
-          stream: true,
-        })
+        if (input.analyticsEnabled) {
+          captureGeneration({
+            deps: input.deps,
+            userId: input.userId,
+            requestId: input.requestId,
+            sessionId: input.sessionId,
+            roundId: input.roundId,
+            appSurface: input.appSurface,
+            generationModel: input.generationModel,
+            routeCtxProvider: input.routeCtxProvider,
+            usage,
+            durationMs: input.durationMs,
+            stream: true,
+          })
+        }
 
         // Debit flux via DB transaction (source of truth)
         // NOTICE: streaming response is already sent, so we cannot reject on failure.
@@ -534,23 +550,25 @@ function streamChatCompletion(input: {
           promptTokens: usage.promptTokens,
           completionTokens: usage.completionTokens,
         })
-        void input.deps.productEventService.track({
-          userId: input.userId,
-          feature: 'gen_ai_chat',
-          action: 'completion_succeeded',
-          status: 'succeeded',
-          source: 'openai.chat.completions',
-          model: input.requestModel,
-          provider: input.routeCtxProvider,
-          metadata: {
-            http_status: input.response.status,
-            duration_ms: input.durationMs,
-            prompt_tokens: usage.promptTokens ?? 0,
-            completion_tokens: usage.completionTokens ?? 0,
-            flux_consumed: actualCharged,
-            stream: true,
-          },
-        })
+        if (input.analyticsEnabled) {
+          void input.deps.productEventService.track({
+            userId: input.userId,
+            feature: 'gen_ai_chat',
+            action: 'completion_succeeded',
+            status: 'succeeded',
+            source: 'openai.chat.completions',
+            model: input.requestModel,
+            provider: input.routeCtxProvider,
+            metadata: {
+              http_status: input.response.status,
+              duration_ms: input.durationMs,
+              prompt_tokens: usage.promptTokens ?? 0,
+              completion_tokens: usage.completionTokens ?? 0,
+              flux_consumed: actualCharged,
+              stream: true,
+            },
+          })
+        }
 
         input.logger.withFields({
           requestId: input.requestId,
@@ -584,6 +602,7 @@ async function completeNonStreamingChat(input: {
   sessionId?: string
   roundId?: string
   appSurface?: AiGenerationAppSurface
+  analyticsEnabled: boolean
   requestModel: string
   generationModel: string
   routeCtxProvider: string
@@ -604,21 +623,23 @@ async function completeNonStreamingChat(input: {
     input.telemetry.failSpan(input.span, 'Failed to parse upstream response body')
     input.generationTrace.fail('Failed to parse upstream response body')
     input.telemetry.recordMetrics({ model: input.requestModel, status: input.response.status, type: 'chat', provider: input.routeCtxProvider, durationMs: input.durationMs, fluxConsumed: 0 })
-    void input.deps.productEventService.track({
-      userId: input.userId,
-      feature: 'gen_ai_chat',
-      action: 'completion_failed',
-      status: 'failed',
-      source: 'openai.chat.completions',
-      model: input.requestModel,
-      provider: input.routeCtxProvider,
-      reason: 'malformed_upstream_response',
-      metadata: {
-        http_status: input.response.status,
-        duration_ms: input.durationMs,
-        stream: false,
-      },
-    })
+    if (input.analyticsEnabled) {
+      void input.deps.productEventService.track({
+        userId: input.userId,
+        feature: 'gen_ai_chat',
+        action: 'completion_failed',
+        status: 'failed',
+        source: 'openai.chat.completions',
+        model: input.requestModel,
+        provider: input.routeCtxProvider,
+        reason: 'malformed_upstream_response',
+        metadata: {
+          http_status: input.response.status,
+          duration_ms: input.durationMs,
+          stream: false,
+        },
+      })
+    }
     throw err
   }
   const usage = extractUsageFromBody(responseBody)
@@ -634,19 +655,21 @@ async function completeNonStreamingChat(input: {
   })
   input.telemetry.recordMetrics({ model: input.requestModel, status: input.response.status, type: 'chat', provider: input.routeCtxProvider, durationMs: input.durationMs, fluxConsumed, ...usage })
 
-  captureGeneration({
-    deps: input.deps,
-    userId: input.userId,
-    requestId: input.requestId,
-    sessionId: input.sessionId,
-    roundId: input.roundId,
-    appSurface: input.appSurface,
-    generationModel: input.generationModel,
-    routeCtxProvider: input.routeCtxProvider,
-    usage,
-    durationMs: input.durationMs,
-    stream: false,
-  })
+  if (input.analyticsEnabled) {
+    captureGeneration({
+      deps: input.deps,
+      userId: input.userId,
+      requestId: input.requestId,
+      sessionId: input.sessionId,
+      roundId: input.roundId,
+      appSurface: input.appSurface,
+      generationModel: input.generationModel,
+      routeCtxProvider: input.routeCtxProvider,
+      usage,
+      durationMs: input.durationMs,
+      stream: false,
+    })
+  }
 
   // Debit flux via DB transaction (source of truth).
   // The upstream call has already happened (cost incurred), so partial
@@ -671,23 +694,25 @@ async function completeNonStreamingChat(input: {
     promptTokens: usage.promptTokens,
     completionTokens: usage.completionTokens,
   })
-  void input.deps.productEventService.track({
-    userId: input.userId,
-    feature: 'gen_ai_chat',
-    action: 'completion_succeeded',
-    status: 'succeeded',
-    source: 'openai.chat.completions',
-    model: input.requestModel,
-    provider: input.routeCtxProvider,
-    metadata: {
-      http_status: input.response.status,
-      duration_ms: input.durationMs,
-      prompt_tokens: usage.promptTokens ?? 0,
-      completion_tokens: usage.completionTokens ?? 0,
-      flux_consumed: actualCharged,
-      stream: false,
-    },
-  })
+  if (input.analyticsEnabled) {
+    void input.deps.productEventService.track({
+      userId: input.userId,
+      feature: 'gen_ai_chat',
+      action: 'completion_succeeded',
+      status: 'succeeded',
+      source: 'openai.chat.completions',
+      model: input.requestModel,
+      provider: input.routeCtxProvider,
+      metadata: {
+        http_status: input.response.status,
+        duration_ms: input.durationMs,
+        prompt_tokens: usage.promptTokens ?? 0,
+        completion_tokens: usage.completionTokens ?? 0,
+        flux_consumed: actualCharged,
+        stream: false,
+      },
+    })
+  }
 
   input.logger.withFields({
     requestId: input.requestId,

--- a/server/apps/api/src/routes/openai/v1/operations/speech-generation/index.ts
+++ b/server/apps/api/src/routes/openai/v1/operations/speech-generation/index.ts
@@ -7,6 +7,8 @@ export interface SpeechGenerationOperationRequest {
   userId: string
   body: Record<string, unknown>
   sessionId?: string
+  analyticsEnabled: boolean
+  contentCaptureAllowed: boolean
   abortSignal?: AbortSignal
 }
 

--- a/server/apps/api/src/routes/openai/v1/route.test.ts
+++ b/server/apps/api/src/routes/openai/v1/route.test.ts
@@ -15,6 +15,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createV1Routes } from '.'
 import { ApiError } from '../../../utils/error'
 import {
+  AIRI_ANALYTICS_CONSENT_HEADER,
   AIRI_CHAT_APP_SURFACE_HEADER,
   AIRI_CHAT_ROUND_ID_HEADER,
   AIRI_CHAT_SESSION_ID_HEADER,
@@ -985,6 +986,104 @@ describe('v1CompletionsRoutes', () => {
       })
     })
 
+    it('fails closed for mobile chat analytics until the app grants consent', async () => {
+      const llmRouter = createMockLlmRouter({
+        route: vi.fn(async (_req, ctx) => {
+          if (ctx) {
+            ctx.provider = 'openrouter'
+            ctx.upstreamModel = 'openai/gpt-4o-mini'
+          }
+          return new Response(JSON.stringify({
+            choices: [],
+            usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }) as any,
+      })
+      const llmTracing = createMockLlmTracing()
+      const productEventService = createMockProductEventService()
+      const app = createTestApp(
+        createMockFluxService(),
+        createMockConfigKV(),
+        undefined,
+        undefined,
+        undefined,
+        llmRouter,
+        llmTracing,
+        productEventService,
+      )
+
+      await app.fetch(
+        new Request('http://localhost/api/v1/openai/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [AIRI_CHAT_APP_SURFACE_HEADER]: 'mobile',
+          },
+          body: JSON.stringify({ model: 'chat-auto', messages: [{ role: 'user', content: 'private' }] }),
+        }),
+        { user: testUser } as any,
+      )
+
+      expect(llmTracing.startChatGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({ contentCaptureAllowed: false }),
+      )
+      expect(productEventService.track).not.toHaveBeenCalled()
+      expect(productEventService.trackGeneration).not.toHaveBeenCalled()
+    })
+
+    it('captures content-free mobile generation metadata after explicit consent without exporting chat content', async () => {
+      const llmRouter = createMockLlmRouter({
+        route: vi.fn(async (_req, ctx) => {
+          if (ctx) {
+            ctx.provider = 'openrouter'
+            ctx.upstreamModel = 'openai/gpt-4o-mini'
+          }
+          return new Response(JSON.stringify({
+            choices: [],
+            usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }) as any,
+      })
+      const llmTracing = createMockLlmTracing()
+      const productEventService = createMockProductEventService()
+      const app = createTestApp(
+        createMockFluxService(),
+        createMockConfigKV(),
+        undefined,
+        undefined,
+        undefined,
+        llmRouter,
+        llmTracing,
+        productEventService,
+      )
+
+      await app.fetch(
+        new Request('http://localhost/api/v1/openai/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [AIRI_CHAT_APP_SURFACE_HEADER]: 'mobile',
+            [AIRI_ANALYTICS_CONSENT_HEADER]: 'granted',
+          },
+          body: JSON.stringify({ model: 'chat-auto', messages: [{ role: 'user', content: 'private' }] }),
+        }),
+        { user: testUser } as any,
+      )
+
+      expect(llmTracing.startChatGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({ contentCaptureAllowed: false }),
+      )
+      expect(productEventService.trackGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({ appSurface: 'mobile', captureSurface: 'server' }),
+      )
+    })
+
     it('uses request-level correlation for server-captured generations without chat headers', async () => {
       const llmRouter = createMockLlmRouter({
         route: vi.fn(async (_req, ctx) => {
@@ -1234,6 +1333,45 @@ describe('v1CompletionsRoutes', () => {
           body: expect.stringContaining('"model":"tts-1-hd"'),
         }),
       )
+    })
+
+    it('does not export mobile speech content or product events without consent', async () => {
+      const llmRouter = createMockLlmRouter({
+        routeTts: vi.fn(async () => new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: { 'Content-Type': 'audio/mpeg' },
+        })),
+      })
+      const llmTracing = createMockLlmTracing()
+      const productEventService = createMockProductEventService()
+      const app = createTestApp(
+        createMockFluxService(),
+        createMockConfigKV({ DEFAULT_TTS_MODEL: 'tts-1-hd' }),
+        undefined,
+        undefined,
+        undefined,
+        llmRouter,
+        llmTracing,
+        productEventService,
+      )
+
+      await app.fetch(
+        new Request('http://localhost/api/v1/audio/speech', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [AIRI_CHAT_APP_SURFACE_HEADER]: 'mobile',
+            [AIRI_ANALYTICS_CONSENT_HEADER]: 'denied',
+          },
+          body: JSON.stringify({ model: 'auto', input: 'private reply', voice: 'alloy' }),
+        }),
+        { user: testUser } as any,
+      )
+
+      expect(llmTracing.startTtsGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({ contentCaptureAllowed: false }),
+      )
+      expect(productEventService.track).not.toHaveBeenCalled()
     })
 
     it('rejects disabled provider catalog TTS models before billing or upstream routing', async () => {

--- a/server/apps/api/src/services/domain/llm-tracing/index.test.ts
+++ b/server/apps/api/src/services/domain/llm-tracing/index.test.ts
@@ -16,6 +16,7 @@ vi.mock('@langfuse/tracing', () => ({
 }))
 
 const BASE_INPUT = {
+  contentCaptureAllowed: true,
   input: [{ role: 'user', content: 'hi' }],
   model: 'openai/gpt-5-mini',
   requestId: 'req-1',
@@ -69,6 +70,15 @@ describe('startChatGeneration', () => {
       )
       expect(generationStub.otelSpan.setAttribute).toHaveBeenCalledWith('langfuse.user.id', 'user-1')
       expect(generationStub.otelSpan.setAttribute).toHaveBeenCalledWith('langfuse.session.id', 'sess-9')
+    })
+
+    it('returns a no-op trace when request consent forbids content capture', () => {
+      const trace = startChatGeneration({ ...BASE_INPUT, contentCaptureAllowed: false })
+      trace.succeed({ output: 'private', promptTokens: 1, completionTokens: 1 })
+
+      expect(startObservation).not.toHaveBeenCalled()
+      expect(generationStub.update).not.toHaveBeenCalled()
+      expect(generationStub.end).not.toHaveBeenCalled()
     })
 
     it('omits session attribute when no sessionId is supplied', () => {
@@ -160,6 +170,7 @@ describe('startChatGeneration', () => {
     it('creates a TTS generation and records character usage without buffering audio', () => {
       // @example /audio/speech request: text in, content-type metadata out
       const trace = startTtsGeneration({
+        contentCaptureAllowed: true,
         input: { text: 'hello', voice: 'alloy', responseFormat: 'mp3' },
         model: 'tts-1',
         requestId: 'tts-1',

--- a/server/apps/api/src/services/domain/llm-tracing/index.ts
+++ b/server/apps/api/src/services/domain/llm-tracing/index.ts
@@ -61,6 +61,8 @@ function extractSseDeltaText(sseLine: string): string {
 
 /** Parameters identifying a request a Langfuse generation traces. */
 interface GenerationInput {
+  /** Whether this request may export prompt or generated content to Langfuse. */
+  contentCaptureAllowed: boolean
   /** Provider-domain input payload, recorded verbatim as trace input. */
   input: unknown
   /** Resolved upstream model id (after `auto` aliases are replaced). */
@@ -181,7 +183,7 @@ function startGeneration(input: GenerationInput): {
   succeed: (result: GenerationResult) => void
   fail: (statusMessage: string) => void
 } | null {
-  if (!tracingActive())
+  if (!input.contentCaptureAllowed || !tracingActive())
     return null
 
   const baseMetadata = { requestId: input.requestId, ...input.metadata }
@@ -237,6 +239,7 @@ function startGeneration(input: GenerationInput): {
  */
 export function startChatGeneration(input: ChatGenerationInput): ChatGenerationTrace {
   const generation = startGeneration({
+    contentCaptureAllowed: input.contentCaptureAllowed,
     input: input.input,
     model: input.model,
     requestId: input.requestId,
@@ -299,6 +302,7 @@ export function startChatGeneration(input: ChatGenerationInput): ChatGenerationT
  */
 export function startTtsGeneration(input: TtsGenerationInput): TtsGenerationTrace {
   const generation = startGeneration({
+    contentCaptureAllowed: input.contentCaptureAllowed,
     input: input.input,
     model: input.model,
     requestId: input.requestId,

--- a/server/apps/api/src/services/domain/openai-speech/index.ts
+++ b/server/apps/api/src/services/domain/openai-speech/index.ts
@@ -62,6 +62,8 @@ export interface OpenAiSpeechRequest {
   userId: string
   body: Record<string, unknown>
   sessionId?: string
+  analyticsEnabled: boolean
+  contentCaptureAllowed: boolean
   abortSignal?: AbortSignal
 }
 
@@ -127,19 +129,21 @@ export function createOpenAiSpeechService(deps: OpenAiSpeechServiceDeps) {
       voice: requestVoice,
     }).log('tts speech request')
 
-    void deps.productEventService.track({
-      userId: input.userId,
-      feature: 'tts',
-      action: 'speech_requested',
-      status: 'started',
-      source: analytics.source,
-      model: requestModel,
-      metadata: {
-        input_chars: inputText.length,
-        trigger: analytics.trigger,
-        ...voiceMetadata,
-      },
-    })
+    if (input.analyticsEnabled) {
+      void deps.productEventService.track({
+        userId: input.userId,
+        feature: 'tts',
+        action: 'speech_requested',
+        status: 'started',
+        source: analytics.source,
+        model: requestModel,
+        metadata: {
+          input_chars: inputText.length,
+          trigger: analytics.trigger,
+          ...voiceMetadata,
+        },
+      })
+    }
 
     const flux = await deps.fluxService.getFlux(input.userId)
     try {
@@ -149,24 +153,26 @@ export function createOpenAiSpeechService(deps: OpenAiSpeechServiceDeps) {
       if (!(err instanceof ApiError) || err.statusCode !== 402)
         throw err
 
-      void deps.productEventService.track({
-        userId: input.userId,
-        feature: 'tts',
-        action: 'speech_blocked',
-        status: 'blocked',
-        source: analytics.source,
-        model: requestModel,
-        reason: 'insufficient_balance',
-        metadata: {
-          input_chars: inputText.length,
-          billing_units: billingUnits,
-          block_reason: 'insufficient_balance',
-          balance_state: 'insufficient',
-          flux_balance_bucket: fluxBalanceBucket(flux.flux),
-          trigger: analytics.trigger,
-          ...voiceMetadata,
-        },
-      })
+      if (input.analyticsEnabled) {
+        void deps.productEventService.track({
+          userId: input.userId,
+          feature: 'tts',
+          action: 'speech_blocked',
+          status: 'blocked',
+          source: analytics.source,
+          model: requestModel,
+          reason: 'insufficient_balance',
+          metadata: {
+            input_chars: inputText.length,
+            billing_units: billingUnits,
+            block_reason: 'insufficient_balance',
+            balance_state: 'insufficient',
+            flux_balance_bucket: fluxBalanceBucket(flux.flux),
+            trigger: analytics.trigger,
+            ...voiceMetadata,
+          },
+        })
+      }
       logger.withError(err).withFields({
         requestId,
         userId: input.userId,
@@ -190,6 +196,7 @@ export function createOpenAiSpeechService(deps: OpenAiSpeechServiceDeps) {
     }
 
     const generationTrace = deps.llmTracing.startTtsGeneration({
+      contentCaptureAllowed: input.analyticsEnabled && input.contentCaptureAllowed,
       input: ttsInput,
       model: requestModel,
       requestId,
@@ -227,23 +234,25 @@ export function createOpenAiSpeechService(deps: OpenAiSpeechServiceDeps) {
         provider: routeCtx.provider,
         status: failure.status,
       })
-      void deps.productEventService.track({
-        userId: input.userId,
-        feature: 'tts',
-        action: 'speech_failed',
-        status: 'failed',
-        source: analytics.source,
-        model: requestModel,
-        provider: routeCtx.provider,
-        reason: failure.reason,
-        metadata: {
-          http_status: failure.status,
-          duration_ms: Date.now() - startedAt,
-          failure_reason: failure.reason,
-          trigger: analytics.trigger,
-          ...voiceMetadata,
-        },
-      })
+      if (input.analyticsEnabled) {
+        void deps.productEventService.track({
+          userId: input.userId,
+          feature: 'tts',
+          action: 'speech_failed',
+          status: 'failed',
+          source: analytics.source,
+          model: requestModel,
+          provider: routeCtx.provider,
+          reason: failure.reason,
+          metadata: {
+            http_status: failure.status,
+            duration_ms: Date.now() - startedAt,
+            failure_reason: failure.reason,
+            trigger: analytics.trigger,
+            ...voiceMetadata,
+          },
+        })
+      }
       throw err
     }
 
@@ -255,23 +264,25 @@ export function createOpenAiSpeechService(deps: OpenAiSpeechServiceDeps) {
       span.end()
       generationTrace.fail(`Gateway ${response.status}`)
       recordMetrics({ model: requestModel, status: response.status, provider: routeCtx.provider, durationMs, fluxConsumed: 0 })
-      void deps.productEventService.track({
-        userId: input.userId,
-        feature: 'tts',
-        action: 'speech_failed',
-        status: 'failed',
-        source: analytics.source,
-        model: requestModel,
-        provider: routeCtx.provider,
-        reason: 'upstream_error',
-        metadata: {
-          http_status: response.status,
-          duration_ms: durationMs,
-          failure_reason: 'upstream_error',
-          trigger: analytics.trigger,
-          ...voiceMetadata,
-        },
-      })
+      if (input.analyticsEnabled) {
+        void deps.productEventService.track({
+          userId: input.userId,
+          feature: 'tts',
+          action: 'speech_failed',
+          status: 'failed',
+          source: analytics.source,
+          model: requestModel,
+          provider: routeCtx.provider,
+          reason: 'upstream_error',
+          metadata: {
+            http_status: response.status,
+            duration_ms: durationMs,
+            failure_reason: 'upstream_error',
+            trigger: analytics.trigger,
+            ...voiceMetadata,
+          },
+        })
+      }
       logger.withFields({ requestId, userId: input.userId, model: requestModel, status: response.status, durationMs })
         .warn('tts speech delivered with upstream error status')
       return new Response(response.body, {
@@ -306,25 +317,27 @@ export function createOpenAiSpeechService(deps: OpenAiSpeechServiceDeps) {
     }
 
     recordMetrics({ model: requestModel, status: response.status, provider: routeCtx.provider, durationMs, fluxConsumed })
-    void deps.productEventService.track({
-      userId: input.userId,
-      feature: 'tts',
-      action: 'speech_succeeded',
-      status: 'succeeded',
-      source: analytics.source,
-      model: requestModel,
-      provider: routeCtx.provider,
-      metadata: {
-        http_status: response.status,
-        input_chars: inputText.length,
-        billing_units: billingUnits,
-        cost_multiplier: voicePackRequest.costMultiplier,
-        duration_ms: durationMs,
-        flux_consumed: fluxConsumed,
-        trigger: analytics.trigger,
-        ...voiceMetadata,
-      },
-    })
+    if (input.analyticsEnabled) {
+      void deps.productEventService.track({
+        userId: input.userId,
+        feature: 'tts',
+        action: 'speech_succeeded',
+        status: 'succeeded',
+        source: analytics.source,
+        model: requestModel,
+        provider: routeCtx.provider,
+        metadata: {
+          http_status: response.status,
+          input_chars: inputText.length,
+          billing_units: billingUnits,
+          cost_multiplier: voicePackRequest.costMultiplier,
+          duration_ms: durationMs,
+          flux_consumed: fluxConsumed,
+          trigger: analytics.trigger,
+          ...voiceMetadata,
+        },
+      })
+    }
     deps.requestLogService.logRequest({
       userId: input.userId,
       model: requestModel,


### PR DESCRIPTION
## What changed

- add an explicit mobile analytics-consent contract for chat and speech requests
- fail closed for mobile requests that do not grant analytics consent
- suppress optional PostHog and product-event writes when consent is denied
- never export mobile chat prompts, responses, or TTS text to Langfuse, even after analytics opt-in
- keep operational billing, request logs, and content-free metrics intact

## Why

AIRI Lite exposes an opt-in product analytics setting and promises that analytics excludes chat content. The API previously emitted server-side analytics independently of that setting and could trace prompt or output content.

## Impact

Existing web and Electron behavior remains unchanged unless a client sends an explicit denial. Mobile analytics now follows the in-app consent state, while mobile content remains excluded from Langfuse.

## Checks

- `pnpm exec vitest run server/apps/api/src/routes/openai/v1/route.test.ts server/apps/api/src/services/domain/llm-tracing/index.test.ts` (77 tests passed)
- `pnpm -F @proj-airi/api-server typecheck`
- repository commit hook (`moeru-lint --fix`) passed for all 8 changed files
