### PR TITLE
fix(ui): support unset button size

### DIFF
--- a/docs/ai/context/ui-components.md
+++ b/docs/ai/context/ui-components.md
@@ -114,10 +114,14 @@ surface, border, shape, or color styling.
 | `label` | `string?` | — | Button text |
 | `disabled` | `boolean?` | `false` | Disabled state |
 | `loading` | `boolean?` | `false` | Loading state |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'unset'` | `'md'` | Preset size; `unset` leaves sizing to the caller |
 | `block` | `boolean?` | `false` | Full width |
 
 **Slots**: `default` (fallback when no `label`)
+
+`size="unset"` omits the preset padding and text-size classes in `BasicButton`,
+`Button`, and `GhostButton`. Callers must supply any required sizing, including
+fixed dimensions for circular buttons.
 
 ### Button
 

--- a/packages/ui/src/components/misc/button.vue
+++ b/packages/ui/src/components/misc/button.vue
@@ -24,6 +24,7 @@ const circleSizeClasses: Record<ButtonSize, string> = {
   sm: 'h-8 w-8',
   md: 'h-10 w-10',
   lg: 'h-12 w-12',
+  unset: '',
 }
 
 const colorClasses: Record<ButtonColor, Record<ButtonVariant, string[]>> = {

--- a/packages/ui/src/components/misc/ghost-button.vue
+++ b/packages/ui/src/components/misc/ghost-button.vue
@@ -19,6 +19,7 @@ const sizeClasses: Record<ButtonSize, string> = {
   sm: 'min-h-7 px-2! py-1! text-xs',
   md: 'min-h-8 px-3! py-1.5! text-sm',
   lg: 'min-h-10 px-4! py-2! text-base',
+  unset: '',
 }
 
 const basicProps = computed(() => ({


### PR DESCRIPTION
## Summary

- add the missing unset entry to the solid circle-button size map
- add the missing unset entry to the ghost-button size map
- preserve the intended BasicButton behavior: unset contributes no sizing classes

## Context

Current main@93af669d1 extends ButtonSize with unset, but these two exhaustive Record<ButtonSize, string> maps still only cover sm, md, and lg. The official main-branch Type Check is consequently failing with TS2741 in both files: https://github.com/moeru-ai/airi/actions/runs/30849985730/job/91807368742

## Validation

- reproduced both TS2741 failures before the fix
- pnpm --filter @proj-airi/ui typecheck
- pnpm --filter @proj-airi/ui-loading-screens typecheck
- pnpm run build:packages (28/28 tasks)
- pnpm run typecheck (all 50 scoped workspace projects)
- targeted moeru-lint (0 warnings, 0 errors)
- git diff --check