### PR TITLE
fix(stage-tamagotchi): register router hot updates

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/main.ts
+++ b/apps/stage-tamagotchi/src/renderer/main.ts
@@ -12,7 +12,7 @@ import { createPinia } from 'pinia'
 import { setupLayouts } from 'virtual:generated-layouts'
 import { createApp } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
-import { routes } from 'vue-router/auto-routes'
+import { handleHotUpdate, routes } from 'vue-router/auto-routes'
 
 import App from './App.vue'
 
@@ -50,6 +50,14 @@ const router = createRouter({
   // TODO: vite-plugin-vue-layouts is long deprecated, replace with another layout solution
   routes: setupLayouts(routes as RouteRecordRaw[]),
 })
+
+if (import.meta.hot) {
+  handleHotUpdate(router, (updatedRoutes) => {
+    router.clearRoutes()
+    for (const route of setupLayouts(updatedRoutes))
+      router.addRoute(route)
+  })
+}
 
 createApp(App)
   .use(MotionPlugin)


### PR DESCRIPTION
## Summary

- register Vue Router's generated-route HMR handler in the stage-tamagotchi renderer
- reapply `setupLayouts()` when generated routes change so route updates preserve layout wrappers

## Root cause

The renderer imported `routes` from `vue-router/auto-routes` without registering `handleHotUpdate(router)`. When the generated routes module changed, Vue Router could not find an active router and invalidated the module, causing a renderer reload.

## Impact

Route changes can now be applied through Vue Router HMR without the `Cannot replace the routes because there is no active router` invalidation. The separate full reload emitted by the deprecated `vite-plugin-vue-layouts` remains outside this PR's scope.

## Validation

- verified through Electron CDP that `vue-router/auto-routes` hot-updates without the missing-router invalidation
- `pnpm lint` (0 errors; 7 existing warnings)
- `pnpm exec eslint apps/stage-tamagotchi/src/renderer/main.ts`
- `git diff --check`
- `pnpm -F @proj-airi/stage-tamagotchi typecheck` is currently blocked by pre-existing `ButtonSize.unset` errors in `packages/ui/src/components/misc/button.vue` and `ghost-button.vue`
