### PR TITLE
feat(stage-ui): add Voicebox local Qwen TTS and Whisper ASR providers

### DIFF
--- a/apps/stage-tamagotchi/electron.vite.config.ts
+++ b/apps/stage-tamagotchi/electron.vite.config.ts
@@ -150,6 +150,14 @@ export default defineConfig({
     },
 
     server: {
+      proxy: {
+        // Development renderer requests use the same Voicebox bridge as Stage Web.
+        '/__voicebox': {
+          target: 'http://127.0.0.1:17493',
+          changeOrigin: true,
+          rewrite: path => path.replace(/^\/__voicebox/, ''),
+        },
+      },
       fs: {
         // To mute errors like:
         //   The request id ".../node_modules/@fontsource/sniglet/files/sniglet-latin-400-normal.woff" is outside of Vite serving allow list.

--- a/apps/stage-web/vite.config.ts
+++ b/apps/stage-web/vite.config.ts
@@ -76,6 +76,15 @@ export default defineConfig({
     },
   },
   server: {
+    proxy: {
+      // Voicebox 0.5.0 rejects arbitrary local web origins. Keep local model
+      // traffic same-origin while preserving Voicebox as a separate process.
+      '/__voicebox': {
+        target: 'http://127.0.0.1:17493',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/__voicebox/, ''),
+      },
+    },
     fs: {
       // To mute errors like:
       //   The request id ".../node_modules/@fontsource/sniglet/files/sniglet-latin-400-normal.woff" is outside of Vite serving allow list.

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1064,6 +1064,38 @@ pages:
         OpenAI, Azure Speech
     description: LLMs, speech providers, etc.
     provider:
+      voicebox-local:
+        fields:
+          base-url:
+            description: Address of the local Voicebox API server.
+          language:
+            label: Language
+            description: Language hint sent to the local speech model.
+            options:
+              zh: Chinese
+              en: English
+              ja: Japanese
+              ko: Korean
+          model:
+            label: Model
+            description: Model managed by the local Voicebox application.
+        validators:
+          config: Check Voicebox configuration
+          health: Check Voicebox service
+      voicebox-local-speech:
+        title: Voicebox (Local Qwen TTS)
+        description: Generate speech locally with the Qwen TTS model loaded by Voicebox.
+        notice:
+          title: Voicebox must be running
+          description: AIRI uses the Qwen model and voice profiles already managed by Voicebox. No API key is required.
+        playground:
+          default-text: 你好，这是 AIRI 的本地千问语音测试。
+      voicebox-local-transcription:
+        title: Voicebox (Local Whisper ASR)
+        description: Transcribe microphone audio locally with Whisper managed by Voicebox.
+        notice:
+          title: First transcription downloads Whisper
+          description: Voicebox downloads the selected Whisper model on first use. Wait for the download to finish, then retry the recording.
       app-local-audio-transcription:
         title: App (Local)
         description: https://github.com/moeru-ai/xsai-transformers

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -1013,6 +1013,38 @@ pages:
         转录（语音转文本）模型服务来源，例如 Whisper.cpp, OpenAI, Azure Speech
     description: LLM，语音合成，语音识别服务来源等
     provider:
+      voicebox-local:
+        fields:
+          base-url:
+            description: 本机 Voicebox API 服务地址。
+          language:
+            label: 语言
+            description: 发送给本地语音模型的语言提示。
+            options:
+              zh: 中文
+              en: 英文
+              ja: 日文
+              ko: 韩文
+          model:
+            label: 模型
+            description: 由本机 Voicebox 管理的模型。
+        validators:
+          config: 检查 Voicebox 配置
+          health: 检查 Voicebox 服务
+      voicebox-local-speech:
+        title: Voicebox（本地千问 TTS）
+        description: 使用 Voicebox 已加载的千问 TTS 模型在本机生成语音。
+        notice:
+          title: 需要启动 Voicebox
+          description: AIRI 会使用 Voicebox 已管理的千问模型和声音档案，无需 API 密钥。
+        playground:
+          default-text: 你好，这是 AIRI 的本地千问语音测试。
+      voicebox-local-transcription:
+        title: Voicebox（本地 Whisper ASR）
+        description: 使用 Voicebox 管理的 Whisper 在本机识别麦克风音频。
+        notice:
+          title: 首次识别需要下载 Whisper
+          description: Voicebox 会在首次使用时下载所选 Whisper 模型。下载完成后重新录音即可。
       app-local-audio-transcription:
         title: 应用内（本地）
         description: https://github.com/moeru-ai/xsai-transformers

--- a/packages/stage-pages/src/pages/settings/providers/speech/voicebox-local-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/voicebox-local-speech.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import type { SpeechProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import {
+  Alert,
+  SpeechPlayground,
+  SpeechProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { VOICEBOX_SPEECH_PROVIDER_ID } from '@proj-airi/stage-ui/libs/providers/providers/voicebox'
+import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { Callout, FieldCombobox } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+interface VoiceboxSpeechConfig {
+  baseUrl?: string
+  language?: string
+  model?: string
+}
+
+const defaultModel = 'qwen-tts-1.7B'
+const defaultLanguage = 'zh'
+
+const { t } = useI18n()
+const providersStore = useProvidersStore()
+const speechStore = useSpeechStore()
+const { providers } = storeToRefs(providersStore)
+
+function ensureConfig() {
+  providers.value[VOICEBOX_SPEECH_PROVIDER_ID] ??= {}
+  return providers.value[VOICEBOX_SPEECH_PROVIDER_ID] as VoiceboxSpeechConfig
+}
+
+const model = computed({
+  get: () => (providers.value[VOICEBOX_SPEECH_PROVIDER_ID] as VoiceboxSpeechConfig | undefined)?.model || defaultModel,
+  set: (value: string) => {
+    ensureConfig().model = value
+  },
+})
+
+const language = computed({
+  get: () => (providers.value[VOICEBOX_SPEECH_PROVIDER_ID] as VoiceboxSpeechConfig | undefined)?.language || defaultLanguage,
+  set: (value: string) => {
+    ensureConfig().language = value
+  },
+})
+
+const modelOptions = computed(() => {
+  const models = providersStore.getModelsForProvider(VOICEBOX_SPEECH_PROVIDER_ID)
+  const availableModels = models.length > 0
+    ? models
+    : [{ id: defaultModel, name: 'Qwen TTS 1.7B' }]
+
+  return availableModels.map(item => ({ label: item.name, value: item.id }))
+})
+
+const languageOptions = computed(() => [
+  { label: t('settings.pages.providers.provider.voicebox-local.fields.language.options.zh'), value: 'zh' },
+  { label: t('settings.pages.providers.provider.voicebox-local.fields.language.options.en'), value: 'en' },
+  { label: t('settings.pages.providers.provider.voicebox-local.fields.language.options.ja'), value: 'ja' },
+  { label: t('settings.pages.providers.provider.voicebox-local.fields.language.options.ko'), value: 'ko' },
+])
+
+const availableVoices = computed(() => speechStore.availableVoices[VOICEBOX_SPEECH_PROVIDER_ID] || [])
+const voicesLoading = computed(() => speechStore.isLoadingSpeechProviderVoices)
+
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
+  const provider = await providersStore.getProviderInstance<SpeechProviderWithExtraOptions<string, VoiceboxSpeechConfig>>(VOICEBOX_SPEECH_PROVIDER_ID)
+  if (!provider)
+    throw new Error('Failed to initialize the local Voicebox speech provider.')
+
+  const config = providersStore.getProviderConfig(VOICEBOX_SPEECH_PROVIDER_ID)
+  return await speechStore.speech(
+    provider,
+    modelId || model.value,
+    input,
+    voiceId,
+    {
+      ...config,
+      language: language.value,
+    },
+  )
+}
+
+onMounted(async () => {
+  const config = ensureConfig()
+  config.model ??= defaultModel
+  config.language ??= defaultLanguage
+
+  await Promise.all([
+    providersStore.fetchModelsForProvider(VOICEBOX_SPEECH_PROVIDER_ID),
+    speechStore.loadVoicesForProvider(VOICEBOX_SPEECH_PROVIDER_ID),
+  ])
+})
+
+const {
+  isValidating,
+  isValid,
+  validationMessage,
+  forceValid,
+} = useProviderValidation(VOICEBOX_SPEECH_PROVIDER_ID)
+</script>
+
+<template>
+  <SpeechProviderSettings
+    :provider-id="VOICEBOX_SPEECH_PROVIDER_ID"
+    :default-model="defaultModel"
+  >
+    <template #basic-settings>
+      <Callout :label="t('settings.pages.providers.provider.voicebox-local-speech.notice.title')">
+        {{ t('settings.pages.providers.provider.voicebox-local-speech.notice.description') }}
+      </Callout>
+    </template>
+
+    <template #voice-settings>
+      <FieldCombobox
+        v-model="model"
+        :label="t('settings.pages.providers.provider.voicebox-local.fields.model.label')"
+        :description="t('settings.pages.providers.provider.voicebox-local.fields.model.description')"
+        :options="modelOptions"
+        :disabled="providersStore.isLoadingModels[VOICEBOX_SPEECH_PROVIDER_ID]"
+        layout="vertical"
+      />
+      <FieldCombobox
+        v-model="language"
+        :label="t('settings.pages.providers.provider.voicebox-local.fields.language.label')"
+        :description="t('settings.pages.providers.provider.voicebox-local.fields.language.description')"
+        :options="languageOptions"
+        layout="vertical"
+      />
+    </template>
+
+    <template #playground>
+      <SpeechPlayground
+        :available-voices="availableVoices"
+        :generate-speech="handleGenerateSpeech"
+        :api-key-configured="true"
+        :voices-loading="voicesLoading"
+        :default-text="t('settings.pages.providers.provider.voicebox-local-speech.playground.default-text')"
+      />
+    </template>
+
+    <template #advanced-settings>
+      <Alert v-if="!isValid && isValidating === 0 && validationMessage" type="error">
+        <template #title>
+          {{ validationMessage }}
+        </template>
+        <template #content>
+          <button type="button" class="text-xs underline" @click="forceValid">
+            {{ t('settings.pages.providers.common.continueAnyway') }}
+          </button>
+        </template>
+      </Alert>
+      <Alert v-if="isValid && isValidating === 0" type="success">
+        <template #title>
+          {{ t('settings.dialogs.onboarding.validationSuccess') }}
+        </template>
+      </Alert>
+    </template>
+  </SpeechProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  titleKey: settings.pages.providers.provider.voicebox-local-speech.title
+  subtitleKey: settings.title
+  descriptionKey: settings.pages.providers.provider.voicebox-local-speech.description
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/voicebox-local-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/voicebox-local-transcription.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import {
+  Alert,
+  TranscriptionPlayground,
+  TranscriptionProviderSettings,
+} from '@proj-airi/stage-ui/components'
+import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { VOICEBOX_TRANSCRIPTION_PROVIDER_ID } from '@proj-airi/stage-ui/libs/providers/providers/voicebox'
+import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
+import { useProvidersStore } from '@proj-airi/stage-ui/stores/providers'
+import { Callout, FieldCombobox } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+interface VoiceboxTranscriptionConfig {
+  baseUrl?: string
+  language?: string
+  model?: string
+}
+
+const defaultModel = 'base'
+const defaultLanguage = 'zh'
+
+const { t } = useI18n()
+const hearingStore = useHearingStore()
+const providersStore = useProvidersStore()
+const { providers } = storeToRefs(providersStore)
+
+function ensureConfig() {
+  providers.value[VOICEBOX_TRANSCRIPTION_PROVIDER_ID] ??= {}
+  return providers.value[VOICEBOX_TRANSCRIPTION_PROVIDER_ID] as VoiceboxTranscriptionConfig
+}
+
+const model = computed({
+  get: () => (providers.value[VOICEBOX_TRANSCRIPTION_PROVIDER_ID] as VoiceboxTranscriptionConfig | undefined)?.model || defaultModel,
+  set: (value: string) => {
+    ensureConfig().model = value
+  },
+})
+
+const modelOptions = computed(() => {
+  const models = providersStore.getModelsForProvider(VOICEBOX_TRANSCRIPTION_PROVIDER_ID)
+  const availableModels = models.length > 0
+    ? models
+    : [{ id: defaultModel, name: 'Whisper Base' }]
+
+  return availableModels.map(item => ({ label: item.name, value: item.id }))
+})
+
+async function handleGenerateTranscription(file: File) {
+  const provider = await providersStore.getProviderInstance<TranscriptionProviderWithExtraOptions<string, VoiceboxTranscriptionConfig>>(VOICEBOX_TRANSCRIPTION_PROVIDER_ID)
+  if (!provider)
+    throw new Error('Failed to initialize the local Voicebox transcription provider.')
+
+  return await hearingStore.transcription(
+    VOICEBOX_TRANSCRIPTION_PROVIDER_ID,
+    provider,
+    model.value,
+    file,
+    'json',
+    { providerOptions: { language: ensureConfig().language || defaultLanguage } },
+  )
+}
+
+onMounted(async () => {
+  const config = ensureConfig()
+  config.model ??= defaultModel
+  config.language ??= defaultLanguage
+  await providersStore.fetchModelsForProvider(VOICEBOX_TRANSCRIPTION_PROVIDER_ID)
+})
+
+const {
+  isValidating,
+  isValid,
+  validationMessage,
+  forceValid,
+} = useProviderValidation(VOICEBOX_TRANSCRIPTION_PROVIDER_ID)
+</script>
+
+<template>
+  <TranscriptionProviderSettings
+    :provider-id="VOICEBOX_TRANSCRIPTION_PROVIDER_ID"
+    :default-model="defaultModel"
+  >
+    <template #basic-settings>
+      <Callout :label="t('settings.pages.providers.provider.voicebox-local-transcription.notice.title')">
+        {{ t('settings.pages.providers.provider.voicebox-local-transcription.notice.description') }}
+      </Callout>
+      <FieldCombobox
+        v-model="model"
+        :label="t('settings.pages.providers.provider.voicebox-local.fields.model.label')"
+        :description="t('settings.pages.providers.provider.voicebox-local.fields.model.description')"
+        :options="modelOptions"
+        :disabled="providersStore.isLoadingModels[VOICEBOX_TRANSCRIPTION_PROVIDER_ID]"
+        layout="vertical"
+      />
+    </template>
+
+    <template #playground>
+      <TranscriptionPlayground
+        :generate-transcription="handleGenerateTranscription"
+        :api-key-configured="true"
+      />
+    </template>
+
+    <template #advanced-settings>
+      <Alert v-if="!isValid && isValidating === 0 && validationMessage" type="error">
+        <template #title>
+          {{ validationMessage }}
+        </template>
+        <template #content>
+          <button type="button" class="text-xs underline" @click="forceValid">
+            {{ t('settings.pages.providers.common.continueAnyway') }}
+          </button>
+        </template>
+      </Alert>
+      <Alert v-if="isValid && isValidating === 0" type="success">
+        <template #title>
+          {{ t('settings.dialogs.onboarding.validationSuccess') }}
+        </template>
+      </Alert>
+    </template>
+  </TranscriptionProviderSettings>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  titleKey: settings.pages.providers.provider.voicebox-local-transcription.title
+  subtitleKey: settings.title
+  descriptionKey: settings.pages.providers.provider.voicebox-local-transcription.description
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-ui/src/components/scenarios/providers/speech-provider-settings.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/speech-provider-settings.vue
@@ -135,7 +135,12 @@ function handleResetVoiceSettings() {
           :description="t('settings.pages.providers.common.section.basic.description')"
           :on-reset="handleResetVoiceSettings"
         >
-          <ProviderApiKeyInput v-model="apiKey" :provider-name="providerMetadata?.localizedName" :placeholder="props.placeholder || 'API Key'" />
+          <ProviderApiKeyInput
+            v-if="providerMetadata?.requiresCredentials !== false"
+            v-model="apiKey"
+            :provider-name="providerMetadata?.localizedName"
+            :placeholder="props.placeholder || 'API Key'"
+          />
           <!-- Slot for provider-specific basic settings -->
           <slot name="basic-settings" />
         </ProviderBasicSettings>

--- a/packages/stage-ui/src/components/scenarios/providers/transcription-provider-settings.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/transcription-provider-settings.vue
@@ -81,7 +81,12 @@ function handleResetTranscriptionSettings() {
           :description="t('settings.pages.providers.common.section.basic.description')"
           :on-reset="handleResetTranscriptionSettings"
         >
-          <ProviderApiKeyInput v-model="apiKey" :provider-name="providerMetadata?.localizedName" :placeholder="props.placeholder || 'API Key'" />
+          <ProviderApiKeyInput
+            v-if="providerMetadata?.requiresCredentials !== false"
+            v-model="apiKey"
+            :provider-name="providerMetadata?.localizedName"
+            :placeholder="props.placeholder || 'API Key'"
+          />
           <!-- Slot for provider-specific basic settings -->
           <slot name="basic-settings" />
         </ProviderBasicSettings>

--- a/packages/stage-ui/src/libs/providers/providers/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/index.ts
@@ -35,6 +35,7 @@ import './mimo'
 import './cloudflare-workers-ai'
 import './azure-ai-foundry'
 import './official'
+import './voicebox'
 
 export {
   getDefaultStreamingModel,

--- a/packages/stage-ui/src/libs/providers/providers/voicebox/index.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/voicebox/index.test.ts
@@ -1,0 +1,204 @@
+import type { SpeechProviderWithExtraOptions, TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import { generateSpeech } from '@xsai/generate-speech'
+import { generateTranscription } from '@xsai/generate-transcription'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  providerVoiceboxSpeech,
+  providerVoiceboxTranscription,
+  VOICEBOX_SPEECH_PROVIDER_ID,
+  VOICEBOX_TRANSCRIPTION_PROVIDER_ID,
+} from './index'
+
+const config = {
+  baseUrl: 'http://127.0.0.1:17493/',
+  language: 'zh',
+  model: 'qwen-tts-1.7B',
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('voicebox local speech provider', () => {
+  it('adapts OpenAI-shaped speech requests to the Voicebox Qwen stream endpoint', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(new Uint8Array([82, 73, 70, 70]), {
+      headers: { 'Content-Type': 'audio/wav' },
+      status: 200,
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = providerVoiceboxSpeech.createProvider(config) as SpeechProviderWithExtraOptions<string, { language?: string }>
+    const audio = await generateSpeech({
+      ...provider.speech('qwen-tts-1.7B', { language: 'zh' }),
+      input: '你好',
+      voice: 'profile-1',
+    })
+
+    expect(audio.byteLength).toBe(4)
+    expect(String(fetchMock.mock.calls[0][0])).toBe('http://127.0.0.1:17493/generate/stream')
+
+    const request = fetchMock.mock.calls[0][1]
+    expect(request?.method).toBe('POST')
+    expect(JSON.parse(String(request?.body))).toEqual({
+      engine: 'qwen',
+      language: 'zh',
+      model_size: '1.7B',
+      profile_id: 'profile-1',
+      text: '你好',
+    })
+  })
+
+  it('routes local development requests through the Voicebox Vite proxy', async () => {
+    const fetchMock = vi.fn(async () => new Response(new Uint8Array([82, 73, 70, 70]), {
+      headers: { 'Content-Type': 'audio/wav' },
+      status: 200,
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('location', {
+      hostname: '127.0.0.1',
+      origin: 'http://127.0.0.1:5173',
+      protocol: 'http:',
+    })
+
+    const provider = providerVoiceboxSpeech.createProvider(config) as SpeechProviderWithExtraOptions<string, { language?: string }>
+    await generateSpeech({
+      ...provider.speech('qwen-tts-1.7B', { language: 'zh' }),
+      input: '你好',
+      voice: 'profile-1',
+    })
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe('http://127.0.0.1:5173/__voicebox/generate/stream')
+  })
+
+  it('loads Qwen models and cloned voice profiles from Voicebox', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        models: [
+          {
+            display_name: 'Qwen TTS 1.7B',
+            downloaded: true,
+            downloading: false,
+            model_name: 'qwen-tts-1.7B',
+          },
+        ],
+      }))
+      .mockResolvedValueOnce(Response.json([
+        {
+          description: null,
+          id: 'profile-1',
+          language: 'zh',
+          name: '我的声音',
+        },
+      ]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = providerVoiceboxSpeech.createProvider(config)
+    const models = await providerVoiceboxSpeech.extraMethods?.listModels?.(config, provider)
+    const voices = await providerVoiceboxSpeech.extraMethods?.listVoices?.(config, provider)
+
+    expect(models).toEqual([
+      {
+        id: 'qwen-tts-1.7B',
+        name: 'Qwen TTS 1.7B',
+        provider: VOICEBOX_SPEECH_PROVIDER_ID,
+        description: 'Ready',
+      },
+    ])
+    expect(voices).toEqual([
+      {
+        id: 'profile-1',
+        name: '我的声音',
+        provider: VOICEBOX_SPEECH_PROVIDER_ID,
+        description: undefined,
+        languages: [{ code: 'zh', title: 'ZH' }],
+      },
+    ])
+  })
+})
+
+describe('voicebox local transcription provider', () => {
+  it('adapts OpenAI-shaped transcription uploads to the Voicebox endpoint', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => Response.json({
+      duration: 1.25,
+      text: '你好',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const transcriptionConfig = {
+      ...config,
+      model: 'base',
+    }
+    const provider = providerVoiceboxTranscription.createProvider(transcriptionConfig) as TranscriptionProviderWithExtraOptions<string, { language?: string }>
+    const result = await generateTranscription({
+      ...provider.transcription('base', { language: 'zh' }),
+      file: new File([new Uint8Array([1, 2, 3])], 'recording.wav', { type: 'audio/wav' }),
+      fileName: 'recording.wav',
+      language: 'zh',
+    })
+
+    expect(result.text).toBe('你好')
+    expect(String(fetchMock.mock.calls[0][0])).toBe('http://127.0.0.1:17493/transcribe')
+
+    const request = fetchMock.mock.calls[0][1]
+    expect(request?.method).toBe('POST')
+    expect(request?.body).toBeInstanceOf(FormData)
+
+    const body = request?.body as FormData
+    expect(body.get('model')).toBe('base')
+    expect(body.get('language')).toBe('zh')
+    expect((body.get('file') as File).name).toBe('recording.wav')
+  })
+
+  it('surfaces the recoverable Whisper download state as a provider error', async () => {
+    const fetchMock = vi.fn(async () => Response.json({
+      detail: {
+        message: 'Whisper model base is being downloaded. Please wait and try again.',
+        model_name: 'whisper-base',
+      },
+    }, { status: 202 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const provider = providerVoiceboxTranscription.createProvider({
+      ...config,
+      model: 'base',
+    }) as TranscriptionProviderWithExtraOptions<string, { language?: string }>
+
+    await expect(generateTranscription({
+      ...provider.transcription('base', { language: 'zh' }),
+      file: new File([new Uint8Array([1, 2, 3])], 'recording.wav', { type: 'audio/wav' }),
+      fileName: 'recording.wav',
+    })).rejects.toThrow(/Whisper model base is being downloaded/)
+  })
+
+  it('lists Voicebox Whisper models using the model name expected by the transcription endpoint', async () => {
+    const fetchMock = vi.fn(async () => Response.json({
+      models: [
+        {
+          display_name: 'Whisper Base',
+          downloaded: true,
+          downloading: false,
+          model_name: 'whisper-base',
+        },
+      ],
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const transcriptionConfig = {
+      ...config,
+      model: 'base',
+    }
+    const provider = providerVoiceboxTranscription.createProvider(transcriptionConfig)
+    const models = await providerVoiceboxTranscription.extraMethods?.listModels?.(transcriptionConfig, provider)
+
+    expect(models).toEqual([
+      {
+        id: 'base',
+        name: 'Whisper Base',
+        provider: VOICEBOX_TRANSCRIPTION_PROVIDER_ID,
+        description: 'Ready',
+      },
+    ])
+  })
+})

--- a/packages/stage-ui/src/libs/providers/providers/voicebox/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/voicebox/index.ts
@@ -1,0 +1,463 @@
+import type { SpeechProviderWithExtraOptions, TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import { errorMessageFrom } from '@moeru/std'
+import { z } from 'zod'
+
+import { defineProvider } from '../registry'
+
+export const VOICEBOX_SPEECH_PROVIDER_ID = 'voicebox-local-speech'
+export const VOICEBOX_TRANSCRIPTION_PROVIDER_ID = 'voicebox-local-transcription'
+
+const VOICEBOX_DEFAULT_BASE_URL = 'http://127.0.0.1:17493/'
+const VOICEBOX_COMPATIBLE_BASE_URL = 'http://voicebox.invalid/v1/'
+const VOICEBOX_DEV_PROXY_PATH = '/__voicebox'
+const VOICEBOX_DEFAULT_SPEECH_MODEL = 'qwen-tts-1.7B'
+const VOICEBOX_DEFAULT_TRANSCRIPTION_MODEL = 'base'
+
+const voiceboxBaseConfigSchema = z.object({
+  baseUrl: z.string().default(VOICEBOX_DEFAULT_BASE_URL),
+  language: z.string().default('zh'),
+})
+
+const voiceboxSpeechConfigSchema = voiceboxBaseConfigSchema.extend({
+  model: z.string().default(VOICEBOX_DEFAULT_SPEECH_MODEL),
+})
+
+const voiceboxTranscriptionConfigSchema = voiceboxBaseConfigSchema.extend({
+  model: z.string().default(VOICEBOX_DEFAULT_TRANSCRIPTION_MODEL),
+})
+
+type VoiceboxSpeechConfig = z.input<typeof voiceboxSpeechConfigSchema>
+type VoiceboxTranscriptionConfig = z.input<typeof voiceboxTranscriptionConfigSchema>
+
+interface VoiceboxSpeechOptions {
+  language?: string
+}
+
+interface VoiceboxTranscriptionOptions {
+  language?: string
+}
+
+interface VoiceboxHealthResponse {
+  status?: string
+}
+
+interface VoiceboxModelStatus {
+  display_name: string
+  downloaded: boolean
+  downloading: boolean
+  model_name: string
+}
+
+interface VoiceboxModelStatusResponse {
+  models: VoiceboxModelStatus[]
+}
+
+interface VoiceboxProfile {
+  description?: string | null
+  id: string
+  language: string
+  name: string
+}
+
+interface VoiceboxErrorEnvelope {
+  detail?: string | { message?: string }
+  error?: string | { message?: string }
+  message?: string
+}
+
+interface VoiceboxSpeechRequestBody {
+  input?: unknown
+  language?: unknown
+  model?: unknown
+  voice?: unknown
+}
+
+interface VoiceboxSpeechModel {
+  engine: 'qwen' | 'qwen_custom_voice'
+  modelSize: '0.6B' | '1.7B'
+}
+
+function normalizedBaseUrl(value: string | undefined) {
+  const baseUrl = value?.trim() || VOICEBOX_DEFAULT_BASE_URL
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+}
+
+function isLoopbackHostname(hostname: string) {
+  return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1'
+}
+
+/**
+ * Resolves Voicebox API requests through the local Vite proxy during
+ * development. Production builds connect directly because the proxy route
+ * only exists while Vite's development server is running.
+ */
+function voiceboxEndpoint(baseUrl: string | undefined, path: string) {
+  const base = new URL(normalizedBaseUrl(baseUrl))
+  const location = globalThis.location
+
+  if (
+    import.meta.env.DEV
+      && location
+      && (location.protocol === 'http:' || location.protocol === 'https:')
+      && isLoopbackHostname(location.hostname)
+      && isLoopbackHostname(base.hostname)
+      && base.port === '17493'
+  ) {
+    return new URL(`${VOICEBOX_DEV_PROXY_PATH}${path}`, location.origin)
+  }
+
+  return new URL(path.replace(/^\//, ''), base)
+}
+
+function requestVoicebox(baseUrl: string | undefined, path: string, init?: RequestInit) {
+  return globalThis.fetch(voiceboxEndpoint(baseUrl, path), {
+    ...init,
+    credentials: 'omit',
+  })
+}
+
+async function responseJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response))
+  }
+
+  return await response.json() as T
+}
+
+async function responseErrorMessage(response: Response) {
+  const fallback = `Voicebox request failed: HTTP ${response.status} ${response.statusText}`
+
+  try {
+    const body = await response.json() as VoiceboxErrorEnvelope
+    if (typeof body.detail === 'string')
+      return body.detail
+    if (body.detail && typeof body.detail.message === 'string')
+      return body.detail.message
+    if (typeof body.error === 'string')
+      return body.error
+    if (body.error && typeof body.error.message === 'string')
+      return body.error.message
+    if (typeof body.message === 'string')
+      return body.message
+  }
+  catch {
+  }
+
+  return fallback
+}
+
+function errorResponse(message: string, status = 400) {
+  return Response.json({
+    error: {
+      code: status === 503 ? 'model_loading' : 'invalid_request',
+      message,
+      type: status === 503 ? 'service_unavailable_error' : 'invalid_request_error',
+    },
+  }, { status })
+}
+
+async function mapPreparingResponse(response: Response, fallback: string) {
+  if (response.status !== 202)
+    return response
+
+  return errorResponse(await responseErrorMessage(response).catch(() => fallback), 503)
+}
+
+function parseSpeechRequestBody(body: BodyInit | null | undefined): VoiceboxSpeechRequestBody | undefined {
+  if (typeof body !== 'string')
+    return undefined
+
+  try {
+    const value = JSON.parse(body) as unknown
+    return value && typeof value === 'object' ? value as VoiceboxSpeechRequestBody : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+function speechModel(modelId: string): VoiceboxSpeechModel | undefined {
+  const baseMatch = /^qwen-tts-(0\.6b|1\.7b)$/i.exec(modelId)
+  if (baseMatch) {
+    return {
+      engine: 'qwen',
+      modelSize: baseMatch[1].toLowerCase() === '1.7b' ? '1.7B' : '0.6B',
+    }
+  }
+
+  const customVoiceMatch = /^qwen-custom-voice-(0\.6b|1\.7b)$/i.exec(modelId)
+  if (customVoiceMatch) {
+    return {
+      engine: 'qwen_custom_voice',
+      modelSize: customVoiceMatch[1].toLowerCase() === '1.7b' ? '1.7B' : '0.6B',
+    }
+  }
+
+  return undefined
+}
+
+function speechFetch(config: VoiceboxSpeechConfig, configuredModel: string, options?: VoiceboxSpeechOptions): typeof fetch {
+  return async (_input, init) => {
+    const body = parseSpeechRequestBody(init?.body)
+    if (!body)
+      return errorResponse('Voicebox received an invalid speech request body.')
+
+    const input = typeof body.input === 'string' ? body.input.trim() : ''
+    const profileId = typeof body.voice === 'string' ? body.voice.trim() : ''
+    const modelId = typeof body.model === 'string' ? body.model : configuredModel
+    const model = speechModel(modelId)
+
+    if (!input)
+      return errorResponse('Speech text is required.')
+    if (!profileId)
+      return errorResponse('Select a Voicebox voice profile before generating speech.')
+    if (!model)
+      return errorResponse(`Unsupported Voicebox speech model: ${modelId}`)
+
+    const language = typeof body.language === 'string'
+      ? body.language
+      : options?.language || config.language || 'zh'
+
+    const response = await requestVoicebox(config.baseUrl, '/generate/stream', {
+      body: JSON.stringify({
+        engine: model.engine,
+        language,
+        model_size: model.modelSize,
+        profile_id: profileId,
+        text: input,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      signal: init?.signal,
+    })
+    const preparedResponse = await mapPreparingResponse(response, 'Voicebox is preparing the selected Qwen TTS model. Wait for the download to finish and try again.')
+
+    if (preparedResponse.ok && !preparedResponse.headers.get('Content-Type')?.startsWith('audio/')) {
+      return errorResponse('Voicebox returned a non-audio response for speech generation.', 502)
+    }
+
+    return preparedResponse
+  }
+}
+
+function transcriptionModel(modelId: string) {
+  return modelId.replace(/^whisper-/i, '') || VOICEBOX_DEFAULT_TRANSCRIPTION_MODEL
+}
+
+function transcriptionFetch(config: VoiceboxTranscriptionConfig, configuredModel: string, options?: VoiceboxTranscriptionOptions): typeof fetch {
+  return async (_input, init) => {
+    if (typeof FormData === 'undefined' || !(init?.body instanceof FormData))
+      return errorResponse('Voicebox received an invalid transcription request body.')
+
+    const sourceFile = init.body.get('file')
+    if (!(sourceFile instanceof Blob))
+      return errorResponse('An audio file is required for transcription.')
+
+    const requestModel = init.body.get('model')
+    const requestLanguage = init.body.get('language')
+    const form = new FormData()
+    const fileName = typeof File !== 'undefined' && sourceFile instanceof File && sourceFile.name
+      ? sourceFile.name
+      : 'recording.wav'
+
+    form.append('file', sourceFile, fileName)
+    form.append('model', transcriptionModel(typeof requestModel === 'string' ? requestModel : configuredModel))
+    form.append('language', typeof requestLanguage === 'string' ? requestLanguage : options?.language || config.language || 'zh')
+
+    const response = await requestVoicebox(config.baseUrl, '/transcribe', {
+      body: form,
+      method: 'POST',
+      signal: init.signal,
+    })
+
+    return await mapPreparingResponse(response, 'Voicebox is downloading the selected Whisper model. Wait for the download to finish and try again.')
+  }
+}
+
+function configValidator<TConfig extends { baseUrl?: string }>({ t }: { t: (key: string) => string }) {
+  return {
+    id: 'voicebox:check-config',
+    name: t('settings.pages.providers.provider.voicebox-local.validators.config'),
+    validator: (config: TConfig) => {
+      const errors: Array<{ error: unknown }> = []
+      try {
+        const url = new URL(normalizedBaseUrl(config.baseUrl))
+        if (!['http:', 'https:'].includes(url.protocol))
+          errors.push({ error: new Error('Voicebox Base URL must use HTTP or HTTPS.') })
+      }
+      catch {
+        errors.push({ error: new Error('Voicebox Base URL must be an absolute URL.') })
+      }
+
+      return {
+        errors,
+        reason: errors.map(item => errorMessageFrom(item.error) ?? 'Invalid Voicebox configuration.').join(', '),
+        reasonKey: '',
+        valid: errors.length === 0,
+      }
+    },
+  }
+}
+
+function healthValidator<TConfig extends { baseUrl?: string }>({ t }: { t: (key: string) => string }) {
+  return {
+    id: 'voicebox:check-health',
+    name: t('settings.pages.providers.provider.voicebox-local.validators.health'),
+    schedule: {
+      intervalMs: 15_000,
+      mode: 'interval' as const,
+    },
+    validator: async (config: TConfig) => {
+      const errors: Array<{ error: unknown }> = []
+
+      try {
+        const health = await requestVoicebox(config.baseUrl, '/health', { method: 'GET' }).then(responseJson<VoiceboxHealthResponse>)
+        if (health.status !== 'healthy')
+          errors.push({ error: new Error(`Voicebox reported status: ${health.status || 'unknown'}.`) })
+      }
+      catch (error) {
+        errors.push({ error })
+      }
+
+      return {
+        errors,
+        reason: errors.length > 0
+          ? errors.map(item => errorMessageFrom(item.error) ?? 'Voicebox is unavailable.').join(', ')
+          : '',
+        reasonKey: '',
+        valid: errors.length === 0,
+      }
+    },
+  }
+}
+
+function baseConfigMetadata(t: (key: string) => string) {
+  return {
+    baseUrl: voiceboxBaseConfigSchema.shape.baseUrl.meta({
+      labelLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.base-url.label'),
+      descriptionLocalized: t('settings.pages.providers.provider.voicebox-local.fields.base-url.description'),
+      placeholderLocalized: VOICEBOX_DEFAULT_BASE_URL,
+    }),
+    language: voiceboxBaseConfigSchema.shape.language.meta({
+      labelLocalized: t('settings.pages.providers.provider.voicebox-local.fields.language.label'),
+      descriptionLocalized: t('settings.pages.providers.provider.voicebox-local.fields.language.description'),
+    }),
+  }
+}
+
+export const providerVoiceboxSpeech = defineProvider<VoiceboxSpeechConfig>({
+  id: VOICEBOX_SPEECH_PROVIDER_ID,
+  name: 'Voicebox (Local Qwen TTS)',
+  nameLocalize: ({ t }) => t('settings.pages.providers.provider.voicebox-local-speech.title'),
+  description: 'Local Qwen TTS through Voicebox.',
+  descriptionLocalize: ({ t }) => t('settings.pages.providers.provider.voicebox-local-speech.description'),
+  tasks: ['text-to-speech', 'tts'],
+  icon: 'i-solar:soundwave-bold-duotone',
+  requiresCredentials: false,
+  createProviderConfig: ({ t }) => voiceboxSpeechConfigSchema.extend({
+    ...baseConfigMetadata(t),
+    model: voiceboxSpeechConfigSchema.shape.model.meta({
+      labelLocalized: t('settings.pages.providers.provider.voicebox-local.fields.model.label'),
+      descriptionLocalized: t('settings.pages.providers.provider.voicebox-local.fields.model.description'),
+    }),
+  }),
+  createProvider(config) {
+    const model = config.model || VOICEBOX_DEFAULT_SPEECH_MODEL
+    const provider: SpeechProviderWithExtraOptions<string, VoiceboxSpeechOptions> = {
+      speech: (requestedModel, options) => ({
+        ...options,
+        baseURL: VOICEBOX_COMPATIBLE_BASE_URL,
+        fetch: speechFetch(config, requestedModel || model, options),
+        model: requestedModel || model,
+      }),
+    }
+    return provider
+  },
+  extraMethods: {
+    listModels: async (config) => {
+      const response = await requestVoicebox(config.baseUrl, '/models/status', { method: 'GET' }).then(responseJson<VoiceboxModelStatusResponse>)
+      return response.models
+        .filter(model => model.model_name.startsWith('qwen-tts-') || model.model_name.startsWith('qwen-custom-voice-'))
+        .map(model => ({
+          id: model.model_name,
+          name: model.display_name,
+          provider: VOICEBOX_SPEECH_PROVIDER_ID,
+          description: model.downloaded ? 'Ready' : model.downloading ? 'Downloading' : 'Downloads on first use',
+        }))
+    },
+    listVoices: async (config) => {
+      const profiles = await requestVoicebox(config.baseUrl, '/profiles', { method: 'GET' }).then(responseJson<VoiceboxProfile[]>)
+      return profiles.map(profile => ({
+        id: profile.id,
+        name: profile.name,
+        provider: VOICEBOX_SPEECH_PROVIDER_ID,
+        description: profile.description || undefined,
+        languages: [{ code: profile.language, title: profile.language.toUpperCase() }],
+      }))
+    },
+  },
+  validationRequiredWhen: () => true,
+  validators: {
+    validateConfig: [configValidator<VoiceboxSpeechConfig>],
+    validateProvider: [healthValidator<VoiceboxSpeechConfig>],
+  },
+})
+
+export const providerVoiceboxTranscription = defineProvider<VoiceboxTranscriptionConfig>({
+  id: VOICEBOX_TRANSCRIPTION_PROVIDER_ID,
+  name: 'Voicebox (Local Whisper ASR)',
+  nameLocalize: ({ t }) => t('settings.pages.providers.provider.voicebox-local-transcription.title'),
+  description: 'Local Whisper transcription through Voicebox.',
+  descriptionLocalize: ({ t }) => t('settings.pages.providers.provider.voicebox-local-transcription.description'),
+  tasks: ['speech-to-text', 'automatic-speech-recognition', 'asr', 'stt'],
+  icon: 'i-solar:microphone-3-bold-duotone',
+  requiresCredentials: false,
+  createProviderConfig: ({ t }) => voiceboxTranscriptionConfigSchema.extend({
+    ...baseConfigMetadata(t),
+    model: voiceboxTranscriptionConfigSchema.shape.model.meta({
+      labelLocalized: t('settings.pages.providers.provider.voicebox-local.fields.model.label'),
+      descriptionLocalized: t('settings.pages.providers.provider.voicebox-local.fields.model.description'),
+    }),
+  }),
+  createProvider(config) {
+    const model = config.model || VOICEBOX_DEFAULT_TRANSCRIPTION_MODEL
+    const provider: TranscriptionProviderWithExtraOptions<string, VoiceboxTranscriptionOptions> = {
+      transcription: (requestedModel, options) => ({
+        ...options,
+        baseURL: VOICEBOX_COMPATIBLE_BASE_URL,
+        fetch: transcriptionFetch(config, requestedModel || model, options),
+        model: requestedModel || model,
+      }),
+    }
+    return provider
+  },
+  extraMethods: {
+    listModels: async (config) => {
+      const response = await requestVoicebox(config.baseUrl, '/models/status', { method: 'GET' }).then(responseJson<VoiceboxModelStatusResponse>)
+      return response.models
+        .filter(model => model.model_name.startsWith('whisper-'))
+        .map(model => ({
+          id: transcriptionModel(model.model_name),
+          name: model.display_name,
+          provider: VOICEBOX_TRANSCRIPTION_PROVIDER_ID,
+          description: model.downloaded ? 'Ready' : model.downloading ? 'Downloading' : 'Downloads on first use',
+        }))
+    },
+  },
+  capabilities: {
+    transcription: {
+      generateOutput: true,
+      protocol: 'http',
+      streamInput: false,
+      streamOutput: false,
+    },
+  },
+  validationRequiredWhen: () => true,
+  validators: {
+    validateConfig: [configValidator<VoiceboxTranscriptionConfig>],
+    validateProvider: [healthValidator<VoiceboxTranscriptionConfig>],
+  },
+})

--- a/packages/stage-ui/src/libs/providers/source-metadata.ts
+++ b/packages/stage-ui/src/libs/providers/source-metadata.ts
@@ -96,6 +96,8 @@ const providerSourceMetadataById = {
   'together-ai': paidCloud,
   'volcengine': paidCloud,
   'volcengine-coding-plan': paidCloud,
+  'voicebox-local-speech': freeLocal,
+  'voicebox-local-transcription': freeLocal,
   'xai': paidCloud,
   'zai': paidCloud,
 } satisfies Record<string, ProviderSourceMetadata | false>


### PR DESCRIPTION
## Description

Adds two credential-free local provider options backed by the Voicebox desktop app at `http://127.0.0.1:17493`:

- **voicebox-local-speech** — Qwen TTS via `/generate/stream`
- **voicebox-local-transcription** — Whisper ASR via `/transcribe`

Implementation notes:

- Provider definitions follow the existing `defineProvider` registry pattern; `requiresCredentials: false` hides the API-key input in the settings components
- In dev, requests route through a Vite `/__voicebox` proxy so local model traffic stays same-origin (Voicebox 0.5.0 rejects arbitrary local web origins); production builds connect directly to the local service
- New settings pages with model/language pickers, config + health validators, and first-run download notices
- en/zh-Hans i18n strings; source metadata marked as `freeLocal`
- 6 unit tests cover request adaptation, dev proxy routing, model/voice listing, and Whisper download error mapping

## Linked Issues

None

## Additional Context

- Requires Voicebox running locally; no API key needed
- Voicebox `202` responses (model downloading) are surfaced as a recoverable `model_loading` error
- Verified: 6/6 unit tests pass, ESLint clean, independent review passed
