### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-rvJU/H9ontlAwz2hcq5eUfsvS1R7EIg77kFDZsdVyEE=
+sha256-Plm74KPBXTRdjqq11S7ttGZuaZ8mrC2mzhPAAILGLWk=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.