### PR TITLE
fix: fix Gemini 400 error caused by strict schema required fields

### DIFF
--- a/packages/stage-ui/src/tools/character/orchestrator/spark-command-shared.ts
+++ b/packages/stage-ui/src/tools/character/orchestrator/spark-command-shared.ts
@@ -36,8 +36,8 @@ export const sparkNotifyCommandItemSchema = z.object({
 }).strict()
 
 export const sparkCommandMetadataEntrySchema = z.object({
-  key: z.string().describe('Metadata key.'),
-  value: z.union([z.string(), z.number(), z.boolean(), z.null()]).describe('Metadata value.'),
+  key: z.string().optional().describe('Metadata key.'),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional().describe('Metadata value.'),
 }).strict()
 
 export const sparkCommandContextSchema = z.object({


### PR DESCRIPTION
…spark-command

### Summary
- Fixed a `400 INVALID_ARGUMENT` error encountered when using Google Gemini (via OpenRouter / Google AI Studio) with the `spark-command` tool.
- The strict JSON schema validation for nested metadata properties was throwing an error: `property is not defined` due to missing property definitions alongside `required` fields.

### Root Cause
When converting complex Zod union types in `sparkCommandMetadataEntrySchema` to JSON schema, the `required: ["key", "value"]` fields were being generated or retained without clear corresponding property types for Gemini's strict validator.

### Solution
- Added `.optional()` to `key` and `value` fields in `sparkCommandMetadataEntrySchema` within `packages/stage-ui/src/tools/character/orchestrator/spark-command-shared.ts`.
- This prevents Gemini from rejecting the tool declaration payload due to undefined required properties.
