### PR TITLE
fix(discord): show live bot connection status

### DIFF
--- a/integrations/discord-bot/package.json
+++ b/integrations/discord-bot/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "start": "tsx --env-file=.env --env-file-if-exists=.env.local src/index.ts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/integrations/discord-bot/src/adapters/airi-adapter.test.ts
+++ b/integrations/discord-bot/src/adapters/airi-adapter.test.ts
@@ -160,4 +160,36 @@ describe('discord adapter connection status', () => {
       data: expect.objectContaining({ phase: 'configuration-needed' }),
     }))
   })
+
+  it('cancels an in-progress connection when the integration is disabled', async () => {
+    const adapter = new DiscordAdapter({})
+    const channel = mocks.FakeServerChannel.instances[0]!
+    const discord = mocks.FakeDiscordClient.instances[0]!
+    const configure = channel.handlers.get('module:configure')!
+    let resolveLogin: () => void
+    discord.login.mockImplementationOnce(() => new Promise<undefined>((resolve) => {
+      resolveLogin = () => resolve(undefined)
+    }))
+
+    const enable = configure({ data: { config: { enabled: true, token: 'bot-token' } } })
+    await vi.waitFor(() => expect(discord.login).toHaveBeenCalledTimes(1))
+    const disable = configure({ data: { config: { enabled: false } } })
+    resolveLogin!()
+
+    await Promise.all([enable, disable])
+
+    expect(adapter).toBeInstanceOf(DiscordAdapter)
+    expect(discord.destroy).toHaveBeenCalledTimes(1)
+    expect(channel.sent).toContainEqual(expect.objectContaining({
+      type: 'module:status',
+      data: expect.objectContaining({ phase: 'configuration-needed' }),
+    }))
+
+    discord.emit('ready', { user: { id: 'bot-id', tag: 'AIRI#0001' } })
+
+    expect(channel.sent).not.toContainEqual(expect.objectContaining({
+      type: 'module:status',
+      data: expect.objectContaining({ phase: 'ready' }),
+    }))
+  })
 })

--- a/integrations/discord-bot/src/adapters/airi-adapter.test.ts
+++ b/integrations/discord-bot/src/adapters/airi-adapter.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DiscordAdapter } from './airi-adapter'
+
+const mocks = vi.hoisted(() => {
+  interface ConfigEvent {
+    data: { config?: unknown }
+  }
+  interface ConnectionStatus {
+    type: string
+    data: {
+      phase?: string
+      reason?: string
+    }
+  }
+
+  class FakeServerChannel {
+    static instances: FakeServerChannel[] = []
+    readonly handlers = new Map<string, (event: ConfigEvent) => Promise<void> | void>()
+    readonly sent: ConnectionStatus[] = []
+
+    constructor(_options: unknown) {
+      FakeServerChannel.instances.push(this)
+    }
+
+    onEvent(type: string, handler: (event: ConfigEvent) => Promise<void> | void) {
+      this.handlers.set(type, handler)
+    }
+
+    send(event: ConnectionStatus) {
+      this.sent.push(event)
+    }
+
+    close = vi.fn()
+  }
+
+  class FakeDiscordClient {
+    static instances: FakeDiscordClient[] = []
+    readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+    readonly isReady = vi.fn(() => false)
+    readonly login = vi.fn(async () => undefined)
+    readonly destroy = vi.fn(async () => undefined)
+    readonly channels = { fetch: vi.fn() }
+
+    constructor(_options: unknown) {
+      FakeDiscordClient.instances.push(this)
+    }
+
+    on(type: string, listener: (...args: unknown[]) => void) {
+      this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+      return this
+    }
+
+    once(type: string, listener: (...args: unknown[]) => void) {
+      return this.on(type, listener)
+    }
+
+    emit(type: string, ...args: unknown[]) {
+      for (const listener of this.listeners.get(type) ?? []) {
+        listener(...args)
+      }
+    }
+  }
+
+  return {
+    FakeServerChannel,
+    FakeDiscordClient,
+    reset() {
+      FakeServerChannel.instances = []
+      FakeDiscordClient.instances = []
+    },
+  }
+})
+
+vi.mock('@guiiai/logg', () => ({
+  useLogg: () => ({
+    useGlobalConfig: () => ({
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      withError: () => ({ error: vi.fn() }),
+    }),
+  }),
+}))
+
+vi.mock('@proj-airi/server-sdk', () => ({
+  Client: mocks.FakeServerChannel,
+}))
+
+vi.mock('@proj-airi/server-shared/types', () => ({
+  ContextUpdateStrategy: { Replace: 'replace' },
+}))
+
+vi.mock('discord.js', () => ({
+  Client: mocks.FakeDiscordClient,
+  Events: {
+    ClientReady: 'ready',
+    Error: 'error',
+    ShardDisconnect: 'disconnect',
+    MessageCreate: 'message',
+    InteractionCreate: 'interaction',
+  },
+  GatewayIntentBits: {
+    Guilds: 1,
+    GuildVoiceStates: 2,
+    GuildMessages: 4,
+    MessageContent: 8,
+    DirectMessages: 16,
+  },
+  Partials: { Channel: 'channel' },
+}))
+
+vi.mock('../bots/discord/commands', () => ({
+  handlePing: vi.fn(),
+  registerCommands: vi.fn(),
+  VoiceManager: class {},
+}))
+
+describe('discord adapter connection status', () => {
+  beforeEach(() => {
+    mocks.reset()
+  })
+
+  it('only reports ready after Discord emits ClientReady', async () => {
+    const adapter = new DiscordAdapter({ discordToken: 'bot-token' })
+    const channel = mocks.FakeServerChannel.instances[0]!
+    const discord = mocks.FakeDiscordClient.instances[0]!
+    const configure = channel.handlers.get('module:configure')!
+
+    expect(adapter).toBeInstanceOf(DiscordAdapter)
+    await configure({ data: { config: { enabled: true, token: 'bot-token' } } })
+
+    expect(channel.sent).toContainEqual(expect.objectContaining({
+      type: 'module:status',
+      data: expect.objectContaining({ phase: 'preparing' }),
+    }))
+    expect(channel.sent).not.toContainEqual(expect.objectContaining({
+      type: 'module:status',
+      data: expect.objectContaining({ phase: 'ready' }),
+    }))
+
+    discord.emit('ready', { user: { id: 'bot-id', tag: 'AIRI#0001' } })
+
+    expect(channel.sent).toContainEqual(expect.objectContaining({
+      type: 'module:status',
+      data: expect.objectContaining({ phase: 'ready' }),
+    }))
+  })
+
+  it('reports a non-ready status when the integration is disabled', async () => {
+    const adapter = new DiscordAdapter({})
+    const channel = mocks.FakeServerChannel.instances[0]!
+    const configure = channel.handlers.get('module:configure')!
+
+    expect(adapter).toBeInstanceOf(DiscordAdapter)
+    await configure({ data: { config: { enabled: false } } })
+
+    expect(channel.sent).toContainEqual(expect.objectContaining({
+      type: 'module:status',
+      data: expect.objectContaining({ phase: 'configuration-needed' }),
+    }))
+  })
+})

--- a/integrations/discord-bot/src/adapters/airi-adapter.ts
+++ b/integrations/discord-bot/src/adapters/airi-adapter.ts
@@ -11,6 +11,15 @@ import { Client, Events, GatewayIntentBits, Partials } from 'discord.js'
 import { handlePing, registerCommands, VoiceManager } from '../bots/discord/commands'
 
 const log = useLogg('DiscordAdapter').useGlobalConfig()
+const discordClientIdentity = {
+  id: 'discord',
+  extension: { id: 'discord' },
+} as const
+const discordStatusIdentity = {
+  id: 'discord',
+  kind: 'plugin',
+  plugin: { id: 'discord' },
+} as const
 
 export interface DiscordAdapterConfig {
   discordToken?: string
@@ -77,11 +86,13 @@ export class DiscordAdapter {
     // Initialize AIRI client
     this.airiClient = new ServerChannel({
       name: 'discord',
+      identity: discordClientIdentity,
       possibleEvents: [
         'input:text',
         'input:text:voice',
         'input:voice',
         'module:configure',
+        'module:status',
         'output:gen-ai:chat:message',
       ],
       token: config.airiToken,
@@ -109,32 +120,37 @@ export class DiscordAdapter {
           const { token, enabled } = config
 
           if (enabled === false) {
-            if (this.discordClient.isReady) {
+            if (this.discordClient.isReady()) {
               log.log('Disabling Discord bot as per configuration...')
               await this.discordClient.destroy()
             }
+            this.publishConnectionStatus('configuration-needed', 'Discord integration is disabled.')
             return
           }
 
           // If enabled, but no token is provided, stop the bot if it's running.
           if (!token) {
             log.warn('Discord bot enabled, but no token provided. Stopping bot.')
-            if (this.discordClient.isReady) {
+            if (this.discordClient.isReady()) {
               await this.discordClient.destroy()
             }
+            this.publishConnectionStatus('configuration-needed', 'A Discord bot token is required.')
             return
           }
 
           // Connect or reconnect if token changed or client is not ready.
-          if (this.discordToken !== token || !this.discordClient.isReady) {
+          if (this.discordToken !== token || !this.discordClient.isReady()) {
             this.discordToken = token
-            if (this.discordClient.isReady) {
+            if (this.discordClient.isReady()) {
               log.log('Reconnecting Discord client with new token...')
               await this.discordClient.destroy()
             }
             log.log('Connecting Discord client...')
+            this.publishConnectionStatus('preparing', 'Connecting to Discord.')
             await this.discordClient.login(this.discordToken)
-            log.log('Discord client connected.')
+          }
+          else {
+            this.publishConnectionStatus('ready')
           }
         }
         else {
@@ -143,6 +159,7 @@ export class DiscordAdapter {
       }
       catch (error) {
         log.withError(error as Error).error('Failed to apply Discord configuration.')
+        this.publishConnectionStatus('failed', errorReason(error, 'Failed to connect to Discord.'))
       }
       finally {
         this.isReconnecting = false
@@ -201,10 +218,19 @@ export class DiscordAdapter {
     })
 
     // Set up Discord event handlers
-    this.discordClient.once(Events.ClientReady, async (readyClient) => {
+    this.discordClient.on(Events.ClientReady, async (readyClient) => {
       log.log(`Discord bot ready! User: ${readyClient.user.tag}`)
+      this.publishConnectionStatus('ready')
       // Register commands dynamically using the authenticated client's ID and token
       await registerCommands(this.discordToken, readyClient.user.id)
+    })
+
+    this.discordClient.on(Events.Error, (error) => {
+      this.publishConnectionStatus('failed', error.message)
+    })
+
+    this.discordClient.on(Events.ShardDisconnect, () => {
+      this.publishConnectionStatus('failed', 'Discord connection closed.')
     })
 
     // Handle text messages from Discord
@@ -326,6 +352,7 @@ export class DiscordAdapter {
     log.log('Stopping Discord adapter...')
     try {
       await this.discordClient.destroy()
+      this.publishConnectionStatus('configuration-needed', 'Discord integration stopped.')
       this.airiClient.close()
       log.log('Discord adapter stopped')
     }
@@ -334,4 +361,28 @@ export class DiscordAdapter {
       throw error
     }
   }
+
+  private publishConnectionStatus(phase: 'configuration-needed' | 'preparing' | 'ready' | 'failed', reason?: string) {
+    this.airiClient.send({
+      type: 'module:status',
+      data: {
+        identity: discordStatusIdentity,
+        phase,
+        reason,
+      },
+    })
+  }
+}
+
+function errorReason(error: unknown, fallback: string): string {
+  if (
+    typeof error === 'object'
+    && error !== null
+    && 'message' in error
+    && typeof error.message === 'string'
+  ) {
+    return error.message
+  }
+
+  return fallback
 }

--- a/integrations/discord-bot/src/adapters/airi-adapter.ts
+++ b/integrations/discord-bot/src/adapters/airi-adapter.ts
@@ -66,7 +66,10 @@ export class DiscordAdapter {
   private discordClient: Client
   private discordToken: string
   private voiceManager: VoiceManager
-  private isReconnecting = false
+  private pendingConfig?: DiscordConfig
+  private configurationWorker?: Promise<void>
+  private desiredConfig?: DiscordConfig
+  private hasDiscordConnectionAttempt = false
 
   constructor(config: DiscordAdapterConfig) {
     this.discordToken = config.discordToken || env.DISCORD_TOKEN || ''
@@ -107,63 +110,21 @@ export class DiscordAdapter {
   private setupEventHandlers(): void {
     // Handle configuration from UI
     this.airiClient.onEvent('module:configure', async (event) => {
-      if (this.isReconnecting) {
-        log.warn('A reconnect is already in progress, skipping this configuration event.')
+      log.log('Received Discord configuration:', event.data.config)
+
+      if (!isDiscordConfig(event.data.config)) {
+        log.warn('Invalid Discord configuration received, skipping...')
         return
       }
-      this.isReconnecting = true
-      try {
-        log.log('Received Discord configuration:', event.data.config)
 
-        if (isDiscordConfig(event.data.config)) {
-          const config = event.data.config as DiscordConfig
-          const { token, enabled } = config
+      this.desiredConfig = event.data.config
+      this.pendingConfig = event.data.config
 
-          if (enabled === false) {
-            if (this.discordClient.isReady()) {
-              log.log('Disabling Discord bot as per configuration...')
-              await this.discordClient.destroy()
-            }
-            this.publishConnectionStatus('configuration-needed', 'Discord integration is disabled.')
-            return
-          }
-
-          // If enabled, but no token is provided, stop the bot if it's running.
-          if (!token) {
-            log.warn('Discord bot enabled, but no token provided. Stopping bot.')
-            if (this.discordClient.isReady()) {
-              await this.discordClient.destroy()
-            }
-            this.publishConnectionStatus('configuration-needed', 'A Discord bot token is required.')
-            return
-          }
-
-          // Connect or reconnect if token changed or client is not ready.
-          if (this.discordToken !== token || !this.discordClient.isReady()) {
-            this.discordToken = token
-            if (this.discordClient.isReady()) {
-              log.log('Reconnecting Discord client with new token...')
-              await this.discordClient.destroy()
-            }
-            log.log('Connecting Discord client...')
-            this.publishConnectionStatus('preparing', 'Connecting to Discord.')
-            await this.discordClient.login(this.discordToken)
-          }
-          else {
-            this.publishConnectionStatus('ready')
-          }
-        }
-        else {
-          log.warn('Invalid Discord configuration received, skipping...')
-        }
+      if (!this.configurationWorker) {
+        this.configurationWorker = this.processConfigurationQueue()
       }
-      catch (error) {
-        log.withError(error as Error).error('Failed to apply Discord configuration.')
-        this.publishConnectionStatus('failed', errorReason(error, 'Failed to connect to Discord.'))
-      }
-      finally {
-        this.isReconnecting = false
-      }
+
+      await this.configurationWorker
     })
 
     // Handle input from AIRI system
@@ -219,6 +180,10 @@ export class DiscordAdapter {
 
     // Set up Discord event handlers
     this.discordClient.on(Events.ClientReady, async (readyClient) => {
+      if (!this.shouldReportReady()) {
+        return
+      }
+
       log.log(`Discord bot ready! User: ${readyClient.user.tag}`)
       this.publishConnectionStatus('ready')
       // Register commands dynamically using the authenticated client's ID and token
@@ -335,6 +300,7 @@ export class DiscordAdapter {
     try {
       // Log in to Discord if token is available
       if (this.discordToken) {
+        this.hasDiscordConnectionAttempt = true
         await this.discordClient.login(this.discordToken)
         log.log('Discord adapter started successfully')
       }
@@ -371,6 +337,73 @@ export class DiscordAdapter {
         reason,
       },
     })
+  }
+
+  private async processConfigurationQueue() {
+    try {
+      while (this.pendingConfig) {
+        const config = this.pendingConfig
+        this.pendingConfig = undefined
+
+        try {
+          await this.applyConfiguration(config)
+        }
+        catch (error) {
+          log.withError(error as Error).error('Failed to apply Discord configuration.')
+          this.publishConnectionStatus('failed', errorReason(error, 'Failed to connect to Discord.'))
+        }
+      }
+    }
+    finally {
+      this.configurationWorker = undefined
+    }
+  }
+
+  private async applyConfiguration(config: DiscordConfig) {
+    const { token, enabled } = config
+
+    if (enabled === false) {
+      log.log('Disabling Discord bot as per configuration...')
+      await this.destroyDiscordClient()
+      this.publishConnectionStatus('configuration-needed', 'Discord integration is disabled.')
+      return
+    }
+
+    if (!token) {
+      log.warn('Discord bot enabled, but no token provided. Stopping bot.')
+      await this.destroyDiscordClient()
+      this.publishConnectionStatus('configuration-needed', 'A Discord bot token is required.')
+      return
+    }
+
+    if (this.discordToken !== token || !this.discordClient.isReady()) {
+      await this.destroyDiscordClient()
+      this.discordToken = token
+      this.hasDiscordConnectionAttempt = true
+      log.log('Connecting Discord client...')
+      this.publishConnectionStatus('preparing', 'Connecting to Discord.')
+      await this.discordClient.login(this.discordToken)
+      return
+    }
+
+    this.publishConnectionStatus('ready')
+  }
+
+  private async destroyDiscordClient() {
+    if (!this.hasDiscordConnectionAttempt) {
+      return
+    }
+
+    await this.discordClient.destroy()
+    this.hasDiscordConnectionAttempt = false
+  }
+
+  private shouldReportReady() {
+    return !this.desiredConfig
+      || (
+        this.desiredConfig.enabled !== false
+        && this.desiredConfig.token === this.discordToken
+      )
   }
 }
 

--- a/integrations/discord-bot/vitest.config.ts
+++ b/integrations/discord-bot/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/stage-ui/src/components/modules/MessagingDiscord.vue
+++ b/packages/stage-ui/src/components/modules/MessagingDiscord.vue
@@ -7,7 +7,7 @@ import { useDiscordStore } from '../../stores/modules/discord'
 
 const { t } = useI18n()
 const discordStore = useDiscordStore()
-const { enabled, token, configured } = storeToRefs(discordStore)
+const { enabled, token, connected } = storeToRefs(discordStore)
 
 function saveSettings() {
   discordStore.saveSettings()
@@ -38,7 +38,7 @@ function saveSettings() {
       />
     </div>
 
-    <div v-if="configured" class="mt-4 rounded-lg bg-green-100 p-4 text-green-800">
+    <div v-if="connected" class="mt-4 rounded-lg bg-green-100 p-4 text-green-800">
       {{ t('settings.pages.modules.messaging-discord.configured') }}
     </div>
   </div>

--- a/packages/stage-ui/src/composables/use-modules-list.ts
+++ b/packages/stage-ui/src/composables/use-modules-list.ts
@@ -127,7 +127,7 @@ export function useModulesList() {
       description: t('settings.pages.modules.messaging-discord.description'),
       icon: 'i-simple-icons:discord',
       to: '/settings/modules/messaging-discord',
-      configured: discordStore.configured,
+      configured: discordStore.connected,
       category: 'messaging',
     },
     {

--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -55,6 +55,7 @@ const serverSdkMocks = vi.hoisted(() => {
 
     emit(type: string, data: any) {
       const event = { type, data }
+      this.options.onAnyMessage?.(event)
       for (const callback of this.listeners.get(type) ?? []) {
         void callback(event)
       }
@@ -189,6 +190,45 @@ describe('channel-server store reconnect', () => {
       readTimeout: 60_000,
       pingInterval: 20_000,
     })
+  })
+
+  it('replays the latest status for each module to late subscribers', async () => {
+    const store = useModsServerChannelStore()
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    client.emit('module:status', {
+      identity: { id: 'discord', kind: 'plugin', plugin: { id: 'discord' } },
+      phase: 'ready',
+    })
+    client.emit('module:status', {
+      identity: { id: 'twitter', kind: 'plugin', plugin: { id: 'twitter' } },
+      phase: 'ready',
+    })
+    client.emit('module:status', {
+      identity: { id: 'discord', kind: 'plugin', plugin: { id: 'discord' } },
+      phase: 'failed',
+    })
+
+    const onStatus = vi.fn()
+    store.onEvent('module:status', onStatus)
+
+    expect(onStatus).toHaveBeenCalledTimes(2)
+    expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        identity: expect.objectContaining({ id: 'discord' }),
+        phase: 'failed',
+      }),
+    }))
+    expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        identity: expect.objectContaining({ id: 'twitter' }),
+        phase: 'ready',
+      }),
+    }))
   })
 
   it('notifies onReconnected callbacks when the websocket becomes ready again', async () => {

--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -231,6 +231,30 @@ describe('channel-server store reconnect', () => {
     }))
   })
 
+  it('does not replay a status for a de-announced extension module', async () => {
+    const store = useModsServerChannelStore()
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    client.emit('module:status', {
+      identity: { id: 'discord', kind: 'plugin', plugin: { id: 'discord' } },
+      phase: 'ready',
+    })
+    client.emit('extension:module:de-announced', {
+      name: 'discord',
+      identity: { id: 'discord', extension: { id: 'discord' } },
+      possibleEvents: [],
+    })
+
+    const onStatus = vi.fn()
+    store.onEvent('module:status', onStatus)
+
+    expect(onStatus).not.toHaveBeenCalled()
+  })
+
   it('notifies onReconnected callbacks when the websocket becomes ready again', async () => {
     const store = useModsServerChannelStore()
     const onReconnected = vi.fn()

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -71,6 +71,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
   const websocketAuthToken = useLocalStorage('settings/connection/websocket-auth-token', '')
   const registeredListeners: ChannelListenerEntry[] = []
   const replayableEvents = new Map<keyof WebSocketEvents, WebSocketBaseEvent<any, any>>()
+  const moduleStatusEvents = new Map<string, WebSocketBaseEvent<'module:status', WebSocketEvents['module:status']>>()
 
   const basePossibleEvents: Array<keyof WebSocketEvents> = [
     'context:update',
@@ -145,8 +146,13 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
         },
         possibleEvents,
         onAnyMessage: (event) => {
-          if (REPLAYABLE_EVENT_TYPES.has(event.type as keyof WebSocketEvents))
+          if (event.type === 'module:status') {
+            const moduleStatusEvent = event as WebSocketBaseEvent<'module:status', WebSocketEvents['module:status']>
+            moduleStatusEvents.set(moduleStatusEvent.data.identity.id, moduleStatusEvent)
+          }
+          else if (REPLAYABLE_EVENT_TYPES.has(event.type as keyof WebSocketEvents)) {
             replayableEvents.set(event.type as keyof WebSocketEvents, event as WebSocketBaseEvent<any, any>)
+          }
 
           useWebSocketInspectorStore().add('incoming', event)
         },
@@ -285,9 +291,16 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     registeredListeners.push(entry)
     initializeListeners()
 
-    const replayableEvent = replayableEvents.get(type)
-    if (replayableEvent)
-      void Promise.resolve(callback(replayableEvent as WebSocketBaseEvent<E, WebSocketEvents[E]>))
+    if (type === 'module:status') {
+      for (const moduleStatusEvent of moduleStatusEvents.values()) {
+        void Promise.resolve(callback(moduleStatusEvent as WebSocketBaseEvent<E, WebSocketEvents[E]>))
+      }
+    }
+    else {
+      const replayableEvent = replayableEvents.get(type)
+      if (replayableEvent)
+        void Promise.resolve(callback(replayableEvent as WebSocketBaseEvent<E, WebSocketEvents[E]>))
+    }
 
     return () => {
       const index = registeredListeners.indexOf(entry)
@@ -357,6 +370,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     initializing.value = null
     clearListeners()
     replayableEvents.clear()
+    moduleStatusEvents.clear()
 
     if (client.value) {
       client.value.close()

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -81,6 +81,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     'module:configure',
     'module:de-announced',
     'module:status',
+    'extension:module:de-announced',
     'module:consumer:register',
     'module:consumer:unregister',
     'module:authenticated',
@@ -149,6 +150,10 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
           if (event.type === 'module:status') {
             const moduleStatusEvent = event as WebSocketBaseEvent<'module:status', WebSocketEvents['module:status']>
             moduleStatusEvents.set(moduleStatusEvent.data.identity.id, moduleStatusEvent)
+          }
+          else if (event.type === 'module:de-announced' || event.type === 'extension:module:de-announced') {
+            const { identity } = event.data as { identity: { id: string } }
+            moduleStatusEvents.delete(identity.id)
           }
           else if (REPLAYABLE_EVENT_TYPES.has(event.type as keyof WebSocketEvents)) {
             replayableEvents.set(event.type as keyof WebSocketEvents, event as WebSocketBaseEvent<any, any>)

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -79,6 +79,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     'module:announced',
     'module:configure',
     'module:de-announced',
+    'module:status',
     'module:consumer:register',
     'module:consumer:unregister',
     'module:authenticated',

--- a/packages/stage-ui/src/stores/modules/discord.ts
+++ b/packages/stage-ui/src/stores/modules/discord.ts
@@ -1,15 +1,27 @@
 import { useLocalStorageManualReset } from '@proj-airi/stage-shared/composables'
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { ref } from 'vue'
 
 import { useConfiguratorByModsChannelServer } from '../configurator'
+import { useModsServerChannelStore } from '../mods/api/channel-server'
 
 export const useDiscordStore = defineStore('discord', () => {
   const configurator = useConfiguratorByModsChannelServer()
   const enabled = useLocalStorageManualReset<boolean>('settings/discord/enabled', false)
   const token = useLocalStorageManualReset<string>('settings/discord/token', '')
+  const connected = ref(false)
+  const modsChannel = useModsServerChannelStore()
+
+  modsChannel.onEvent('module:status', (event) => {
+    if (event.data.identity.plugin.id !== 'discord') {
+      return
+    }
+
+    connected.value = event.data.phase === 'ready'
+  })
 
   function saveSettings() {
+    connected.value = false
     // Data is automatically saved to localStorage via useLocalStorage
     // Also broadcast configuration to backend
     configurator.updateFor('discord', {
@@ -18,20 +30,17 @@ export const useDiscordStore = defineStore('discord', () => {
     })
   }
 
-  const configured = computed(() => {
-    return !!token.value.trim()
-  })
-
   function resetState() {
     enabled.reset()
     token.reset()
+    connected.value = false
     saveSettings()
   }
 
   return {
     enabled,
     token,
-    configured,
+    connected,
     saveSettings,
     resetState,
   }


### PR DESCRIPTION
## Summary

- Publish Discord adapter lifecycle events only after an actual Discord gateway connection is ready, and publish non-ready events for disabled, missing-token, failed, and disconnected states.
- Listen for Discord module status in the settings store and show the green configuration indicator only while the bot is live.
- Fix the adapter's readiness checks to call `Client#isReady()`.
- Add focused Discord adapter connection-status tests and a package test command.

## Validation

- `pnpm --filter @proj-airi/discord-bot test`
- `pnpm --filter @proj-airi/discord-bot typecheck`
- `pnpm exec eslint integrations/discord-bot/src/adapters/airi-adapter.ts integrations/discord-bot/src/adapters/airi-adapter.test.ts integrations/discord-bot/vitest.config.ts packages/stage-ui/src/stores/modules/discord.ts packages/stage-ui/src/components/modules/MessagingDiscord.vue packages/stage-ui/src/stores/mods/api/channel-server.ts`
- `git diff --check`

Fixes #2243
