### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-u1bQQuDZv88NBguOjqJHaWsU0m7U5CtXQGqQ6I+0gJU=
+sha256-ovPOyYSpYnUrsAZkMFo7vxrdjp60OueWiHfp0+sp+V0=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.