### PR TITLE
fix(api-server): pin Eventa WebSocket protocol

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5338,8 +5338,8 @@ importers:
         specifier: 'catalog:'
         version: 5.4.0(@opentelemetry/api@1.9.1)
       '@moeru/eventa':
-        specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        specifier: 1.0.0-beta.13
+        version: 1.0.0-beta.13(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -8081,6 +8081,26 @@ packages:
       electron:
         optional: true
       h3:
+        optional: true
+      web-worker:
+        optional: true
+
+  '@moeru/eventa@1.0.0-beta.13':
+    resolution: {integrity: sha512-zar2haIEkttvDJkBMSv4nEjo3OMhePDwr65nOBJFb6rXLbUjZQ+El6OuPDQZMbuxA+pcKwZhOT6AvamNXxjHfQ==}
+    peerDependencies:
+      '@tauri-apps/api': '>=2'
+      electron: '>=39'
+      h3: '>=2.0.1-rc.22'
+      hono: '>=4.12.25'
+      web-worker: ^1.5.0
+    peerDependenciesMeta:
+      '@tauri-apps/api':
+        optional: true
+      electron:
+        optional: true
+      h3:
+        optional: true
+      hono:
         optional: true
       web-worker:
         optional: true
@@ -22940,6 +22960,16 @@ snapshots:
     optionalDependencies:
       electron: 41.2.1
       h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.22))
+      web-worker: 1.5.0
+
+  '@moeru/eventa@1.0.0-beta.13(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)':
+    dependencies:
+      nanoid: 6.0.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      electron: 41.2.1
+      h3: 2.0.1-rc.25
+      hono: 4.11.3
       web-worker: 1.5.0
 
   '@moeru/eventa@1.0.0-beta.14(electron@40.8.5)(h3@2.0.1-rc.25)(web-worker@1.5.0)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,7 +1450,7 @@ importers:
         version: 3.8.1
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.22)))(hono@4.12.2)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -2334,7 +2334,7 @@ importers:
         version: 3.8.1
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(hono@4.11.3)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -2719,7 +2719,7 @@ importers:
         version: 3.8.1
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -3639,7 +3639,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -3764,7 +3764,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -3776,7 +3776,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@xsai/shared-chat':
         specifier: 'catalog:'
         version: 0.5.0-beta.8
@@ -3785,7 +3785,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -3807,7 +3807,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@proj-airi/plugin-sdk':
         specifier: workspace:*
         version: link:../plugin-sdk
@@ -3943,7 +3943,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
 
   packages/server-shared:
     dependencies:
@@ -3955,7 +3955,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -4070,7 +4070,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -4219,7 +4219,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@nekopaw/tempora':
         specifier: 'catalog:'
         version: 0.4.0-alpha.1
@@ -4246,7 +4246,7 @@ importers:
         version: 3.8.1
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(hono@4.11.3)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -4944,7 +4944,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@pixiv/three-vrm':
         specifier: 'catalog:'
         version: 3.5.2(@types/three@0.184.0)(three@0.184.0)
@@ -5176,7 +5176,7 @@ importers:
     dependencies:
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -5273,7 +5273,7 @@ importers:
         version: 1.2.4
       '@moeru/eventa':
         specifier: 'catalog:'
-        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)
+        version: 1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)
       '@moeru/std':
         specifier: 'catalog:'
         version: 0.1.0-beta.17
@@ -22991,13 +22991,21 @@ snapshots:
       hono: 4.12.2
       web-worker: 1.5.0
 
-  '@moeru/eventa@1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(hono@4.11.3)(web-worker@1.5.0)':
+  '@moeru/eventa@1.0.0-beta.14(electron@41.2.1)(h3@2.0.1-rc.25)(web-worker@1.5.0)':
     dependencies:
       nanoid: 6.0.1
       picomatch: 4.0.4
     optionalDependencies:
       electron: 41.2.1
       h3: 2.0.1-rc.25
+      web-worker: 1.5.0
+
+  '@moeru/eventa@1.0.0-beta.14(electron@41.2.1)(hono@4.11.3)(web-worker@1.5.0)':
+    dependencies:
+      nanoid: 6.0.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      electron: 41.2.1
       hono: 4.11.3
       web-worker: 1.5.0
 

--- a/server/apps/api/package.json
+++ b/server/apps/api/package.json
@@ -28,7 +28,7 @@
     "@hono/otel": "catalog:",
     "@langfuse/otel": "catalog:",
     "@langfuse/tracing": "catalog:",
-    "@moeru/eventa": "catalog:",
+    "@moeru/eventa": "1.0.0-beta.13",
     "@moeru/std": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/api-logs": "catalog:",


### PR DESCRIPTION
## Summary

- Pin the API server to `@moeru/eventa@1.0.0-beta.13`.
- Keep the workspace Eventa catalog at `1.0.0-beta.14`.
- Add the server-specific Eventa resolution to the pnpm lockfile.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build:packages`
- `pnpm typecheck`
- `pnpm lint`
