### PR TITLE
feat(api-server): 接入 StepFun 流式 TTS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1801,33 +1801,6 @@ importers:
         specifier: 'catalog:'
         version: 3.2.6(typescript@5.9.3)
 
-  apps/stage-pocket/ios/DerivedData/C7F38B99-FA7A-44C4-A739-DFE441C9AD8B/SourcePackages/checkouts/OSBarcodeLib-iOS:
-    devDependencies:
-      '@semantic-release/changelog':
-        specifier: ^6.0.0
-        version: 6.0.3(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/commit-analyzer':
-        specifier: ^13.0.0
-        version: 13.0.1(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/exec':
-        specifier: ^7.0.0
-        version: 7.1.0(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/git':
-        specifier: ^10.0.0
-        version: 10.0.1(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/github':
-        specifier: ^12.0.0
-        version: 12.0.9(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/npm':
-        specifier: ^13.0.0
-        version: 13.1.5(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/release-notes-generator':
-        specifier: ^14.0.0
-        version: 14.1.1(semantic-release@25.0.9(typescript@5.9.3))
-      semantic-release:
-        specifier: ^25.0.0
-        version: 25.0.9(typescript@5.9.3)
-
   apps/stage-tamagotchi:
     dependencies:
       '@date-fns/utc':
@@ -2151,7 +2124,7 @@ importers:
         version: 3.0.2(electron@41.2.1)
       '@electron-toolkit/tsconfig':
         specifier: 'catalog:'
-        version: 2.0.0(@types/node@25.6.0)
+        version: 2.0.0(@types/node@24.12.2)
       '@electron-toolkit/utils':
         specifier: 'catalog:'
         version: 4.0.0(electron@41.2.1)
@@ -2190,7 +2163,7 @@ importers:
         version: 3.1.0
       '@intlify/unplugin-vue-i18n':
         specifier: 'catalog:'
-        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.7.0))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.7.0))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -2226,10 +2199,10 @@ importers:
         version: link:../../packages/ui-transitions
       '@proj-airi/unplugin-fetch':
         specifier: 'catalog:'
-        version: 0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@proj-airi/unplugin-live2d-sdk':
         specifier: 'catalog:'
-        version: 0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       '@types/audioworklet':
         specifier: 'catalog:'
         version: 0.0.97
@@ -2256,7 +2229,7 @@ importers:
         version: 2.10.3
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@vue-macros/volar':
         specifier: 'catalog:'
         version: 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
@@ -2289,7 +2262,7 @@ importers:
         version: 6.8.3
       electron-vite:
         specifier: 'catalog:'
-        version: 5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       get-port-please:
         specifier: 'catalog:'
         version: 3.2.0
@@ -2310,31 +2283,31 @@ importers:
         version: 2.2.6
       unocss-preset-scrollbar:
         specifier: 'catalog:'
-        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.0.0(unocss@66.6.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       unplugin-info:
         specifier: 'catalog:'
-        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unplugin-yaml:
         specifier: 'catalog:'
-        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-bundle-visualizer:
         specifier: 'catalog:'
         version: 1.2.1(rolldown@1.0.0-rc.16)(rollup@4.60.1)
       vite-plugin-mkcert:
         specifier: 'catalog:'
-        version: 2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-vue-devtools:
         specifier: 'catalog:'
-        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
+        version: 8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       vite-plugin-vue-layouts:
         specifier: 'catalog:'
-        version: 0.11.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       vue-macros:
         specifier: 'catalog:'
-        version: 3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+        version: 3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.6(typescript@5.9.3)
@@ -5543,18 +5516,6 @@ packages:
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
-  '@actions/core@3.0.1':
-    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
-
-  '@actions/exec@3.0.0':
-    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
-
-  '@actions/http-client@4.0.1':
-    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
-
-  '@actions/io@3.0.2':
-    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
-
   '@agentclientprotocol/sdk@1.3.0':
     resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
     peerDependencies:
@@ -6584,10 +6545,6 @@ packages:
 
   '@codemirror/view@6.39.7':
     resolution: {integrity: sha512-3Vif9hnNHJnl2YgOtkR/wzGzhYcQ8gy3LGdUhkLUU8xSBbgsTxrE8he/CMTpeINm5TgxLe2FmzvF6IYQL/BSAg==}
-
-  '@colors/colors@1.5.0':
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
-    engines: {node: '>=0.1.90'}
 
   '@cryptography/aes@0.1.1':
     resolution: {integrity: sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==}
@@ -8350,60 +8307,6 @@ packages:
 
   '@nxg-org/mineflayer-util-plugin@1.8.4':
     resolution: {integrity: sha512-hPaCZxU0Aq+gUSi/l6x7n32hUG6bnDugAMoQXD2dFE/gyNkmRSpmgH5+Y6G41w3H8P3Nl++upGCOlaxvZ7RuoA==}
-
-  '@octokit/auth-token@6.0.0':
-    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
-    engines: {node: '>= 20'}
-
-  '@octokit/core@7.0.7':
-    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
-    engines: {node: '>= 20'}
-
-  '@octokit/endpoint@11.0.4':
-    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
-    engines: {node: '>= 20'}
-
-  '@octokit/graphql@9.0.4':
-    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
-    engines: {node: '>= 20'}
-
-  '@octokit/openapi-types@27.0.0':
-    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
-
-  '@octokit/openapi-types@28.0.0':
-    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
-
-  '@octokit/plugin-paginate-rest@14.0.0':
-    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@octokit/core': '>=6'
-
-  '@octokit/plugin-retry@8.1.1':
-    resolution: {integrity: sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@octokit/core': '>=7'
-
-  '@octokit/plugin-throttling@11.0.5':
-    resolution: {integrity: sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@octokit/core': ^7.0.0
-
-  '@octokit/request-error@7.1.1':
-    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
-    engines: {node: '>= 20'}
-
-  '@octokit/request@10.0.13':
-    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
-    engines: {node: '>= 20'}
-
-  '@octokit/types@16.0.0':
-    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
-
-  '@octokit/types@17.0.0':
-    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -10655,59 +10558,6 @@ packages:
     resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
-  '@semantic-release/changelog@6.0.3':
-    resolution: {integrity: sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==}
-    engines: {node: '>=14.17'}
-    peerDependencies:
-      semantic-release: '>=18.0.0'
-
-  '@semantic-release/commit-analyzer@13.0.1':
-    resolution: {integrity: sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==}
-    engines: {node: '>=20.8.1'}
-    peerDependencies:
-      semantic-release: '>=20.1.0'
-
-  '@semantic-release/error@3.0.0':
-    resolution: {integrity: sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==}
-    engines: {node: '>=14.17'}
-
-  '@semantic-release/error@4.0.0':
-    resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
-    engines: {node: '>=18'}
-
-  '@semantic-release/exec@7.1.0':
-    resolution: {integrity: sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==}
-    engines: {node: '>=20.8.1'}
-    peerDependencies:
-      semantic-release: '>=24.1.0'
-
-  '@semantic-release/git@10.0.1':
-    resolution: {integrity: sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==}
-    engines: {node: '>=14.17'}
-    peerDependencies:
-      semantic-release: '>=18.0.0'
-
-  '@semantic-release/github@12.0.9':
-    resolution: {integrity: sha512-ODIqb0V3QqndipryEEiaBxUQCFjvv7Oese5Dt4omMGa60YRNEW0Sx3K+zri0uac2Y6S9nOlMehciWIzvvRCTGQ==}
-    engines: {node: ^22.14.0 || >= 24.10.0}
-    peerDependencies:
-      semantic-release: '>=24.1.0'
-
-  '@semantic-release/npm@13.1.5':
-    resolution: {integrity: sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==}
-    engines: {node: ^22.14.0 || >= 24.10.0}
-    peerDependencies:
-      semantic-release: '>=20.1.0'
-
-  '@semantic-release/release-notes-generator@14.1.1':
-    resolution: {integrity: sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==}
-    engines: {node: '>=20.8.1'}
-    peerDependencies:
-      semantic-release: '>=20.1.0'
-
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
 
@@ -10783,10 +10633,6 @@ packages:
     resolution: {integrity: sha512-sUKOu2lb5vGIWADNNLpscyj07DAeQZU3KLbnE2Tj53tW6BbDQKMly2CCfnR4oYzqtRELCPWfwaPg+Q0T8qfKBg==}
     deprecated: Contains a breaking change that should be a major version bump
 
-  '@simple-libs/stream-utils@1.2.0':
-    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
-    engines: {node: '>=18'}
-
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
@@ -10797,10 +10643,6 @@ packages:
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
-    engines: {node: '>=18'}
-
-  '@sindresorhus/merge-streams@4.0.0':
-    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
   '@snazzah/davey-android-arm-eabi@0.1.11':
@@ -11310,9 +11152,6 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
-
-  '@types/normalize-package-data@2.4.4':
-    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
   '@types/nprogress@0.2.3':
     resolution: {integrity: sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==}
@@ -12378,18 +12217,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agent-base@9.0.0:
-    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
-    engines: {node: '>= 20'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
-
-  aggregate-error@5.0.0:
-    resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
-    engines: {node: '>=18'}
-
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -12443,10 +12270,6 @@ packages:
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-
-  ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -12504,9 +12327,6 @@ packages:
   args-tokenizer@0.3.0:
     resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
-  argv-formatter@1.0.0:
-    resolution: {integrity: sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==}
-
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -12526,9 +12346,6 @@ packages:
   array-differ@4.0.0:
     resolution: {integrity: sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  array-ify@1.0.0:
-    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
   array-union@1.0.2:
     resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
@@ -12711,9 +12528,6 @@ packages:
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-
-  before-after-hook@4.0.0:
-    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   best-effort-json-parser@1.4.0:
     resolution: {integrity: sha512-gYmXQicIXaaspBdCLqok3t0JXYdi3Cr9oIgYh2+9rEWiNhLvi/89cguCWXZJWp0FgBR6YoEE9YkbZEfqKdqs+Q==}
@@ -12908,9 +12722,6 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  bottleneck@2.19.5:
-    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
-
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
@@ -13041,10 +12852,6 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
   camelcase@4.1.0:
     resolution: {integrity: sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==}
     engines: {node: '>=4'}
@@ -13084,10 +12891,6 @@ packages:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
     engines: {node: '>=12'}
 
-  chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
-
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -13098,10 +12901,6 @@ packages:
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
-
-  char-regex@1.0.2:
-    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
-    engines: {node: '>=10'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -13165,14 +12964,6 @@ packages:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
 
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-
-  clean-stack@5.3.0:
-    resolution: {integrity: sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==}
-    engines: {node: '>=14.16'}
-
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
@@ -13185,11 +12976,6 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-highlight@2.1.11:
-    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
-    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
-    hasBin: true
-
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -13197,10 +12983,6 @@ packages:
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
-
-  cli-table3@0.6.5:
-    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
-    engines: {node: 10.* || >= 12.*}
 
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
@@ -13213,16 +12995,9 @@ packages:
   cliss@0.0.2:
     resolution: {integrity: sha512-6rj9pgdukjT994Md13JCUAgTk91abAKrygL9sAvmHY4F6AKMOV8ccGaxhUUfcBuyg3sundWnn3JE0Mc9W6ZYqw==}
 
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
@@ -13239,15 +13014,9 @@ packages:
     resolution: {integrity: sha512-Zvxo5inxwvoGMI0R+cXV+5nVbl/Gw7zYV1Msn9mn7loC6CK941CjvsBplgClJV83T4UXID+SXhtfVulfaBat5w==}
     engines: {node: '>=22.10.0'}
 
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
-
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -13347,9 +13116,6 @@ packages:
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
-  compare-func@2.0.0:
-    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
-
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
@@ -13402,32 +13168,6 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-angular@8.3.1:
-    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-writer@8.4.0:
-    resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  conventional-commits-filter@5.0.0:
-    resolution: {integrity: sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==}
-    engines: {node: '>=18'}
-
-  conventional-commits-parser@6.4.0:
-    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  convert-hrtime@5.0.0:
-    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
-    engines: {node: '>=12'}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -13469,15 +13209,6 @@ packages:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
 
-  cosmiconfig@9.0.2:
-    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
 
@@ -13505,10 +13236,6 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
-
-  crypto-random-string@4.0.0:
-    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
-    engines: {node: '>=12'}
 
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
@@ -13841,10 +13568,6 @@ packages:
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
-  dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
-
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
@@ -13893,10 +13616,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dot-prop@5.3.0:
-    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
-    engines: {node: '>=8'}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -14128,9 +13847,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  duplexer2@0.1.4:
-    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
-
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -14245,9 +13961,6 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  emojilib@2.4.0:
-    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
-
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -14302,10 +14015,6 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
-
-  env-ci@11.2.0:
-    resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
-    engines: {node: ^18.17 || >=20.6.1}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -14694,14 +14403,6 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
-  execa@9.6.1:
-    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
-    engines: {node: ^18.19.0 || >=20.5.0}
-
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
@@ -14828,14 +14529,6 @@ packages:
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
-  figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
-    engines: {node: '>=4'}
-
-  figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -14910,10 +14603,6 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
-
-  find-versions@6.0.0:
-    resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
-    engines: {node: '>=18'}
 
   firefox-profile@4.7.0:
     resolution: {integrity: sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==}
@@ -15070,10 +14759,6 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  function-timeout@1.0.2:
-    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
-    engines: {node: '>=18'}
-
   functional-red-black-tree@1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
 
@@ -15138,14 +14823,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
@@ -15163,9 +14840,6 @@ packages:
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
-
-  git-log-parser@1.2.1:
-    resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
 
   git-up@8.1.1:
     resolution: {integrity: sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==}
@@ -15322,11 +14996,6 @@ packages:
       crossws:
         optional: true
 
-  handlebars@4.7.9:
-    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
   har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
     engines: {node: '>=4'}
@@ -15335,10 +15004,6 @@ packages:
     resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
     engines: {node: '>=6'}
     deprecated: this library is no longer supported
-
-  has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -15427,9 +15092,6 @@ packages:
     resolution: {integrity: sha512-MXaWVJVeAgNzLoEAjbsu+cwcN9XhvgURDLJqmDUXXEYO7DUV6eK8LK3Fy6mLgfP73GdtVjTtZan6gj7xhPUrLA==}
     hasBin: true
 
-  highlight.js@10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
-
   histoire@1.0.0-beta.1:
     resolution: {integrity: sha512-hzhFiqlL9Ko1B2APCamGIchM3Bjng5+CTX7kLL1q/NB2Lp4Uqpe4ZZicc7RU4CTCe4Vj7Q/Eb3UE/IacL1Ta5g==}
     hasBin: true
@@ -15453,10 +15115,6 @@ packages:
     resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
     engines: {node: '>=16.9.0'}
 
-  hook-std@4.0.0:
-    resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
-    engines: {node: '>=20'}
-
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -15466,14 +15124,6 @@ packages:
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
-
-  hosted-git-info@7.0.2:
-    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -15515,10 +15165,6 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-agent@9.1.0:
-    resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
-    engines: {node: '>= 20'}
-
   http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
@@ -15531,21 +15177,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  https-proxy-agent@9.1.0:
-    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
-    engines: {node: '>= 20'}
-
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-
-  human-signals@8.0.1:
-    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
-    engines: {node: '>=18.18.0'}
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -15596,17 +15230,9 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
-
   import-from-esm@1.3.4:
     resolution: {integrity: sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==}
     engines: {node: '>=16.20'}
-
-  import-from-esm@2.0.0:
-    resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
-    engines: {node: '>=18.20'}
 
   import-in-the-middle@3.0.0:
     resolution: {integrity: sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==}
@@ -15623,17 +15249,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
-
-  index-to-position@1.2.0:
-    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
-    engines: {node: '>=18'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -15797,10 +15415,6 @@ packages:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
 
-  is-obj@2.0.0:
-    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
-    engines: {node: '>=8'}
-
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
@@ -15842,24 +15456,12 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
-
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
 
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
@@ -15909,10 +15511,6 @@ packages:
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
-  issue-parser@7.0.2:
-    resolution: {integrity: sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==}
-    engines: {node: ^18.17 || >=20.6.1}
-
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -15936,10 +15534,6 @@ packages:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  java-properties@1.0.2:
-    resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
-    engines: {node: '>= 0.6.0'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -16021,12 +15615,6 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
-  json-parse-better-errors@1.0.2:
-    resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
-
-  json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -16048,9 +15636,6 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
-  json-with-bigint@3.5.10:
-    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -16297,10 +15882,6 @@ packages:
     resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
     engines: {node: '>=18.0.0'}
 
-  load-json-file@4.0.0:
-    resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
-    engines: {node: '>=4'}
-
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
@@ -16320,14 +15901,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.18.1:
-    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
-
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.capitalize@4.2.1:
-    resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -16383,9 +15958,6 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-
-  lodash.uniqby@4.7.0:
-    resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -16450,10 +16022,6 @@ packages:
   magicli@0.0.8:
     resolution: {integrity: sha512-x/eBenweAHF+DsYy172sK4doRxZl0yrJnfxhLJiN7H6hPM3Ya0PfI6uBZshZ3ScFFSQD7HXgBqMdbnXKEZsO1g==}
 
-  make-asynchronous@1.1.0:
-    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
-    engines: {node: '>=18'}
-
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -16500,17 +16068,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  marked-terminal@7.3.0:
-    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      marked: '>=1 <16'
-
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
-    hasBin: true
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -16581,10 +16138,6 @@ packages:
 
   mediabunny@1.40.1:
     resolution: {integrity: sha512-HU/stGzAkdWaJIly6ypbUVgAUvT9kt39DIg0IaErR7/1fwtTmgUYs4i8uEPYcgcjPjbB9gtBmUXOLnXi6J2LDw==}
-
-  meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -16739,18 +16292,9 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  mime@4.1.0:
-    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -16995,12 +16539,6 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neo-async@2.6.2:
-    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  nerf-dart@1.0.0:
-    resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
-
   neverthrow@8.2.0:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
@@ -17032,10 +16570,6 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
-
-  node-emoji@2.2.0:
-    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
-    engines: {node: '>=18'}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -17095,14 +16629,6 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
-  normalize-package-data@6.0.2:
-    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
-  normalize-package-data@8.0.0:
-    resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -17111,92 +16637,9 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
-  normalize-url@9.0.1:
-    resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
-    engines: {node: '>=20'}
-
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  npm-run-path@6.0.0:
-    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
-    engines: {node: '>=18'}
-
-  npm@11.19.0:
-    resolution: {integrity: sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/metavuln-calculator'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
 
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
@@ -17269,10 +16712,6 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
-
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -17362,18 +16801,6 @@ packages:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
 
-  p-each-series@3.0.0:
-    resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
-    engines: {node: '>=12'}
-
-  p-event@6.0.1:
-    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
-    engines: {node: '>=16.17'}
-
-  p-filter@4.1.0:
-    resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
-    engines: {node: '>=18'}
-
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
@@ -17406,18 +16833,6 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
-  p-reduce@2.1.0:
-    resolution: {integrity: sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==}
-    engines: {node: '>=8'}
-
-  p-reduce@3.0.0:
-    resolution: {integrity: sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==}
-    engines: {node: '>=12'}
-
-  p-timeout@6.1.4:
-    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
-    engines: {node: '>=14.16'}
-
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
@@ -17442,10 +16857,6 @@ packages:
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
   parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
     engines: {node: '>=14'}
@@ -17453,25 +16864,9 @@ packages:
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
 
-  parse-json@4.0.0:
-    resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
-    engines: {node: '>=4'}
-
-  parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
-
   parse-json@7.1.1:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
-
-  parse-json@8.3.0:
-    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
-    engines: {node: '>=18'}
-
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
 
   parse-node-version@1.0.1:
     resolution: {integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==}
@@ -17486,15 +16881,6 @@ packages:
   parse-url@9.2.0:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
-
-  parse5@5.1.1:
-    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
-
-  parse5@6.0.1:
-    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -17528,10 +16914,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -17548,10 +16930,6 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
-  path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
 
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
@@ -17635,10 +17013,6 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pify@3.0.0:
-    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
-    engines: {node: '>=4'}
-
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -17703,10 +17077,6 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
-
-  pkg-conf@2.1.0:
-    resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
-    engines: {node: '>=4'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -17866,10 +17236,6 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
-  pretty-ms@9.3.0:
-    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
-    engines: {node: '>=18'}
-
   prism-media@1.3.5:
     resolution: {integrity: sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==}
     peerDependencies:
@@ -18011,15 +17377,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-agent-negotiate@1.1.0:
-    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      kerberos: ^2.0.0
-    peerDependenciesMeta:
-      kerberos:
-        optional: true
-
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
@@ -18123,22 +17480,6 @@ packages:
   read-binary-file-arch@1.0.6:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
-
-  read-package-up@11.0.0:
-    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
-    engines: {node: '>=18'}
-
-  read-package-up@12.0.0:
-    resolution: {integrity: sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==}
-    engines: {node: '>=20'}
-
-  read-pkg@10.1.0:
-    resolution: {integrity: sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==}
-    engines: {node: '>=20'}
-
-  read-pkg@9.0.1:
-    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
-    engines: {node: '>=18'}
 
   readable-stream@1.0.34:
     resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
@@ -18318,14 +17659,6 @@ packages:
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
-  resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -18504,17 +17837,8 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
-  semantic-release@25.0.9:
-    resolution: {integrity: sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==}
-    engines: {node: ^22.14.0 || >= 24.10.0}
-    hasBin: true
-
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
-
-  semver-regex@4.0.5:
-    resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
-    engines: {node: '>=12'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -18611,10 +17935,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  signale@1.4.0:
-    resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
-    engines: {node: '>=6'}
-
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -18641,10 +17961,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  skin-tone@2.0.0:
-    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
-    engines: {node: '>=8'}
 
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
@@ -18734,20 +18050,11 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  spawn-error-forwarder@1.0.0:
-    resolution: {integrity: sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==}
-
   spawn-sync@1.0.15:
     resolution: {integrity: sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==}
 
-  spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
-
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-
-  spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
   spdx-expression-parse@4.0.0:
     resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
@@ -18764,9 +18071,6 @@ packages:
 
   split-skip@0.0.2:
     resolution: {integrity: sha512-weHOi8BolsDnGIwhhWHbA+wKSuSpvWwjRrdj8SdbIIis2vSwOE37CQP8x3EleuzxanUr3AK8BdUy4MkiOULPZg==}
-
-  split2@1.0.0:
-    resolution: {integrity: sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -18851,9 +18155,6 @@ packages:
   store2@2.14.4:
     resolution: {integrity: sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==}
 
-  stream-combiner2@1.1.1:
-    resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
-
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
@@ -18868,10 +18169,6 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  string-width@8.2.2:
-    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
-    engines: {node: '>=20'}
 
   string_decoder@0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
@@ -18909,10 +18206,6 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
-
   strip-bom@5.0.0:
     resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
     engines: {node: '>=12'}
@@ -18924,14 +18217,6 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
-  strip-final-newline@4.0.0:
-    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
-    engines: {node: '>=18'}
 
   strip-indent@4.1.1:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
@@ -18993,10 +18278,6 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
-  super-regex@1.1.0:
-    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
-    engines: {node: '>=18'}
-
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
@@ -19005,17 +18286,9 @@ packages:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
 
-  supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  supports-hyperlinks@3.2.0:
-    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
-    engines: {node: '>=14.18'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -19048,10 +18321,6 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
-
-  tagged-tag@1.0.0:
-    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
-    engines: {node: '>=20'}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
@@ -19086,10 +18355,6 @@ packages:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
 
-  temp-dir@3.0.0:
-    resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
-    engines: {node: '>=14.16'}
-
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
@@ -19100,10 +18365,6 @@ packages:
   tempy@0.6.0:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
     engines: {node: '>=10'}
-
-  tempy@3.2.0:
-    resolution: {integrity: sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==}
-    engines: {node: '>=14.16'}
 
   terser@5.46.1:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
@@ -19160,18 +18421,11 @@ packages:
   through2@0.6.5:
     resolution: {integrity: sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==}
 
-  through2@2.0.5:
-    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
-
   through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
-  time-span@5.1.0:
-    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
-    engines: {node: '>=12'}
 
   timm@1.7.1:
     resolution: {integrity: sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==}
@@ -19255,10 +18509,6 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
-
-  traverse@0.6.8:
-    resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
-    engines: {node: '>= 0.4'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -19346,10 +18596,6 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  tunnel@0.0.6:
-    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
-    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
-
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
@@ -19369,14 +18615,6 @@ packages:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
 
-  type-fest@1.4.0:
-    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
-    engines: {node: '>=10'}
-
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
-
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
@@ -19384,10 +18622,6 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
-
-  type-fest@5.8.0:
-    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
-    engines: {node: '>=20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -19454,11 +18688,6 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
@@ -19513,10 +18742,6 @@ packages:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
 
-  unicode-emoji-modifier-base@1.0.0:
-    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
-    engines: {node: '>=4'}
-
   unicode-match-property-ecmascript@2.0.0:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
     engines: {node: '>=4'}
@@ -19529,17 +18754,9 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
-  unicorn-magic@0.1.0:
-    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
-    engines: {node: '>=18'}
-
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
-
-  unicorn-magic@0.4.0:
-    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
-    engines: {node: '>=20'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -19559,10 +18776,6 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
-
-  unique-string@3.0.0:
-    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
-    engines: {node: '>=12'}
 
   unist-builder@4.0.0:
     resolution: {integrity: sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==}
@@ -19590,9 +18803,6 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
-  universal-user-agent@7.0.3:
-    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -19866,10 +19076,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url-join@5.0.0:
-    resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
@@ -19923,9 +19129,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -20475,9 +19678,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
   wordwrapjs@3.0.0:
     resolution: {integrity: sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==}
     engines: {node: '>=4.0.0'}
@@ -20694,32 +19894,16 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs-parser@7.0.0:
     resolution: {integrity: sha512-WhzC+xgstid9MbVUktco/bf+KJG+Uu6vMX0LN1sLJvwmbCQVxb4D8LzogobonKycNasCZLdOzTAk1SK7+K7swg==}
-
-  yargs@16.2.2:
-    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
-    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yargs@18.1.0:
-    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -20775,22 +19959,6 @@ snapshots:
       many-keys-map: 2.0.1
 
   '@acemir/cssom@0.9.31': {}
-
-  '@actions/core@3.0.1':
-    dependencies:
-      '@actions/exec': 3.0.0
-      '@actions/http-client': 4.0.1
-
-  '@actions/exec@3.0.0':
-    dependencies:
-      '@actions/io': 3.0.2
-
-  '@actions/http-client@4.0.1':
-    dependencies:
-      tunnel: 0.0.6
-      undici: 6.24.1
-
-  '@actions/io@3.0.2': {}
 
   '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
     dependencies:
@@ -22221,9 +21389,6 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
-  '@colors/colors@1.5.0':
-    optional: true
-
   '@cryptography/aes@0.1.1': {}
 
   '@csstools/color-helpers@5.1.0': {}
@@ -22417,9 +21582,9 @@ snapshots:
     dependencies:
       electron: 41.2.1
 
-  '@electron-toolkit/tsconfig@2.0.0(@types/node@25.6.0)':
+  '@electron-toolkit/tsconfig@2.0.0(@types/node@24.12.2)':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.2
 
   '@electron-toolkit/utils@4.0.0(electron@41.2.1)':
     dependencies:
@@ -23356,6 +22521,31 @@ snapshots:
       - supports-color
       - typescript
 
+  '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.7.0))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
+      '@intlify/bundle-utils': 11.0.7(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.3.2
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.32)(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@typescript-eslint/scope-manager': 8.63.0
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vue-i18n: 11.3.2(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
   '@intlify/unplugin-vue-i18n@11.0.7(@vue/compiler-dom@3.5.32)(eslint@10.2.1(jiti@2.7.0))(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-i18n@11.3.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1(jiti@2.7.0))
@@ -23976,72 +23166,6 @@ snapshots:
     optional: true
 
   '@nxg-org/mineflayer-util-plugin@1.8.4': {}
-
-  '@octokit/auth-token@6.0.0': {}
-
-  '@octokit/core@7.0.7':
-    dependencies:
-      '@octokit/auth-token': 6.0.0
-      '@octokit/graphql': 9.0.4
-      '@octokit/request': 10.0.13
-      '@octokit/request-error': 7.1.1
-      '@octokit/types': 17.0.0
-      before-after-hook: 4.0.0
-      universal-user-agent: 7.0.3
-
-  '@octokit/endpoint@11.0.4':
-    dependencies:
-      '@octokit/types': 17.0.0
-      universal-user-agent: 7.0.3
-
-  '@octokit/graphql@9.0.4':
-    dependencies:
-      '@octokit/request': 10.0.13
-      '@octokit/types': 17.0.0
-      universal-user-agent: 7.0.3
-
-  '@octokit/openapi-types@27.0.0': {}
-
-  '@octokit/openapi-types@28.0.0': {}
-
-  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
-    dependencies:
-      '@octokit/core': 7.0.7
-      '@octokit/types': 16.0.0
-
-  '@octokit/plugin-retry@8.1.1(@octokit/core@7.0.7)':
-    dependencies:
-      '@octokit/core': 7.0.7
-      '@octokit/request-error': 7.1.1
-      '@octokit/types': 17.0.0
-      bottleneck: 2.19.5
-
-  '@octokit/plugin-throttling@11.0.5(@octokit/core@7.0.7)':
-    dependencies:
-      '@octokit/core': 7.0.7
-      '@octokit/types': 17.0.0
-      bottleneck: 2.19.5
-
-  '@octokit/request-error@7.1.1':
-    dependencies:
-      '@octokit/types': 17.0.0
-
-  '@octokit/request@10.0.13':
-    dependencies:
-      '@octokit/endpoint': 11.0.4
-      '@octokit/request-error': 7.1.1
-      '@octokit/types': 17.0.0
-      content-type: 2.0.0
-      json-with-bigint: 3.5.10
-      universal-user-agent: 7.0.3
-
-  '@octokit/types@16.0.0':
-    dependencies:
-      '@octokit/openapi-types': 27.0.0
-
-  '@octokit/types@17.0.0':
-    dependencies:
-      '@octokit/openapi-types': 28.0.0
 
   '@one-ini/wasm@0.1.1': {}
 
@@ -25565,10 +24689,34 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@proj-airi/unplugin-fetch@0.2.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       ofetch: 1.5.1
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
+    dependencies:
+      ofetch: 1.5.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      yauzl: 3.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@proj-airi/unplugin-live2d-sdk@0.1.7(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
@@ -25924,117 +25072,6 @@ snapshots:
 
   '@sapphire/snowflake@3.5.5': {}
 
-  '@sec-ant/readable-stream@0.4.1': {}
-
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      '@semantic-release/error': 3.0.0
-      aggregate-error: 3.1.0
-      fs-extra: 11.3.4
-      lodash: 4.17.21
-      semantic-release: 25.0.9(typescript@5.9.3)
-
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      conventional-changelog-angular: 8.3.1
-      conventional-changelog-writer: 8.4.0
-      conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.4.0
-      debug: 4.4.3(supports-color@10.2.2)
-      import-from-esm: 2.0.0
-      lodash-es: 4.18.1
-      micromatch: 4.0.8
-      semantic-release: 25.0.9(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@semantic-release/error@3.0.0': {}
-
-  '@semantic-release/error@4.0.0': {}
-
-  '@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 3.1.0
-      debug: 4.4.3(supports-color@10.2.2)
-      execa: 9.6.1
-      lodash-es: 4.18.1
-      parse-json: 8.3.0
-      semantic-release: 25.0.9(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@semantic-release/git@10.0.1(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      '@semantic-release/error': 3.0.0
-      aggregate-error: 3.1.0
-      debug: 4.4.3(supports-color@10.2.2)
-      dir-glob: 3.0.1
-      execa: 5.1.1
-      lodash: 4.17.21
-      micromatch: 4.0.8
-      p-reduce: 2.1.0
-      semantic-release: 25.0.9(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      '@octokit/core': 7.0.7
-      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
-      '@octokit/plugin-retry': 8.1.1(@octokit/core@7.0.7)
-      '@octokit/plugin-throttling': 11.0.5(@octokit/core@7.0.7)
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 5.0.0
-      debug: 4.4.3(supports-color@10.2.2)
-      dir-glob: 3.0.1
-      http-proxy-agent: 9.1.0
-      https-proxy-agent: 9.1.0
-      issue-parser: 7.0.2
-      lodash-es: 4.18.1
-      mime: 4.1.0
-      p-filter: 4.1.0
-      semantic-release: 25.0.9(typescript@5.9.3)
-      tinyglobby: 0.2.17
-      undici: 7.25.0
-      url-join: 5.0.0
-    transitivePeerDependencies:
-      - kerberos
-      - supports-color
-
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      '@actions/core': 3.0.1
-      '@semantic-release/error': 4.0.0
-      aggregate-error: 5.0.0
-      env-ci: 11.2.0
-      execa: 9.6.1
-      fs-extra: 11.3.4
-      lodash-es: 4.18.1
-      nerf-dart: 1.0.0
-      normalize-url: 9.0.1
-      npm: 11.19.0
-      rc: 1.2.8
-      read-pkg: 10.1.0
-      registry-auth-token: 5.1.0
-      semantic-release: 25.0.9(typescript@5.9.3)
-      semver: 7.7.4
-      tempy: 3.2.0
-
-  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3))':
-    dependencies:
-      conventional-changelog-angular: 8.3.1
-      conventional-changelog-writer: 8.4.0
-      conventional-commits-filter: 5.0.0
-      conventional-commits-parser: 6.4.0
-      debug: 4.4.3(supports-color@10.2.2)
-      import-from-esm: 2.0.0
-      lodash-es: 4.18.1
-      read-package-up: 11.0.0
-      semantic-release: 25.0.9(typescript@5.9.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -26133,15 +25170,11 @@ snapshots:
     dependencies:
       '@simple-git/args-pathspec': 1.0.3
 
-  '@simple-libs/stream-utils@1.2.0': {}
-
   '@sindresorhus/base62@1.0.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
-
-  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@snazzah/davey-android-arm-eabi@0.1.11':
     optional: true
@@ -26637,8 +25670,6 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
-
-  '@types/normalize-package-data@2.4.4': {}
 
   '@types/nprogress@0.2.3': {}
 
@@ -27417,6 +26448,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vitejs/plugin-vue@6.0.6(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
@@ -27691,6 +26728,15 @@ snapshots:
       unplugin: 2.3.11
     transitivePeerDependencies:
       - vue
+
+  '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      sirv: 3.0.2
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@vue-macros/devtools@3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -28282,18 +27328,6 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-base@9.0.0: {}
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-
-  aggregate-error@5.0.0:
-    dependencies:
-      clean-stack: 5.3.0
-      indent-string: 5.0.0
-
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -28341,10 +27375,6 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
-
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -28457,8 +27487,6 @@ snapshots:
 
   args-tokenizer@0.3.0: {}
 
-  argv-formatter@1.0.0: {}
-
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -28472,8 +27500,6 @@ snapshots:
   array-back@6.2.2: {}
 
   array-differ@4.0.0: {}
-
-  array-ify@1.0.0: {}
 
   array-union@1.0.2:
     dependencies:
@@ -28630,8 +27656,6 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  before-after-hook@4.0.0: {}
-
   best-effort-json-parser@1.4.0: {}
 
   better-auth@1.4.22(@prisma/client@5.22.0)(better-sqlite3@12.5.0)(drizzle-kit@0.31.10)(drizzle-orm@0.41.0(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/pg@8.20.0)(better-sqlite3@12.5.0)(kysely@0.29.4)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react@19.2.3)(vitest@4.1.4)(vue@3.5.32(typescript@5.9.3)):
@@ -28775,8 +27799,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   boolean@3.2.0: {}
-
-  bottleneck@2.19.5: {}
 
   boxen@8.0.1:
     dependencies:
@@ -28958,8 +27980,6 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  callsites@3.1.0: {}
-
   camelcase@4.1.0: {}
 
   camelcase@8.0.0: {}
@@ -28989,12 +28009,6 @@ snapshots:
     dependencies:
       chalk: 4.1.2
 
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -29003,8 +28017,6 @@ snapshots:
   chalk@5.6.2: {}
 
   change-case@5.4.4: {}
-
-  char-regex@1.0.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -29064,12 +28076,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  clean-stack@2.2.0: {}
-
-  clean-stack@5.3.0:
-    dependencies:
-      escape-string-regexp: 5.0.0
-
   cli-boxes@3.0.0: {}
 
   cli-cursor@3.1.0:
@@ -29080,24 +28086,9 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-highlight@2.1.11:
-    dependencies:
-      chalk: 4.1.2
-      highlight.js: 10.7.3
-      mz: 2.7.0
-      parse5: 5.1.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      yargs: 16.2.2
-
   cli-spinners@2.9.2: {}
 
   cli-spinners@3.4.0: {}
-
-  cli-table3@0.6.5:
-    dependencies:
-      string-width: 4.2.3
-    optionalDependencies:
-      '@colors/colors': 1.5.0
 
   cli-truncate@2.1.0:
     dependencies:
@@ -29121,23 +28112,11 @@ snapshots:
       strip-ansi: 4.0.0
       yargs-parser: 7.0.0
 
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.1.2
-      wrap-ansi: 9.0.2
 
   clone-response@1.0.3:
     dependencies:
@@ -29149,15 +28128,9 @@ snapshots:
 
   clustr@1.0.2: {}
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -29239,11 +28212,6 @@ snapshots:
 
   commondir@1.0.1: {}
 
-  compare-func@2.0.0:
-    dependencies:
-      array-ify: 1.0.0
-      dot-prop: 5.3.0
-
   compare-version@0.1.2: {}
 
   compressible@2.0.18:
@@ -29306,29 +28274,6 @@ snapshots:
 
   content-type@1.0.5: {}
 
-  content-type@2.0.0: {}
-
-  conventional-changelog-angular@8.3.1:
-    dependencies:
-      compare-func: 2.0.0
-
-  conventional-changelog-writer@8.4.0:
-    dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-      conventional-commits-filter: 5.0.0
-      handlebars: 4.7.9
-      meow: 13.2.0
-      semver: 7.7.4
-
-  conventional-commits-filter@5.0.0: {}
-
-  conventional-commits-parser@6.4.0:
-    dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-      meow: 13.2.0
-
-  convert-hrtime@5.0.0: {}
-
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
@@ -29362,15 +28307,6 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@9.0.2(typescript@5.9.3):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 5.9.3
-
   crc@3.8.0:
     dependencies:
       buffer: 5.7.1
@@ -29396,10 +28332,6 @@ snapshots:
       srvx: 0.11.22
 
   crypto-random-string@2.0.0: {}
-
-  crypto-random-string@4.0.0:
-    dependencies:
-      type-fest: 1.4.0
 
   css-line-break@2.1.0:
     dependencies:
@@ -29718,10 +28650,6 @@ snapshots:
       minimatch: 3.1.5
       p-limit: 3.1.0
 
-  dir-glob@3.0.1:
-    dependencies:
-      path-type: 4.0.0
-
   direction@2.0.1: {}
 
   discontinuous-range@1.0.0: {}
@@ -29810,10 +28738,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  dot-prop@5.3.0:
-    dependencies:
-      is-obj: 2.0.0
-
   dot-prop@9.0.0:
     dependencies:
       type-fest: 4.41.0
@@ -29877,10 +28801,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  duplexer2@0.1.4:
-    dependencies:
-      readable-stream: 2.3.8
 
   duplexer@0.1.2: {}
 
@@ -29972,7 +28892,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@5.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -29980,7 +28900,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -30041,8 +28961,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
-
-  emojilib@2.4.0: {}
 
   empathic@2.0.0: {}
 
@@ -30105,11 +29023,6 @@ snapshots:
   entities@7.0.1: {}
 
   entities@8.0.0: {}
-
-  env-ci@11.2.0:
-    dependencies:
-      execa: 8.0.1
-      java-properties: 1.0.2
 
   env-paths@2.2.1: {}
 
@@ -30654,33 +29567,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
-  execa@9.6.1:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      cross-spawn: 7.0.6
-      figures: 6.1.0
-      get-stream: 9.0.1
-      human-signals: 8.0.1
-      is-plain-obj: 4.1.0
-      is-stream: 4.0.1
-      npm-run-path: 6.0.0
-      pretty-ms: 9.3.0
-      signal-exit: 4.1.0
-      strip-final-newline: 4.0.0
-      yoctocolors: 2.1.2
-
   exif-parser@0.1.12: {}
 
   expand-template@2.0.3: {}
@@ -30856,14 +29742,6 @@ snapshots:
 
   fflate@0.8.3: {}
 
-  figures@2.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
-  figures@6.1.0:
-    dependencies:
-      is-unicode-supported: 2.1.0
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -30956,11 +29834,6 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-
-  find-versions@6.0.0:
-    dependencies:
-      semver-regex: 4.0.5
-      super-regex: 1.1.0
 
   firefox-profile@4.7.0:
     dependencies:
@@ -31116,8 +29989,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  function-timeout@1.0.2: {}
-
   functional-red-black-tree@1.0.1: {}
 
   fuse.js@7.1.0: {}
@@ -31188,13 +30059,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-stream@8.0.1: {}
-
-  get-stream@9.0.1:
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
-
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -31226,15 +30090,6 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
-
-  git-log-parser@1.2.1:
-    dependencies:
-      argv-formatter: 1.0.0
-      spawn-error-forwarder: 1.0.0
-      split2: 1.0.0
-      stream-combiner2: 1.1.1
-      through2: 2.0.5
-      traverse: 0.6.8
 
   git-up@8.1.1:
     dependencies:
@@ -31425,23 +30280,12 @@ snapshots:
       rou3: 0.9.1
       srvx: 0.11.22
 
-  handlebars@4.7.9:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
   har-schema@2.0.0: {}
 
   har-validator@5.1.5:
     dependencies:
       ajv: 6.14.0
       har-schema: 2.0.0
-
-  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -31615,8 +30459,6 @@ snapshots:
       gray-matter: 4.0.3
       unplugin: 3.0.0
 
-  highlight.js@10.7.3: {}
-
   histoire@1.0.0-beta.1(@noble/hashes@2.0.1)(@types/node@25.6.0)(bufferutil@4.1.0)(canvas@3.2.3)(less@4.6.4)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(utf-8-validate@5.0.10)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@akryum/tinypool': 0.3.1
@@ -31676,8 +30518,6 @@ snapshots:
 
   hono@4.12.2: {}
 
-  hook-std@4.0.0: {}
-
   hookable@5.5.3: {}
 
   hookable@6.1.1: {}
@@ -31685,14 +30525,6 @@ snapshots:
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
-
-  hosted-git-info@7.0.2:
-    dependencies:
-      lru-cache: 10.4.3
-
-  hosted-git-info@9.0.3:
-    dependencies:
-      lru-cache: 11.3.5
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
     dependencies:
@@ -31746,15 +30578,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@9.1.0:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3(supports-color@10.2.2)
-      proxy-agent-negotiate: 1.1.0
-    transitivePeerDependencies:
-      - kerberos
-      - supports-color
-
   http-signature@1.2.0:
     dependencies:
       assert-plus: 1.0.0
@@ -31773,20 +30596,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@9.1.0:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3(supports-color@10.2.2)
-      proxy-agent-negotiate: 1.1.0
-    transitivePeerDependencies:
-      - kerberos
-      - supports-color
-
   human-signals@2.1.0: {}
-
-  human-signals@5.0.0: {}
-
-  human-signals@8.0.1: {}
 
   iconv-corefoundation@1.1.7:
     dependencies:
@@ -31832,19 +30642,7 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
   import-from-esm@1.3.4:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      import-meta-resolve: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  import-from-esm@2.0.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       import-meta-resolve: 4.2.0
@@ -31864,11 +30662,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  indent-string@4.0.0: {}
-
   indent-string@5.0.0: {}
-
-  index-to-position@1.2.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -32018,8 +30812,6 @@ snapshots:
 
   is-obj@1.0.1: {}
 
-  is-obj@2.0.0: {}
-
   is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -32046,15 +30838,9 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  is-stream@3.0.0: {}
-
-  is-stream@4.0.1: {}
-
   is-typedarray@1.0.0: {}
 
   is-unicode-supported@0.1.0: {}
-
-  is-unicode-supported@2.1.0: {}
 
   is-what@4.1.16: {}
 
@@ -32093,14 +30879,6 @@ snapshots:
 
   isstream@0.1.2: {}
 
-  issue-parser@7.0.2:
-    dependencies:
-      lodash.capitalize: 4.2.1
-      lodash.escaperegexp: 4.1.2
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.uniqby: 4.7.0
-
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -32129,8 +30907,6 @@ snapshots:
       async: 3.2.6
       filelist: 1.0.4
       picocolors: 1.1.1
-
-  java-properties@1.0.2: {}
 
   jiti@2.7.0: {}
 
@@ -32237,10 +31013,6 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
-  json-parse-better-errors@1.0.2: {}
-
-  json-parse-even-better-errors@2.3.1: {}
-
   json-parse-even-better-errors@3.0.2: {}
 
   json-schema-traverse@0.4.1: {}
@@ -32254,8 +31026,6 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
-
-  json-with-bigint@3.5.10: {}
 
   json5@2.2.3: {}
 
@@ -32521,13 +31291,6 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
 
-  load-json-file@4.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 4.0.0
-      pify: 3.0.0
-      strip-bom: 3.0.0
-
   local-pkg@1.1.2:
     dependencies:
       mlly: 1.8.0
@@ -32551,11 +31314,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.18.1: {}
-
   lodash.camelcase@4.3.0: {}
-
-  lodash.capitalize@4.2.1: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -32592,8 +31351,6 @@ snapshots:
   lodash.sortby@4.7.0: {}
 
   lodash.truncate@4.4.2: {}
-
-  lodash.uniqby@4.7.0: {}
 
   lodash@4.17.21: {}
 
@@ -32674,12 +31431,6 @@ snapshots:
       for-each-property: 0.0.4
       inspect-property: 0.0.6
 
-  make-asynchronous@1.1.0:
-    dependencies:
-      p-event: 6.0.1
-      type-fest: 4.41.0
-      web-worker: 1.5.0
-
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
@@ -32737,19 +31488,6 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
-
-  marked-terminal@7.3.0(marked@15.0.12):
-    dependencies:
-      ansi-escapes: 7.2.0
-      ansi-regex: 6.2.2
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      cli-table3: 0.6.5
-      marked: 15.0.12
-      node-emoji: 2.2.0
-      supports-hyperlinks: 3.2.0
-
-  marked@15.0.12: {}
 
   marky@1.3.0: {}
 
@@ -32908,8 +31646,6 @@ snapshots:
     dependencies:
       '@types/dom-mediacapture-transform': 0.1.11
       '@types/dom-webcodecs': 0.1.13
-
-  meow@13.2.0: {}
 
   meow@14.1.0: {}
 
@@ -33158,11 +31894,7 @@ snapshots:
 
   mime@3.0.0: {}
 
-  mime@4.1.0: {}
-
   mimic-fn@2.1.0: {}
-
-  mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -33492,10 +32224,6 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neo-async@2.6.2: {}
-
-  nerf-dart@1.0.0: {}
-
   neverthrow@8.2.0:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.60.1
@@ -33522,13 +32250,6 @@ snapshots:
       semver: 7.7.4
 
   node-domexception@1.0.0: {}
-
-  node-emoji@2.2.0:
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      char-regex: 1.0.2
-      emojilib: 2.4.0
-      skin-tone: 2.0.0
 
   node-fetch-native@1.6.7: {}
 
@@ -33603,38 +32324,13 @@ snapshots:
     dependencies:
       abbrev: 3.0.1
 
-  normalize-package-data@6.0.2:
-    dependencies:
-      hosted-git-info: 7.0.2
-      semver: 7.7.4
-      validate-npm-package-license: 3.0.4
-
-  normalize-package-data@8.0.0:
-    dependencies:
-      hosted-git-info: 9.0.3
-      semver: 7.7.4
-      validate-npm-package-license: 3.0.4
-
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
 
-  normalize-url@9.0.1: {}
-
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
-  npm-run-path@6.0.0:
-    dependencies:
-      path-key: 4.0.0
-      unicorn-magic: 0.3.0
-
-  npm@11.19.0: {}
 
   nprogress@0.2.0: {}
 
@@ -33699,10 +32395,6 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
 
   onetime@7.0.0:
     dependencies:
@@ -33941,16 +32633,6 @@ snapshots:
 
   p-cancelable@2.1.1: {}
 
-  p-each-series@3.0.0: {}
-
-  p-event@6.0.1:
-    dependencies:
-      p-timeout: 6.1.4
-
-  p-filter@4.1.0:
-    dependencies:
-      p-map: 7.0.4
-
   p-limit@1.3.0:
     dependencies:
       p-try: 1.0.0
@@ -33981,12 +32663,6 @@ snapshots:
 
   p-map@7.0.4: {}
 
-  p-reduce@2.1.0: {}
-
-  p-reduce@3.0.0: {}
-
-  p-timeout@6.1.4: {}
-
   p-try@1.0.0: {}
 
   p-try@2.2.0: {}
@@ -34006,27 +32682,11 @@ snapshots:
 
   pako@2.1.0: {}
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
   parse-gitignore@2.0.0: {}
 
   parse-imports-exports@0.2.4:
     dependencies:
       parse-statements: 1.0.11
-
-  parse-json@4.0.0:
-    dependencies:
-      error-ex: 1.3.4
-      json-parse-better-errors: 1.0.2
-
-  parse-json@5.2.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      error-ex: 1.3.4
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
 
   parse-json@7.1.1:
     dependencies:
@@ -34035,14 +32695,6 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
-
-  parse-json@8.3.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      index-to-position: 1.2.0
-      type-fest: 4.41.0
-
-  parse-ms@4.0.0: {}
 
   parse-node-version@1.0.1: {}
 
@@ -34056,14 +32708,6 @@ snapshots:
     dependencies:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    dependencies:
-      parse5: 6.0.1
-
-  parse5@5.1.1: {}
-
-  parse5@6.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -34087,8 +32731,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-key@4.0.0: {}
-
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -34104,8 +32746,6 @@ snapshots:
   path-to-regexp@0.1.12: {}
 
   path-to-regexp@8.3.0: {}
-
-  path-type@4.0.0: {}
 
   path-type@6.0.0: {}
 
@@ -34169,8 +32809,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@2.3.0: {}
-
-  pify@3.0.0: {}
 
   pify@4.0.1:
     optional: true
@@ -34278,11 +32916,6 @@ snapshots:
       gh-pages: 4.0.0
 
   pkce-challenge@5.0.1: {}
-
-  pkg-conf@2.1.0:
-    dependencies:
-      find-up: 2.1.0
-      load-json-file: 4.0.0
 
   pkg-dir@4.2.0:
     dependencies:
@@ -34424,10 +33057,6 @@ snapshots:
   pretty-bytes@5.6.0: {}
 
   pretty-bytes@6.1.1: {}
-
-  pretty-ms@9.3.0:
-    dependencies:
-      parse-ms: 4.0.0
 
   prism-media@1.3.5(opusscript@0.1.1):
     optionalDependencies:
@@ -34654,8 +33283,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent-negotiate@1.1.0: {}
-
   prr@1.0.1:
     optional: true
 
@@ -34768,34 +33395,6 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-
-  read-package-up@11.0.0:
-    dependencies:
-      find-up-simple: 1.0.1
-      read-pkg: 9.0.1
-      type-fest: 4.41.0
-
-  read-package-up@12.0.0:
-    dependencies:
-      find-up-simple: 1.0.1
-      read-pkg: 10.1.0
-      type-fest: 5.8.0
-
-  read-pkg@10.1.0:
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 8.0.0
-      parse-json: 8.3.0
-      type-fest: 5.8.0
-      unicorn-magic: 0.4.0
-
-  read-pkg@9.0.1:
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 6.0.2
-      parse-json: 8.3.0
-      type-fest: 4.41.0
-      unicorn-magic: 0.1.0
 
   readable-stream@1.0.34:
     dependencies:
@@ -35043,10 +33642,6 @@ snapshots:
   reserved-identifiers@1.2.0: {}
 
   resolve-alpn@1.2.1: {}
-
-  resolve-from@4.0.0: {}
-
-  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -35304,44 +33899,7 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  semantic-release@25.0.9(typescript@5.9.3):
-    dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.9(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.9(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.9(typescript@5.9.3))
-      aggregate-error: 5.0.0
-      cosmiconfig: 9.0.2(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
-      env-ci: 11.2.0
-      execa: 9.6.1
-      figures: 6.1.0
-      find-versions: 6.0.0
-      get-stream: 6.0.1
-      git-log-parser: 1.2.1
-      hook-std: 4.0.0
-      hosted-git-info: 9.0.3
-      import-from-esm: 2.0.0
-      lodash-es: 4.18.1
-      marked: 15.0.12
-      marked-terminal: 7.3.0(marked@15.0.12)
-      micromatch: 4.0.8
-      p-each-series: 3.0.0
-      p-reduce: 3.0.0
-      read-package-up: 12.0.0
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      signale: 1.4.0
-      yargs: 18.1.0
-    transitivePeerDependencies:
-      - kerberos
-      - supports-color
-      - typescript
-
   semver-compare@1.0.0: {}
-
-  semver-regex@4.0.5: {}
 
   semver@5.7.2: {}
 
@@ -35504,12 +34062,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  signale@1.4.0:
-    dependencies:
-      chalk: 2.4.2
-      figures: 2.0.0
-      pkg-conf: 2.1.0
-
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -35545,10 +34097,6 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
-
-  skin-tone@2.0.0:
-    dependencies:
-      unicode-emoji-modifier-base: 1.0.0
 
   slash@5.1.0: {}
 
@@ -35660,24 +34208,12 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  spawn-error-forwarder@1.0.0: {}
-
   spawn-sync@1.0.15:
     dependencies:
       concat-stream: 1.6.2
       os-shim: 0.1.3
 
-  spdx-correct@3.2.0:
-    dependencies:
-      spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.22
-
   spdx-exceptions@2.5.0: {}
-
-  spdx-expression-parse@3.0.1:
-    dependencies:
-      spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
 
   spdx-expression-parse@4.0.0:
     dependencies:
@@ -35691,10 +34227,6 @@ snapshots:
   split-skip@0.0.1: {}
 
   split-skip@0.0.2: {}
-
-  split2@1.0.0:
-    dependencies:
-      through2: 2.0.5
 
   split2@4.2.0: {}
 
@@ -35776,11 +34308,6 @@ snapshots:
 
   store2@2.14.4: {}
 
-  stream-combiner2@1.1.1:
-    dependencies:
-      duplexer2: 0.1.4
-      readable-stream: 2.3.8
-
   streamx@2.28.0:
     dependencies:
       events-universal: 1.0.1
@@ -35805,11 +34332,6 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.1.2
-
-  string-width@8.2.2:
-    dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
@@ -35853,17 +34375,11 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  strip-bom@3.0.0: {}
-
   strip-bom@5.0.0: {}
 
   strip-comments@2.0.1: {}
 
   strip-final-newline@2.0.0: {}
-
-  strip-final-newline@3.0.0: {}
-
-  strip-final-newline@4.0.0: {}
 
   strip-indent@4.1.1: {}
 
@@ -35921,30 +34437,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  super-regex@1.1.0:
-    dependencies:
-      function-timeout: 1.0.2
-      make-asynchronous: 1.1.0
-      time-span: 5.1.0
-
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
 
   supports-color@10.2.2: {}
 
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-hyperlinks@3.2.0:
-    dependencies:
-      has-flag: 4.0.0
-      supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -35983,8 +34484,6 @@ snapshots:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  tagged-tag@1.0.0: {}
 
   tapable@2.3.0: {}
 
@@ -36069,8 +34568,6 @@ snapshots:
 
   temp-dir@2.0.0: {}
 
-  temp-dir@3.0.0: {}
-
   temp-file@3.4.0:
     dependencies:
       async-exit-hook: 2.0.1
@@ -36087,13 +34584,6 @@ snapshots:
       temp-dir: 2.0.0
       type-fest: 0.16.0
       unique-string: 2.0.0
-
-  tempy@3.2.0:
-    dependencies:
-      is-stream: 3.0.0
-      temp-dir: 3.0.0
-      type-fest: 2.19.0
-      unique-string: 3.0.0
 
   terser@5.46.1:
     dependencies:
@@ -36159,20 +34649,11 @@ snapshots:
       readable-stream: 1.0.34
       xtend: 4.0.2
 
-  through2@2.0.5:
-    dependencies:
-      readable-stream: 2.3.8
-      xtend: 4.0.2
-
   through2@4.0.2:
     dependencies:
       readable-stream: 3.6.2
 
   through@2.3.8: {}
-
-  time-span@5.1.0:
-    dependencies:
-      convert-hrtime: 5.0.0
 
   timm@1.7.1: {}
 
@@ -36247,8 +34728,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-
-  traverse@0.6.8: {}
 
   tree-kill@1.2.2: {}
 
@@ -36331,8 +34810,6 @@ snapshots:
     dependencies:
       safe-buffer: '@nolyfill/safe-buffer@1.0.44'
 
-  tunnel@0.0.6: {}
-
   turbo@2.9.6:
     optionalDependencies:
       '@turbo/darwin-64': 2.9.6
@@ -36352,17 +34829,9 @@ snapshots:
 
   type-fest@0.16.0: {}
 
-  type-fest@1.4.0: {}
-
-  type-fest@2.19.0: {}
-
   type-fest@3.13.1: {}
 
   type-fest@4.41.0: {}
-
-  type-fest@5.8.0:
-    dependencies:
-      tagged-tag: 1.0.0
 
   type-is@1.6.18:
     dependencies:
@@ -36418,9 +34887,6 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  uglify-js@3.19.3:
-    optional: true
-
   uhyphen@0.2.0: {}
 
   uint4@0.1.2: {}
@@ -36470,8 +34936,6 @@ snapshots:
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
-  unicode-emoji-modifier-base@1.0.0: {}
-
   unicode-match-property-ecmascript@2.0.0:
     dependencies:
       unicode-canonical-property-names-ecmascript: 2.0.1
@@ -36481,11 +34945,7 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
-  unicorn-magic@0.1.0: {}
-
   unicorn-magic@0.3.0: {}
-
-  unicorn-magic@0.4.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -36525,10 +34985,6 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
-
-  unique-string@3.0.0:
-    dependencies:
-      crypto-random-string: 4.0.0
 
   unist-builder@4.0.0:
     dependencies:
@@ -36573,8 +35029,6 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  universal-user-agent@7.0.3: {}
-
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -36583,11 +35037,6 @@ snapshots:
     dependencies:
       '@unocss/preset-mini': 66.6.8
       unocss: 66.6.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-
-  unocss-preset-scrollbar@4.0.0(unocss@66.6.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
-    dependencies:
-      '@unocss/preset-mini': 66.6.8
-      unocss: 66.6.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   unocss@66.6.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -36655,6 +35104,14 @@ snapshots:
       unplugin: 2.3.11
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      unplugin: 2.3.11
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-combine@2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       esbuild: 0.27.2
@@ -36673,6 +35130,19 @@ snapshots:
       esbuild: 0.27.2
       rollup: 2.80.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-info@1.3.2(esbuild@0.27.2)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ci-info: 4.4.0
+      git-url-parse: 16.1.0
+      simple-git: 3.36.0
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -36769,6 +35239,17 @@ snapshots:
       rollup: 2.80.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      unplugin: 3.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.0.0-rc.16
+      rollup: 4.60.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   unplugin-yaml@4.1.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
@@ -36857,8 +35338,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-join@5.0.0: {}
-
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
@@ -36897,11 +35376,6 @@ snapshots:
   valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
-
-  validate-npm-package-license@3.0.4:
-    dependencies:
-      spdx-correct: 3.2.0
-      spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@5.0.1: {}
 
@@ -37014,11 +35488,21 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
@@ -37065,6 +35549,21 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3(supports-color@10.2.2)
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
@@ -37096,6 +35595,13 @@ snapshots:
       - typescript
       - ws
 
+  vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   vite-plugin-mkcert@2.0.0(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -37114,6 +35620,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
   vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -37128,6 +35648,21 @@ snapshots:
       - supports-color
       - vue
 
+  vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   vite-plugin-vue-inspector@5.3.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -37140,6 +35675,16 @@ snapshots:
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-layouts@0.11.0(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.32(typescript@5.9.3)
+      vue-router: 5.0.4(@pinia/colada@1.2.1(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -37427,6 +35972,54 @@ snapshots:
       - vue-tsc
       - webpack
 
+  vue-macros@3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@vue-macros/better-define': 3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/boolean-prop': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/chain-call': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/config': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-emit': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-models': 3.1.2(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-prop': 3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props': 3.1.2(@vue-macros/reactivity-transform@3.1.2(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-props-refs': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-slots': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/define-stylex': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/devtools': 3.1.2(typescript@5.9.3)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vue-macros/export-expose': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-props': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/export-render': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/hoist-static': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/jsx-directive': 3.1.2(typescript@5.9.3)
+      '@vue-macros/named-template': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/reactivity-transform': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/script-lang': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-block': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-component': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/setup-sfc': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-bind': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-emits': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/short-vmodel': 3.1.2(vue@3.5.32(typescript@5.9.3))
+      '@vue-macros/volar': 3.1.2(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3))
+      unplugin: 2.3.11
+      unplugin-combine: 2.3.0(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(unplugin@2.3.11)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      unplugin-vue-define-options: 3.1.2(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rspack/core'
+      - '@vueuse/core'
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - vite
+      - vue-tsc
+      - webpack
+
   vue-macros@3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@vueuse/core@14.2.1(vue@3.5.32(typescript@5.9.3)))(esbuild@0.27.2)(rolldown@1.0.0-rc.16)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.7.0)(less@4.6.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@vue-macros/better-define': 3.1.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(vue@3.5.32(typescript@5.9.3))
@@ -37584,7 +36177,8 @@ snapshots:
 
   web-vitals@4.2.4: {}
 
-  web-worker@1.5.0: {}
+  web-worker@1.5.0:
+    optional: true
 
   webidl-conversions@3.0.1: {}
 
@@ -37674,8 +36268,6 @@ snapshots:
   wlipsync@1.3.0: {}
 
   word-wrap@1.2.5: {}
-
-  wordwrap@1.0.0: {}
 
   wordwrapjs@3.0.0:
     dependencies:
@@ -37972,25 +36564,11 @@ snapshots:
 
   yaml@2.8.3: {}
 
-  yargs-parser@20.2.9: {}
-
   yargs-parser@21.1.1: {}
-
-  yargs-parser@22.0.0: {}
 
   yargs-parser@7.0.0:
     dependencies:
       camelcase: 4.1.0
-
-  yargs@16.2.2:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:
@@ -38001,15 +36579,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.1.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 8.2.2
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:

--- a/server/apps/api/src/routes/admin/config/router/index.ts
+++ b/server/apps/api/src/routes/admin/config/router/index.ts
@@ -24,6 +24,7 @@ import {
 
 import { adminGuard } from '../../../../middlewares/admin-guard'
 import { authGuard } from '../../../../middlewares/auth'
+import { STEPFUN_STREAMING_TTS_MODEL_IDS } from '../../../../services/adapters/config-kv'
 import { createBadRequestError } from '../../../../utils/error'
 
 /**
@@ -106,18 +107,16 @@ const StepfunSliceSchema = object({
   existingKeyEntryId: optional(pipe(string(), nonEmpty(), maxLength(200), NO_PIPE)),
 })
 
-const STEPFUN_STREAMING_MODEL_ID = /^stepfun\/(?:stepaudio-2\.5-tts|step-tts-2|step-tts-mini)$/
-
 const StepfunStreamingSliceSchema = pipe(object({
   kind: literal('stepfun-streaming'),
-  enabled: boolean(),
+  rollout: picklist(['disabled', 'available', 'default']),
   upstreamURL: pipe(string(), regex(/^wss?:\/\/\S+$/, 'upstreamURL must start with ws:// or wss://'), maxLength(500)),
   models: pipe(array(object({
-    id: pipe(string(), regex(STEPFUN_STREAMING_MODEL_ID, 'models[].id must be a supported StepFun streaming model'), maxLength(200)),
+    id: picklist(STEPFUN_STREAMING_TTS_MODEL_IDS, 'models[].id must be a supported StepFun streaming model'),
     name: optional(pipe(string(), nonEmpty(), maxLength(200))),
     description: optional(pipe(string(), nonEmpty(), maxLength(500))),
   })), minLength(1, 'models must not be empty')),
-  defaultModel: pipe(string(), regex(STEPFUN_STREAMING_MODEL_ID, 'defaultModel must be a supported StepFun streaming model'), maxLength(200)),
+  defaultModel: picklist(STEPFUN_STREAMING_TTS_MODEL_IDS, 'defaultModel must be a supported StepFun streaming model'),
   voices: pipe(array(object({
     id: pipe(string(), nonEmpty('voices[].id is required'), maxLength(200)),
     name: optional(pipe(string(), nonEmpty(), maxLength(200))),
@@ -129,7 +128,7 @@ const StepfunStreamingSliceSchema = pipe(object({
   plaintextKey: optional(pipe(string(), nonEmpty('plaintextKey must not be empty when provided'), maxLength(MAX_KEY_LENGTH))),
   keyEntryId: optional(pipe(string(), nonEmpty(), maxLength(200), NO_PIPE)),
   existingKeyEntryId: optional(pipe(string(), nonEmpty(), maxLength(200), NO_PIPE)),
-}), check(config => new Set(config.models.map(model => model.id)).size === config.models.length, 'models[].id must be unique'), check(config => config.models.some(model => model.id === config.defaultModel), 'defaultModel must be present in models'))
+}), check(config => new Set(config.models.map(model => model.id)).size === config.models.length, 'models[].id must be unique'), check(config => config.models.some(model => model.id === config.defaultModel), 'defaultModel must be present in models'), check(config => new Set(config.voices.map(voice => voice.id)).size === config.voices.length, 'voices[].id must be unique'))
 
 const AliyunNlsAsrSliceSchema = object({
   kind: literal('aliyun-nls-asr'),
@@ -220,7 +219,8 @@ const BodySchema = object({
 /**
  * Admin route for seeding / patching the LLM router config tree. Mounted
  * at `POST /api/admin/config/router`; the only supported way to write
- * `LLM_ROUTER_CONFIG`, `UNSPEECH_UPSTREAM`, and the
+ * `LLM_ROUTER_CONFIG`, `UNSPEECH_UPSTREAM`,
+ * `STEPFUN_STREAMING_TTS_UPSTREAM`, and the
  * `DEFAULT_{CHAT,TTS}_MODEL` aliases.
  *
  * Body shape (discriminated on `slices[].kind`):
@@ -246,6 +246,11 @@ const BodySchema = object({
  *       { "kind": "stepfun", "modelName": "stepfun/stepaudio-2.5-tts",
  *         "upstreamModel": "stepaudio-2.5-tts",
  *         "defaultVoice": "cixingnansheng", "plaintextKey": "..." },
+ *       { "kind": "stepfun-streaming", "rollout": "available",
+ *         "upstreamURL": "wss://api.stepfun.com/v1/realtime/audio",
+ *         "models": [{ "id": "stepfun/step-tts-2" }],
+ *         "defaultModel": "stepfun/step-tts-2",
+ *         "voices": [{ "id": "lively-girl" }], "plaintextKey": "..." },
  *       { "kind": "aliyun-nls-asr", "modelName": "auto",
  *         "accessKeyId": "...", "appKey": "...", "plaintextKey": "..." },
  *       { "kind": "unspeech",

--- a/server/apps/api/src/routes/admin/config/router/index.ts
+++ b/server/apps/api/src/routes/admin/config/router/index.ts
@@ -5,8 +5,10 @@ import { Hono } from 'hono'
 import {
   array,
   boolean,
+  check,
   literal,
   maxLength,
+  minLength,
   nonEmpty,
   object,
   optional,
@@ -104,6 +106,31 @@ const StepfunSliceSchema = object({
   existingKeyEntryId: optional(pipe(string(), nonEmpty(), maxLength(200), NO_PIPE)),
 })
 
+const STEPFUN_STREAMING_MODEL_ID = /^stepfun\/(?:stepaudio-2\.5-tts|step-tts-2|step-tts-mini)$/
+
+const StepfunStreamingSliceSchema = pipe(object({
+  kind: literal('stepfun-streaming'),
+  enabled: boolean(),
+  upstreamURL: pipe(string(), regex(/^wss?:\/\/\S+$/, 'upstreamURL must start with ws:// or wss://'), maxLength(500)),
+  models: pipe(array(object({
+    id: pipe(string(), regex(STEPFUN_STREAMING_MODEL_ID, 'models[].id must be a supported StepFun streaming model'), maxLength(200)),
+    name: optional(pipe(string(), nonEmpty(), maxLength(200))),
+    description: optional(pipe(string(), nonEmpty(), maxLength(500))),
+  })), minLength(1, 'models must not be empty')),
+  defaultModel: pipe(string(), regex(STEPFUN_STREAMING_MODEL_ID, 'defaultModel must be a supported StepFun streaming model'), maxLength(200)),
+  voices: pipe(array(object({
+    id: pipe(string(), nonEmpty('voices[].id is required'), maxLength(200)),
+    name: optional(pipe(string(), nonEmpty(), maxLength(200))),
+    description: optional(pipe(string(), nonEmpty(), maxLength(500))),
+    labels: optional(record(string(), string())),
+    languages: optional(array(object({ code: pipe(string(), nonEmpty()), title: pipe(string(), nonEmpty()) }))),
+  })), minLength(1, 'voices must not be empty')),
+  instruction: optional(pipe(string(), nonEmpty(), maxLength(200))),
+  plaintextKey: optional(pipe(string(), nonEmpty('plaintextKey must not be empty when provided'), maxLength(MAX_KEY_LENGTH))),
+  keyEntryId: optional(pipe(string(), nonEmpty(), maxLength(200), NO_PIPE)),
+  existingKeyEntryId: optional(pipe(string(), nonEmpty(), maxLength(200), NO_PIPE)),
+}), check(config => new Set(config.models.map(model => model.id)).size === config.models.length, 'models[].id must be unique'), check(config => config.models.some(model => model.id === config.defaultModel), 'defaultModel must be present in models'))
+
 const AliyunNlsAsrSliceSchema = object({
   kind: literal('aliyun-nls-asr'),
   modelName: pipe(string(), nonEmpty('modelName is required'), maxLength(200), NO_PIPE),
@@ -162,6 +189,7 @@ const SliceSchema = variant('kind', [
   AzureSliceSchema,
   DashscopeSliceSchema,
   StepfunSliceSchema,
+  StepfunStreamingSliceSchema,
   AliyunNlsAsrSliceSchema,
   UnspeechSliceSchema,
 ])

--- a/server/apps/api/src/routes/audio-speech-ws/provider.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/provider.ts
@@ -1,0 +1,126 @@
+import type { ConfigKVService, StepfunStreamingTtsUpstream, UnspeechUpstream } from '../../services/adapters/config-kv'
+import type { StreamingTtsStartCommand } from './providers/types'
+
+import { ofetch } from 'ofetch'
+
+import { STEPFUN_STREAMING_TTS_KEY_CONTEXT } from '../../services/adapters/config-kv'
+import { isUnspeechStreamingModelEnabled, streamingTtsModelResourceId } from '../../services/domain/streaming-tts-policy'
+
+export interface ResolvedStreamingTtsProvider {
+  /** Provider selected by exact public model id. */
+  kind: 'unspeech' | 'stepfun'
+  /** Provider websocket URL, including provider-specific model parameters. */
+  upstreamURL: string
+  /** Ordered encrypted credentials available to this provider. */
+  keys: Array<{ id: string, ciphertext: string }>
+  /** Envelope encryption context that must match the configuration writer. */
+  keyContext: string
+  /** Operator-level StepFun instruction used when the client does not supply one. */
+  instruction?: string
+}
+
+/** A client-visible policy failure found while resolving a streaming provider. */
+export class StreamingTtsResolutionError extends Error {
+  constructor(
+    readonly code: string,
+    readonly closeCode: number,
+    options?: ErrorOptions,
+  ) {
+    super(code, options)
+    this.name = 'StreamingTtsResolutionError'
+  }
+}
+
+/**
+ * Resolves one client start command to exactly one configured provider.
+ *
+ * StepFun in `available` mode only handles its explicit model ids; unSpeech
+ * remains available for all of its configured models. `default` affects the
+ * catalog's selected model, not this deterministic model-to-provider mapping.
+ */
+export async function resolveStreamingTtsProvider(
+  start: StreamingTtsStartCommand,
+  configKV: ConfigKVService,
+): Promise<ResolvedStreamingTtsProvider> {
+  let stepfun: StepfunStreamingTtsUpstream | null
+  let unspeech: UnspeechUpstream | null
+  try {
+    const [loadedStepfun, loadedUnspeech] = await Promise.all([
+      configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'),
+      configKV.getOptional('UNSPEECH_UPSTREAM'),
+    ])
+    stepfun = loadedStepfun ?? null
+    unspeech = loadedUnspeech ?? null
+  }
+  catch (error) {
+    throw new StreamingTtsResolutionError('config_unavailable', 1011, { cause: error })
+  }
+
+  if (stepfun && stepfun.rollout !== 'disabled' && stepfun.models.some(model => model.id === start.model)) {
+    if (!stepfun.voices.some(voice => voice.id === start.voice))
+      throw new StreamingTtsResolutionError('streaming_tts_voice_not_enabled', 1008)
+    if (!isStepfunResponseFormatSupported(start.responseFormat))
+      throw new StreamingTtsResolutionError('streaming_tts_response_format_not_supported', 1008)
+    return {
+      kind: 'stepfun',
+      upstreamURL: stepfunURL(stepfun.baseURL, start.model),
+      keys: stepfun.keys,
+      keyContext: STEPFUN_STREAMING_TTS_KEY_CONTEXT,
+      instruction: stepfun.instruction,
+    }
+  }
+
+  const streaming = unspeech?.streaming
+  if (!unspeech?.restBaseURL || !streaming?.baseURL || streaming.keys.length === 0) {
+    const hasAvailableStepfun = stepfun != null && stepfun.rollout !== 'disabled'
+    throw new StreamingTtsResolutionError(
+      hasAvailableStepfun ? 'streaming_tts_model_not_enabled' : 'streaming_tts_not_configured',
+      1008,
+    )
+  }
+  if (!isUnspeechStreamingModelEnabled(streaming.models ?? [], start.model))
+    throw new StreamingTtsResolutionError('streaming_tts_model_not_enabled', 1008)
+
+  const voicesURL = unspeechVoicesURL(unspeech.restBaseURL, streamingTtsModelResourceId(start.model))
+  let voices: unknown[]
+  try {
+    const data = await ofetch(voicesURL, { timeout: 5000 }) as { voices?: unknown[] }
+    voices = Array.isArray(data.voices) ? data.voices : []
+  }
+  catch (error) {
+    throw new StreamingTtsResolutionError('streaming_tts_voice_catalog_unavailable', 1011, { cause: error })
+  }
+  if (!voices.some(voice => voiceId(voice) === start.voice))
+    throw new StreamingTtsResolutionError('streaming_tts_voice_not_enabled', 1008)
+
+  return {
+    kind: 'unspeech',
+    upstreamURL: streaming.baseURL,
+    keys: streaming.keys,
+    keyContext: 'streaming-tts',
+  }
+}
+
+function isStepfunResponseFormatSupported(format: string | undefined): boolean {
+  return format == null || format === 'mp3' || format === 'opus' || format === 'flac'
+}
+
+function stepfunURL(baseURL: string, model: string): string {
+  const url = new URL(baseURL)
+  url.searchParams.set('model', streamingTtsModelResourceId(model))
+  return url.toString()
+}
+
+function unspeechVoicesURL(restBaseURL: string, resourceId: string): string {
+  const url = new URL(restBaseURL)
+  url.pathname = '/api/voices'
+  url.search = new URLSearchParams({ provider: 'volcengine', model: resourceId }).toString()
+  return url.toString()
+}
+
+function voiceId(voice: unknown): string | null {
+  if (typeof voice !== 'object' || voice == null)
+    return null
+  const id = (voice as { id?: unknown }).id
+  return typeof id === 'string' && id.length > 0 ? id : null
+}

--- a/server/apps/api/src/routes/audio-speech-ws/providers/stepfun.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/providers/stepfun.ts
@@ -1,0 +1,341 @@
+import type { RawData } from 'ws'
+
+import type { StreamingTtsCommand, StreamingTtsProviderEvent, StreamingTtsTransport, StreamingTtsTransportOptions } from './types'
+
+import { Buffer } from 'node:buffer'
+
+import WebSocket from 'ws'
+
+import { errorMessageFrom } from '@moeru/std'
+import { looseObject, optional, record, safeParse, string, unknown as unknownValue } from 'valibot'
+
+const StepfunServerEventSchema = looseObject({
+  type: string(),
+  data: optional(record(string(), unknownValue())),
+})
+
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000
+const DEFAULT_COMPLETION_TIMEOUT_MS = 30000
+
+/**
+ * `connecting -> creating -> ready -> finishing -> terminal` mirrors the
+ * StepFun handshake. Error, close, and abort may enter `terminal` from any
+ * phase; buffered AIRI commands are released only after `response.created`.
+ */
+type StepfunPhase = 'connecting' | 'creating' | 'ready' | 'finishing' | 'terminal'
+
+/**
+ * Creates a native StepFun streaming TTS transport.
+ *
+ * The adapter owns StepFun's ordered handshake, session correlation, JSON
+ * envelope, Base64 decoding, format selection, and command buffering. Callers
+ * only observe AIRI's provider-neutral streaming events.
+ */
+export function createStepfunTransport(options: StreamingTtsTransportOptions & { instruction?: string }): StreamingTtsTransport {
+  let phase: StepfunPhase = 'connecting'
+  let sessionId: string | null = null
+  const pendingCommands: StreamingTtsCommand[] = []
+  const handshakeTimeoutMs = options.timeouts?.handshakeMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS
+  const completionTimeoutMs = options.timeouts?.completionMs ?? DEFAULT_COMPLETION_TIMEOUT_MS
+  let handshakeTimer: ReturnType<typeof setTimeout> | undefined
+  let completionTimer: ReturnType<typeof setTimeout> | undefined
+
+  let ws: WebSocket
+  try {
+    ws = new WebSocket(options.upstreamURL, {
+      headers: { Authorization: `Bearer ${options.keyPlaintext.toString('utf8')}` },
+    })
+  }
+  finally {
+    options.keyPlaintext.fill(0)
+  }
+
+  function emit(event: StreamingTtsProviderEvent) {
+    options.onEvent(event)
+  }
+
+  function clearDeadlines() {
+    if (handshakeTimer)
+      clearTimeout(handshakeTimer)
+    if (completionTimer)
+      clearTimeout(completionTimer)
+    handshakeTimer = undefined
+    completionTimer = undefined
+  }
+
+  function refreshCompletionDeadline() {
+    if (completionTimer)
+      clearTimeout(completionTimer)
+    completionTimer = setTimeout(() => {
+      fail('stepfun_completion_timeout', 'StepFun did not complete the streaming TTS session in time')
+    }, completionTimeoutMs)
+  }
+
+  function fail(code: string, message: string) {
+    if (phase === 'terminal')
+      return
+    phase = 'terminal'
+    clearDeadlines()
+    pendingCommands.length = 0
+    emit({ type: 'failed', code, message })
+    try {
+      ws.terminate()
+    }
+    catch {}
+  }
+
+  function sendJson(value: Record<string, unknown>): boolean {
+    try {
+      ws.send(JSON.stringify(value))
+      return true
+    }
+    catch (error) {
+      fail('stepfun_send_failed', errorMessageFrom(error) ?? 'StepFun websocket send failed')
+      return false
+    }
+  }
+
+  function sendCommand(command: StreamingTtsCommand) {
+    if (!sessionId || (phase !== 'ready' && phase !== 'finishing')) {
+      pendingCommands.push(command)
+      return
+    }
+
+    if (command.type === 'text') {
+      for (const text of splitText(command.text)) {
+        if (!sendJson({ type: 'tts.text.delta', data: { session_id: sessionId, text } }))
+          return
+        emit({ type: 'input-accepted', chars: text.length })
+      }
+      return
+    }
+
+    if (sendJson({ type: 'tts.text.done', data: { session_id: sessionId } })) {
+      phase = 'finishing'
+      refreshCompletionDeadline()
+    }
+  }
+
+  function flushPendingCommands() {
+    const commands = pendingCommands.splice(0)
+    for (const command of commands) {
+      if (phase === 'terminal')
+        return
+      sendCommand(command)
+    }
+  }
+
+  function requireCurrentSession(data: Record<string, unknown> | undefined): boolean {
+    const eventSessionId = stringField(data, 'session_id')
+    if (sessionId && eventSessionId === sessionId)
+      return true
+    fail('stepfun_session_mismatch', 'StepFun returned an event for an unexpected session')
+    return false
+  }
+
+  function handleMessage(data: RawData, isBinary: boolean) {
+    if (phase === 'terminal')
+      return
+    if (isBinary) {
+      fail('stepfun_invalid_binary_event', 'StepFun unexpectedly returned a binary websocket frame')
+      return
+    }
+
+    const parsed = safeParse(StepfunServerEventSchema, JSON.parse(bufferToString(data)))
+    if (!parsed.success) {
+      fail('stepfun_invalid_event', 'StepFun returned a malformed websocket event')
+      return
+    }
+
+    const event = parsed.output
+    switch (event.type) {
+      case 'tts.connection.done': {
+        if (phase !== 'connecting') {
+          fail('stepfun_invalid_transition', `Unexpected ${event.type} while ${phase}`)
+          return
+        }
+        sessionId = stringField(event.data, 'session_id') ?? null
+        if (!sessionId) {
+          fail('stepfun_invalid_event', 'StepFun connection event omitted session_id')
+          return
+        }
+        phase = 'creating'
+        sendJson(createFrame(sessionId, options))
+        return
+      }
+      case 'tts.response.created': {
+        if (phase !== 'creating' || !requireCurrentSession(event.data))
+          return
+        phase = 'ready'
+        if (handshakeTimer)
+          clearTimeout(handshakeTimer)
+        handshakeTimer = undefined
+        emit({ type: 'started' })
+        flushPendingCommands()
+        return
+      }
+      case 'tts.response.sentence.start':
+      case 'tts.response.sentence.end':
+      case 'tts.response.subtitle': {
+        if ((phase !== 'ready' && phase !== 'finishing') || !requireCurrentSession(event.data))
+          return
+        if (phase === 'finishing')
+          refreshCompletionDeadline()
+        const controlEvent = event.type.replace('tts.response.', '') as 'sentence.start' | 'sentence.end' | 'subtitle'
+        emit({ type: 'control', event: controlEvent, payload: event.data ?? {} })
+        return
+      }
+      case 'tts.response.audio.delta': {
+        if ((phase !== 'ready' && phase !== 'finishing') || !requireCurrentSession(event.data))
+          return
+        if (phase === 'finishing')
+          refreshCompletionDeadline()
+        const audio = stringField(event.data, 'audio')
+        if (!audio) {
+          fail('stepfun_invalid_audio_event', 'StepFun audio delta omitted audio')
+          return
+        }
+        const bytes = Buffer.from(audio, 'base64')
+        if (bytes.byteLength === 0) {
+          fail('stepfun_invalid_audio_event', 'StepFun audio delta contained invalid Base64')
+          return
+        }
+        emit({ type: 'audio', data: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer })
+        return
+      }
+      case 'tts.response.audio.done': {
+        if ((phase !== 'ready' && phase !== 'finishing') || !requireCurrentSession(event.data))
+          return
+        phase = 'terminal'
+        clearDeadlines()
+        emit({ type: 'completed' })
+        return
+      }
+      case 'tts.response.error': {
+        const eventSessionId = stringField(event.data, 'session_id')
+        if (eventSessionId && sessionId && eventSessionId !== sessionId) {
+          fail('stepfun_session_mismatch', 'StepFun returned an error for an unexpected session')
+          return
+        }
+        fail(
+          stringField(event.data, 'code') ?? 'stepfun_upstream_error',
+          stringField(event.data, 'message') ?? 'StepFun streaming TTS failed',
+        )
+        return
+      }
+      default:
+        fail('stepfun_unknown_event', `Unsupported StepFun event: ${event.type}`)
+    }
+  }
+
+  ws.on('message', (data, isBinary) => {
+    try {
+      handleMessage(data, isBinary)
+    }
+    catch (error) {
+      fail('stepfun_invalid_event', errorMessageFrom(error) ?? 'StepFun returned an invalid event')
+    }
+  })
+  ws.on('error', error => fail('stepfun_upstream_error', error.message))
+  ws.on('close', (code, reason) => {
+    if (phase === 'terminal')
+      return
+    phase = 'terminal'
+    clearDeadlines()
+    pendingCommands.length = 0
+    emit({ type: 'closed', code, reason: reason.toString() || 'stepfun_upstream_closed' })
+  })
+
+  handshakeTimer = setTimeout(() => {
+    fail('stepfun_handshake_timeout', 'StepFun did not create the streaming TTS session in time')
+  }, handshakeTimeoutMs)
+
+  return {
+    kind: 'stepfun',
+    upstreamURL: options.upstreamURL,
+    keyEntryId: options.keyEntryId,
+    send(command) {
+      if (phase === 'terminal')
+        return
+      sendCommand(command)
+    },
+    abort() {
+      phase = 'terminal'
+      clearDeadlines()
+      pendingCommands.length = 0
+      try {
+        ws.terminate()
+      }
+      catch {}
+    },
+  }
+}
+
+function createFrame(sessionId: string, options: StreamingTtsTransportOptions & { instruction?: string }): Record<string, unknown> {
+  const extraBody = options.start.extraBody ?? {}
+  const sampleRate = numberField(extraBody, 'sample_rate')
+    ?? numberField(recordField(extraBody, 'audio'), 'sample_rate')
+  const speedRatio = numberField(extraBody, 'speed_ratio')
+  const volumeRatio = numberField(extraBody, 'volume_ratio')
+  const instruction = stringField(extraBody, 'instruction') ?? options.instruction
+
+  return {
+    type: 'tts.create',
+    data: {
+      session_id: sessionId,
+      voice_id: options.start.voice,
+      response_format: streamingFormat(options.start.responseFormat),
+      text_normalization: 'standard',
+      mode: 'default',
+      ...(sampleRate !== undefined ? { sample_rate: sampleRate } : {}),
+      ...(speedRatio !== undefined ? { speed_ratio: speedRatio } : {}),
+      ...(volumeRatio !== undefined ? { volume_ratio: volumeRatio } : {}),
+      ...(instruction ? { instruction } : {}),
+    },
+  }
+}
+
+function streamingFormat(value: string | undefined): 'mp3_stream' | 'opus_stream' | 'flac_stream' {
+  switch (value) {
+    case 'opus':
+      return 'opus_stream'
+    case 'flac':
+      return 'flac_stream'
+    default:
+      return 'mp3_stream'
+  }
+}
+
+/** Splits at Unicode code-point boundaries because StepFun caps one delta at 1000 characters. */
+function splitText(text: string): string[] {
+  const characters = Array.from(text)
+  const chunks: string[] = []
+  for (let start = 0; start < characters.length; start += 1000)
+    chunks.push(characters.slice(start, start + 1000).join(''))
+  return chunks
+}
+
+function bufferToString(data: RawData): string {
+  if (Array.isArray(data))
+    return Buffer.concat(data).toString('utf8')
+  if (data instanceof ArrayBuffer)
+    return Buffer.from(data).toString('utf8')
+  return data.toString('utf8')
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function numberField(record: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = record?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function recordField(record: Record<string, unknown> | undefined, key: string): Record<string, unknown> | undefined {
+  const value = record?.[key]
+  return typeof value === 'object' && value != null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}

--- a/server/apps/api/src/routes/audio-speech-ws/providers/types.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/providers/types.ts
@@ -1,0 +1,67 @@
+import type { Buffer } from 'node:buffer'
+
+export interface StreamingTtsStartCommand {
+  /** Canonical public model id used for provider resolution and billing. */
+  model: string
+  /** Provider voice id already selected by the client. */
+  voice: string
+  /** Client audio container request; providers map it to their wire format. */
+  responseFormat?: string
+  /** Provider-neutral optional controls forwarded through the selected adapter. */
+  extraBody?: Record<string, unknown>
+}
+
+export type StreamingTtsCommand
+  = | { type: 'text', text: string }
+    | { type: 'finish' }
+
+export type StreamingTtsProviderEvent
+  = | { type: 'started' }
+    | { type: 'input-accepted', chars: number }
+    | { type: 'audio', data: ArrayBuffer }
+    | { type: 'control', event: 'sentence.start' | 'sentence.end' | 'subtitle', payload: Record<string, unknown> }
+    | { type: 'completed', usageChars?: number }
+    | { type: 'failed', code: string, message: string }
+    | { type: 'closed', code: number, reason: string }
+
+/**
+ * Hides an upstream provider's websocket protocol behind AIRI's streaming TTS
+ * lifecycle. Commands may be submitted while connecting and are delivered in
+ * order once the provider session is ready.
+ */
+export interface StreamingTtsTransport {
+  /** Resolved provider identity used by telemetry. */
+  readonly kind: 'unspeech' | 'stepfun'
+  /** Exact upstream endpoint used for this connection. */
+  readonly upstreamURL: string
+  /** Encrypted key entry identifier used for observability, never the secret. */
+  readonly keyEntryId: string
+  /** Queues or sends one ordered client command until the provider is ready. */
+  send: (command: StreamingTtsCommand) => void
+  /** Immediately stops generation and releases the upstream websocket. */
+  abort: () => void
+}
+
+/** Inputs shared by provider-specific streaming websocket adapters. */
+export interface StreamingTtsTransportOptions {
+  /** Validated client start command. */
+  start: StreamingTtsStartCommand
+  /** Provider endpoint selected by configuration policy. */
+  upstreamURL: string
+  /** Credential identifier recorded in traces. */
+  keyEntryId: string
+  /** Decrypted credential; the adapter must zero it after constructing the websocket. */
+  keyPlaintext: Buffer
+  /** Synchronous provider-neutral event sink owned by the client session. */
+  onEvent: (event: StreamingTtsProviderEvent) => void
+  /** Optional runtime deadlines; adapters apply production defaults when omitted. */
+  timeouts?: Partial<StreamingTtsTransportTimeouts>
+}
+
+/** Deadlines that prevent stalled upstream sessions from retaining resources. */
+export interface StreamingTtsTransportTimeouts {
+  /** Maximum milliseconds from dialing until the provider acknowledges the session. */
+  handshakeMs: number
+  /** Maximum milliseconds without provider progress after finish is sent. */
+  completionMs: number
+}

--- a/server/apps/api/src/routes/audio-speech-ws/providers/unspeech.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/providers/unspeech.ts
@@ -1,0 +1,213 @@
+import type { RawData } from 'ws'
+
+import type { StreamingTtsCommand, StreamingTtsProviderEvent, StreamingTtsTransport, StreamingTtsTransportOptions } from './types'
+
+import WebSocket from 'ws'
+
+import { errorMessageFrom } from '@moeru/std'
+
+import { bufferToString, readUsageChars, toBufferLike } from '../protocol'
+
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000
+const DEFAULT_COMPLETION_TIMEOUT_MS = 30000
+
+/**
+ * unSpeech becomes `ready` when the websocket opens, then remains ready until
+ * finish, completion, failure, close, or abort makes the transport terminal.
+ */
+type UnspeechPhase = 'connecting' | 'ready' | 'finishing' | 'terminal'
+
+/** Wraps unSpeech's AIRI-compatible websocket protocol as a normalized transport. */
+export function createUnspeechTransport(options: StreamingTtsTransportOptions): StreamingTtsTransport {
+  let phase: UnspeechPhase = 'connecting'
+  const pendingCommands: StreamingTtsCommand[] = []
+  const handshakeTimeoutMs = options.timeouts?.handshakeMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS
+  const completionTimeoutMs = options.timeouts?.completionMs ?? DEFAULT_COMPLETION_TIMEOUT_MS
+  let handshakeTimer: ReturnType<typeof setTimeout> | undefined
+  let completionTimer: ReturnType<typeof setTimeout> | undefined
+
+  let ws: WebSocket
+  try {
+    ws = new WebSocket(options.upstreamURL, {
+      headers: { Authorization: `Bearer ${options.keyPlaintext.toString('utf8')}` },
+    })
+  }
+  finally {
+    options.keyPlaintext.fill(0)
+  }
+
+  function emit(event: StreamingTtsProviderEvent) {
+    options.onEvent(event)
+  }
+
+  function clearDeadlines() {
+    if (handshakeTimer)
+      clearTimeout(handshakeTimer)
+    if (completionTimer)
+      clearTimeout(completionTimer)
+    handshakeTimer = undefined
+    completionTimer = undefined
+  }
+
+  function refreshCompletionDeadline() {
+    if (completionTimer)
+      clearTimeout(completionTimer)
+    completionTimer = setTimeout(() => {
+      fail('unspeech_completion_timeout', 'unSpeech did not complete the streaming TTS session in time')
+    }, completionTimeoutMs)
+  }
+
+  function fail(code: string, message: string) {
+    if (phase === 'terminal')
+      return
+    phase = 'terminal'
+    clearDeadlines()
+    pendingCommands.length = 0
+    emit({ type: 'failed', code, message })
+    try {
+      ws.terminate()
+    }
+    catch {}
+  }
+
+  function sendJson(value: Record<string, unknown>): boolean {
+    try {
+      ws.send(JSON.stringify(value))
+      return true
+    }
+    catch (error) {
+      fail('unspeech_send_failed', errorMessageFrom(error) ?? 'unSpeech websocket send failed')
+      return false
+    }
+  }
+
+  function sendCommand(command: StreamingTtsCommand) {
+    if (phase === 'connecting') {
+      pendingCommands.push(command)
+      return
+    }
+    if (phase === 'terminal')
+      return
+
+    if (command.type === 'text') {
+      if (sendJson({ event: 'text', text: command.text }))
+        emit({ type: 'input-accepted', chars: command.text.length })
+      return
+    }
+
+    if (sendJson({ event: 'finish' })) {
+      phase = 'finishing'
+      refreshCompletionDeadline()
+    }
+  }
+
+  function handleControl(data: RawData) {
+    let event: { event?: unknown, payload?: unknown }
+    try {
+      event = JSON.parse(bufferToString(data)) as { event?: unknown, payload?: unknown }
+    }
+    catch {
+      fail('unspeech_invalid_event', 'unSpeech returned malformed JSON')
+      return
+    }
+
+    const payload = isRecord(event.payload) ? event.payload : undefined
+    if (phase === 'finishing' && event.event !== 'session.finished' && event.event !== 'error')
+      refreshCompletionDeadline()
+    switch (event.event) {
+      case 'session.started':
+        if (handshakeTimer)
+          clearTimeout(handshakeTimer)
+        handshakeTimer = undefined
+        emit({ type: 'started' })
+        return
+      case 'sentence.start':
+      case 'sentence.end':
+      case 'subtitle':
+        emit({ type: 'control', event: event.event, payload: payload ?? {} })
+        return
+      case 'session.finished':
+        phase = 'terminal'
+        clearDeadlines()
+        emit({ type: 'completed', usageChars: readUsageChars(payload) ?? undefined })
+        return
+      case 'error':
+        fail(
+          typeof payload?.code === 'string' ? payload.code : 'unspeech_upstream_error',
+          typeof payload?.message === 'string' ? payload.message : 'unSpeech streaming TTS failed',
+        )
+    }
+  }
+
+  ws.on('open', () => {
+    if (phase !== 'connecting')
+      return
+    phase = 'ready'
+    if (!sendJson({
+      event: 'start',
+      model: options.start.model,
+      voice: options.start.voice,
+      ...(options.start.responseFormat ? { response_format: options.start.responseFormat } : {}),
+      ...(options.start.extraBody ? { extra_body: options.start.extraBody } : {}),
+    })) {
+      return
+    }
+
+    const commands = pendingCommands.splice(0)
+    for (const command of commands)
+      sendCommand(command)
+  })
+  ws.on('message', (data, isBinary) => {
+    if (phase === 'terminal')
+      return
+    if (isBinary) {
+      if (phase === 'finishing')
+        refreshCompletionDeadline()
+      emit({ type: 'audio', data: toBufferLike(data) })
+      return
+    }
+    handleControl(data)
+  })
+  ws.on('error', error => fail('unspeech_upstream_error', error.message))
+  ws.on('close', (code, reason) => {
+    if (phase === 'terminal')
+      return
+    phase = 'terminal'
+    clearDeadlines()
+    pendingCommands.length = 0
+    emit({ type: 'closed', code, reason: reason.toString() || 'unspeech_upstream_closed' })
+  })
+
+  handshakeTimer = setTimeout(() => {
+    fail('unspeech_handshake_timeout', 'unSpeech did not start the streaming TTS session in time')
+  }, handshakeTimeoutMs)
+
+  return {
+    kind: 'unspeech',
+    upstreamURL: options.upstreamURL,
+    keyEntryId: options.keyEntryId,
+    send(command) {
+      sendCommand(command)
+    },
+    abort() {
+      const canCancel = phase === 'ready' || phase === 'finishing'
+      phase = 'terminal'
+      clearDeadlines()
+      pendingCommands.length = 0
+      if (canCancel) {
+        try {
+          ws.send(JSON.stringify({ event: 'cancel' }))
+        }
+        catch {}
+      }
+      try {
+        ws.terminate()
+      }
+      catch {}
+    },
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value)
+}

--- a/server/apps/api/src/routes/audio-speech-ws/route.test.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/route.test.ts
@@ -28,6 +28,7 @@ interface MockUpstream {
 async function startMockUpstream(
   scriptedResponses: MockUpstream['scriptedResponses'],
   voices: Array<{ id: string, name?: string }> = [{ id: 'mock', name: 'Mock Voice' }],
+  protocol: 'unspeech' | 'stepfun' = 'unspeech',
 ): Promise<MockUpstream> {
   const receivedFrames: MockUpstream['receivedFrames'] = []
   let observedAuth: string | undefined
@@ -45,6 +46,12 @@ async function startMockUpstream(
 
   wss.on('connection', (ws, req) => {
     observedAuth = req.headers.authorization
+    if (protocol === 'stepfun') {
+      ws.send(JSON.stringify({
+        type: 'tts.connection.done',
+        data: { session_id: 'stepfun-session' },
+      }))
+    }
     let replayed = false
     ws.on('message', async (data, isBinary) => {
       const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer)
@@ -63,11 +70,23 @@ async function startMockUpstream(
         return
 
       let triggerReplay = false
+      if (protocol === 'stepfun') {
+        if (!isBinary) {
+          const event = JSON.parse(decoded as string) as { type?: string }
+          if (event.type === 'tts.create') {
+            ws.send(JSON.stringify({ type: 'tts.response.created', data: { session_id: 'stepfun-session' } }))
+            return
+          }
+          if (event.type === 'tts.text.done')
+            triggerReplay = true
+        }
+      }
+
       if (isBinary) {
         // Streaming protocol's only legal client→server binary frames
         // would be raw audio (we never send any in tests).
       }
-      else {
+      else if (protocol === 'unspeech') {
         try {
           const ev = JSON.parse(decoded as string) as { event?: string }
           if (ev.event === 'finish' || ev.event === 'cancel')
@@ -165,6 +184,13 @@ function makeFakeDeps(overrides: {
   fluxBalance: number
   decryptedKey?: string
   streamingModels?: Array<{ id: string, name?: string, description?: string }>
+  stepfunStreaming?: {
+    enabled: boolean
+    baseURL: string
+    models: Array<{ id: string, name?: string, description?: string }>
+    defaultModel: string
+    voices: Array<{ id: string, name?: string }>
+  }
 }) {
   const ttsMeter = {
     assertCanAfford: vi.fn(async (_userId: string, _newUnits: number, currentBalance: number) => {
@@ -204,6 +230,16 @@ function makeFakeDeps(overrides: {
             ],
           },
         }
+      }
+      if (key === 'STEPFUN_STREAMING_TTS_UPSTREAM') {
+        const config = overrides.stepfunStreaming
+        return config
+          ? {
+              ...config,
+              keys: [{ id: 'test-key-1', ciphertext: 'ENCRYPTED_PLACEHOLDER' }],
+              voices: config.voices.map(voice => ({ ...voice, labels: {}, languages: [] })),
+            }
+          : null
       }
       return null
     }),
@@ -309,6 +345,85 @@ describe('audio-speech-ws route', () => {
         voice_id: 'mock',
         voice_type: 'official_selected',
       }),
+    }))
+  })
+
+  it('translates the AIRI stream protocol to native StepFun websocket events', async () => {
+    const audioPayload = Buffer.from('STEPFUN_AUDIO', 'utf8').toString('base64')
+    const text = 'x'.repeat(2001)
+    upstream = await startMockUpstream([
+      { kind: 'json', payload: { type: 'tts.response.sentence.start', data: { session_id: 'stepfun-session', text: 'hello' } } },
+      { kind: 'json', payload: { type: 'tts.response.audio.delta', data: { session_id: 'stepfun-session', audio: audioPayload } } },
+      { kind: 'json', payload: { type: 'tts.response.sentence.end', data: { session_id: 'stepfun-session', text: 'hello' } } },
+      { kind: 'json', payload: { type: 'tts.response.audio.done', data: { session_id: 'stepfun-session', audio: '' } } },
+    ], [{ id: 'lively-girl', name: 'Lively Girl' }], 'stepfun')
+
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      restBaseURL: upstream.restBaseURL,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        enabled: true,
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2', name: 'Step TTS 2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl', name: 'Lively Girl' }],
+      },
+    })
+    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const events = handlers('user-stepfun')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(r => setTimeout(r, 200))
+
+    const upstreamFrames = upstream.receivedFrames.map(frame => JSON.parse(frame.data as string))
+    expect(upstreamFrames.map(frame => frame.type)).toEqual(['tts.create', 'tts.text.delta', 'tts.text.delta', 'tts.text.delta', 'tts.text.done'])
+    expect(upstreamFrames[0].data).toMatchObject({
+      session_id: 'stepfun-session',
+      voice_id: 'lively-girl',
+      mode: 'default',
+      response_format: 'mp3_stream',
+    })
+    expect(upstreamFrames.slice(1, 4).map(frame => frame.data.text.length)).toEqual([1000, 1000, 1])
+
+    const clientTextFrames = client.sent.filter(s => s.kind === 'text').map(s => JSON.parse(s.data as string))
+    expect(clientTextFrames.map(frame => frame.event)).toEqual(['session.started', 'sentence.start', 'sentence.end', 'session.finished'])
+    expect(client.sent.filter(s => s.kind === 'binary')).toHaveLength(1)
+    expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-stepfun', units: 2001 }))
+  })
+
+  it('settles StepFun text usage when the client cancels before audio completion', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl', name: 'Lively Girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      restBaseURL: upstream.restBaseURL,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        enabled: true,
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2', name: 'Step TTS 2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl', name: 'Lively Girl' }],
+      },
+    })
+    const events = createAudioSpeechWsHandlers(deps as any)('user-stepfun-cancel')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'paid text' }),
+    ])
+    events.onClose?.(new Event('close') as any, client.ctx)
+    await new Promise(r => setTimeout(r, 100))
+
+    expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-stepfun-cancel',
+      units: 9,
     }))
   })
 

--- a/server/apps/api/src/routes/audio-speech-ws/route.test.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/route.test.ts
@@ -2,6 +2,8 @@ import type { AddressInfo } from 'node:net'
 
 import type { WSContext, WSEvents } from 'hono/ws'
 
+import type { AudioSpeechWsHandlersOptions } from './types'
+
 import { Buffer } from 'node:buffer'
 import { createServer } from 'node:http'
 
@@ -22,6 +24,7 @@ interface MockUpstream {
   receivedFrames: Array<{ kind: 'text' | 'binary', data: string | Buffer }>
   /** Auth header observed during handshake. */
   observedAuth: string | undefined
+  disconnectedClients: number
   close: () => Promise<void>
 }
 
@@ -29,9 +32,16 @@ async function startMockUpstream(
   scriptedResponses: MockUpstream['scriptedResponses'],
   voices: Array<{ id: string, name?: string }> = [{ id: 'mock', name: 'Mock Voice' }],
   protocol: 'unspeech' | 'stepfun' = 'unspeech',
+  options: {
+    stepfunCreatedDelayMs?: number
+    suppressStepfunConnectionDone?: boolean
+    suppressStepfunCreated?: boolean
+    scriptedResponseDelayMs?: number
+  } = {},
 ): Promise<MockUpstream> {
   const receivedFrames: MockUpstream['receivedFrames'] = []
   let observedAuth: string | undefined
+  let disconnectedClients = 0
 
   const httpServer = createServer((req, res) => {
     if (req.url?.startsWith('/api/voices')) {
@@ -46,13 +56,16 @@ async function startMockUpstream(
 
   wss.on('connection', (ws, req) => {
     observedAuth = req.headers.authorization
-    if (protocol === 'stepfun') {
+    if (protocol === 'stepfun' && !options.suppressStepfunConnectionDone) {
       ws.send(JSON.stringify({
         type: 'tts.connection.done',
         data: { session_id: 'stepfun-session' },
       }))
     }
     let replayed = false
+    ws.on('close', () => {
+      disconnectedClients += 1
+    })
     ws.on('message', async (data, isBinary) => {
       const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer)
       const decoded = isBinary ? buf : buf.toString('utf8')
@@ -74,7 +87,12 @@ async function startMockUpstream(
         if (!isBinary) {
           const event = JSON.parse(decoded as string) as { type?: string }
           if (event.type === 'tts.create') {
-            ws.send(JSON.stringify({ type: 'tts.response.created', data: { session_id: 'stepfun-session' } }))
+            if (options.suppressStepfunCreated)
+              return
+            if (options.stepfunCreatedDelayMs)
+              await new Promise(resolve => setTimeout(resolve, options.stepfunCreatedDelayMs))
+            if (ws.readyState === 1)
+              ws.send(JSON.stringify({ type: 'tts.response.created', data: { session_id: 'stepfun-session' } }))
             return
           }
           if (event.type === 'tts.text.done')
@@ -104,7 +122,7 @@ async function startMockUpstream(
 
       replayed = true
       for (const resp of scriptedResponses) {
-        await new Promise(resolve => setTimeout(resolve, 5))
+        await new Promise(resolve => setTimeout(resolve, options.scriptedResponseDelayMs ?? 5))
 
         if (resp.kind === 'json')
           ws.send(JSON.stringify(resp.payload), { binary: false })
@@ -127,6 +145,9 @@ async function startMockUpstream(
     receivedFrames,
     get observedAuth() {
       return observedAuth
+    },
+    get disconnectedClients() {
+      return disconnectedClients
     },
     async close() {
       wss.close()
@@ -164,7 +185,7 @@ function makeMockClientWs(): MockClientWs {
     },
     readyState: 1,
     binaryType: 'arraybuffer',
-    raw: {} as any,
+    raw: {},
     protocol: '',
     url: null,
   } as unknown as WSContext
@@ -185,19 +206,20 @@ function makeFakeDeps(overrides: {
   decryptedKey?: string
   streamingModels?: Array<{ id: string, name?: string, description?: string }>
   stepfunStreaming?: {
-    enabled: boolean
+    rollout: 'disabled' | 'available' | 'default'
     baseURL: string
     models: Array<{ id: string, name?: string, description?: string }>
     defaultModel: string
     voices: Array<{ id: string, name?: string }>
   }
+  streamingTtsTimeouts?: { handshakeMs?: number, completionMs?: number }
 }) {
   const ttsMeter = {
     assertCanAfford: vi.fn(async (_userId: string, _newUnits: number, currentBalance: number) => {
       if (currentBalance <= 0)
         throw Object.assign(new Error('Insufficient flux'), { statusCode: 402 })
     }),
-    accumulate: vi.fn(async () => ({
+    accumulate: vi.fn(async (_input: Parameters<AudioSpeechWsHandlersOptions['ttsMeter']['accumulate']>[0]) => ({
       fluxDebited: 1,
       debtAfter: 0,
       balanceAfter: overrides.fluxBalance - 1,
@@ -208,7 +230,7 @@ function makeFakeDeps(overrides: {
     getFlux: vi.fn(async () => ({ flux: overrides.fluxBalance })),
   }
   const requestLogService = {
-    logRequest: vi.fn(async () => undefined),
+    logRequest: vi.fn(async (_input: Parameters<AudioSpeechWsHandlersOptions['requestLogService']['logRequest']>[0]) => undefined),
   }
   const productEventService = {
     track: vi.fn(async () => undefined),
@@ -248,7 +270,21 @@ function makeFakeDeps(overrides: {
     decryptKey: vi.fn(() => Buffer.from(overrides.decryptedKey ?? 'mock-upstream-token', 'utf8')),
   }
 
-  return { configKV, envelopeCrypto, fluxService, ttsMeter, requestLogService, productEventService }
+  return {
+    configKV,
+    envelopeCrypto,
+    fluxService,
+    ttsMeter,
+    requestLogService,
+    productEventService,
+    streamingTtsTimeouts: overrides.streamingTtsTimeouts,
+  }
+}
+
+function createTestHandlers(deps: ReturnType<typeof makeFakeDeps>) {
+  // The fixture intentionally implements only the service methods exercised by
+  // this route. Keep the partial-service adaptation at this single test boundary.
+  return createAudioSpeechWsHandlers(deps as unknown as AudioSpeechWsHandlersOptions)
 }
 
 /** Drives the WSEvents lifecycle as if a real client had connected. */
@@ -256,13 +292,13 @@ async function driveClientSession(events: WSEvents, client: MockClientWs, client
   // onOpen handles the initial dial. The route fires `void dialUpstream()`
   // which is async, so we await a microtask tick to let the upstream
   // dialing kick off.
-  events.onOpen?.(new Event('open') as any, client.ctx)
+  events.onOpen?.(new Event('open'), client.ctx)
   await new Promise(r => setTimeout(r, 50))
 
   for (const frame of clientFrames) {
     const isBinary = Buffer.isBuffer(frame)
     const data = isBinary ? frame : String(frame)
-    events.onMessage?.({ data } as any, client.ctx)
+    events.onMessage?.(new MessageEvent('message', { data }), client.ctx)
     await new Promise(r => setTimeout(r, 20))
   }
 }
@@ -285,7 +321,7 @@ describe('audio-speech-ws route', () => {
     ])
 
     const deps = makeFakeDeps({ upstreamURL: upstream.url, restBaseURL: upstream.restBaseURL, fluxBalance: 100 })
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-123', { voiceType: 'official_selected' })
     const client = makeMockClientWs()
 
@@ -320,7 +356,7 @@ describe('audio-speech-ws route', () => {
     // sniff-from-text-frame fallback (which would be the input string
     // length of "hello streaming tts" = 19).
     expect(deps.ttsMeter.accumulate).toHaveBeenCalledTimes(1)
-    expect((deps.ttsMeter.accumulate.mock.calls[0] as any[])[0]).toMatchObject({
+    expect(deps.ttsMeter.accumulate.mock.calls[0]?.[0]).toMatchObject({
       userId: 'user-123',
       units: 42,
       metadata: { model: 'volcengine/seed-tts-2.0' },
@@ -329,7 +365,7 @@ describe('audio-speech-ws route', () => {
     // Request log gets the model label from the start frame, not the
     // hardcoded fallback.
     expect(deps.requestLogService.logRequest).toHaveBeenCalledTimes(1)
-    expect((deps.requestLogService.logRequest.mock.calls[0] as any[])[0]).toMatchObject({
+    expect(deps.requestLogService.logRequest.mock.calls[0]?.[0]).toMatchObject({
       userId: 'user-123',
       model: 'volcengine/seed-tts-2.0',
       status: 200,
@@ -363,14 +399,14 @@ describe('audio-speech-ws route', () => {
       restBaseURL: upstream.restBaseURL,
       fluxBalance: 100,
       stepfunStreaming: {
-        enabled: true,
+        rollout: 'default',
         baseURL: upstream.url,
         models: [{ id: 'stepfun/step-tts-2', name: 'Step TTS 2' }],
         defaultModel: 'stepfun/step-tts-2',
         voices: [{ id: 'lively-girl', name: 'Lively Girl' }],
       },
     })
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-stepfun')
     const client = makeMockClientWs()
 
@@ -397,40 +433,426 @@ describe('audio-speech-ws route', () => {
     expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-stepfun', units: 2001 }))
   })
 
-  it('settles StepFun text usage when the client cancels before audio completion', async () => {
+  it('closes StepFun immediately and records cancellation separately from billing', async () => {
     upstream = await startMockUpstream([], [{ id: 'lively-girl', name: 'Lively Girl' }], 'stepfun')
     const deps = makeFakeDeps({
       upstreamURL: upstream.url,
       restBaseURL: upstream.restBaseURL,
       fluxBalance: 100,
       stepfunStreaming: {
-        enabled: true,
+        rollout: 'default',
         baseURL: upstream.url,
         models: [{ id: 'stepfun/step-tts-2', name: 'Step TTS 2' }],
         defaultModel: 'stepfun/step-tts-2',
         voices: [{ id: 'lively-girl', name: 'Lively Girl' }],
       },
     })
-    const events = createAudioSpeechWsHandlers(deps as any)('user-stepfun-cancel')
+    const events = createTestHandlers(deps)('user-stepfun-cancel')
     const client = makeMockClientWs()
+    let releaseBilling: (() => void) | undefined
+    deps.ttsMeter.accumulate.mockImplementation(async () => new Promise((resolve) => {
+      releaseBilling = () => resolve({
+        fluxDebited: 1,
+        debtAfter: 0,
+        balanceAfter: 99,
+        unbilledFlux: 0,
+      })
+    }))
 
     await driveClientSession(events, client, [
       JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
       JSON.stringify({ event: 'text', text: 'paid text' }),
     ])
-    events.onClose?.(new Event('close') as any, client.ctx)
-    await new Promise(r => setTimeout(r, 100))
+    events.onClose?.(new CloseEvent('close'), client.ctx)
+    await new Promise(r => setTimeout(r, 30))
 
+    expect(upstream.disconnectedClients).toBe(1)
     expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'user-stepfun-cancel',
       units: 9,
     }))
+    expect(deps.requestLogService.logRequest).not.toHaveBeenCalled()
+
+    releaseBilling?.()
+    await new Promise(r => setTimeout(r, 30))
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 499 }))
+    expect(deps.productEventService.track).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'speech_cancelled',
+      status: 'cancelled',
+      reason: 'client_disconnected',
+    }))
+    expect(deps.productEventService.track).not.toHaveBeenCalledWith(expect.objectContaining({ action: 'speech_succeeded' }))
+  })
+
+  it('cancels immediately while start configuration is still pending', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const readConfig = deps.configKV.getOptional.getMockImplementation()
+    let releaseConfig: (() => void) | undefined
+    const configGate = new Promise<void>((resolve) => {
+      releaseConfig = resolve
+    })
+    deps.configKV.getOptional.mockImplementation(async (key) => {
+      await configGate
+      return readConfig?.(key) ?? null
+    })
+    const events = createTestHandlers(deps)('user-stepfun-explicit-cancel')
+    const client = makeMockClientWs()
+
+    events.onOpen?.(new Event('open'), client.ctx)
+    events.onMessage?.(new MessageEvent('message', {
+      data: JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+    }), client.ctx)
+    await new Promise(resolve => setTimeout(resolve, 10))
+    events.onMessage?.(new MessageEvent('message', {
+      data: JSON.stringify({ event: 'cancel' }),
+    }), client.ctx)
+    await new Promise(resolve => setTimeout(resolve, 30))
+
+    expect(client.closed).toBe(true)
+    expect(upstream.observedAuth).toBeUndefined()
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 499 }))
+    expect(deps.productEventService.track).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'speech_cancelled',
+      status: 'cancelled',
+      reason: 'client_cancelled',
+    }))
+
+    releaseConfig?.()
+    await new Promise(resolve => setTimeout(resolve, 30))
+    expect(upstream.observedAuth).toBeUndefined()
+  })
+
+  it('fails and releases a StepFun connection that never completes its handshake', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl' }], 'stepfun', { suppressStepfunConnectionDone: true })
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      streamingTtsTimeouts: { handshakeMs: 25, completionMs: 100 },
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-timeout')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+    ])
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(client.sent.filter(frame => frame.kind === 'text').map(frame => JSON.parse(frame.data as string))).toContainEqual(
+      expect.objectContaining({ event: 'error', code: 'stepfun_handshake_timeout' }),
+    )
+    expect(upstream.disconnectedClients).toBe(1)
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 502 }))
+  })
+
+  it('fails and releases an unSpeech connection that never completes after finish', async () => {
+    upstream = await startMockUpstream([
+      { kind: 'json', payload: { event: 'session.started' } },
+    ])
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      restBaseURL: upstream.restBaseURL,
+      fluxBalance: 100,
+      streamingTtsTimeouts: { handshakeMs: 100, completionMs: 25 },
+    })
+    const events = createTestHandlers(deps)('user-unspeech-timeout')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'volcengine/seed-tts-2.0', voice: 'mock' }),
+      JSON.stringify({ event: 'text', text: 'timeout input' }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(resolve => setTimeout(resolve, 80))
+
+    expect(client.sent.filter(frame => frame.kind === 'text').map(frame => JSON.parse(frame.data as string))).toContainEqual(
+      expect.objectContaining({ event: 'error', code: 'unspeech_completion_timeout' }),
+    )
+    expect(upstream.disconnectedClients).toBe(1)
+    expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({ units: 13 }))
+  })
+
+  it('keeps a long StepFun completion alive while audio progress continues', async () => {
+    const audio = Buffer.from('progress').toString('base64')
+    upstream = await startMockUpstream([
+      { kind: 'json', payload: { type: 'tts.response.audio.delta', data: { session_id: 'stepfun-session', audio } } },
+      { kind: 'json', payload: { type: 'tts.response.audio.delta', data: { session_id: 'stepfun-session', audio } } },
+      { kind: 'json', payload: { type: 'tts.response.audio.delta', data: { session_id: 'stepfun-session', audio } } },
+      { kind: 'json', payload: { type: 'tts.response.audio.done', data: { session_id: 'stepfun-session' } } },
+    ], [{ id: 'lively-girl' }], 'stepfun', { scriptedResponseDelayMs: 15 })
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      streamingTtsTimeouts: { handshakeMs: 100, completionMs: 25 },
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-progress')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'long healthy output' }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(client.sent.filter(frame => frame.kind === 'binary')).toHaveLength(3)
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 200 }))
+    expect(deps.productEventService.track).not.toHaveBeenCalledWith(expect.objectContaining({ reason: 'stepfun_completion_timeout' }))
+  })
+
+  it('never bills less than text accepted by unSpeech when upstream usage under-reports', async () => {
+    upstream = await startMockUpstream([
+      { kind: 'json', payload: { event: 'session.started' } },
+      { kind: 'json', payload: { event: 'session.finished', payload: { usage: { text_words: 0 } } } },
+    ])
+    const deps = makeFakeDeps({ upstreamURL: upstream.url, restBaseURL: upstream.restBaseURL, fluxBalance: 100 })
+    const events = createTestHandlers(deps)('user-unspeech-under-report')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'volcengine/seed-tts-2.0', voice: 'mock' }),
+      JSON.stringify({ event: 'text', text: 'accepted text' }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(resolve => setTimeout(resolve, 80))
+
+    expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({ units: 13 }))
+  })
+
+  it('allows unSpeech to validate the model when the curated model list is empty', async () => {
+    upstream = await startMockUpstream([
+      { kind: 'json', payload: { event: 'session.started' } },
+      { kind: 'json', payload: { event: 'session.finished', payload: {} } },
+    ])
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      restBaseURL: upstream.restBaseURL,
+      fluxBalance: 100,
+      streamingModels: [],
+    })
+    const events = createTestHandlers(deps)('user-unspeech-upstream-policy')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'volcengine/upstream-model', voice: 'mock' }),
+      JSON.stringify({ event: 'text', text: 'hello' }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(resolve => setTimeout(resolve, 80))
+
+    expect(upstream.observedAuth).toBe('Bearer mock-upstream-token')
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 200 }))
+  })
+
+  it('does not bill text that never reached a created StepFun session', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl' }], 'stepfun', { stepfunCreatedDelayMs: 200 })
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-unaccepted')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'not accepted' }),
+    ])
+    events.onClose?.(new CloseEvent('close'), client.ctx)
+    await new Promise(r => setTimeout(r, 30))
+
+    expect(deps.ttsMeter.accumulate).not.toHaveBeenCalled()
+    expect(upstream.receivedFrames.map(frame => JSON.parse(frame.data as string).type)).toEqual(['tts.create'])
+  })
+
+  it('records a StepFun response error as failure while charging only accepted text', async () => {
+    upstream = await startMockUpstream([
+      { kind: 'json', payload: { type: 'tts.response.error', data: { session_id: 'stepfun-session', code: 'provider_busy', message: 'busy' } } },
+    ], [{ id: 'lively-girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-error')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'bill accepted text' }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(r => setTimeout(r, 80))
+
+    expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({ units: 18 }))
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 502 }))
+    expect(deps.productEventService.track).toHaveBeenCalledWith(expect.objectContaining({ action: 'speech_failed', reason: 'provider_busy' }))
+    expect(deps.productEventService.track).not.toHaveBeenCalledWith(expect.objectContaining({ action: 'speech_succeeded' }))
+  })
+
+  it('rejects StepFun events that do not belong to the active session', async () => {
+    upstream = await startMockUpstream([
+      {
+        kind: 'json',
+        payload: {
+          type: 'tts.response.audio.delta',
+          data: { session_id: 'another-session', audio: Buffer.from('wrong-session').toString('base64') },
+        },
+      },
+    ], [{ id: 'lively-girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-correlation')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'hello' }),
+      JSON.stringify({ event: 'finish' }),
+    ])
+    await new Promise(r => setTimeout(r, 80))
+
+    const controlFrames = client.sent.filter(frame => frame.kind === 'text').map(frame => JSON.parse(frame.data as string))
+    expect(controlFrames).toContainEqual(expect.objectContaining({ event: 'error', code: 'stepfun_session_mismatch' }))
+    expect(client.sent.filter(frame => frame.kind === 'binary')).toHaveLength(0)
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 502 }))
+  })
+
+  it('rejects an oversized streaming session before forwarding text upstream', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-limit')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'x'.repeat(20001) }),
+    ])
+    await new Promise(r => setTimeout(r, 30))
+
+    expect(client.closeCode).toBe(1009)
+    expect(upstream.receivedFrames.map(frame => JSON.parse(frame.data as string).type)).toEqual(['tts.create'])
+    expect(deps.ttsMeter.accumulate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a StepFun response format that cannot preserve the client contract', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    const events = createTestHandlers(deps)('user-stepfun-format')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl', response_format: 'aac' }),
+    ])
+
+    expect(upstream.observedAuth).toBeUndefined()
+    expect(client.sent.filter(frame => frame.kind === 'text').map(frame => JSON.parse(frame.data as string))).toContainEqual(
+      expect.objectContaining({ event: 'error', code: 'streaming_tts_response_format_not_supported' }),
+    )
+  })
+
+  it('bills accepted text when a later affordability window is blocked', async () => {
+    upstream = await startMockUpstream([], [{ id: 'lively-girl' }], 'stepfun')
+    const deps = makeFakeDeps({
+      upstreamURL: upstream.url,
+      fluxBalance: 100,
+      stepfunStreaming: {
+        rollout: 'available',
+        baseURL: upstream.url,
+        models: [{ id: 'stepfun/step-tts-2' }],
+        defaultModel: 'stepfun/step-tts-2',
+        voices: [{ id: 'lively-girl' }],
+      },
+    })
+    deps.ttsMeter.assertCanAfford.mockImplementation(async (_userId, units) => {
+      if (units > 2000)
+        throw Object.assign(new Error('Insufficient flux'), { statusCode: 402 })
+    })
+    const events = createTestHandlers(deps)('user-stepfun-window')
+    const client = makeMockClientWs()
+
+    await driveClientSession(events, client, [
+      JSON.stringify({ event: 'start', model: 'stepfun/step-tts-2', voice: 'lively-girl' }),
+      JSON.stringify({ event: 'text', text: 'x'.repeat(2000) }),
+      JSON.stringify({ event: 'text', text: 'x' }),
+    ])
+    await new Promise(r => setTimeout(r, 50))
+
+    expect(client.closeCode).toBe(1008)
+    expect(deps.ttsMeter.accumulate).toHaveBeenCalledWith(expect.objectContaining({ units: 2000 }))
+    expect(deps.requestLogService.logRequest).toHaveBeenCalledWith(expect.objectContaining({ status: 402 }))
+    expect(deps.productEventService.track).toHaveBeenCalledWith(expect.objectContaining({ action: 'speech_blocked' }))
   })
 
   it('refuses the session with insufficient_flux when the user is broke', async () => {
     upstream = await startMockUpstream([])
     const deps = makeFakeDeps({ upstreamURL: upstream.url, restBaseURL: upstream.restBaseURL, fluxBalance: 0 })
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-broke', { trigger: 'auto', source: 'chat_auto_tts' })
     const client = makeMockClientWs()
 
@@ -468,9 +890,9 @@ describe('audio-speech-ws route', () => {
 
   it('refuses with streaming_tts_not_configured when UNSPEECH_UPSTREAM.streaming is empty', async () => {
     const deps = makeFakeDeps({ upstreamURL: 'ws://unused', fluxBalance: 100 })
-    deps.configKV.getOptional = vi.fn(async () => null) as any
+    deps.configKV.getOptional.mockImplementation(async () => null)
 
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-noconf')
     const client = makeMockClientWs()
 
@@ -495,7 +917,7 @@ describe('audio-speech-ws route', () => {
       fluxBalance: 100,
       streamingModels: [{ id: 'volcengine/seed-tts-2.0', name: 'Seed-TTS 2.0' }],
     })
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-disabled-model')
     const client = makeMockClientWs()
 
@@ -521,7 +943,7 @@ describe('audio-speech-ws route', () => {
   it('refuses an unknown streaming voice before dialing upstream', async () => {
     upstream = await startMockUpstream([], [{ id: 'enabled-voice', name: 'Enabled Voice' }])
     const deps = makeFakeDeps({ upstreamURL: upstream.url, restBaseURL: upstream.restBaseURL, fluxBalance: 100 })
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-disabled-voice')
     const client = makeMockClientWs()
 
@@ -554,7 +976,7 @@ describe('audio-speech-ws route', () => {
     ])
 
     const deps = makeFakeDeps({ upstreamURL: upstream.url, restBaseURL: upstream.restBaseURL, fluxBalance: 100 })
-    const handlers = createAudioSpeechWsHandlers(deps as any)
+    const handlers = createTestHandlers(deps)
     const events = handlers('user-no-usage')
     const client = makeMockClientWs()
 
@@ -567,7 +989,7 @@ describe('audio-speech-ws route', () => {
     await new Promise(r => setTimeout(r, 200))
 
     expect(deps.ttsMeter.accumulate).toHaveBeenCalledTimes(1)
-    expect((deps.ttsMeter.accumulate.mock.calls[0] as any[])[0]).toMatchObject({
+    expect(deps.ttsMeter.accumulate.mock.calls[0]?.[0]).toMatchObject({
       userId: 'user-no-usage',
       units: 10, // "hello" + "world" = 10 chars
     })

--- a/server/apps/api/src/routes/audio-speech-ws/session.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/session.ts
@@ -1,17 +1,13 @@
-import type { WSContext } from 'hono/ws'
-import type { RawData } from 'ws'
+import type { Buffer } from 'node:buffer'
 
-import type { StepfunStreamingTtsUpstream, UnspeechUpstream } from '../../services/adapters/config-kv'
-import type { FluxService } from '../../services/domain/flux'
+import type { WSContext } from 'hono/ws'
+
+import type { StreamingTtsProviderEvent, StreamingTtsStartCommand, StreamingTtsTransport } from './providers/types'
 import type { AudioSpeechWsHandlersOptions } from './types'
 
-import { Buffer } from 'node:buffer'
-
-import WebSocket from 'ws'
-
 import { useLogger } from '@guiiai/logg'
+import { errorMessageFrom } from '@moeru/std'
 import { context as otelContext, SpanStatusCode, trace } from '@opentelemetry/api'
-import { ofetch } from 'ofetch'
 
 import { fluxBalanceBucket } from '../../services/domain/flux-balance'
 import { ApiError } from '../../utils/error'
@@ -23,34 +19,41 @@ import {
   AIRI_ATTR_GEN_AI_OPERATION_KIND,
   GEN_AI_ATTR_REQUEST_MODEL,
 } from '../../utils/observability'
-import { bufferToString, readUsageChars, toBufferLike } from './protocol'
+import { resolveStreamingTtsProvider, StreamingTtsResolutionError } from './provider'
+import { createStepfunTransport } from './providers/stepfun'
+import { createUnspeechTransport } from './providers/unspeech'
 
 const log = useLogger('audio-speech-ws').useGlobalConfig()
 
-/**
- * Conservative pre-flight estimate: assume the worst-case streaming session
- * synthesises ~2k input chars before billing materialises. Users below this
- * affordability threshold are refused before the upstream ws is dialed —
- * mirrors the pre-flight pattern at /audio/speech (handleTTS).
- */
 const STREAMING_PREFLIGHT_CHARS_ESTIMATE = 2000
-
+const MAX_STREAMING_INPUT_CHARS = 20000
+const MAX_STREAMING_TEXT_FRAMES = 512
 const STREAM_MODEL_LABEL_FALLBACK = 'streaming-tts'
-const STEPFUN_STREAMING_TTS_AAD_MODEL_NAME = 'stepfun-streaming-tts'
 
 const tracer = trace.getTracer('audio-speech-ws')
 
 /**
- * Mutable state for one streaming speech websocket connection.
+ * One-way lifecycle for a client session. `settling` is entered exactly once
+ * before transport shutdown and owns all asynchronous persistence work.
  */
+type SessionPhase = 'awaiting-start' | 'connecting' | 'streaming' | 'finishing' | 'settling' | 'closed'
+
+interface SessionOutcome {
+  kind: 'completed' | 'cancelled' | 'failed' | 'blocked'
+  status: number
+  reason: string
+}
+
+type ClientCommand
+  = | { type: 'start', value: StreamingTtsStartCommand }
+    | { type: 'text', text: string }
+    | { type: 'finish' }
+    | { type: 'cancel' }
+
+/** Mutable state for one streaming speech websocket connection. */
 export interface AudioSpeechSessionState {
-  /** Stores the accepted client websocket. */
   attachClient: (ws: WSContext) => void
-  /** Reads config, checks balance, decrypts the upstream key, and dials upstream after the start frame is accepted. */
-  dialUpstream: () => Promise<void>
-  /** Forwards a client frame or queues it while the upstream connection opens. */
   handleClientMessage: (message: { data: unknown }, ws: WSContext) => void
-  /** Cancels upstream and finalizes the span when the client disconnects. */
   handleClientClose: () => void
 }
 
@@ -65,18 +68,11 @@ export interface AudioSpeechSessionAnalytics {
 }
 
 /**
- * Creates the per-connection streaming speech state machine.
+ * Creates a provider-neutral streaming TTS session.
  *
- * Use when:
- * - A Hono websocket connection has been accepted for a verified user.
- * - Client frames must be proxied to unSpeech while billing and request logs
- *   are handled at session end.
- *
- * Expects:
- * - `UNSPEECH_UPSTREAM.streaming` has a base URL and at least one encrypted key.
- *
- * Returns:
- * - A connection-scoped state object with no global peer registry.
+ * The session owns client command ordering, affordability, bounded input,
+ * billing, telemetry, and one terminal outcome. Provider websocket protocols
+ * remain behind {@link StreamingTtsTransport}.
  */
 export function createSessionState(
   userId: string,
@@ -87,42 +83,121 @@ export function createSessionState(
   const startedAt = Date.now()
   const analytics = normalizeAnalytics(analyticsInput)
   const span = tracer.startSpan('llm.gateway.tts.stream', {
-    attributes: {
-      [AIRI_ATTR_GEN_AI_OPERATION_KIND]: 'text_to_speech_stream',
-    },
+    attributes: { [AIRI_ATTR_GEN_AI_OPERATION_KIND]: 'text_to_speech_stream' },
   })
 
+  let phase: SessionPhase = 'awaiting-start'
   let clientWs: WSContext | null = null
-  let upstreamWs: WebSocket | null = null
-  let upstreamReady = false
-  let closed = false
-  let billed = false
-  let startFrameAccepted = false
-  let startValidationStarted = false
-  let dialStarted = false
-  let totalInputChars = 0
+  let transport: StreamingTtsTransport | null = null
+  let messageChain = Promise.resolve()
+  let receivedInputChars = 0
+  let acceptedInputChars = 0
+  let textFrameCount = 0
+  let affordabilityCheckedChars = 0
   let preflightFluxBalance: number | undefined
   let modelLabel = STREAM_MODEL_LABEL_FALLBACK
   let voiceLabel: string | undefined
-  let startFrame: StreamingTtsStartFrame | null = null
-  let provider: StreamingProvider | null = null
-  let stepfunSessionId: string | null = null
-  let stepfunSessionCreated = false
-  /**
-   * Frames the client sent before the upstream finished dialing. Buffered to
-   * avoid silently dropping the `start` frame; flushed in arrival order once
-   * the upstream ws transitions to OPEN.
-   */
-  const pendingClientFrames: Array<{ data: Buffer | string, isBinary: boolean }> = []
+  let providerLabel: 'unspeech' | 'stepfun' | undefined
 
   function attachClient(ws: WSContext) {
     clientWs = ws
   }
 
-  async function dialUpstream() {
-    if (dialStarted)
+  function handleClientMessage(message: { data: unknown }, ws: WSContext) {
+    if (isTerminalPhase())
       return
-    dialStarted = true
+
+    const command = parseClientCommand(message.data)
+    // Cancel is an out-of-band terminal command. It must not wait behind
+    // provider/configuration I/O already queued by start or text commands.
+    if (command?.type === 'cancel') {
+      settleSession({ kind: 'cancelled', status: 499, reason: 'client_cancelled' })
+      return
+    }
+
+    messageChain = messageChain
+      .then(() => processClientCommand(command))
+      .catch((error) => {
+        log.withError(error).warn('streaming tts client command failed')
+        failSession(errorCode(error), errorMessageFrom(error) ?? 'Streaming TTS client command failed')
+        try {
+          ws.close(1011, errorCode(error))
+        }
+        catch {}
+      })
+  }
+
+  function handleClientClose() {
+    settleSession({ kind: 'cancelled', status: 499, reason: 'client_disconnected' })
+  }
+
+  async function processClientCommand(command: ClientCommand | null) {
+    if (phase === 'settling' || phase === 'closed')
+      return
+
+    if (!command) {
+      failSession('invalid_client_frame', 'Invalid streaming TTS client frame', 1008)
+      return
+    }
+
+    if (command.type === 'start') {
+      if (phase !== 'awaiting-start') {
+        failSession('unexpected_start_frame', 'Streaming TTS start frame must be sent exactly once', 1008)
+        return
+      }
+      await startSession(command.value)
+      return
+    }
+
+    if (phase === 'awaiting-start') {
+      failSession('invalid_start_frame', 'The first streaming TTS frame must be start', 1008)
+      return
+    }
+
+    // `handleClientMessage` settles cancel before queueing. Keep this guard so
+    // the command union remains exhaustive if another caller is introduced.
+    if (command.type === 'cancel') {
+      settleSession({ kind: 'cancelled', status: 499, reason: 'client_cancelled' })
+      return
+    }
+
+    if (!transport || isTerminalPhase())
+      return
+
+    if (command.type === 'finish') {
+      if (phase === 'finishing') {
+        failSession('duplicate_finish_frame', 'Streaming TTS finish frame was already sent', 1008)
+        return
+      }
+      phase = 'finishing'
+      transport.send({ type: 'finish' })
+      return
+    }
+
+    if (phase === 'finishing') {
+      failSession('text_after_finish', 'Streaming TTS text cannot follow finish', 1008)
+      return
+    }
+
+    const nextChars = receivedInputChars + command.text.length
+    const nextFrames = textFrameCount + 1
+    if (nextChars > MAX_STREAMING_INPUT_CHARS || nextFrames > MAX_STREAMING_TEXT_FRAMES) {
+      failSession('streaming_tts_input_limit_exceeded', 'Streaming TTS session input exceeds the configured limit', 1009)
+      return
+    }
+
+    await ensureAffordable(nextChars)
+    if (isTerminalPhase())
+      return
+    receivedInputChars = nextChars
+    textFrameCount = nextFrames
+    transport.send({ type: 'text', text: command.text })
+  }
+
+  async function startSession(start: StreamingTtsStartCommand) {
+    phase = 'connecting'
+    modelLabel = start.model
+    voiceLabel = start.voice
 
     void opts.productEventService.track({
       userId,
@@ -137,518 +212,190 @@ export function createSessionState(
       },
     })
 
-    if (!provider) {
-      closeWithError(1008, 'streaming_tts_not_configured')
-      return
+    let resolved
+    try {
+      resolved = await resolveStreamingTtsProvider(start, opts.configKV)
     }
+    catch (error) {
+      if (error instanceof StreamingTtsResolutionError) {
+        failSession(error.code, error.message, error.closeCode)
+        return
+      }
+      throw error
+    }
+    if (isTerminalPhase())
+      return
 
-    // Pre-flight balance check: refuse before dialing if the user cannot
-    // afford the worst-case session.
     try {
       const flux = await opts.fluxService.getFlux(userId)
       preflightFluxBalance = flux.flux
       await opts.ttsMeter.assertCanAfford(userId, STREAMING_PREFLIGHT_CHARS_ESTIMATE, flux.flux)
+      affordabilityCheckedChars = STREAMING_PREFLIGHT_CHARS_ESTIMATE
     }
-    catch (err) {
-      log.withError(err).withFields({ userId }).warn('pre-flight rejected streaming tts')
-      // assertCanAfford throws PaymentRequiredError (402) — translate to ws
-      // policy-violation close. The client can read the close code/reason to
-      // surface a 'top up' prompt.
-      if (isPaymentRequiredError(err))
-        closeWithBlockedPreflight(1008, 'insufficient_flux')
-      else
-        closeWithError(1011, 'flux_preflight_failed')
+    catch (error) {
+      if (isPaymentRequiredError(error)) {
+        blockForInsufficientBalance()
+        return
+      }
+      failSession('flux_preflight_failed', 'Streaming TTS affordability check failed')
       return
     }
+    if (isTerminalPhase())
+      return
 
-    // Decrypt the first key. Streaming surface does not do per-attempt key
-    // rotation: a live ws cannot transparently switch upstream mid-session
-    // without breaking audio continuity. Fallback policy belongs at the
-    // session-retry layer (next client connect), not inline.
-    const entry = provider.keys[0]
+    const key = resolved.keys[0]
     let keyPlaintext: Buffer
     try {
-      keyPlaintext = opts.envelopeCrypto.decryptKey(entry.ciphertext, {
-        modelName: provider.aadModelName,
-        keyEntryId: entry.id,
+      keyPlaintext = opts.envelopeCrypto.decryptKey(key.ciphertext, {
+        modelName: resolved.keyContext,
+        keyEntryId: key.id,
       })
     }
-    catch (err) {
-      log.withError(err).withFields({ keyEntryId: entry.id }).error('decrypt failed for streaming tts key')
-      closeWithError(1011, 'decrypt_failed')
+    catch (error) {
+      log.withError(error).withFields({ keyEntryId: key.id }).error('decrypt failed for streaming tts key')
+      failSession('decrypt_failed', 'Streaming TTS credential could not be decrypted')
       return
     }
 
-    const upstreamURL = provider.baseURL
-    span.setAttribute(AIRI_ATTR_GEN_AI_GATEWAY_UPSTREAM_URL, upstreamURL)
-    span.setAttribute(AIRI_ATTR_GEN_AI_GATEWAY_KEY_ID, entry.id)
-
-    let upstream: WebSocket
-    try {
-      upstream = new WebSocket(upstreamURL, {
-        headers: {
-          Authorization: `Bearer ${keyPlaintext.toString('utf8')}`,
-        },
-      })
-    }
-    finally {
-      // Wipe plaintext immediately — the ws lib has already serialized the
-      // header into its outgoing handshake buffer.
-      keyPlaintext.fill(0)
-    }
-
-    upstreamWs = upstream
-
-    upstream.on('open', () => {
-      upstreamReady = true
-      if (provider?.kind === 'stepfun')
-        return
-      // Flush anything the client sent during dial.
-      for (const frame of pendingClientFrames) {
-        try {
-          upstream.send(frame.data, { binary: frame.isBinary })
-        }
-        catch (err) {
-          log.withError(err).warn('failed to flush queued client frame')
-        }
-      }
-      pendingClientFrames.length = 0
-    })
-
-    upstream.on('message', (data, isBinary) => {
-      handleUpstreamMessage(data, isBinary)
-    })
-
-    upstream.on('close', (code, reason) => {
-      log.withFields({ userId, code, reason: reason?.toString() }).debug('upstream ws closed')
-      settleStepfunSession('upstream_closed')
-    })
-
-    upstream.on('error', (err) => {
-      log.withError(err).withFields({ userId }).warn('upstream ws error')
-      span.recordException(err)
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
-      void opts.productEventService.track({
-        userId,
-        feature: 'tts',
-        action: 'speech_failed',
-        status: 'failed',
-        source: analytics.source,
-        model: modelLabel,
-        reason: 'upstream_error',
-        metadata: {
-          duration_ms: Date.now() - startedAt,
-          trigger: analytics.trigger,
-          ...streamingVoiceMetadata(voiceLabel, analytics.voiceType),
-        },
-      })
-      try {
-        clientWs?.send(JSON.stringify({
-          event: 'error',
-          code: 'upstream_error',
-          message: err.message,
-        }))
-      }
-      catch {}
-      settleStepfunSession('upstream_error')
-    })
-  }
-
-  function handleClientMessage(message: { data: unknown }, ws: WSContext) {
-    if (closed)
-      return
-
-    const isBinary = !(typeof message.data === 'string')
-    const payload: Buffer | string = typeof message.data === 'string'
-      ? message.data
-      : message.data instanceof Buffer
-        ? message.data
-        : message.data instanceof ArrayBuffer
-          ? Buffer.from(message.data)
-          : Buffer.from(message.data as ArrayBufferLike)
-
-    if (!startValidationStarted) {
-      if (isBinary || typeof payload !== 'string') {
-        closeWithError(1008, 'invalid_start_frame')
-        return
-      }
-
-      const parsedStartFrame = parseStartFrame(payload)
-      if (!parsedStartFrame) {
-        closeWithError(1008, 'invalid_start_frame')
-        return
-      }
-
-      startValidationStarted = true
-      modelLabel = parsedStartFrame.model
-      voiceLabel = parsedStartFrame.voice
-      startFrame = parsedStartFrame
-      pendingClientFrames.push({ data: payload, isBinary })
-      void validateStartFrame(parsedStartFrame).then((resolvedProvider) => {
-        if (!resolvedProvider || closed)
-          return
-        provider = resolvedProvider
-        startFrameAccepted = true
-        void dialUpstream()
-      }).catch((err) => {
-        log.withError(err).error('streaming tts start validation failed unexpectedly')
-        closeWithError(1011, 'streaming_tts_start_validation_failed')
-      })
-      return
-    }
-
-    // Sniff input chars from text frames so billing has a fallback when
-    // upstream usage.text_words is absent. Only the `text` event contributes;
-    // start/finish/cancel do not.
-    if (!isBinary && typeof payload === 'string') {
-      maybeAccountInputChars(payload)
-    }
-
-    if (!startFrameAccepted && !dialStarted) {
-      pendingClientFrames.push({ data: payload, isBinary })
-      return
-    }
-
-    if (!upstreamWs || !upstreamReady) {
-      pendingClientFrames.push({ data: payload, isBinary })
-      return
-    }
-
-    if (provider?.kind === 'stepfun' && !stepfunSessionCreated) {
-      pendingClientFrames.push({ data: payload, isBinary })
-      return
-    }
-
-    try {
-      if (provider?.kind === 'stepfun') {
-        for (const frame of stepfunClientFrames(payload, isBinary, stepfunSessionId))
-          upstreamWs.send(frame)
-      }
-      else {
-        upstreamWs.send(payload, { binary: isBinary })
-      }
-    }
-    catch (err) {
-      log.withError(err).warn('failed to forward client frame to upstream')
-      try {
-        ws.close(1011, 'upstream_send_failed')
-      }
-      catch {}
-    }
-  }
-
-  function handleClientClose() {
-    if (closed)
-      return
-    // Client dropped — best-effort cancel upstream so the upstream session
-    // releases its resources. We do not wait for SessionCanceled ack.
-    if (upstreamWs && upstreamReady && provider?.kind === 'unspeech') {
-      try {
-        upstreamWs.send(JSON.stringify({ event: 'cancel' }))
-      }
-      catch {}
-    }
-    settleStepfunSession('client_disconnected')
-  }
-
-  function handleUpstreamMessage(data: RawData, isBinary: boolean) {
-    if (provider?.kind === 'stepfun') {
-      handleStepfunMessage(data, isBinary)
-      return
-    }
-    if (!clientWs)
-      return
-    if (isBinary) {
-      // Audio binary frames pass through verbatim.
-      try {
-        clientWs.send(toBufferLike(data))
-      }
-      catch (err) {
-        log.withError(err).warn('failed to forward upstream audio to client')
-      }
-      return
-    }
-
-    // Control frame: forward to client AND inspect for usage / model labels.
-    const text = bufferToString(data)
-    try {
-      clientWs.send(text)
-    }
-    catch (err) {
-      log.withError(err).warn('failed to forward upstream control frame to client')
-    }
-
-    try {
-      const evt = JSON.parse(text) as { event?: string, payload?: Record<string, unknown> }
-      handleUpstreamControlEvent(evt)
-    }
-    catch {
-      // unspeech only ever sends JSON on text frames per the v1 spec; a parse
-      // failure here is a bug in unspeech or a wire corruption. Don't kill
-      // the session over it — the client gets the raw frame regardless.
-    }
-  }
-
-  function handleUpstreamControlEvent(evt: { event?: string, payload?: Record<string, unknown> }) {
-    switch (evt.event) {
-      case 'session.finished': {
-        // Pull authoritative usage from upstream when present. Falls back to
-        // the client-text-frame estimate accumulated in handleClientMessage.
-        const usageChars = readUsageChars(evt.payload)
-        const billUnits = usageChars ?? totalInputChars
-        if (billUnits > 0)
-          void billSession(billUnits, 'session.finished')
-        else
-          finalize()
-        break
-      }
-      case 'error': {
-        const code = typeof evt.payload?.code === 'string' ? evt.payload.code : 'upstream_error'
-        log.withFields({ userId, code, message: String(evt.payload?.message ?? '') }).warn('upstream sent error event')
-        span.setStatus({ code: SpanStatusCode.ERROR, message: code })
-        break
-      }
-      // session.started / sentence.* / subtitle — no server-side action, pure
-      // pass-through to client.
-    }
-  }
-
-  /**
-   * Translates StepFun's JSON/Base64 websocket events into AIRI's established
-   * streaming wire protocol so the browser can keep consuming binary audio
-   * and `sentence.*` / `session.finished` control frames unchanged.
-   */
-  function handleStepfunMessage(data: RawData, isBinary: boolean) {
-    if (!clientWs || !upstreamWs || !provider || provider.kind !== 'stepfun')
-      return
-    if (isBinary) {
-      log.warn('StepFun streaming TTS unexpectedly sent a binary frame')
-      return
-    }
-
-    let event: StepfunServerEvent
-    try {
-      event = JSON.parse(bufferToString(data)) as StepfunServerEvent
-    }
-    catch {
-      log.warn('StepFun streaming TTS sent a malformed JSON frame')
-      return
-    }
-
-    switch (event.type) {
-      case 'tts.connection.done': {
-        const sessionId = event.data?.session_id
-        if (!sessionId || !startFrame) {
-          closeWithError(1011, 'stepfun_invalid_connection_event')
-          return
-        }
-        stepfunSessionId = sessionId
-        upstreamWs.send(JSON.stringify(stepfunCreateFrame(sessionId, startFrame, provider.instruction)))
-        break
-      }
-      case 'tts.response.created': {
-        if (!stepfunSessionId || event.data?.session_id !== stepfunSessionId)
-          return
-        stepfunSessionCreated = true
-        clientWs.send(JSON.stringify({ event: 'session.started' }))
-        const frames = pendingClientFrames.splice(0)
-        for (const frame of frames) {
-          for (const translated of stepfunClientFrames(frame.data, frame.isBinary, stepfunSessionId))
-            upstreamWs.send(translated)
-        }
-        break
-      }
-      case 'tts.response.sentence.start':
-        forwardStepfunControl('sentence.start', event.data)
-        break
-      case 'tts.response.sentence.end':
-        forwardStepfunControl('sentence.end', event.data)
-        break
-      case 'tts.response.subtitle':
-        forwardStepfunControl('subtitle', event.data)
-        break
-      case 'tts.response.audio.delta': {
-        const audio = event.data?.audio
-        if (typeof audio !== 'string') {
-          closeWithError(1011, 'stepfun_invalid_audio_event')
-          return
-        }
-        clientWs.send(Buffer.from(audio, 'base64'))
-        break
-      }
-      case 'tts.response.audio.done':
-        clientWs.send(JSON.stringify({ event: 'session.finished' }))
-        settleStepfunSession('stepfun.audio.done')
-        break
-      case 'tts.response.error': {
-        const code = event.data?.code ?? 'stepfun_upstream_error'
-        const message = event.data?.message ?? code
-        span.setStatus({ code: SpanStatusCode.ERROR, message })
-        clientWs.send(JSON.stringify({ event: 'error', code, message }))
-        settleStepfunSession('stepfun.response.error')
-        break
-      }
-    }
-  }
-
-  function forwardStepfunControl(event: 'sentence.start' | 'sentence.end' | 'subtitle', payload: Record<string, unknown> | undefined) {
-    try {
-      clientWs?.send(JSON.stringify({ event, payload: payload ?? {} }))
-    }
-    catch (err) {
-      log.withError(err).warn('failed to forward StepFun control frame to client')
-    }
-  }
-
-  /**
-   * StepFun does not report character usage on terminal events. Once text has
-   * been handed to its session, bill the accepted text even when a client
-   * cancels or the provider errors before `tts.response.audio.done` arrives.
-   */
-  function settleStepfunSession(reason: string) {
-    if (provider?.kind === 'stepfun' && totalInputChars > 0) {
-      void billSession(totalInputChars, reason)
-      return
-    }
-    finalize()
-  }
-
-  function maybeAccountInputChars(rawText: string) {
-    try {
-      const parsed = JSON.parse(rawText) as { event?: string, text?: string }
-      if (parsed.event === 'text' && typeof parsed.text === 'string') {
-        totalInputChars += parsed.text.length
-      }
-      else if (parsed.event === 'start') {
-        // Capture model label for OTel attrs / request log.
-        const model = (parsed as Record<string, unknown>).model
-        if (typeof model === 'string' && model.length > 0)
-          modelLabel = model
-        const voice = (parsed as Record<string, unknown>).voice
-        if (typeof voice === 'string' && voice.length > 0)
-          voiceLabel = voice
-      }
-    }
-    catch {
-      // Non-JSON text frame from client — ignore for billing, will fail
-      // upstream-side anyway.
-    }
-  }
-
-  async function validateStartFrame(frame: StreamingTtsStartFrame): Promise<StreamingProvider | null> {
-    let stepfun: StepfunStreamingTtsUpstream | null
-    let unspeech: UnspeechUpstream | null
-    try {
-      const [loadedStepfun, loadedUnspeech] = await Promise.all([
-        opts.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'),
-        opts.configKV.getOptional('UNSPEECH_UPSTREAM'),
-      ])
-      stepfun = (loadedStepfun as StepfunStreamingTtsUpstream | null | undefined) ?? null
-      unspeech = (loadedUnspeech as UnspeechUpstream | null | undefined) ?? null
-    }
-    catch (err) {
-      log.withError(err).error('streaming tts configuration read failed before start')
-      closeWithError(1011, 'config_unavailable')
-      return null
-    }
-
-    if (stepfun?.enabled) {
-      if (!stepfun.models.some(model => model.id === frame.model)) {
-        closeWithError(1008, 'streaming_tts_model_not_enabled')
-        return null
-      }
-      if (!stepfun.voices.some(voice => voice.id === frame.voice)) {
-        closeWithError(1008, 'streaming_tts_voice_not_enabled')
-        return null
-      }
-      return {
-        kind: 'stepfun',
-        baseURL: stepfunURL(stepfun.baseURL, frame.model),
-        keys: stepfun.keys,
-        aadModelName: STEPFUN_STREAMING_TTS_AAD_MODEL_NAME,
-        instruction: stepfun.instruction,
-      }
-    }
-
-    const upstreamConfig = unspeech?.streaming
-    if (!unspeech?.restBaseURL || !upstreamConfig?.baseURL || upstreamConfig.keys.length === 0) {
-      closeWithError(1008, 'streaming_tts_not_configured')
-      return null
-    }
-
-    const configuredModels = upstreamConfig.models ?? []
-    if (!configuredModels.some((model: { id: string }) => model.id === frame.model)) {
-      closeWithError(1008, 'streaming_tts_model_not_enabled')
-      return null
-    }
-
-    const resourceId = streamingModelResourceId(frame.model)
-    const voicesURL = streamingVoicesURL(unspeech.restBaseURL, resourceId)
-    if (!voicesURL) {
-      closeWithError(1011, 'streaming_tts_voice_catalog_unavailable')
-      return null
-    }
-
-    let data: { voices?: unknown[] }
-    try {
-      data = await ofetch(voicesURL, { timeout: 5000 }) as { voices?: unknown[] }
-    }
-    catch (err) {
-      log.withError(err).withFields({ voicesURL }).warn('streaming tts voice catalog fetch failed')
-      closeWithError(1011, 'streaming_tts_voice_catalog_unavailable')
-      return null
-    }
-
-    const voices = Array.isArray(data.voices) ? data.voices : []
-    if (!voices.some(voice => streamingVoiceId(voice) === frame.voice)) {
-      closeWithError(1008, 'streaming_tts_voice_not_enabled')
-      return null
-    }
-
-    return {
-      kind: 'unspeech',
-      baseURL: upstreamConfig.baseURL,
-      keys: upstreamConfig.keys,
-      aadModelName: STREAM_MODEL_LABEL_FALLBACK,
-    }
-  }
-
-  async function billSession(units: number, reason: string) {
-    if (billed)
-      return
-    billed = true
+    providerLabel = resolved.kind
+    span.setAttribute(AIRI_ATTR_GEN_AI_GATEWAY_UPSTREAM_URL, resolved.upstreamURL)
+    span.setAttribute(AIRI_ATTR_GEN_AI_GATEWAY_KEY_ID, key.id)
     span.setAttribute(GEN_AI_ATTR_REQUEST_MODEL, modelLabel)
 
-    let flux: Awaited<ReturnType<FluxService['getFlux']>>
+    const transportOptions = {
+      start,
+      upstreamURL: resolved.upstreamURL,
+      keyEntryId: key.id,
+      keyPlaintext,
+      onEvent: handleProviderEvent,
+      timeouts: opts.streamingTtsTimeouts,
+    }
     try {
-      flux = await opts.fluxService.getFlux(userId)
+      transport = resolved.kind === 'stepfun'
+        ? createStepfunTransport({ ...transportOptions, instruction: resolved.instruction })
+        : createUnspeechTransport(transportOptions)
     }
-    catch (err) {
-      log.withError(err).withFields({ userId }).warn('flux read failed at session end')
-      finalize()
-      return
+    catch (error) {
+      keyPlaintext.fill(0)
+      failSession('upstream_connect_failed', errorMessageFrom(error) ?? 'Streaming TTS upstream connection failed')
     }
+  }
 
-    let fluxConsumed = 0
+  async function ensureAffordable(nextChars: number) {
+    if (nextChars <= affordabilityCheckedChars)
+      return
+    if (preflightFluxBalance === undefined)
+      throw new Error('Streaming TTS affordability state is unavailable')
+
+    const nextCheck = Math.ceil(nextChars / STREAMING_PREFLIGHT_CHARS_ESTIMATE) * STREAMING_PREFLIGHT_CHARS_ESTIMATE
     try {
-      const result = await otelContext.with(trace.setSpan(otelContext.active(), span), () =>
-        opts.ttsMeter.accumulate({
-          userId,
-          units,
-          currentBalance: flux.flux,
-          requestId,
-          metadata: { model: modelLabel },
-        }))
-      fluxConsumed = result.fluxDebited
-      span.setAttribute(AIRI_ATTR_BILLING_FLUX_CONSUMED, fluxConsumed)
+      await opts.ttsMeter.assertCanAfford(userId, nextCheck, preflightFluxBalance)
+      affordabilityCheckedChars = nextCheck
     }
-    catch (err) {
-      // Billing failure is surfaced but does not retroactively reject the
-      // already-delivered audio — the user got the audio, the meter retains
-      // the debt for the next request to settle (per FluxMeter rollback path).
-      log.withError(err).withFields({ userId, units, reason }).error('billing accumulate failed for streaming tts')
-      span.recordException(err as Error)
-      span.setStatus({ code: SpanStatusCode.ERROR, message: 'billing_failed' })
+    catch (error) {
+      if (isPaymentRequiredError(error)) {
+        blockForInsufficientBalance(nextCheck)
+        return
+      }
+      throw error
+    }
+  }
+
+  function handleProviderEvent(event: StreamingTtsProviderEvent) {
+    if (phase === 'settling' || phase === 'closed')
+      return
+
+    switch (event.type) {
+      case 'started':
+        if (phase === 'connecting')
+          phase = 'streaming'
+        sendClient({ event: 'session.started' })
+        return
+      case 'input-accepted':
+        acceptedInputChars += event.chars
+        return
+      case 'audio':
+        if (!sendClient(event.data))
+          settleSession({ kind: 'cancelled', status: 499, reason: 'client_unavailable' })
+        return
+      case 'control':
+        if (!sendClient({ event: event.event, payload: event.payload }))
+          settleSession({ kind: 'cancelled', status: 499, reason: 'client_unavailable' })
+        return
+      case 'completed':
+        sendClient({ event: 'session.finished' })
+        settleSession(
+          { kind: 'completed', status: 200, reason: 'session_finished' },
+          Math.max(event.usageChars ?? 0, acceptedInputChars),
+        )
+        return
+      case 'failed':
+        sendClient({ event: 'error', code: event.code, message: event.message })
+        settleSession({ kind: 'failed', status: 502, reason: event.code })
+        return
+      case 'closed':
+        settleSession({ kind: 'failed', status: 502, reason: event.reason || `upstream_closed_${event.code}` })
+    }
+  }
+
+  function failSession(code: string, message: string, closeCode = 1011) {
+    if (phase === 'settling' || phase === 'closed')
+      return
+    span.setStatus({ code: SpanStatusCode.ERROR, message: code })
+    sendClient({ event: 'error', code, message })
+    settleSession(
+      { kind: 'failed', status: closeCode === 1008 || closeCode === 1009 ? 400 : 500, reason: code },
+      acceptedInputChars,
+      { code: closeCode, reason: code },
+    )
+  }
+
+  function settleSession(
+    outcome: SessionOutcome,
+    units = acceptedInputChars,
+    clientClose?: { code: number, reason: string },
+  ) {
+    if (phase === 'settling' || phase === 'closed')
+      return
+    phase = 'settling'
+
+    // Closing transport and client is synchronous with the terminal decision.
+    // Billing and logging must never keep provider generation alive.
+    transport?.abort()
+    closeClient(clientClose?.code, clientClose?.reason)
+
+    if (outcome.kind !== 'completed')
+      span.setStatus({ code: SpanStatusCode.ERROR, message: outcome.reason })
+
+    void persistOutcome(outcome, units).finally(() => {
+      if (phase === 'closed')
+        return
+      phase = 'closed'
+      span.end()
+    })
+  }
+
+  async function persistOutcome(outcome: SessionOutcome, units: number) {
+    let fluxConsumed = 0
+    if (units > 0) {
+      try {
+        const flux = await opts.fluxService.getFlux(userId)
+        const result = await otelContext.with(trace.setSpan(otelContext.active(), span), () =>
+          opts.ttsMeter.accumulate({
+            userId,
+            units,
+            currentBalance: flux.flux,
+            requestId,
+            metadata: { model: modelLabel },
+          }))
+        fluxConsumed = result.fluxDebited
+        span.setAttribute(AIRI_ATTR_BILLING_FLUX_CONSUMED, fluxConsumed)
+      }
+      catch (error) {
+        log.withError(error).withFields({ userId, units, reason: outcome.reason }).error('billing accumulate failed for streaming tts')
+        span.recordException(error as Error)
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'billing_failed' })
+      }
     }
 
     const durationMs = Date.now() - startedAt
@@ -656,22 +403,21 @@ export function createSessionState(
       await opts.requestLogService.logRequest({
         userId,
         model: modelLabel,
-        status: 200,
+        status: outcome.status,
         durationMs,
         fluxConsumed,
       })
     }
-    catch (err) {
-      log.withError(err).warn('failed to write request log for streaming tts')
+    catch (error) {
+      log.withError(error).warn('failed to write request log for streaming tts')
     }
 
-    void opts.productEventService.track({
+    const common = {
       userId,
-      feature: 'tts',
-      action: 'speech_succeeded',
-      status: 'succeeded',
+      feature: 'tts' as const,
       source: analytics.source,
       model: modelLabel,
+      provider: providerLabel,
       metadata: {
         input_chars: units,
         duration_ms: durationMs,
@@ -679,113 +425,134 @@ export function createSessionState(
         trigger: analytics.trigger,
         ...streamingVoiceMetadata(voiceLabel, analytics.voiceType),
       },
-    })
-
-    finalize()
+    }
+    if (outcome.kind === 'completed') {
+      void opts.productEventService.track({
+        ...common,
+        action: 'speech_succeeded',
+        status: 'succeeded',
+      })
+    }
+    else if (outcome.kind === 'blocked') {
+      void opts.productEventService.track({
+        ...common,
+        action: 'speech_blocked',
+        status: 'blocked',
+        reason: 'insufficient_balance',
+        metadata: {
+          ...common.metadata,
+          block_reason: 'insufficient_balance',
+          balance_state: 'insufficient',
+          flux_balance_bucket: fluxBalanceBucket(preflightFluxBalance),
+        },
+      })
+    }
+    else if (outcome.kind === 'cancelled') {
+      void opts.productEventService.track({
+        ...common,
+        action: 'speech_cancelled',
+        status: 'cancelled',
+        reason: outcome.reason,
+      })
+    }
+    else {
+      void opts.productEventService.track({
+        ...common,
+        action: 'speech_failed',
+        status: 'failed',
+        reason: outcome.reason,
+      })
+    }
   }
 
-  function finalize() {
-    if (closed)
+  function blockForInsufficientBalance(requiredUnits = STREAMING_PREFLIGHT_CHARS_ESTIMATE) {
+    if (isTerminalPhase())
       return
-    closed = true
+    sendClient({ event: 'error', code: 'insufficient_flux', message: 'insufficient_flux' })
+    settleSession(
+      { kind: 'blocked', status: 402, reason: 'insufficient_balance' },
+      acceptedInputChars,
+      { code: 1008, reason: 'insufficient_flux' },
+    )
+    span.setAttribute('airi.billing.required_units', requiredUnits)
+  }
+
+  function sendClient(value: Record<string, unknown> | ArrayBuffer): boolean {
+    if (!clientWs)
+      return false
     try {
-      upstreamWs?.close()
+      clientWs.send(value instanceof ArrayBuffer ? value : JSON.stringify(value))
+      return true
+    }
+    catch (error) {
+      log.withError(error).warn('failed to send streaming tts frame to client')
+      return false
+    }
+  }
+
+  function closeClient(code?: number, reason?: string) {
+    try {
+      clientWs?.close(code, reason)
     }
     catch {}
-    try {
-      clientWs?.close()
-    }
-    catch {}
-    span.end()
   }
 
-  function closeWithError(code: number, reason: string) {
-    if (closed)
-      return
-    span.setStatus({ code: SpanStatusCode.ERROR, message: reason })
-    void opts.productEventService.track({
-      userId,
-      feature: 'tts',
-      action: 'speech_failed',
-      status: 'failed',
-      source: analytics.source,
-      model: modelLabel,
-      reason,
-      metadata: {
-        close_code: code,
-        duration_ms: Date.now() - startedAt,
-        trigger: analytics.trigger,
-        ...streamingVoiceMetadata(voiceLabel, analytics.voiceType),
-      },
-    })
-    if (clientWs) {
-      try {
-        clientWs.send(JSON.stringify({ event: 'error', code: reason, message: reason }))
-      }
-      catch {}
-      try {
-        clientWs.close(code, reason)
-      }
-      catch {}
-    }
-    closed = true
-    span.end()
+  function isTerminalPhase() {
+    return phase === 'settling' || phase === 'closed'
   }
 
-  function closeWithBlockedPreflight(code: number, reason: string) {
-    if (closed)
-      return
-    void opts.productEventService.track({
-      userId,
-      feature: 'tts',
-      action: 'speech_blocked',
-      status: 'blocked',
-      source: analytics.source,
-      model: modelLabel,
-      reason: 'insufficient_balance',
-      metadata: {
-        block_reason: 'insufficient_balance',
-        balance_state: 'insufficient',
-        flux_balance_bucket: fluxBalanceBucket(preflightFluxBalance),
-        billing_units: STREAMING_PREFLIGHT_CHARS_ESTIMATE,
-        close_code: code,
-        duration_ms: Date.now() - startedAt,
-        trigger: analytics.trigger,
-        ...streamingVoiceMetadata(voiceLabel, analytics.voiceType),
-      },
-    })
-    if (clientWs) {
-      try {
-        clientWs.send(JSON.stringify({ event: 'error', code: reason, message: reason }))
-      }
-      catch {}
-      try {
-        clientWs.close(code, reason)
-      }
-      catch {}
-    }
-    closed = true
-    span.end()
+  return { attachClient, handleClientMessage, handleClientClose }
+}
+
+function parseClientCommand(data: unknown): ClientCommand | null {
+  if (typeof data !== 'string')
+    return null
+
+  let parsed: Record<string, unknown>
+  try {
+    const value = JSON.parse(data) as unknown
+    if (!isRecord(value))
+      return null
+    parsed = value
+  }
+  catch {
+    return null
   }
 
-  return {
-    attachClient,
-    dialUpstream,
-    handleClientMessage,
-    handleClientClose,
+  switch (parsed.event) {
+    case 'start':
+      if (typeof parsed.model !== 'string' || parsed.model.length === 0)
+        return null
+      if (typeof parsed.voice !== 'string' || parsed.voice.length === 0)
+        return null
+      return {
+        type: 'start',
+        value: {
+          model: parsed.model,
+          voice: parsed.voice,
+          responseFormat: typeof parsed.response_format === 'string' ? parsed.response_format : undefined,
+          extraBody: isRecord(parsed.extra_body) ? parsed.extra_body : undefined,
+        },
+      }
+    case 'text':
+      return typeof parsed.text === 'string' && parsed.text.length > 0
+        ? { type: 'text', text: parsed.text }
+        : null
+    case 'finish':
+      return { type: 'finish' }
+    case 'cancel':
+      return { type: 'cancel' }
+    default:
+      return null
   }
 }
 
 function normalizeAnalytics(input: AudioSpeechSessionAnalytics): Required<AudioSpeechSessionAnalytics> {
   return {
-    trigger: normalizeTrigger(input.trigger),
+    trigger: input.trigger === 'auto' ? 'auto' : 'manual',
     source: normalizeSource(input.source),
     voiceType: normalizeVoiceType(input.voiceType),
   }
-}
-
-function normalizeTrigger(trigger: AudioSpeechSessionAnalytics['trigger']): StreamingTtsTrigger {
-  return trigger === 'auto' ? 'auto' : 'manual'
 }
 
 function normalizeSource(source: AudioSpeechSessionAnalytics['source']): StreamingTtsSource {
@@ -800,9 +567,6 @@ function normalizeSource(source: AudioSpeechSessionAnalytics['source']): Streami
   }
 }
 
-/**
- * Normalizes streaming TTS voice type into bounded analytics values.
- */
 function normalizeVoiceType(voiceType: AudioSpeechSessionAnalytics['voiceType']): StreamingTtsVoiceType {
   switch (voiceType) {
     case 'official_default':
@@ -815,9 +579,6 @@ function normalizeVoiceType(voiceType: AudioSpeechSessionAnalytics['voiceType'])
   }
 }
 
-/**
- * Builds reusable streaming TTS voice metadata after the start frame is known.
- */
 function streamingVoiceMetadata(voiceId: string | undefined, voiceType: StreamingTtsVoiceType): Record<string, unknown> {
   return {
     ...(voiceId ? { voice_id: voiceId } : {}),
@@ -825,189 +586,16 @@ function streamingVoiceMetadata(voiceId: string | undefined, voiceType: Streamin
   }
 }
 
-function isPaymentRequiredError(err: unknown): boolean {
-  if (err instanceof ApiError)
-    return err.statusCode === 402
-  return typeof err === 'object'
-    && err != null
-    && 'statusCode' in err
-    && (err as { statusCode?: unknown }).statusCode === 402
+function isPaymentRequiredError(error: unknown): boolean {
+  if (error instanceof ApiError)
+    return error.statusCode === 402
+  return isRecord(error) && error.statusCode === 402
 }
 
-interface StreamingProvider {
-  kind: 'unspeech' | 'stepfun'
-  baseURL: string
-  keys: Array<{ id: string, ciphertext: string }>
-  aadModelName: string
-  instruction?: string
-}
-
-interface StepfunServerEvent {
-  type?: string
-  data?: {
-    session_id?: string
-    text?: string
-    audio?: string
-    code?: string
-    message?: string
-    [key: string]: unknown
-  }
-}
-
-interface StreamingTtsStartFrame {
-  event: 'start'
-  model: string
-  voice: string
-  responseFormat?: string
-  extraBody?: Record<string, unknown>
-}
-
-function parseStartFrame(rawText: string): StreamingTtsStartFrame | null {
-  try {
-    const parsed = JSON.parse(rawText) as Record<string, unknown>
-    if (parsed.event !== 'start')
-      return null
-    if (typeof parsed.model !== 'string' || parsed.model.length === 0)
-      return null
-    if (typeof parsed.voice !== 'string' || parsed.voice.length === 0)
-      return null
-    return {
-      event: 'start',
-      model: parsed.model,
-      voice: parsed.voice,
-      responseFormat: typeof parsed.response_format === 'string' ? parsed.response_format : undefined,
-      extraBody: isRecord(parsed.extra_body) ? parsed.extra_body : undefined,
-    }
-  }
-  catch {
-    return null
-  }
-}
-
-/**
- * Builds the provider websocket URL while treating the operator's configured
- * base path as authoritative: direct API and Step Plan differ only by path.
- */
-function stepfunURL(baseURL: string, model: string): string {
-  const url = new URL(baseURL)
-  url.searchParams.set('model', streamingModelResourceId(model))
-  return url.toString()
-}
-
-function stepfunCreateFrame(sessionId: string, start: StreamingTtsStartFrame, instruction: string | undefined): Record<string, unknown> {
-  const extraBody = start.extraBody ?? {}
-  const responseFormat = stepfunStreamingFormat(start.responseFormat)
-  const sampleRate = numberFromRecord(extraBody, 'sample_rate')
-    ?? numberFromRecord(isRecord(extraBody.audio) ? extraBody.audio : undefined, 'sample_rate')
-  const speedRatio = numberFromRecord(extraBody, 'speed_ratio')
-  const volumeRatio = numberFromRecord(extraBody, 'volume_ratio')
-  const requestInstruction = stringFromRecord(extraBody, 'instruction')
-
-  return {
-    type: 'tts.create',
-    data: {
-      session_id: sessionId,
-      voice_id: start.voice,
-      response_format: responseFormat,
-      text_normalization: 'standard',
-      mode: 'default',
-      ...(sampleRate ? { sample_rate: sampleRate } : {}),
-      ...(speedRatio ? { speed_ratio: speedRatio } : {}),
-      ...(volumeRatio ? { volume_ratio: volumeRatio } : {}),
-      ...(requestInstruction ?? instruction ? { instruction: requestInstruction ?? instruction } : {}),
-    },
-  }
-}
-
-/**
- * Converts AIRI's provider-neutral client frames into StepFun commands.
- * The `start` frame is intentionally consumed by {@link stepfunCreateFrame}.
- */
-function stepfunClientFrames(payload: Buffer | string, isBinary: boolean, sessionId: string | null): string[] {
-  if (isBinary || !sessionId || typeof payload !== 'string')
-    return []
-
-  let frame: { event?: unknown, text?: unknown }
-  try {
-    frame = JSON.parse(payload) as { event?: unknown, text?: unknown }
-  }
-  catch {
-    return []
-  }
-
-  if (frame.event === 'text' && typeof frame.text === 'string') {
-    return splitStepfunText(frame.text).map(text => JSON.stringify({
-      type: 'tts.text.delta',
-      data: { session_id: sessionId, text },
-    }))
-  }
-  if (frame.event === 'finish')
-    return [JSON.stringify({ type: 'tts.text.done', data: { session_id: sessionId } })]
-  return []
-}
-
-/**
- * AIRI concatenates audio deltas until a sentence boundary before decoding.
- * StepFun's non-streaming delta formats are independent files, so request a
- * stream variant whenever the provider offers one.
- */
-function stepfunStreamingFormat(value: string | undefined): 'mp3_stream' | 'opus_stream' | 'flac_stream' {
-  switch (value) {
-    case 'opus':
-      return 'opus_stream'
-    case 'flac':
-      return 'flac_stream'
-    default:
-      return 'mp3_stream'
-  }
-}
-
-/** Splits only at Unicode code-point boundaries, as StepFun caps one delta at 1000 characters. */
-function splitStepfunText(text: string): string[] {
-  const characters = Array.from(text)
-  const chunks: string[] = []
-  for (let start = 0; start < characters.length; start += 1000)
-    chunks.push(characters.slice(start, start + 1000).join(''))
-  return chunks
+function errorCode(error: unknown): string {
+  return error instanceof StreamingTtsResolutionError ? error.code : 'streaming_tts_internal_error'
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value != null && !Array.isArray(value)
-}
-
-function numberFromRecord(record: Record<string, unknown> | undefined, key: string): number | undefined {
-  const value = record?.[key]
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
-}
-
-function stringFromRecord(record: Record<string, unknown> | undefined, key: string): string | undefined {
-  const value = record?.[key]
-  return typeof value === 'string' && value.length > 0 ? value : undefined
-}
-
-function streamingModelResourceId(model: string): string {
-  return model.includes('/') ? model.split('/', 2)[1] : model
-}
-
-function streamingVoicesURL(restBaseURL: string, resourceId: string): string | null {
-  try {
-    const url = new URL(restBaseURL)
-    url.pathname = '/api/voices'
-    // NOTICE: The streaming websocket path is currently backed only by the
-    // Volcengine Unspeech adapter. If another streaming provider is added,
-    // thread provider identity through the start-frame validation path instead
-    // of deriving it from the model id here.
-    url.search = new URLSearchParams({ provider: 'volcengine', model: resourceId }).toString()
-    return url.toString()
-  }
-  catch {
-    return null
-  }
-}
-
-function streamingVoiceId(voice: unknown): string | null {
-  if (typeof voice !== 'object' || voice == null)
-    return null
-  const id = (voice as { id?: unknown }).id
-  return typeof id === 'string' && id.length > 0 ? id : null
 }

--- a/server/apps/api/src/routes/audio-speech-ws/session.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/session.ts
@@ -1,6 +1,7 @@
 import type { WSContext } from 'hono/ws'
 import type { RawData } from 'ws'
 
+import type { StepfunStreamingTtsUpstream, UnspeechUpstream } from '../../services/adapters/config-kv'
 import type { FluxService } from '../../services/domain/flux'
 import type { AudioSpeechWsHandlersOptions } from './types'
 
@@ -35,6 +36,7 @@ const log = useLogger('audio-speech-ws').useGlobalConfig()
 const STREAMING_PREFLIGHT_CHARS_ESTIMATE = 2000
 
 const STREAM_MODEL_LABEL_FALLBACK = 'streaming-tts'
+const STEPFUN_STREAMING_TTS_AAD_MODEL_NAME = 'stepfun-streaming-tts'
 
 const tracer = trace.getTracer('audio-speech-ws')
 
@@ -102,6 +104,10 @@ export function createSessionState(
   let preflightFluxBalance: number | undefined
   let modelLabel = STREAM_MODEL_LABEL_FALLBACK
   let voiceLabel: string | undefined
+  let startFrame: StreamingTtsStartFrame | null = null
+  let provider: StreamingProvider | null = null
+  let stepfunSessionId: string | null = null
+  let stepfunSessionCreated = false
   /**
    * Frames the client sent before the upstream finished dialing. Buffered to
    * avoid silently dropping the `start` frame; flushed in arrival order once
@@ -131,18 +137,7 @@ export function createSessionState(
       },
     })
 
-    let unspeech: Awaited<ReturnType<AudioSpeechWsHandlersOptions['configKV']['getOptional']>>
-    try {
-      unspeech = await opts.configKV.getOptional('UNSPEECH_UPSTREAM')
-    }
-    catch (err) {
-      log.withError(err).error('UNSPEECH_UPSTREAM read failed')
-      closeWithError(1011, 'config_unavailable')
-      return
-    }
-
-    const upstreamConfig = unspeech?.streaming
-    if (!upstreamConfig || !upstreamConfig.baseURL || upstreamConfig.keys.length === 0) {
+    if (!provider) {
       closeWithError(1008, 'streaming_tts_not_configured')
       return
     }
@@ -170,11 +165,11 @@ export function createSessionState(
     // rotation: a live ws cannot transparently switch upstream mid-session
     // without breaking audio continuity. Fallback policy belongs at the
     // session-retry layer (next client connect), not inline.
-    const entry = upstreamConfig.keys[0]
+    const entry = provider.keys[0]
     let keyPlaintext: Buffer
     try {
       keyPlaintext = opts.envelopeCrypto.decryptKey(entry.ciphertext, {
-        modelName: STREAM_MODEL_LABEL_FALLBACK,
+        modelName: provider.aadModelName,
         keyEntryId: entry.id,
       })
     }
@@ -184,7 +179,7 @@ export function createSessionState(
       return
     }
 
-    const upstreamURL = upstreamConfig.baseURL
+    const upstreamURL = provider.baseURL
     span.setAttribute(AIRI_ATTR_GEN_AI_GATEWAY_UPSTREAM_URL, upstreamURL)
     span.setAttribute(AIRI_ATTR_GEN_AI_GATEWAY_KEY_ID, entry.id)
 
@@ -206,6 +201,8 @@ export function createSessionState(
 
     upstream.on('open', () => {
       upstreamReady = true
+      if (provider?.kind === 'stepfun')
+        return
       // Flush anything the client sent during dial.
       for (const frame of pendingClientFrames) {
         try {
@@ -224,7 +221,7 @@ export function createSessionState(
 
     upstream.on('close', (code, reason) => {
       log.withFields({ userId, code, reason: reason?.toString() }).debug('upstream ws closed')
-      finalize()
+      settleStepfunSession('upstream_closed')
     })
 
     upstream.on('error', (err) => {
@@ -253,7 +250,7 @@ export function createSessionState(
         }))
       }
       catch {}
-      finalize()
+      settleStepfunSession('upstream_error')
     })
   }
 
@@ -276,19 +273,21 @@ export function createSessionState(
         return
       }
 
-      const startFrame = parseStartFrame(payload)
-      if (!startFrame) {
+      const parsedStartFrame = parseStartFrame(payload)
+      if (!parsedStartFrame) {
         closeWithError(1008, 'invalid_start_frame')
         return
       }
 
       startValidationStarted = true
-      modelLabel = startFrame.model
-      voiceLabel = startFrame.voice
+      modelLabel = parsedStartFrame.model
+      voiceLabel = parsedStartFrame.voice
+      startFrame = parsedStartFrame
       pendingClientFrames.push({ data: payload, isBinary })
-      void validateStartFrame(startFrame).then((accepted) => {
-        if (!accepted || closed)
+      void validateStartFrame(parsedStartFrame).then((resolvedProvider) => {
+        if (!resolvedProvider || closed)
           return
+        provider = resolvedProvider
         startFrameAccepted = true
         void dialUpstream()
       }).catch((err) => {
@@ -315,8 +314,19 @@ export function createSessionState(
       return
     }
 
+    if (provider?.kind === 'stepfun' && !stepfunSessionCreated) {
+      pendingClientFrames.push({ data: payload, isBinary })
+      return
+    }
+
     try {
-      upstreamWs.send(payload, { binary: isBinary })
+      if (provider?.kind === 'stepfun') {
+        for (const frame of stepfunClientFrames(payload, isBinary, stepfunSessionId))
+          upstreamWs.send(frame)
+      }
+      else {
+        upstreamWs.send(payload, { binary: isBinary })
+      }
     }
     catch (err) {
       log.withError(err).warn('failed to forward client frame to upstream')
@@ -332,16 +342,20 @@ export function createSessionState(
       return
     // Client dropped — best-effort cancel upstream so the upstream session
     // releases its resources. We do not wait for SessionCanceled ack.
-    if (upstreamWs && upstreamReady) {
+    if (upstreamWs && upstreamReady && provider?.kind === 'unspeech') {
       try {
         upstreamWs.send(JSON.stringify({ event: 'cancel' }))
       }
       catch {}
     }
-    finalize()
+    settleStepfunSession('client_disconnected')
   }
 
   function handleUpstreamMessage(data: RawData, isBinary: boolean) {
+    if (provider?.kind === 'stepfun') {
+      handleStepfunMessage(data, isBinary)
+      return
+    }
     if (!clientWs)
       return
     if (isBinary) {
@@ -399,6 +413,106 @@ export function createSessionState(
     }
   }
 
+  /**
+   * Translates StepFun's JSON/Base64 websocket events into AIRI's established
+   * streaming wire protocol so the browser can keep consuming binary audio
+   * and `sentence.*` / `session.finished` control frames unchanged.
+   */
+  function handleStepfunMessage(data: RawData, isBinary: boolean) {
+    if (!clientWs || !upstreamWs || !provider || provider.kind !== 'stepfun')
+      return
+    if (isBinary) {
+      log.warn('StepFun streaming TTS unexpectedly sent a binary frame')
+      return
+    }
+
+    let event: StepfunServerEvent
+    try {
+      event = JSON.parse(bufferToString(data)) as StepfunServerEvent
+    }
+    catch {
+      log.warn('StepFun streaming TTS sent a malformed JSON frame')
+      return
+    }
+
+    switch (event.type) {
+      case 'tts.connection.done': {
+        const sessionId = event.data?.session_id
+        if (!sessionId || !startFrame) {
+          closeWithError(1011, 'stepfun_invalid_connection_event')
+          return
+        }
+        stepfunSessionId = sessionId
+        upstreamWs.send(JSON.stringify(stepfunCreateFrame(sessionId, startFrame, provider.instruction)))
+        break
+      }
+      case 'tts.response.created': {
+        if (!stepfunSessionId || event.data?.session_id !== stepfunSessionId)
+          return
+        stepfunSessionCreated = true
+        clientWs.send(JSON.stringify({ event: 'session.started' }))
+        const frames = pendingClientFrames.splice(0)
+        for (const frame of frames) {
+          for (const translated of stepfunClientFrames(frame.data, frame.isBinary, stepfunSessionId))
+            upstreamWs.send(translated)
+        }
+        break
+      }
+      case 'tts.response.sentence.start':
+        forwardStepfunControl('sentence.start', event.data)
+        break
+      case 'tts.response.sentence.end':
+        forwardStepfunControl('sentence.end', event.data)
+        break
+      case 'tts.response.subtitle':
+        forwardStepfunControl('subtitle', event.data)
+        break
+      case 'tts.response.audio.delta': {
+        const audio = event.data?.audio
+        if (typeof audio !== 'string') {
+          closeWithError(1011, 'stepfun_invalid_audio_event')
+          return
+        }
+        clientWs.send(Buffer.from(audio, 'base64'))
+        break
+      }
+      case 'tts.response.audio.done':
+        clientWs.send(JSON.stringify({ event: 'session.finished' }))
+        settleStepfunSession('stepfun.audio.done')
+        break
+      case 'tts.response.error': {
+        const code = event.data?.code ?? 'stepfun_upstream_error'
+        const message = event.data?.message ?? code
+        span.setStatus({ code: SpanStatusCode.ERROR, message })
+        clientWs.send(JSON.stringify({ event: 'error', code, message }))
+        settleStepfunSession('stepfun.response.error')
+        break
+      }
+    }
+  }
+
+  function forwardStepfunControl(event: 'sentence.start' | 'sentence.end' | 'subtitle', payload: Record<string, unknown> | undefined) {
+    try {
+      clientWs?.send(JSON.stringify({ event, payload: payload ?? {} }))
+    }
+    catch (err) {
+      log.withError(err).warn('failed to forward StepFun control frame to client')
+    }
+  }
+
+  /**
+   * StepFun does not report character usage on terminal events. Once text has
+   * been handed to its session, bill the accepted text even when a client
+   * cancels or the provider errors before `tts.response.audio.done` arrives.
+   */
+  function settleStepfunSession(reason: string) {
+    if (provider?.kind === 'stepfun' && totalInputChars > 0) {
+      void billSession(totalInputChars, reason)
+      return
+    }
+    finalize()
+  }
+
   function maybeAccountInputChars(rawText: string) {
     try {
       const parsed = JSON.parse(rawText) as { event?: string, text?: string }
@@ -421,34 +535,58 @@ export function createSessionState(
     }
   }
 
-  async function validateStartFrame(frame: StreamingTtsStartFrame): Promise<boolean> {
-    let unspeech: Awaited<ReturnType<AudioSpeechWsHandlersOptions['configKV']['getOptional']>>
+  async function validateStartFrame(frame: StreamingTtsStartFrame): Promise<StreamingProvider | null> {
+    let stepfun: StepfunStreamingTtsUpstream | null
+    let unspeech: UnspeechUpstream | null
     try {
-      unspeech = await opts.configKV.getOptional('UNSPEECH_UPSTREAM')
+      const [loadedStepfun, loadedUnspeech] = await Promise.all([
+        opts.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'),
+        opts.configKV.getOptional('UNSPEECH_UPSTREAM'),
+      ])
+      stepfun = (loadedStepfun as StepfunStreamingTtsUpstream | null | undefined) ?? null
+      unspeech = (loadedUnspeech as UnspeechUpstream | null | undefined) ?? null
     }
     catch (err) {
-      log.withError(err).error('UNSPEECH_UPSTREAM read failed before streaming tts start')
+      log.withError(err).error('streaming tts configuration read failed before start')
       closeWithError(1011, 'config_unavailable')
-      return false
+      return null
+    }
+
+    if (stepfun?.enabled) {
+      if (!stepfun.models.some(model => model.id === frame.model)) {
+        closeWithError(1008, 'streaming_tts_model_not_enabled')
+        return null
+      }
+      if (!stepfun.voices.some(voice => voice.id === frame.voice)) {
+        closeWithError(1008, 'streaming_tts_voice_not_enabled')
+        return null
+      }
+      return {
+        kind: 'stepfun',
+        baseURL: stepfunURL(stepfun.baseURL, frame.model),
+        keys: stepfun.keys,
+        aadModelName: STEPFUN_STREAMING_TTS_AAD_MODEL_NAME,
+        instruction: stepfun.instruction,
+      }
     }
 
     const upstreamConfig = unspeech?.streaming
     if (!unspeech?.restBaseURL || !upstreamConfig?.baseURL || upstreamConfig.keys.length === 0) {
       closeWithError(1008, 'streaming_tts_not_configured')
-      return false
+      return null
     }
 
     const configuredModels = upstreamConfig.models ?? []
     if (!configuredModels.some((model: { id: string }) => model.id === frame.model)) {
       closeWithError(1008, 'streaming_tts_model_not_enabled')
-      return false
+      return null
     }
 
     const resourceId = streamingModelResourceId(frame.model)
     const voicesURL = streamingVoicesURL(unspeech.restBaseURL, resourceId)
     if (!voicesURL) {
       closeWithError(1011, 'streaming_tts_voice_catalog_unavailable')
-      return false
+      return null
     }
 
     let data: { voices?: unknown[] }
@@ -458,16 +596,21 @@ export function createSessionState(
     catch (err) {
       log.withError(err).withFields({ voicesURL }).warn('streaming tts voice catalog fetch failed')
       closeWithError(1011, 'streaming_tts_voice_catalog_unavailable')
-      return false
+      return null
     }
 
     const voices = Array.isArray(data.voices) ? data.voices : []
     if (!voices.some(voice => streamingVoiceId(voice) === frame.voice)) {
       closeWithError(1008, 'streaming_tts_voice_not_enabled')
-      return false
+      return null
     }
 
-    return true
+    return {
+      kind: 'unspeech',
+      baseURL: upstreamConfig.baseURL,
+      keys: upstreamConfig.keys,
+      aadModelName: STREAM_MODEL_LABEL_FALLBACK,
+    }
   }
 
   async function billSession(units: number, reason: string) {
@@ -691,10 +834,32 @@ function isPaymentRequiredError(err: unknown): boolean {
     && (err as { statusCode?: unknown }).statusCode === 402
 }
 
+interface StreamingProvider {
+  kind: 'unspeech' | 'stepfun'
+  baseURL: string
+  keys: Array<{ id: string, ciphertext: string }>
+  aadModelName: string
+  instruction?: string
+}
+
+interface StepfunServerEvent {
+  type?: string
+  data?: {
+    session_id?: string
+    text?: string
+    audio?: string
+    code?: string
+    message?: string
+    [key: string]: unknown
+  }
+}
+
 interface StreamingTtsStartFrame {
   event: 'start'
   model: string
   voice: string
+  responseFormat?: string
+  extraBody?: Record<string, unknown>
 }
 
 function parseStartFrame(rawText: string): StreamingTtsStartFrame | null {
@@ -710,11 +875,114 @@ function parseStartFrame(rawText: string): StreamingTtsStartFrame | null {
       event: 'start',
       model: parsed.model,
       voice: parsed.voice,
+      responseFormat: typeof parsed.response_format === 'string' ? parsed.response_format : undefined,
+      extraBody: isRecord(parsed.extra_body) ? parsed.extra_body : undefined,
     }
   }
   catch {
     return null
   }
+}
+
+/**
+ * Builds the provider websocket URL while treating the operator's configured
+ * base path as authoritative: direct API and Step Plan differ only by path.
+ */
+function stepfunURL(baseURL: string, model: string): string {
+  const url = new URL(baseURL)
+  url.searchParams.set('model', streamingModelResourceId(model))
+  return url.toString()
+}
+
+function stepfunCreateFrame(sessionId: string, start: StreamingTtsStartFrame, instruction: string | undefined): Record<string, unknown> {
+  const extraBody = start.extraBody ?? {}
+  const responseFormat = stepfunStreamingFormat(start.responseFormat)
+  const sampleRate = numberFromRecord(extraBody, 'sample_rate')
+    ?? numberFromRecord(isRecord(extraBody.audio) ? extraBody.audio : undefined, 'sample_rate')
+  const speedRatio = numberFromRecord(extraBody, 'speed_ratio')
+  const volumeRatio = numberFromRecord(extraBody, 'volume_ratio')
+  const requestInstruction = stringFromRecord(extraBody, 'instruction')
+
+  return {
+    type: 'tts.create',
+    data: {
+      session_id: sessionId,
+      voice_id: start.voice,
+      response_format: responseFormat,
+      text_normalization: 'standard',
+      mode: 'default',
+      ...(sampleRate ? { sample_rate: sampleRate } : {}),
+      ...(speedRatio ? { speed_ratio: speedRatio } : {}),
+      ...(volumeRatio ? { volume_ratio: volumeRatio } : {}),
+      ...(requestInstruction ?? instruction ? { instruction: requestInstruction ?? instruction } : {}),
+    },
+  }
+}
+
+/**
+ * Converts AIRI's provider-neutral client frames into StepFun commands.
+ * The `start` frame is intentionally consumed by {@link stepfunCreateFrame}.
+ */
+function stepfunClientFrames(payload: Buffer | string, isBinary: boolean, sessionId: string | null): string[] {
+  if (isBinary || !sessionId || typeof payload !== 'string')
+    return []
+
+  let frame: { event?: unknown, text?: unknown }
+  try {
+    frame = JSON.parse(payload) as { event?: unknown, text?: unknown }
+  }
+  catch {
+    return []
+  }
+
+  if (frame.event === 'text' && typeof frame.text === 'string') {
+    return splitStepfunText(frame.text).map(text => JSON.stringify({
+      type: 'tts.text.delta',
+      data: { session_id: sessionId, text },
+    }))
+  }
+  if (frame.event === 'finish')
+    return [JSON.stringify({ type: 'tts.text.done', data: { session_id: sessionId } })]
+  return []
+}
+
+/**
+ * AIRI concatenates audio deltas until a sentence boundary before decoding.
+ * StepFun's non-streaming delta formats are independent files, so request a
+ * stream variant whenever the provider offers one.
+ */
+function stepfunStreamingFormat(value: string | undefined): 'mp3_stream' | 'opus_stream' | 'flac_stream' {
+  switch (value) {
+    case 'opus':
+      return 'opus_stream'
+    case 'flac':
+      return 'flac_stream'
+    default:
+      return 'mp3_stream'
+  }
+}
+
+/** Splits only at Unicode code-point boundaries, as StepFun caps one delta at 1000 characters. */
+function splitStepfunText(text: string): string[] {
+  const characters = Array.from(text)
+  const chunks: string[] = []
+  for (let start = 0; start < characters.length; start += 1000)
+    chunks.push(characters.slice(start, start + 1000).join(''))
+  return chunks
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value)
+}
+
+function numberFromRecord(record: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = record?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function stringFromRecord(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 function streamingModelResourceId(model: string): string {

--- a/server/apps/api/src/routes/audio-speech-ws/types.ts
+++ b/server/apps/api/src/routes/audio-speech-ws/types.ts
@@ -4,6 +4,7 @@ import type { FluxService } from '../../services/domain/flux'
 import type { ProductEventService } from '../../services/domain/product-events'
 import type { RequestLogService } from '../../services/domain/request-log'
 import type { EnvelopeCrypto } from '../../utils/envelope-crypto'
+import type { StreamingTtsTransportOptions } from './providers/types'
 
 /**
  * Dependencies required by the streaming speech websocket proxy.
@@ -21,4 +22,6 @@ export interface AudioSpeechWsHandlersOptions {
   requestLogService: RequestLogService
   /** Writes first-party product analytics for distinct-user aggregation. */
   productEventService: ProductEventService
+  /** Overrides provider deadlines, primarily for constrained deployments and deterministic tests. */
+  streamingTtsTimeouts?: StreamingTtsTransportOptions['timeouts']
 }

--- a/server/apps/api/src/routes/openai/v1/operations/speech-catalog/index.ts
+++ b/server/apps/api/src/routes/openai/v1/operations/speech-catalog/index.ts
@@ -5,6 +5,7 @@ import { useLogger } from '@guiiai/logg'
 import { ofetch } from 'ofetch'
 
 import { catalogVoiceResponse } from '../../../../../services/domain/provider-catalog/provider-voices'
+import { isUnspeechStreamingModelEnabled, streamingTtsModelResourceId } from '../../../../../services/domain/streaming-tts-policy'
 import { createBadGatewayError, createBadRequestError, createServiceUnavailableError } from '../../../../../utils/error'
 
 const VOICE_PACK_MODEL_ID = 'voice-pack'
@@ -81,35 +82,42 @@ export function createSpeechCatalogOperation(deps: V1RouteDeps): SpeechCatalogOp
    * No empty-array fallback: the UI surfaces a real failure state.
    */
   async function listStreamingVoices(input: ListStreamingVoicesInput) {
-    const stepfun = await deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM')
-    if (stepfun?.enabled) {
-      const model = input.model
-      const matchedModel = model
-        ? stepfun.models.find(item => item.id === model || item.id === `stepfun/${model}`)
-        : undefined
-      if (model && !matchedModel)
-        throw createBadRequestError('streaming voices: model is not enabled', 'STREAMING_TTS_MODEL_NOT_ENABLED')
-
-      const recommended = (await deps.configKV.getOptional('DEFAULT_TTS_VOICES'))?.[matchedModel?.id ?? stepfun.defaultModel] ?? {}
+    const [stepfun, unspeech] = await Promise.all([
+      deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'),
+      deps.configKV.getOptional('UNSPEECH_UPSTREAM'),
+    ])
+    const model = input.model
+    const stepfunAvailable = stepfun != null && stepfun.rollout !== 'disabled'
+    const selectedStepfunModel = stepfunAvailable
+      ? model
+        ? stepfun.models.find(item => item.id === model)
+        : stepfun.rollout === 'default'
+          ? stepfun.models.find(item => item.id === stepfun.defaultModel)
+          : undefined
+      : undefined
+    if (stepfun && selectedStepfunModel) {
+      const recommended = (await deps.configKV.getOptional('DEFAULT_TTS_VOICES'))?.[selectedStepfunModel.id] ?? {}
       return Response.json({ voices: stepfun.voices, recommended })
     }
 
-    const unspeech = await deps.configKV.getOptional('UNSPEECH_UPSTREAM')
+    const unspeechModels = unspeech?.streaming?.models ?? []
+    const unspeechModelEnabled = model == null
+      || (unspeech?.streaming != null && isUnspeechStreamingModelEnabled(unspeechModels, model))
+    if (!unspeechModelEnabled)
+      throw createBadRequestError('streaming voices: model is not enabled', 'STREAMING_TTS_MODEL_NOT_ENABLED')
     if (!unspeech?.streaming?.baseURL)
       throw createServiceUnavailableError('streaming tts upstream not configured', 'STREAMING_TTS_NOT_CONFIGURED')
 
     // Pass through the api_resource_id (e.g. `seed-tts-2.0`). unspeech
     // filters the embedded Volcengine catalogue server-side; absent model
     // means "return everything streaming-safe".
-    const model = input.model
-
     let voicesURL: string
     try {
       const u = new URL(unspeech.restBaseURL)
       u.pathname = '/api/voices'
       const params = new URLSearchParams({ provider: 'volcengine' })
       if (model)
-        params.set('model', model)
+        params.set('model', streamingTtsModelResourceId(model))
       u.search = `?${params.toString()}`
       voicesURL = u.toString()
     }
@@ -173,34 +181,28 @@ export function createSpeechCatalogOperation(deps: V1RouteDeps): SpeechCatalogOp
   }
 
   async function listStreamingSpeechModels() {
-    const stepfun = await deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM')
-    if (stepfun?.enabled) {
-      return Response.json({
-        available: true,
-        models: stepfun.models.map(m => ({
-          id: m.id,
-          name: m.name ?? m.id,
-          description: m.description,
-        })),
-        default: stepfun.defaultModel,
-      })
-    }
-
-    const unspeech = await deps.configKV.getOptional('UNSPEECH_UPSTREAM')
-    const models = unspeech?.streaming?.models ?? []
+    const [stepfun, unspeech] = await Promise.all([
+      deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'),
+      deps.configKV.getOptional('UNSPEECH_UPSTREAM'),
+    ])
+    const unspeechModels = unspeech?.streaming?.models ?? []
+    const stepfunModels = stepfun?.rollout === 'disabled' ? [] : (stepfun?.models ?? [])
+    const models = [...unspeechModels, ...stepfunModels]
     // `available` is the operator-controlled visibility switch the client gates
     // the streaming provider on. It tracks whether `UNSPEECH_UPSTREAM.streaming`
     // is configured at all — not whether `models[]` happens to be empty — so an
     // operator who has wired the upstream but not yet curated models still
     // surfaces the provider rather than silently hiding it.
     return Response.json({
-      available: !!unspeech?.streaming?.baseURL,
+      available: !!unspeech?.streaming?.baseURL || stepfunModels.length > 0,
       models: models.map(m => ({
         id: m.id,
         name: m.name ?? m.id,
         description: m.description,
       })),
-      default: unspeech?.streaming?.defaultModel ?? null,
+      default: stepfun?.rollout === 'default'
+        ? stepfun.defaultModel
+        : (unspeech?.streaming?.defaultModel ?? null),
     })
   }
 

--- a/server/apps/api/src/routes/openai/v1/operations/speech-catalog/index.ts
+++ b/server/apps/api/src/routes/openai/v1/operations/speech-catalog/index.ts
@@ -81,6 +81,19 @@ export function createSpeechCatalogOperation(deps: V1RouteDeps): SpeechCatalogOp
    * No empty-array fallback: the UI surfaces a real failure state.
    */
   async function listStreamingVoices(input: ListStreamingVoicesInput) {
+    const stepfun = await deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM')
+    if (stepfun?.enabled) {
+      const model = input.model
+      const matchedModel = model
+        ? stepfun.models.find(item => item.id === model || item.id === `stepfun/${model}`)
+        : undefined
+      if (model && !matchedModel)
+        throw createBadRequestError('streaming voices: model is not enabled', 'STREAMING_TTS_MODEL_NOT_ENABLED')
+
+      const recommended = (await deps.configKV.getOptional('DEFAULT_TTS_VOICES'))?.[matchedModel?.id ?? stepfun.defaultModel] ?? {}
+      return Response.json({ voices: stepfun.voices, recommended })
+    }
+
     const unspeech = await deps.configKV.getOptional('UNSPEECH_UPSTREAM')
     if (!unspeech?.streaming?.baseURL)
       throw createServiceUnavailableError('streaming tts upstream not configured', 'STREAMING_TTS_NOT_CONFIGURED')
@@ -160,6 +173,19 @@ export function createSpeechCatalogOperation(deps: V1RouteDeps): SpeechCatalogOp
   }
 
   async function listStreamingSpeechModels() {
+    const stepfun = await deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM')
+    if (stepfun?.enabled) {
+      return Response.json({
+        available: true,
+        models: stepfun.models.map(m => ({
+          id: m.id,
+          name: m.name ?? m.id,
+          description: m.description,
+        })),
+        default: stepfun.defaultModel,
+      })
+    }
+
     const unspeech = await deps.configKV.getOptional('UNSPEECH_UPSTREAM')
     const models = unspeech?.streaming?.models ?? []
     // `available` is the operator-controlled visibility switch the client gates

--- a/server/apps/api/src/routes/openai/v1/route.test.ts
+++ b/server/apps/api/src/routes/openai/v1/route.test.ts
@@ -1964,6 +1964,62 @@ describe('v1CompletionsRoutes', () => {
       expect(data.default).toBe('volcengine/seed-tts-2.0')
     })
 
+    it('exposes StepFun for explicit selection without replacing the current default', async () => {
+      const app = createTestApp(createMockFluxService(), createMockConfigKV({
+        UNSPEECH_UPSTREAM: {
+          restBaseURL: 'http://unspeech.local:5933',
+          streaming: {
+            baseURL: 'wss://unspeech.local',
+            keys: [{ id: 'volc-key', ciphertext: 'enc' }],
+            models: [{ id: 'volcengine/seed-tts-2.0' }],
+            defaultModel: 'volcengine/seed-tts-2.0',
+          },
+        },
+        STEPFUN_STREAMING_TTS_UPSTREAM: {
+          rollout: 'available',
+          baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
+          keys: [{ id: 'step-key', ciphertext: 'enc' }],
+          models: [{ id: 'stepfun/step-tts-2' }],
+          defaultModel: 'stepfun/step-tts-2',
+          voices: [{ id: 'lively-girl', labels: {}, languages: [] }],
+        },
+      }))
+
+      const res = await app.fetch(new Request('http://localhost/api/v1/audio/models/streaming'), { user: testUser } as any)
+      const data = await res.json() as { models: Array<{ id: string }>, default: string }
+
+      expect(data.models.map(model => model.id)).toEqual(['volcengine/seed-tts-2.0', 'stepfun/step-tts-2'])
+      expect(data.default).toBe('volcengine/seed-tts-2.0')
+    })
+
+    it('switches only the default when StepFun rollout is default', async () => {
+      const app = createTestApp(createMockFluxService(), createMockConfigKV({
+        UNSPEECH_UPSTREAM: {
+          restBaseURL: 'http://unspeech.local:5933',
+          streaming: {
+            baseURL: 'wss://unspeech.local',
+            keys: [{ id: 'volc-key', ciphertext: 'enc' }],
+            models: [{ id: 'volcengine/seed-tts-2.0' }],
+            defaultModel: 'volcengine/seed-tts-2.0',
+          },
+        },
+        STEPFUN_STREAMING_TTS_UPSTREAM: {
+          rollout: 'default',
+          baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
+          keys: [{ id: 'step-key', ciphertext: 'enc' }],
+          models: [{ id: 'stepfun/step-tts-2' }],
+          defaultModel: 'stepfun/step-tts-2',
+          voices: [{ id: 'lively-girl', labels: {}, languages: [] }],
+        },
+      }))
+
+      const res = await app.fetch(new Request('http://localhost/api/v1/audio/models/streaming'), { user: testUser } as any)
+      const data = await res.json() as { models: Array<{ id: string }>, default: string }
+
+      expect(data.models.map(model => model.id)).toEqual(['volcengine/seed-tts-2.0', 'stepfun/step-tts-2'])
+      expect(data.default).toBe('stepfun/step-tts-2')
+    })
+
     it('returns default: null when operator has not set a streaming default', async () => {
       const app = createTestApp(
         createMockFluxService(),
@@ -1985,6 +2041,28 @@ describe('v1CompletionsRoutes', () => {
       )
 
       const data = await res.json() as { default: string | null }
+      expect(data.default).toBeNull()
+    })
+
+    it('keeps default null when StepFun is only available for explicit selection', async () => {
+      const app = createTestApp(createMockFluxService(), createMockConfigKV({
+        STEPFUN_STREAMING_TTS_UPSTREAM: {
+          rollout: 'available',
+          baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
+          keys: [{ id: 'step-key', ciphertext: 'enc' }],
+          models: [{ id: 'stepfun/step-tts-2' }],
+          defaultModel: 'stepfun/step-tts-2',
+          voices: [{ id: 'lively-girl', labels: {}, languages: [] }],
+        },
+      }))
+
+      const res = await app.fetch(
+        new Request('http://localhost/api/v1/audio/models/streaming', { method: 'GET' }),
+        { user: testUser } as any,
+      )
+      const data = await res.json() as { available: boolean, default: string | null }
+
+      expect(data.available).toBe(true)
       expect(data.default).toBeNull()
     })
 
@@ -2408,6 +2486,33 @@ describe('v1CompletionsRoutes', () => {
       globalThis.fetch = vi.fn(async () => new Response(body, { status })) as any
     }
 
+    it('returns StepFun voices only for the canonical configured model id', async () => {
+      const configKV = createMockConfigKV({
+        STEPFUN_STREAMING_TTS_UPSTREAM: {
+          rollout: 'available',
+          baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
+          keys: [{ id: 'step-key', ciphertext: 'enc' }],
+          models: [{ id: 'stepfun/step-tts-2' }],
+          defaultModel: 'stepfun/step-tts-2',
+          voices: [{ id: 'lively-girl', name: 'Lively Girl', labels: {}, languages: [] }],
+        },
+      })
+      const app = createTestApp(createMockFluxService(), configKV)
+
+      const exact = await app.fetch(
+        new Request('http://localhost/api/v1/audio/voices/streaming?model=stepfun/step-tts-2'),
+        { user: testUser } as any,
+      )
+      const alias = await app.fetch(
+        new Request('http://localhost/api/v1/audio/voices/streaming?model=step-tts-2'),
+        { user: testUser } as any,
+      )
+
+      expect(exact.status).toBe(200)
+      expect(await exact.json()).toMatchObject({ voices: [{ id: 'lively-girl' }] })
+      expect(alias.status).toBe(400)
+    })
+
     it('returns the streaming-model bucket of DEFAULT_TTS_VOICES when ?model= matches', async () => {
       mockUnspeechVoices([{ id: 'zh_female_vv_uranus_bigtts', name: 'Vivi 2.0' }])
       const configKV = createMockConfigKV({
@@ -2428,6 +2533,36 @@ describe('v1CompletionsRoutes', () => {
       expect(res.status).toBe(200)
       const data = await res.json() as { recommended: Record<string, string> }
       expect(data.recommended).toEqual({ 'zh-cn': 'zh_female_vv_uranus_bigtts' })
+    })
+
+    it('normalizes a canonical unSpeech model id before querying its voice catalog', async () => {
+      let requestedURL = ''
+      globalThis.fetch = vi.fn(async (input) => {
+        requestedURL = String(input)
+        return new Response(JSON.stringify({ voices: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }) as any
+      const configKV = createMockConfigKV({
+        UNSPEECH_UPSTREAM: {
+          restBaseURL: 'http://unspeech.local:5933',
+          streaming: {
+            baseURL: 'ws://unspeech.local:5933/v1/audio/speech/stream',
+            keys: [{ id: 'k1', ciphertext: 'enc' }],
+            models: [{ id: 'volcengine/seed-tts-2.0' }],
+          },
+        },
+      })
+      const app = createTestApp(createMockFluxService(), configKV)
+
+      const res = await app.fetch(
+        new Request('http://localhost/api/v1/audio/voices/streaming?model=volcengine/seed-tts-2.0'),
+        { user: testUser } as any,
+      )
+
+      expect(res.status).toBe(200)
+      expect(new URL(requestedURL).searchParams.get('model')).toBe('seed-tts-2.0')
     })
 
     it('returns empty recommended when ?model= is omitted', async () => {

--- a/server/apps/api/src/services/adapters/config-kv.test.ts
+++ b/server/apps/api/src/services/adapters/config-kv.test.ts
@@ -88,6 +88,24 @@ describe('configKVService', () => {
       })
   })
 
+  it('rejects unsupported native StepFun models at the ConfigKV boundary', async () => {
+    redis._store.set(configRedisKey('STEPFUN_STREAMING_TTS_UPSTREAM'), JSON.stringify({
+      rollout: 'available',
+      baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
+      keys: [{ id: 'step-key', ciphertext: 'encrypted' }],
+      models: [{ id: 'stepfun/unsupported-model' }],
+      defaultModel: 'stepfun/unsupported-model',
+      voices: [{ id: 'lively-girl' }],
+    }))
+
+    await expect(service.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'))
+      .rejects
+      .toMatchObject({
+        statusCode: 503,
+        errorCode: 'CONFIG_INVALID',
+      })
+  })
+
   it('set should write value to Redis with prefix', async () => {
     await service.set('FLUX_PER_REQUEST', 10)
 

--- a/server/apps/api/src/services/adapters/config-kv.ts
+++ b/server/apps/api/src/services/adapters/config-kv.ts
@@ -164,10 +164,47 @@ export const streamingTtsUpstreamSchema = object({
   defaultModel: optional(string()),
 })
 
+/**
+ * Dedicated StepFun streaming TTS configuration.
+ *
+ * StepFun's websocket protocol is not compatible with unSpeech's streaming
+ * wire format, so it owns an explicit configuration entry and enable switch.
+ * Keeping the switch in this record lets operators validate the provider
+ * without changing the current streaming default before a measured rollout.
+ */
+export const stepfunStreamingTtsUpstreamSchema = pipe(object({
+  enabled: optional(boolean(), false),
+  baseURL: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.baseURL must not be empty')),
+  keys: pipe(array(keyEntrySchema), check(v => v.length >= 1, 'STEPFUN_STREAMING_TTS_UPSTREAM.keys must contain at least 1 entry')),
+  models: pipe(
+    array(object({
+      id: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.models[].id must not be empty')),
+      name: optional(string()),
+      description: optional(string()),
+    })),
+    check(v => v.length >= 1, 'STEPFUN_STREAMING_TTS_UPSTREAM.models must contain at least 1 entry'),
+  ),
+  defaultModel: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.defaultModel must not be empty')),
+  voices: pipe(
+    array(object({
+      id: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.voices[].id must not be empty')),
+      name: optional(string()),
+      description: optional(string()),
+      labels: optional(record(string(), any()), {}),
+      languages: optional(array(object({ code: string(), title: string() })), []),
+    })),
+    check(v => v.length >= 1, 'STEPFUN_STREAMING_TTS_UPSTREAM.voices must contain at least 1 entry'),
+  ),
+  instruction: optional(pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.instruction must not be empty'))),
+}), check(config => new Set(config.models.map(model => model.id)).size === config.models.length, 'STEPFUN_STREAMING_TTS_UPSTREAM.models[].id must be unique'), check(config => config.models.some(model => model.id === config.defaultModel), 'STEPFUN_STREAMING_TTS_UPSTREAM.defaultModel must be present in models'))
+
 export const unspeechUpstreamSchema = object({
   restBaseURL: pipe(string(), nonEmpty('UNSPEECH_UPSTREAM.restBaseURL must not be empty')),
   streaming: optional(streamingTtsUpstreamSchema),
 })
+
+export type UnspeechUpstream = InferOutput<typeof unspeechUpstreamSchema>
+export type StepfunStreamingTtsUpstream = InferOutput<typeof stepfunStreamingTtsUpstreamSchema>
 
 export const ttsModelSchema = pipe(
   object({
@@ -281,6 +318,11 @@ const ConfigEntrySchemas = {
   // carry the upstream-provider API key (Volcengine X-Api-Key), not an
   // unspeech tenant token (unspeech itself is unauthenticated).
   UNSPEECH_UPSTREAM: optional(unspeechUpstreamSchema),
+  // A dedicated native StepFun WebSocket provider. It is deliberately
+  // separate from UNSPEECH_UPSTREAM because their request/response protocols
+  // differ. `enabled: false` keeps the existing Volcengine path active until
+  // an operator completes a measured switch.
+  STEPFUN_STREAMING_TTS_UPSTREAM: optional(stepfunStreamingTtsUpstreamSchema),
 } as const
 
 type ConfigDefinitions = {

--- a/server/apps/api/src/services/adapters/config-kv.ts
+++ b/server/apps/api/src/services/adapters/config-kv.ts
@@ -164,27 +164,43 @@ export const streamingTtsUpstreamSchema = object({
   defaultModel: optional(string()),
 })
 
+/** Canonical public model ids supported by StepFun's native TTS websocket. */
+export const STEPFUN_STREAMING_TTS_MODEL_IDS = [
+  'stepfun/stepaudio-2.5-tts',
+  'stepfun/step-tts-2',
+  'stepfun/step-tts-mini',
+] as const
+
+/** Encryption context shared by the writer and runtime credential reader. */
+export const STEPFUN_STREAMING_TTS_KEY_CONTEXT = 'stepfun-streaming-tts'
+
+/**
+ * Controls whether StepFun is hidden, available for explicit model selection,
+ * or also owns the default streaming model.
+ */
+export const stepfunStreamingTtsRolloutSchema = picklist(['disabled', 'available', 'default'])
+
 /**
  * Dedicated StepFun streaming TTS configuration.
  *
  * StepFun's websocket protocol is not compatible with unSpeech's streaming
- * wire format, so it owns an explicit configuration entry and enable switch.
- * Keeping the switch in this record lets operators validate the provider
- * without changing the current streaming default before a measured rollout.
+ * wire format, so it owns an explicit configuration entry and rollout mode.
+ * `available` permits explicit model selection without changing the default;
+ * `default` performs the measured cutover.
  */
 export const stepfunStreamingTtsUpstreamSchema = pipe(object({
-  enabled: optional(boolean(), false),
+  rollout: optional(stepfunStreamingTtsRolloutSchema, 'disabled'),
   baseURL: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.baseURL must not be empty')),
   keys: pipe(array(keyEntrySchema), check(v => v.length >= 1, 'STEPFUN_STREAMING_TTS_UPSTREAM.keys must contain at least 1 entry')),
   models: pipe(
     array(object({
-      id: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.models[].id must not be empty')),
+      id: picklist(STEPFUN_STREAMING_TTS_MODEL_IDS, 'STEPFUN_STREAMING_TTS_UPSTREAM.models[].id is not supported'),
       name: optional(string()),
       description: optional(string()),
     })),
     check(v => v.length >= 1, 'STEPFUN_STREAMING_TTS_UPSTREAM.models must contain at least 1 entry'),
   ),
-  defaultModel: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.defaultModel must not be empty')),
+  defaultModel: picklist(STEPFUN_STREAMING_TTS_MODEL_IDS, 'STEPFUN_STREAMING_TTS_UPSTREAM.defaultModel is not supported'),
   voices: pipe(
     array(object({
       id: pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.voices[].id must not be empty')),
@@ -196,7 +212,7 @@ export const stepfunStreamingTtsUpstreamSchema = pipe(object({
     check(v => v.length >= 1, 'STEPFUN_STREAMING_TTS_UPSTREAM.voices must contain at least 1 entry'),
   ),
   instruction: optional(pipe(string(), nonEmpty('STEPFUN_STREAMING_TTS_UPSTREAM.instruction must not be empty'))),
-}), check(config => new Set(config.models.map(model => model.id)).size === config.models.length, 'STEPFUN_STREAMING_TTS_UPSTREAM.models[].id must be unique'), check(config => config.models.some(model => model.id === config.defaultModel), 'STEPFUN_STREAMING_TTS_UPSTREAM.defaultModel must be present in models'))
+}), check(config => new Set(config.models.map(model => model.id)).size === config.models.length, 'STEPFUN_STREAMING_TTS_UPSTREAM.models[].id must be unique'), check(config => config.models.some(model => model.id === config.defaultModel), 'STEPFUN_STREAMING_TTS_UPSTREAM.defaultModel must be present in models'), check(config => new Set(config.voices.map(voice => voice.id)).size === config.voices.length, 'STEPFUN_STREAMING_TTS_UPSTREAM.voices[].id must be unique'))
 
 export const unspeechUpstreamSchema = object({
   restBaseURL: pipe(string(), nonEmpty('UNSPEECH_UPSTREAM.restBaseURL must not be empty')),
@@ -318,10 +334,9 @@ const ConfigEntrySchemas = {
   // carry the upstream-provider API key (Volcengine X-Api-Key), not an
   // unspeech tenant token (unspeech itself is unauthenticated).
   UNSPEECH_UPSTREAM: optional(unspeechUpstreamSchema),
-  // A dedicated native StepFun WebSocket provider. It is deliberately
-  // separate from UNSPEECH_UPSTREAM because their request/response protocols
-  // differ. `enabled: false` keeps the existing Volcengine path active until
-  // an operator completes a measured switch.
+  // Native StepFun WebSocket provider. `rollout: available` exposes its models
+  // for explicit selection while preserving the existing default; `default`
+  // performs the operator-controlled cutover.
   STEPFUN_STREAMING_TTS_UPSTREAM: optional(stepfunStreamingTtsUpstreamSchema),
 } as const
 

--- a/server/apps/api/src/services/domain/admin/router-config/index.ts
+++ b/server/apps/api/src/services/domain/admin/router-config/index.ts
@@ -2,7 +2,7 @@ import type Redis from 'ioredis'
 import type { InferOutput } from 'valibot'
 
 import type { EnvelopeCrypto } from '../../../../utils/envelope-crypto'
-import type { asrModelSchema, ConfigKVService, llmModelSchema, llmRouterConfigSchema, ttsModelSchema, unspeechUpstreamSchema } from '../../../adapters/config-kv'
+import type { asrModelSchema, ConfigKVService, llmModelSchema, llmRouterConfigSchema, stepfunStreamingTtsUpstreamSchema, ttsModelSchema, unspeechUpstreamSchema } from '../../../adapters/config-kv'
 
 import { useLogger } from '@guiiai/logg'
 
@@ -16,6 +16,7 @@ import { createBadRequestError } from '../../../../utils/error'
  * `DECRYPT_FAILED` at session start.
  */
 const STREAMING_TTS_AAD_MODEL_NAME = 'streaming-tts'
+const STEPFUN_STREAMING_TTS_AAD_MODEL_NAME = 'stepfun-streaming-tts'
 
 /** Default key entry id per provider. Operator can override per request. */
 const DEFAULT_KEY_ENTRY_IDS = {
@@ -25,6 +26,7 @@ const DEFAULT_KEY_ENTRY_IDS = {
   'azure': 'azure-tts-prod-1',
   'dashscope-cosyvoice': 'dashscope-tts-prod-1',
   'stepfun': 'stepfun-tts-prod-1',
+  'stepfun-streaming': 'stepfun-streaming-prod-1',
   'unspeech': 'volcengine-prod-1',
   'aliyun-nls-asr': 'aliyun-nls-asr-prod-1',
 } as const
@@ -39,6 +41,7 @@ type LlmModel = InferOutput<typeof llmModelSchema>
 type TtsModel = InferOutput<typeof ttsModelSchema>
 type AsrModel = InferOutput<typeof asrModelSchema>
 type UnspeechUpstream = InferOutput<typeof unspeechUpstreamSchema>
+type StepfunStreamingTtsUpstream = InferOutput<typeof stepfunStreamingTtsUpstreamSchema>
 type KeyEntry = LlmModel['upstreams'][number]['keys'][number]
 type LlmSliceKind = 'openrouter' | 'bedrock' | 'openai-compatible'
 
@@ -57,6 +60,7 @@ export type SliceInput
     | AzureSliceInput
     | DashscopeSliceInput
     | StepfunSliceInput
+    | StepfunStreamingSliceInput
     | AliyunNlsAsrSliceInput
     | UnspeechSliceInput
 
@@ -161,6 +165,22 @@ export interface StepfunSliceInput {
   existingKeyEntryId?: string
 }
 
+/** Operator-owned native StepFun websocket TTS configuration. */
+export interface StepfunStreamingSliceInput {
+  kind: 'stepfun-streaming'
+  /** Enables StepFun for the shared official streaming TTS provider. */
+  enabled: boolean
+  /** `wss://api.stepfun.com/v1/realtime/audio` or the Step Plan equivalent. */
+  upstreamURL: string
+  models: Array<{ id: string, name?: string, description?: string }>
+  defaultModel: string
+  voices: Array<{ id: string, name?: string, description?: string, labels?: Record<string, unknown>, languages?: Array<{ code: string, title: string }> }>
+  instruction?: string
+  plaintextKey?: string
+  keyEntryId?: string
+  existingKeyEntryId?: string
+}
+
 export interface UnspeechSliceInput {
   kind: 'unspeech'
   /** unspeech REST root: `http(s)://host:port` (no trailing slash, no path). */
@@ -235,7 +255,14 @@ interface UnspeechSlice {
   keyEntryId: string | null
 }
 
-type BuiltSlice = LlmModelSlice | TtsModelSlice | AsrModelSlice | UnspeechSlice
+interface StepfunStreamingSlice {
+  target: 'stepfun-streaming'
+  kind: 'stepfun-streaming'
+  value: StepfunStreamingTtsUpstream
+  keyEntryId: string
+}
+
+type BuiltSlice = LlmModelSlice | TtsModelSlice | AsrModelSlice | UnspeechSlice | StepfunStreamingSlice
 
 /**
  * Encrypts an OpenRouter slice into the LLM_ROUTER_CONFIG.llm shape.
@@ -483,6 +510,33 @@ export function buildUnspeechSlice(input: UnspeechSliceInput, envelope: Envelope
   }
 }
 
+/** Encrypts the native StepFun streaming TTS configuration. */
+export function buildStepfunStreamingSlice(input: StepfunStreamingSliceInput, envelope: EnvelopeCrypto): StepfunStreamingSlice {
+  const keyEntryId = input.keyEntryId ?? DEFAULT_KEY_ENTRY_IDS['stepfun-streaming']
+  const ciphertext = envelope.encryptKey(requiredPlaintextKey(input.plaintextKey, input.kind), {
+    modelName: STEPFUN_STREAMING_TTS_AAD_MODEL_NAME,
+    keyEntryId,
+  })
+  return {
+    target: 'stepfun-streaming',
+    kind: input.kind,
+    keyEntryId,
+    value: {
+      enabled: input.enabled,
+      baseURL: input.upstreamURL,
+      keys: [{ id: keyEntryId, ciphertext }],
+      models: input.models,
+      defaultModel: input.defaultModel,
+      voices: input.voices.map(voice => ({
+        ...voice,
+        labels: voice.labels ?? {},
+        languages: voice.languages ?? [],
+      })),
+      ...(input.instruction ? { instruction: input.instruction } : {}),
+    },
+  }
+}
+
 function requiredPlaintextKey(value: string | undefined, kind: SliceInput['kind']): string {
   if (value?.trim())
     return value
@@ -665,6 +719,35 @@ function buildUnspeechSlicePreservingKey(input: UnspeechSliceInput, envelope: En
   }
 }
 
+function buildStepfunStreamingSlicePreservingKey(
+  input: StepfunStreamingSliceInput,
+  envelope: EnvelopeCrypto,
+  existing: StepfunStreamingTtsUpstream | undefined | null,
+): StepfunStreamingSlice {
+  if (input.plaintextKey?.trim())
+    return buildStepfunStreamingSlice(input, envelope)
+
+  const key = preservedKeyOrThrow(existing ?? undefined, input.existingKeyEntryId ?? input.keyEntryId, input.kind)
+  return {
+    target: 'stepfun-streaming',
+    kind: input.kind,
+    keyEntryId: key.id,
+    value: {
+      enabled: input.enabled,
+      baseURL: input.upstreamURL,
+      keys: [key],
+      models: input.models,
+      defaultModel: input.defaultModel,
+      voices: input.voices.map(voice => ({
+        ...voice,
+        labels: voice.labels ?? {},
+        languages: voice.languages ?? [],
+      })),
+      ...(input.instruction ? { instruction: input.instruction } : {}),
+    },
+  }
+}
+
 /**
  * Encrypts a slice input. Routes to the per-kind builder.
  *
@@ -678,6 +761,7 @@ export function buildSlice(
   existing?: {
     routerConfig?: LlmRouterConfig | null
     unspeech?: UnspeechUpstream | null
+    stepfunStreaming?: StepfunStreamingTtsUpstream | null
   },
 ): BuiltSlice {
   switch (input.kind) {
@@ -695,6 +779,8 @@ export function buildSlice(
       return buildAliyunNlsAsrSlicePreservingKey(input, envelope, existing?.routerConfig?.asr?.models[input.modelName])
     case 'unspeech':
       return buildUnspeechSlicePreservingKey(input, envelope, existing?.unspeech)
+    case 'stepfun-streaming':
+      return buildStepfunStreamingSlicePreservingKey(input, envelope, existing?.stepfunStreaming)
   }
 }
 
@@ -811,7 +897,7 @@ export interface ApplyInput {
 
 export interface AppliedSummary {
   kind: SliceInput['kind']
-  target: 'llm-router' | 'unspeech'
+  target: 'llm-router' | 'unspeech' | 'stepfun-streaming'
   surface?: 'llm' | 'tts' | 'asr'
   modelName?: string
   keyEntryId: string | null
@@ -823,6 +909,7 @@ export interface ApplyResult {
   preview: {
     LLM_ROUTER_CONFIG?: unknown
     UNSPEECH_UPSTREAM?: unknown
+    STEPFUN_STREAMING_TTS_UPSTREAM?: unknown
     DEFAULT_CHAT_MODEL?: string
     DEFAULT_TTS_MODEL?: string
     DEFAULT_TTS_VOICES?: Record<string, Record<string, string>>
@@ -843,6 +930,9 @@ export interface CurrentRouterConfigResult {
 function sliceNeedsExistingKey(slice: SliceInput): boolean {
   if (slice.kind === 'unspeech')
     return slice.streaming != null && !slice.streaming.plaintextKey?.trim()
+
+  if (slice.kind === 'stepfun-streaming')
+    return !slice.plaintextKey?.trim()
 
   return !slice.plaintextKey?.trim()
 }
@@ -991,6 +1081,24 @@ function slicesFromUnspeech(unspeech: UnspeechUpstream | null): UnspeechSliceInp
   }]
 }
 
+function slicesFromStepfunStreaming(config: StepfunStreamingTtsUpstream | null): StepfunStreamingSliceInput[] {
+  if (!config)
+    return []
+
+  const key = config.keys[0]
+  return [{
+    kind: 'stepfun-streaming',
+    enabled: config.enabled,
+    upstreamURL: config.baseURL,
+    models: config.models,
+    defaultModel: config.defaultModel,
+    voices: config.voices,
+    instruction: config.instruction,
+    keyEntryId: key?.id,
+    existingKeyEntryId: key?.id,
+  }]
+}
+
 function azureRegionFromBaseURL(baseURL: string): string | null {
   const match = /^https:\/\/([^.]+)\.tts\.speech\.microsoft\.com\//u.exec(baseURL)
   return match?.[1] ?? null
@@ -1045,12 +1153,14 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
     const [
       routerConfig,
       unspeech,
+      stepfunStreaming,
       chatModel,
       ttsModel,
       ttsVoices,
     ] = await Promise.all([
       deps.configKV.getOptional('LLM_ROUTER_CONFIG'),
       deps.configKV.getOptional('UNSPEECH_UPSTREAM'),
+      deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM'),
       deps.configKV.getOptional('DEFAULT_CHAT_MODEL'),
       deps.configKV.getOptional('DEFAULT_TTS_MODEL'),
       deps.configKV.getOptional('DEFAULT_TTS_VOICES'),
@@ -1059,6 +1169,7 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
     const slices: SliceInput[] = [
       ...slicesFromRouterConfig(routerConfig ?? null),
       ...slicesFromUnspeech(unspeech ?? null),
+      ...slicesFromStepfunStreaming(stepfunStreaming ?? null),
     ]
     const defaults: NonNullable<ApplyInput['defaults']> = {}
     if (chatModel)
@@ -1073,6 +1184,8 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
       preview.LLM_ROUTER_CONFIG = redactCiphertext(routerConfig)
     if (unspeech)
       preview.UNSPEECH_UPSTREAM = redactCiphertext(unspeech)
+    if (stepfunStreaming)
+      preview.STEPFUN_STREAMING_TTS_UPSTREAM = redactCiphertext(stepfunStreaming)
     if (chatModel)
       preview.DEFAULT_CHAT_MODEL = chatModel
     if (ttsModel)
@@ -1091,6 +1204,7 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
       missingKeys: [
         ...(routerConfig ? [] : ['LLM_ROUTER_CONFIG']),
         ...(unspeech ? [] : ['UNSPEECH_UPSTREAM']),
+        ...(stepfunStreaming ? [] : ['STEPFUN_STREAMING_TTS_UPSTREAM']),
         ...(chatModel ? [] : ['DEFAULT_CHAT_MODEL']),
         ...(ttsModel ? [] : ['DEFAULT_TTS_MODEL']),
       ],
@@ -1110,14 +1224,20 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
     if (unspeechCount > 1)
       throw createBadRequestError('At most one unspeech slice per request', 'INVALID_BODY')
 
-    const hasRouterInput = input.slices.some(s => s.kind !== 'unspeech')
+    const stepfunStreamingCount = input.slices.filter(s => s.kind === 'stepfun-streaming').length
+    if (stepfunStreamingCount > 1)
+      throw createBadRequestError('At most one stepfun-streaming slice per request', 'INVALID_BODY')
+
+    const hasRouterInput = input.slices.some(s => s.kind !== 'unspeech' && s.kind !== 'stepfun-streaming')
     const hasUnspeechInput = input.slices.some(s => s.kind === 'unspeech')
+    const hasStepfunStreamingInput = input.slices.some(s => s.kind === 'stepfun-streaming')
     const shouldReadRouterConfig = hasRouterInput
       && (input.mode === 'merge' || input.slices.some(sliceNeedsExistingKey))
     const shouldReadUnspeech = hasUnspeechInput
-    const [existingRouterConfig, existingUnspeech] = await Promise.all([
+    const [existingRouterConfig, existingUnspeech, existingStepfunStreaming] = await Promise.all([
       shouldReadRouterConfig ? deps.configKV.getOptional('LLM_ROUTER_CONFIG') : Promise.resolve(null),
       shouldReadUnspeech ? deps.configKV.getOptional('UNSPEECH_UPSTREAM') : Promise.resolve(null),
+      hasStepfunStreamingInput ? deps.configKV.getOptional('STEPFUN_STREAMING_TTS_UPSTREAM') : Promise.resolve(null),
     ])
 
     // Step 1: encrypt new keys and preserve existing ciphertexts when the
@@ -1125,10 +1245,12 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
     const built = input.slices.map(s => buildSlice(s, deps.envelope, {
       routerConfig: existingRouterConfig,
       unspeech: existingUnspeech,
+      stepfunStreaming: existingStepfunStreaming,
     }))
 
     const routerSlices = built.filter((s): s is LlmModelSlice | TtsModelSlice | AsrModelSlice => s.target === 'llm-router')
     const unspeechSlice = built.find((s): s is UnspeechSlice => s.target === 'unspeech')
+    const stepfunStreamingSlice = built.find((s): s is StepfunStreamingSlice => s.target === 'stepfun-streaming')
 
     // Step 2: build the next LLM_ROUTER_CONFIG tree if any LLM/TTS/ASR slice
     // was supplied. `merge` reads existing first; `reset` skips the read.
@@ -1159,11 +1281,15 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
       }
     }
 
+    const nextStepfunStreaming = stepfunStreamingSlice?.value
+
     const preview: ApplyResult['preview'] = {}
     if (nextRouterConfig)
       preview.LLM_ROUTER_CONFIG = redactCiphertext(nextRouterConfig)
     if (nextUnspeech)
       preview.UNSPEECH_UPSTREAM = redactCiphertext(nextUnspeech)
+    if (nextStepfunStreaming)
+      preview.STEPFUN_STREAMING_TTS_UPSTREAM = redactCiphertext(nextStepfunStreaming)
     if (input.defaults?.chatModel)
       preview.DEFAULT_CHAT_MODEL = input.defaults.chatModel
     if (input.defaults?.ttsModel)
@@ -1171,7 +1297,7 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
     if (input.defaults?.ttsVoices)
       preview.DEFAULT_TTS_VOICES = input.defaults.ttsVoices
 
-    const applied: AppliedSummary[] = built.map(s => s.target === 'unspeech'
+    const applied: AppliedSummary[] = built.map(s => s.target === 'unspeech' || s.target === 'stepfun-streaming'
       ? { kind: s.kind, target: s.target, keyEntryId: s.keyEntryId }
       : { kind: s.kind, target: s.target, surface: s.surface, modelName: s.modelName, keyEntryId: s.keyEntryId })
 
@@ -1195,6 +1321,10 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
     if (nextUnspeech) {
       await deps.configKV.set('UNSPEECH_UPSTREAM', nextUnspeech as never)
       invalidatedKeys.push('UNSPEECH_UPSTREAM')
+    }
+    if (nextStepfunStreaming) {
+      await deps.configKV.set('STEPFUN_STREAMING_TTS_UPSTREAM', nextStepfunStreaming as never)
+      invalidatedKeys.push('STEPFUN_STREAMING_TTS_UPSTREAM')
     }
     if (input.defaults?.chatModel) {
       await deps.configKV.set('DEFAULT_CHAT_MODEL', input.defaults.chatModel)

--- a/server/apps/api/src/services/domain/admin/router-config/index.ts
+++ b/server/apps/api/src/services/domain/admin/router-config/index.ts
@@ -7,6 +7,7 @@ import type { asrModelSchema, ConfigKVService, llmModelSchema, llmRouterConfigSc
 import { useLogger } from '@guiiai/logg'
 
 import { createBadRequestError } from '../../../../utils/error'
+import { STEPFUN_STREAMING_TTS_KEY_CONTEXT } from '../../../adapters/config-kv'
 
 /**
  * AAD label used when encrypting/decrypting the streaming TTS upstream key.
@@ -16,7 +17,6 @@ import { createBadRequestError } from '../../../../utils/error'
  * `DECRYPT_FAILED` at session start.
  */
 const STREAMING_TTS_AAD_MODEL_NAME = 'streaming-tts'
-const STEPFUN_STREAMING_TTS_AAD_MODEL_NAME = 'stepfun-streaming-tts'
 
 /** Default key entry id per provider. Operator can override per request. */
 const DEFAULT_KEY_ENTRY_IDS = {
@@ -168,12 +168,12 @@ export interface StepfunSliceInput {
 /** Operator-owned native StepFun websocket TTS configuration. */
 export interface StepfunStreamingSliceInput {
   kind: 'stepfun-streaming'
-  /** Enables StepFun for the shared official streaming TTS provider. */
-  enabled: boolean
+  /** Controls explicit availability and ownership of the global streaming default. */
+  rollout: 'disabled' | 'available' | 'default'
   /** `wss://api.stepfun.com/v1/realtime/audio` or the Step Plan equivalent. */
   upstreamURL: string
-  models: Array<{ id: string, name?: string, description?: string }>
-  defaultModel: string
+  models: StepfunStreamingTtsUpstream['models']
+  defaultModel: StepfunStreamingTtsUpstream['defaultModel']
   voices: Array<{ id: string, name?: string, description?: string, labels?: Record<string, unknown>, languages?: Array<{ code: string, title: string }> }>
   instruction?: string
   plaintextKey?: string
@@ -514,7 +514,7 @@ export function buildUnspeechSlice(input: UnspeechSliceInput, envelope: Envelope
 export function buildStepfunStreamingSlice(input: StepfunStreamingSliceInput, envelope: EnvelopeCrypto): StepfunStreamingSlice {
   const keyEntryId = input.keyEntryId ?? DEFAULT_KEY_ENTRY_IDS['stepfun-streaming']
   const ciphertext = envelope.encryptKey(requiredPlaintextKey(input.plaintextKey, input.kind), {
-    modelName: STEPFUN_STREAMING_TTS_AAD_MODEL_NAME,
+    modelName: STEPFUN_STREAMING_TTS_KEY_CONTEXT,
     keyEntryId,
   })
   return {
@@ -522,7 +522,7 @@ export function buildStepfunStreamingSlice(input: StepfunStreamingSliceInput, en
     kind: input.kind,
     keyEntryId,
     value: {
-      enabled: input.enabled,
+      rollout: input.rollout,
       baseURL: input.upstreamURL,
       keys: [{ id: keyEntryId, ciphertext }],
       models: input.models,
@@ -733,7 +733,7 @@ function buildStepfunStreamingSlicePreservingKey(
     kind: input.kind,
     keyEntryId: key.id,
     value: {
-      enabled: input.enabled,
+      rollout: input.rollout,
       baseURL: input.upstreamURL,
       keys: [key],
       models: input.models,
@@ -1088,7 +1088,7 @@ function slicesFromStepfunStreaming(config: StepfunStreamingTtsUpstream | null):
   const key = config.keys[0]
   return [{
     kind: 'stepfun-streaming',
-    enabled: config.enabled,
+    rollout: config.rollout,
     upstreamURL: config.baseURL,
     models: config.models,
     defaultModel: config.defaultModel,
@@ -1204,7 +1204,6 @@ export function createAdminRouterConfigService(deps: AdminRouterConfigDeps) {
       missingKeys: [
         ...(routerConfig ? [] : ['LLM_ROUTER_CONFIG']),
         ...(unspeech ? [] : ['UNSPEECH_UPSTREAM']),
-        ...(stepfunStreaming ? [] : ['STEPFUN_STREAMING_TTS_UPSTREAM']),
         ...(chatModel ? [] : ['DEFAULT_CHAT_MODEL']),
         ...(ttsModel ? [] : ['DEFAULT_TTS_MODEL']),
       ],

--- a/server/apps/api/src/services/domain/admin/router-config/tests/admin-router-config.test.ts
+++ b/server/apps/api/src/services/domain/admin/router-config/tests/admin-router-config.test.ts
@@ -14,6 +14,7 @@ import {
   buildNextRouterConfig,
   buildOpenRouterSlice,
   buildStepfunSlice,
+  buildStepfunStreamingSlice,
   buildUnspeechSlice,
   createAdminRouterConfigService,
   redactCiphertext,
@@ -287,6 +288,29 @@ describe('buildStepfunSlice', () => {
   })
 })
 
+describe('buildStepfunStreamingSlice', () => {
+  it('encrypts the native websocket credential under its dedicated AAD label', () => {
+    const built = buildStepfunStreamingSlice({
+      kind: 'stepfun-streaming',
+      enabled: false,
+      upstreamURL: 'wss://api.stepfun.com/v1/realtime/audio',
+      models: [{ id: 'stepfun/step-tts-2', name: 'Step TTS 2' }],
+      defaultModel: 'stepfun/step-tts-2',
+      voices: [{ id: 'lively-girl', name: 'Lively Girl' }],
+      plaintextKey: 'stepfun-secret',
+    }, freshEnvelope())
+
+    expect(built.target).toBe('stepfun-streaming')
+    expect(built.value).toMatchObject({
+      enabled: false,
+      baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
+      defaultModel: 'stepfun/step-tts-2',
+      voices: [{ id: 'lively-girl', labels: {}, languages: [] }],
+    })
+    expect(built.value.keys[0]?.id).toBe('stepfun-streaming-prod-1')
+  })
+})
+
 describe('buildUnspeechSlice', () => {
   it('writes restBaseURL with no streaming subtree when the slice omits streaming', () => {
     const envelope = freshEnvelope()
@@ -554,6 +578,25 @@ describe('createAdminRouterConfigService', () => {
         { kind: 'unspeech', restBaseURL: 'http://b' },
       ],
     })).rejects.toThrow(/At most one unspeech/i)
+  })
+
+  it('rejects multiple native StepFun streaming slices', async () => {
+    const service = createAdminRouterConfigService({ configKV: kv.service, envelope, redis })
+    const stepfunSlice = {
+      kind: 'stepfun-streaming' as const,
+      enabled: false,
+      upstreamURL: 'wss://api.stepfun.com/v1/realtime/audio',
+      models: [{ id: 'stepfun/step-tts-2' }],
+      defaultModel: 'stepfun/step-tts-2',
+      voices: [{ id: 'lively-girl' }],
+      plaintextKey: 'stepfun-secret',
+    }
+
+    await expect(service.apply({
+      mode: 'merge',
+      dryRun: true,
+      slices: [stepfunSlice, stepfunSlice],
+    })).rejects.toThrow(/At most one stepfun-streaming/i)
   })
 
   it('merge mode reads existing LLM_ROUTER_CONFIG and preserves untouched models', async () => {

--- a/server/apps/api/src/services/domain/admin/router-config/tests/admin-router-config.test.ts
+++ b/server/apps/api/src/services/domain/admin/router-config/tests/admin-router-config.test.ts
@@ -292,7 +292,7 @@ describe('buildStepfunStreamingSlice', () => {
   it('encrypts the native websocket credential under its dedicated AAD label', () => {
     const built = buildStepfunStreamingSlice({
       kind: 'stepfun-streaming',
-      enabled: false,
+      rollout: 'disabled' as const,
       upstreamURL: 'wss://api.stepfun.com/v1/realtime/audio',
       models: [{ id: 'stepfun/step-tts-2', name: 'Step TTS 2' }],
       defaultModel: 'stepfun/step-tts-2',
@@ -302,7 +302,7 @@ describe('buildStepfunStreamingSlice', () => {
 
     expect(built.target).toBe('stepfun-streaming')
     expect(built.value).toMatchObject({
-      enabled: false,
+      rollout: 'disabled' as const,
       baseURL: 'wss://api.stepfun.com/v1/realtime/audio',
       defaultModel: 'stepfun/step-tts-2',
       voices: [{ id: 'lively-girl', labels: {}, languages: [] }],
@@ -584,10 +584,10 @@ describe('createAdminRouterConfigService', () => {
     const service = createAdminRouterConfigService({ configKV: kv.service, envelope, redis })
     const stepfunSlice = {
       kind: 'stepfun-streaming' as const,
-      enabled: false,
+      rollout: 'disabled' as const,
       upstreamURL: 'wss://api.stepfun.com/v1/realtime/audio',
-      models: [{ id: 'stepfun/step-tts-2' }],
-      defaultModel: 'stepfun/step-tts-2',
+      models: [{ id: 'stepfun/step-tts-2' as const }],
+      defaultModel: 'stepfun/step-tts-2' as const,
       voices: [{ id: 'lively-girl' }],
       plaintextKey: 'stepfun-secret',
     }
@@ -724,6 +724,7 @@ describe('createAdminRouterConfigService', () => {
     expect(current.request.defaults.chatModel).toBe('chat-live')
     expect(JSON.stringify(current.preview)).toContain('<ciphertext: 17 chars>')
     expect(JSON.stringify(current.preview)).not.toContain('secret-ciphertext')
+    expect(current.missingKeys).not.toContain('STEPFUN_STREAMING_TTS_UPSTREAM')
   })
 
   it('current classifies Bedrock and generic OpenAI-compatible LLM upstreams by baseURL', async () => {

--- a/server/apps/api/src/services/domain/product-events.ts
+++ b/server/apps/api/src/services/domain/product-events.ts
@@ -12,7 +12,7 @@ const logger = useLogger('product-events')
 
 export type ProductFeature = 'auth' | 'chat' | 'gen_ai_chat' | 'tts' | 'billing' | 'voice_pack'
 
-export type ProductEventStatus = 'started' | 'succeeded' | 'failed' | 'blocked'
+export type ProductEventStatus = 'started' | 'succeeded' | 'failed' | 'blocked' | 'cancelled'
 
 export type ProductAction
   = | 'user_signed_up'
@@ -25,6 +25,7 @@ export type ProductAction
     | 'speech_succeeded'
     | 'speech_failed'
     | 'speech_blocked'
+    | 'speech_cancelled'
     | 'voice_pack_created'
     | 'voice_pack_updated'
     | 'voice_pack_disabled'

--- a/server/apps/api/src/services/domain/streaming-tts-policy.ts
+++ b/server/apps/api/src/services/domain/streaming-tts-policy.ts
@@ -1,0 +1,30 @@
+/** Minimal model shape accepted by streaming TTS visibility policy. */
+export interface StreamingTtsModelSelection {
+  id: string
+}
+
+/**
+ * Decides whether an unSpeech streaming model can be selected.
+ *
+ * An empty curated list intentionally delegates filtering to unSpeech. A
+ * non-empty list is an operator allowlist. Catalog and websocket resolution
+ * must share this rule so visible models are always startable.
+ */
+export function isUnspeechStreamingModelEnabled(
+  models: StreamingTtsModelSelection[],
+  requestedModel: string,
+): boolean {
+  return models.length === 0 || models.some(model => model.id === requestedModel)
+}
+
+/**
+ * Converts a canonical public model id into the resource id expected by
+ * unSpeech's upstream voice catalog.
+ *
+ * Before: `volcengine/seed-tts-2.0`
+ * After: `seed-tts-2.0`
+ */
+export function streamingTtsModelResourceId(model: string): string {
+  const separator = model.indexOf('/')
+  return separator >= 0 ? model.slice(separator + 1) : model
+}


### PR DESCRIPTION
## 用户路径

官方提供商配置将 StepFun 原生 WebSocket 流式 TTS 设为 `available` 后，客户端可以显式选择 StepFun 模型；设为 `default` 后才切换默认模型。AIRI 客户端继续使用既有 `/api/v1/audio/speech/ws` 协议。

## 设计

- 会话层只负责客户端命令顺序、输入边界、Flux 预检与结算、日志和产品事件
- StepFun 与 unSpeech 各自封装握手、协议状态机、命令缓冲、事件转换、超时和关闭
- provider resolution、model visibility 和 resource id normalization 共享同一策略
- rollout 明确区分 `disabled`、`available`、`default`，只有 `default` 会接管默认流量

## 变更

- 接入 StepFun 原生双向流式 TTS，支持 Unicode 安全的 1000 字符分块、Base64 音频增量和 session correlation
- 增加连接握手和完成阶段无进度超时，收到有效音频或控制进度时续期
- cancel 和客户端断开立即终止上游，不等待配置、计费或日志 I/O
- 结算只计算已成功发送给 provider 的文本，且上游 usage 不得低于已接受字符数
- 区分 completed、cancelled、failed、blocked，对应 200、499、5xx、402 和独立产品事件
- 增加 20,000 字符、512 文本帧硬上限，以及分段 Flux 可负担性检查
- 严格校验 StepFun canonical model、voice、response format、配置重复项和密钥 AAD 上下文

## 验证

- `pnpm exec vitest run server/apps/api/src/routes/audio-speech-ws/route.test.ts server/apps/api/src/services/adapters/config-kv.test.ts server/apps/api/src/services/domain/admin/router-config/tests/admin-router-config.test.ts server/apps/api/src/routes/openai/v1/route.test.ts server/apps/api/src/services/domain/product-events.test.ts`，5 files / 144 tests passed
- `pnpm -F @proj-airi/api-server typecheck`，通过
- `pnpm lint`，0 errors，7 条既有无关 warnings
- `git diff --check`，通过
- `gpt-5.6-sol` high reasoning 独立复审两轮，最终 no findings
- CI 的 Lint、Type Check、全部 Build Test、Check Provenance、Prepare preview 和 autofix 均通过
- CI Unit Test 连续两次仅失败于既有 `packages/stage-ui` BroadcastChannel/context bridge 用例，6 failed / 631 passed；本次 server TTS 目标测试没有失败

## 未验证

- 尚未使用真实 StepFun 凭据执行上游 WebSocket smoke、首包延迟和音质 A/B
- 本地完整 `pnpm typecheck` 仍受 fresh worktree 中 `server-shared` 对 `@proj-airi/plugin-protocol/types` 构建产物依赖影响；CI Type Check 与本次 API workspace typecheck 均已通过
- CI 尚未全绿，剩余失败限定在上述与本次改动无关的 Stage UI Unit Test，本 PR 未扩大范围修改该协议测试
- 配置默认仍为 `disabled`，尚未切换生产默认提供商
