### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-ovPOyYSpYnUrsAZkMFo7vxrdjp60OueWiHfp0+sp+V0=
+sha256-DUNaQCCxioZ/kN8qNyrg3WqA/KcIn5dLvewxtEprcQE=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency lock hash to keep package installations reproducible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->