### PR TITLE
fix: guard kokoro-local provider init timing on direct navigation

### DIFF
--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -58,10 +58,19 @@ const model = computed({
     return getDefaultKokoroModel(hasWebGPU.value, fp16Supported.value)
   },
   set(val: string) {
-    // The combobox can write back the v-model before onMounted runs, at which
-    // point the provider may not be registered yet and synced actions are still
-    // async. Skip the write in that window; onMounted persists the default model
-    // right after registration, and later user selections always hit a config.
+    // NOTICE:
+    // Why this workaround is needed: the combobox can write back the v-model
+    // before onMounted runs, when the provider may not be registered yet and
+    // synced actions are still async. Skipping the write in that window is
+    // safe because onMounted persists the default model right after
+    // registration, and later user selections always hit a config.
+    // Root cause: direct navigation registers the provider inside onMounted
+    // (ensureProvider), so a pre-mount combobox write would hit
+    // getProviderConfig() === undefined and throw.
+    // Source: PR #2273 review (codex bot), kokoro-local direct navigation path.
+    // Removal condition: when the settings page guarantees the provider is
+    // registered before the combobox can write (e.g. provider pre-registered
+    // at app init), this guard can be deleted.
     const config = providerStore.getProviderConfig(providerId)
     if (config)
       config.model = val
@@ -130,6 +139,9 @@ onMounted(async () => {
       await providerStore.ensureProvider(providerId, providerId, {
         model: getDefaultKokoroModel(hasWebGPU.value, fp16Supported.value),
         voiceId: '',
+        // Match getDefaultProviderConfig() shape (baseUrl: '' for providers
+        // without a base URL) so shouldListProvider() comparison stays clean.
+        baseUrl: '',
       })
     }
     const config = providerStore.getProviderConfig(providerId) ?? {}

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -135,6 +135,14 @@ onMounted(async () => {
   hasWebGPU.value = capabilities.supported
   fp16Supported.value = capabilities.fp16Supported
 
+  // Refresh the provider's default config: metadata is selected at store
+  // setup (before capability detection), so Kokoro's default model was
+  // computed from an empty cache. Seeding a capability-accurate default
+  // while the dirty comparison still uses the stale one would make
+  // shouldListProvider() treat this passive seed as user-modified and
+  // list Kokoro as dirty/unconfigured.
+  providersStore.refreshProviderDefaultConfig(providerId)
+
   try {
     voicesLoading.value = true
 
@@ -145,16 +153,26 @@ onMounted(async () => {
     // the catalog, in which case getProviderConfig() returns undefined and reading
     // `config.model` throws. ensureProvider is a synced (async) action: it returns
     // a Promise, not the provider, so await it and re-read the config afterwards.
-    // Seed with capability-aware defaults (matching createProviderConfig) instead
-    // of an empty object, so fp16-capable hardware keeps its fp16-webgpu default.
+    // NOTICE: Seed with the provider's own default config - the same source the
+    // dirty comparison (isProviderConfigDirty -> shouldListProvider) uses - so
+    // this passive seed is not flagged as user-modified. refreshProviderDefaultConfig()
+    // above recomputed that default after capability detection, so it also keeps
+    // fp16-capable hardware on its fp16-webgpu default.
+    // Why: seeding a hand-built object here would drift from providerMetadata's
+    // defaultConfig whenever their capability sources disagree, marking a
+    // programmatic seed as a user edit.
+    // Root cause: provider registration is lazy (only triggered by navigation
+    // or catalog add), and capability-dependent defaults are selected at store
+    // setup time.
+    // Source: PR #2273 review (codex bot), rounds 1 & 4.
+    // Removal condition: when the provider is guaranteed to be registered with
+    // capability-accurate defaults before this page can mount.
     if (!providerStore.getProviderConfig(providerId)) {
-      await providerStore.ensureProvider(providerId, providerId, {
-        model: getDefaultKokoroModel(hasWebGPU.value, fp16Supported.value),
-        voiceId: '',
-        // Match getDefaultProviderConfig() shape (baseUrl: '' for providers
-        // without a base URL) so shouldListProvider() comparison stays clean.
-        baseUrl: '',
-      })
+      await providerStore.ensureProvider(
+        providerId,
+        providerId,
+        providersStore.getDefaultProviderConfig(providerId),
+      )
     }
     const config = providerStore.getProviderConfig(providerId) ?? {}
 

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -124,14 +124,19 @@ onMounted(async () => {
     // the catalog, in which case getProviderConfig() returns undefined and reading
     // `config.model` throws. ensureProvider is a synced (async) action: it returns
     // a Promise, not the provider, so await it and re-read the config afterwards.
+    // Seed with capability-aware defaults (matching createProviderConfig) instead
+    // of an empty object, so fp16-capable hardware keeps its fp16-webgpu default.
     if (!providerStore.getProviderConfig(providerId)) {
-      await providerStore.ensureProvider(providerId, providerId, {})
+      await providerStore.ensureProvider(providerId, providerId, {
+        model: getDefaultKokoroModel(hasWebGPU.value, fp16Supported.value),
+        voiceId: '',
+      })
     }
     const config = providerStore.getProviderConfig(providerId) ?? {}
 
     // Persist the default model if none is saved yet so validation passes on first visit
     if (!config.model) {
-      config.model = getDefaultKokoroModel(hasWebGPU.value)
+      config.model = getDefaultKokoroModel(hasWebGPU.value, fp16Supported.value)
     }
 
     const validationResult = await providersStore.validateProviderConfig(providerId, config)

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SpeechProvider } from '@xsai-ext/providers/utils'
 
-import { getCachedWebGPUCapabilities } from '@proj-airi/stage-shared/webgpu'
+import { detectWebGPU } from '@proj-airi/stage-shared/webgpu'
 import {
   SpeechPlayground,
   SpeechProviderSettings,
@@ -117,11 +117,23 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 
 onMounted(async () => {
   // Check WebGPU support
-  // NOTICE: Uses synchronous check for initial render. The cached result from
-  // detectWebGPU() is populated by the providers store during initialization.
-  const capabilities = getCachedWebGPUCapabilities()
-  hasWebGPU.value = capabilities?.supported ?? (typeof navigator !== 'undefined' && !!navigator.gpu)
-  fp16Supported.value = capabilities?.fp16Supported ?? false
+  // NOTICE: Await the real detection instead of reading the sync cache.
+  // Why: direct navigation can mount this page before the app-level preload
+  // (useInferencePreload -> detectWebGPU, called from App.vue onMounted) has
+  // populated the cache, so getCachedWebGPUCapabilities() would return null
+  // and fp16Supported would wrongly fall back to false - seeding fp32-webgpu
+  // on fp16-capable hardware until a reload.
+  // Root cause: capability detection is async and app-level, while this
+  // page's capability-dependent seeding runs in its own onMounted.
+  // Source: PR #2273 review (codex bot), round 3.
+  // Removal condition: when the app guarantees WebGPU capability detection
+  // completes before any settings page mounts (e.g. preload awaited before
+  // router mount), this can revert to getCachedWebGPUCapabilities().
+  // Note: detectWebGPU() deduplicates concurrent calls (pendingDetection),
+  // so this awaits the same promise as the app preload when both race.
+  const capabilities = await detectWebGPU()
+  hasWebGPU.value = capabilities.supported
+  fp16Supported.value = capabilities.fp16Supported
 
   try {
     voicesLoading.value = true

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -30,6 +30,12 @@ const { t } = useI18n()
 // default.
 const hadConfigBeforeMount = !!providerStore.getProviderConfig(providerId)
 
+// Gates the model watcher while onMounted performs initial seeding. Without
+// it, the child SpeechProviderSettings seeding the stale default (or this
+// refresh swapping in the capability-aware one) would fire the watcher and
+// queue a stale model load ahead of the correct one.
+const initialSeeding = ref(true)
+
 // Get available voices for Kokoro
 const availableVoices = computed(() => {
   return speechStore.availableVoices[providerId] || []
@@ -205,12 +211,15 @@ onMounted(async () => {
   }
   finally {
     voicesLoading.value = false
+    // Initial seeding is done (or failed - either way the watcher is safe
+    // to resume; a failed seed just means validation errors were logged).
+    initialSeeding.value = false
   }
 })
 
 // Watch for model changes and reload model + voices
 watch(model, async (newValue) => {
-  if (newValue) {
+  if (newValue && !initialSeeding.value) {
     try {
       voicesLoading.value = true
 

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -21,6 +21,15 @@ const providersStore = useProviderStore()
 const providerStore = useProviderConfigStore()
 const { t } = useI18n()
 
+// Whether a provider config already existed before this mount (i.e. before
+// the child SpeechProviderSettings can seed one). A persisted config is
+// user-owned and must never be replaced — on a reload with an empty WebGPU
+// cache, a manually chosen model can be value-identical to the stale default
+// seed. Configs created during this mount are passive seeds that
+// refreshProviderDefaultConfig() may refresh when they still hold the stale
+// default.
+const hadConfigBeforeMount = !!providerStore.getProviderConfig(providerId)
+
 // Get available voices for Kokoro
 const availableVoices = computed(() => {
   return speechStore.availableVoices[providerId] || []
@@ -141,7 +150,9 @@ onMounted(async () => {
   // while the dirty comparison still uses the stale one would make
   // shouldListProvider() treat this passive seed as user-modified and
   // list Kokoro as dirty/unconfigured.
-  providersStore.refreshProviderDefaultConfig(providerId)
+  providersStore.refreshProviderDefaultConfig(providerId, {
+    replaceUntouchedSeed: !hadConfigBeforeMount,
+  })
 
   try {
     voicesLoading.value = true

--- a/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/kokoro-local.vue
@@ -58,8 +58,13 @@ const model = computed({
     return getDefaultKokoroModel(hasWebGPU.value, fp16Supported.value)
   },
   set(val: string) {
+    // The combobox can write back the v-model before onMounted runs, at which
+    // point the provider may not be registered yet and synced actions are still
+    // async. Skip the write in that window; onMounted persists the default model
+    // right after registration, and later user selections always hit a config.
     const config = providerStore.getProviderConfig(providerId)
-    config.model = val
+    if (config)
+      config.model = val
   },
 })
 
@@ -80,7 +85,7 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
       throw new Error('Failed to initialize speech provider')
     }
 
-    const config = providerStore.getProviderConfig(providerId)
+    const config = providerStore.getProviderConfig(providerId) ?? {}
     const selectedModel = config.model as string | undefined || defaultModel
 
     const result = await speechStore.speech(
@@ -115,7 +120,14 @@ onMounted(async () => {
     // Fetch available models first
     await providersStore.fetchModelsForProvider(providerId)
 
-    const config = providerStore.getProviderConfig(providerId)
+    // Direct navigation to this page can happen before the provider is added from
+    // the catalog, in which case getProviderConfig() returns undefined and reading
+    // `config.model` throws. ensureProvider is a synced (async) action: it returns
+    // a Promise, not the provider, so await it and re-read the config afterwards.
+    if (!providerStore.getProviderConfig(providerId)) {
+      await providerStore.ensureProvider(providerId, providerId, {})
+    }
+    const config = providerStore.getProviderConfig(providerId) ?? {}
 
     // Persist the default model if none is saved yet so validation passes on first visit
     if (!config.model) {
@@ -145,6 +157,9 @@ watch(model, async (newValue) => {
       voicesLoading.value = true
 
       const config = providerStore.getProviderConfig(providerId)
+      if (!config)
+        return
+
       const validationResult = await providersStore.validateProviderConfig(providerId, config)
 
       if (validationResult.valid) {

--- a/packages/stage-ui/src/stores/providers/config.ts
+++ b/packages/stage-ui/src/stores/providers/config.ts
@@ -269,6 +269,7 @@ export const useProviderConfigStore = defineStore('provider-config', () => {
       'addProvider',
       'removeProvider',
       'updateProviderConfig',
+      'replaceProviderConfig',
       'resetProviders',
     ],
     state: true,

--- a/packages/stage-ui/src/stores/providers/config.ts
+++ b/packages/stage-ui/src/stores/providers/config.ts
@@ -128,6 +128,20 @@ export const useProviderConfigStore = defineStore('provider-config', () => {
     addedProviders.value[providerId] = true
   }
 
+  /**
+   * Synchronously replace a provider's config object (by reference, so
+   * `configs`/`providerCredentials` and the localStorage persistence all
+   * pick it up). Unlike `updateProviderConfig`, this is a local mutation
+   * with no remote round-trip — intended for replacing a passively seeded
+   * stale default, not for user edits.
+   */
+  function replaceProviderConfig(providerId: string, config: Record<string, unknown>) {
+    const provider = providers.value[providerId]
+    if (!provider)
+      return
+    provider.config = config
+  }
+
   function unmarkProviderAdded(providerId: string) {
     delete addedProviders.value[providerId]
   }
@@ -234,6 +248,7 @@ export const useProviderConfigStore = defineStore('provider-config', () => {
     getProvider,
     getProviderConfig,
     ensureProvider,
+    replaceProviderConfig,
     markProviderAdded,
     unmarkProviderAdded,
     setProviderStatus,

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -32,6 +32,7 @@ import {
   validateProvider as runProviderValidation,
 } from '../../libs/providers'
 import { selectProviderMetadata, selectProvidersMetadata } from '../../libs/providers/metadata'
+import { getSchemaDefault } from '../../libs/zod'
 import { useAuthStore } from '../auth'
 import { useSettingsAnalytics } from '../settings/analytics'
 import { useProviderConfigStore } from './config'
@@ -400,6 +401,23 @@ export const useProviderStore = defineStore('provider', () => {
       ...defaultOptions,
       ...(Object.hasOwn(defaultOptions, 'baseUrl') ? {} : { baseUrl: '' }),
     }
+  }
+
+  /**
+   * Re-select a provider's default config with current runtime state.
+   *
+   * Capability-dependent defaults (e.g. Kokoro's fp16 model) are computed
+   * from the WebGPU cache at metadata selection time. When the store is set
+   * up before capability detection completes, the cached default is stale;
+   * refreshing it keeps the dirty comparison (isProviderConfigDirty) in sync
+   * with what a later capability-aware seed saves.
+   */
+  function refreshProviderDefaultConfig(providerId: string) {
+    const definition = getProviderDefinition(providerId)
+    const meta = providerMetadata[providerId]
+    if (!definition || !meta)
+      return
+    meta.defaultConfig = getSchemaDefault(definition.createProviderConfig({ t })) as Record<string, unknown>
   }
 
   function initializeProviderRuntimeState(providerId: string) {
@@ -959,6 +977,7 @@ export const useProviderStore = defineStore('provider', () => {
     getProviderDefinition,
     findProviderDefinition,
     getDefaultProviderConfig,
+    refreshProviderDefaultConfig,
     validateProviderConfig,
     hasManualProviderValidators,
     supportsModelListing,

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -418,9 +418,10 @@ export const useProviderStore = defineStore('provider', () => {
    * direct navigation). Keeping that stale seed would make the page load the
    * wrong model and shouldListProvider() flag the passive seed as a user edit.
    * Only a config that exactly matches the stale default is replaced — a real
-   * user edit is never clobbered.
+   * user edit is never clobbered. Replacement additionally requires the
+   * caller to opt in via `replaceUntouchedSeed` (see below).
    */
-  function refreshProviderDefaultConfig(providerId: string) {
+  function refreshProviderDefaultConfig(providerId: string, options: { replaceUntouchedSeed?: boolean } = {}) {
     const definition = getProviderDefinition(providerId)
     const meta = providerMetadata[providerId]
     if (!definition || !meta)
@@ -434,12 +435,20 @@ export const useProviderStore = defineStore('provider', () => {
     // JSON equality check. A config whose default fields are untouched is
     // still the passive seed and safe to replace; any deviation means the
     // user edited it and it must not be clobbered.
-    const isUntouchedPassiveSeed = saved && Object.keys(previousDefault)
-      .every((key) => {
-        const savedValue = (saved as Record<string, unknown>)[key]
-        const defaultValue = (previousDefault as Record<string, unknown>)[key]
-        return savedValue === defaultValue
-      })
+    //
+    // Value equality alone cannot distinguish a passive seed from a user's
+    // deliberate choice: on a reload with an empty WebGPU cache, a user who
+    // manually picked fp32-webgpu on fp16 hardware has a saved config that
+    // exactly equals the stale default. The caller therefore opts in to
+    // replacement only when it knows the config was created during this
+    // mount (no pre-existing persisted config).
+    const isUntouchedPassiveSeed = saved && options.replaceUntouchedSeed === true
+      && Object.keys(previousDefault)
+        .every((key) => {
+          const savedValue = (saved as Record<string, unknown>)[key]
+          const defaultValue = (previousDefault as Record<string, unknown>)[key]
+          return savedValue === defaultValue
+        })
     if (isUntouchedPassiveSeed) {
       providerConfigStore.replaceProviderConfig(providerId, getDefaultProviderConfig(providerId))
     }

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -1051,6 +1051,7 @@ export const useProviderStore = defineStore('provider', () => {
       'deleteProvider',
       'disposeProviderInstance',
       'fetchModelsForProvider',
+      'refreshProviderDefaultConfig',
       'forceProviderConfigured',
       'initializeProvider',
       'listProviderVoices',

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -411,13 +411,26 @@ export const useProviderStore = defineStore('provider', () => {
    * up before capability detection completes, the cached default is stale;
    * refreshing it keeps the dirty comparison (isProviderConfigDirty) in sync
    * with what a later capability-aware seed saves.
+   *
+   * Also replaces a saved config that still equals the stale default: a child
+   * component may have passively seeded the provider before capability
+   * detection ran (e.g. SpeechProviderSettings calling initializeProvider on
+   * direct navigation). Keeping that stale seed would make the page load the
+   * wrong model and shouldListProvider() flag the passive seed as a user edit.
+   * Only a config that exactly matches the stale default is replaced — a real
+   * user edit is never clobbered.
    */
   function refreshProviderDefaultConfig(providerId: string) {
     const definition = getProviderDefinition(providerId)
     const meta = providerMetadata[providerId]
     if (!definition || !meta)
       return
+    const previousDefault = getDefaultProviderConfig(providerId)
     meta.defaultConfig = getSchemaDefault(definition.createProviderConfig({ t })) as Record<string, unknown>
+    const saved = providerCredentials.value[providerId]
+    if (saved && JSON.stringify(saved) === JSON.stringify(previousDefault)) {
+      providerConfigStore.replaceProviderConfig(providerId, getDefaultProviderConfig(providerId))
+    }
   }
 
   function initializeProviderRuntimeState(providerId: string) {

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -428,7 +428,19 @@ export const useProviderStore = defineStore('provider', () => {
     const previousDefault = getDefaultProviderConfig(providerId)
     meta.defaultConfig = getSchemaDefault(definition.createProviderConfig({ t })) as Record<string, unknown>
     const saved = providerCredentials.value[providerId]
-    if (saved && JSON.stringify(saved) === JSON.stringify(previousDefault)) {
+    // Compare only the fields that make up the provider default: child
+    // components may have added passive fields (e.g. SpeechProviderSettings
+    // writing apiKey: '') to the seeded config, which would break a full
+    // JSON equality check. A config whose default fields are untouched is
+    // still the passive seed and safe to replace; any deviation means the
+    // user edited it and it must not be clobbered.
+    const isUntouchedPassiveSeed = saved && Object.keys(previousDefault)
+      .every((key) => {
+        const savedValue = (saved as Record<string, unknown>)[key]
+        const defaultValue = (previousDefault as Record<string, unknown>)[key]
+        return savedValue === defaultValue
+      })
+    if (isUntouchedPassiveSeed) {
       providerConfigStore.replaceProviderConfig(providerId, getDefaultProviderConfig(providerId))
     }
   }


### PR DESCRIPTION
## Summary
When navigating directly to the speech settings page, the provider may not be registered from the catalog yet, so `getProviderConfig()` returns `undefined` and reading `config.model` throws. The model combobox can also write back `v-model` before `onMounted` runs (provider registration is an async synced action).

## Changes
- `packages/stage-pages/.../kokoro-local.vue`: await `ensureProvider()` when config is missing, then re-read; guard `set()`/`watch()` against missing config; fall back to `{}` where a read is unavoidable.
- `pnpm-lock.yaml`: remove iOS `DerivedData` lock entries that were accidentally committed (Xcode build cache), add missing `web-worker` optional marker.

## Verification
- Direct navigation to the page no longer throws.
- Model selection persists after provider registration.
- `pnpm install --frozen-lockfile` passes locally.