### PR TITLE
feat(tools/proxy-router): add selective WireGuard router with TUN toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,16 @@ docs/ai/context/verifications/
 # Generated from packages/i18n/glossary/terms.yaml at upload time. Never committed, so it
 # cannot drift from its source.
 packages/i18n/glossary/glossary.tbx
+
+# proxy-router runtime state and WireGuard credentials — never commit live data
+/tools/proxy-router/providers/**/*.conf
+/tools/proxy-router/wgcf-account.toml
+/tools/proxy-router/wgcf-account.toml.*
+/tools/proxy-router/wgcf-profile.conf
+/tools/proxy-router/router.json
+/tools/proxy-router/sing-box.json
+/tools/proxy-router/sing-box.json.debug
+/tools/proxy-router/sing-box.json.last-good
+/tools/proxy-router/sing-box.pid
+/tools/proxy-router/sing-box.log*
+/tools/proxy-router/state/

--- a/tools/proxy-router/README.md
+++ b/tools/proxy-router/README.md
@@ -1,0 +1,523 @@
+# proxy-router
+
+Selective tunnel router with per-provider failover, powered by [sing-box](https://sing-box.sagernet.org/).
+Spiritual successor to `tools/opencode-zen-vpn` (retired).
+
+## What it does
+
+Runs a local mixed HTTP/SOCKS proxy at `127.0.0.1:2080` and routes only
+matching domains/IPs through a WireGuard tunnel — everything else goes direct.
+Routes can point at different tunnel providers (e.g. `roblox.com ->
+cloudflare` and `opencode.ai -> proton`), and each provider keeps a pool of
+profiles that rotate on demand (rate limits, server death) while the listener
+stays up (config is hot-reloaded via SIGHUP, no restart). The default template
+keeps the route table conservative; `proxy-router setup --preset` applies the
+validated Proton/WARP presets explicitly.
+
+On the current deployment, OpenCode Zen uses the Proton pool and Roblox uses
+Cloudflare WARP. Direct egress remains the fallback when all tunnel exits are
+unhealthy.
+
+Core CLI runs on macOS, Linux, and Windows. The macOS-only bits (`up`/`down`
+and the launchd keep-alive) are guarded and print a clear message elsewhere.
+
+## Requirements
+
+- Python 3.10+ (stdlib only — no pip install)
+- sing-box **1.12.0 or newer** — bundled in the release archives
+  (`bin/sing-box`), or available on `PATH`, or pointed at via `SING_BOX` env
+  var. Older binaries are rejected up front: the generated config relies on
+  the 1.12+ dialer `domain_resolver`, route `default_domain_resolver` and the
+  `hijack-dns` rule action.
+
+## Install
+
+MacOS / Linux:
+
+```sh
+tar xzf proxy-router-<version>-<os>.tar.gz
+cd proxy-router
+./install.sh          # installs to ~/.local/share/proxy-router, links `proxy-router` on PATH
+```
+
+Windows (PowerShell):
+
+```powershell
+Expand-Archive proxy-router-<version>-windows-amd64.zip
+cd proxy-router
+powershell -ExecutionPolicy Bypass -File install.ps1
+```
+
+Then initialize the config and use the setup TUI/guide path:
+
+```sh
+proxy-router init
+proxy-router setup --guide all
+proxy-router setup --import-proton ~/Downloads/protonvpn-*.conf
+proxy-router setup --import-warp ~/Downloads/wgcf-profile.conf  # optional
+proxy-router setup --preset
+proxy-router setup --check
+proxy-router setup --bridge-install  # install the Hermes OpenCode rotation bridge
+proxy-router setup --bridge-force-install  # overwrite an existing bridge file
+proxy-router setup --bridge-check    # verify the installed bridge
+proxy-router ensure
+```
+
+`proxy-router setup` with no flags opens the custom terminal wizard. It never
+enables TUN mode or starts monitoring unless you explicitly choose those
+operations. Menu item 9 installs/verifies the Hermes OpenCode auto-rotation
+bridge (placed at `$OPENCODE_ZEN_VPN_ROOT/proxy-manager.sh`).
+
+## Layout
+
+```
+router.py                    engine + CLI (single file, stdlib only)
+setup_tui.py                 custom terminal setup wizard + safe imports
+monitor.py                   opt-in latency/ping/speed monitor worker
+router.example.json          config template (port, providers, cooldowns, route table)
+guides/proton-vpn-free.md    Proton VPN Free WireGuard guide
+guides/cloudflare-warp.md    Cloudflare WARP/wgcf guide
+install.sh / install.ps1     installers
+bin/sing-box(.exe)           bundled engine binary (release archives only)
+examples/keepalive.sh        re-arms the engine if the listener dies
+examples/com.proxy-router.keepalive.plist.template   launchd agent loading keepalive
+examples/hermes-opencode.sh  bounded model-run wrapper with automatic rotation
+examples/proxy-manager.sh   bridge for the Hermes opencode-server-rotation plugin
+tests/                       unit tests (unittest, no deps)
+providers/<provider>/        WireGuard configs, one file per profile (chmod 600)
+state/                       active profile + cooldown markers (gitignored)
+sing-box.json / .pid / .log  runtime state (gitignored)
+```
+
+## Usage
+
+```sh
+./router.py ensure                # start engine if the listener is down (idempotent)
+./router.py start / stop / status
+./router.py routes               # list route table
+./router.py vpn on               # full TUN mode: route everything via the engines' rules
+./router.py vpn off              # stop the TUN, back to proxy mode
+./router.py vpn restart          # stop + re-enter TUN in one step (single elevation prompt)
+./router.py vpn status           # show current mode and liveness
+./router.py add --domain example.com --provider proton [--id my-route]
+./router.py add --ip 1.2.3.0/24 --provider proton [--id my-route]
+./router.py remove <id>
+./router.py rotate <provider>    # switch to next healthy profile, hot reload
+./router.py rotate <provider> --reason 503|429|timeout|1010  # mark CURRENT exit failed upstream, prefer a different one
+./router.py rotate <provider> --force   # switch anyway, ignoring cooldowns and blocked exits
+./router.py rotate <provider> --no-probe # skip the post-switch egress probe
+./router.py rotate --if-due      # scheduled rotation: only when the interval elapsed (exit 3 = not due)
+./router.py provider-count proton # rotation candidates (retry budget)
+./router.py with-proxy [--timeout-ms 300] [--force-proxy|--force-direct] -- <cmd...>
+                                 # fail-open runner: exec <cmd> through the proxy when up, else direct
+./router.py with-proxy --check   # health check: prints proxy URL + exit 0 when up, exit 1 when down
+./router.py egress probe [provider]  # probe current exit(s) through the tunnel, persist health
+./router.py egress show [provider]   # print persisted egress records (JSON)
+./router.py egress check [--provider <name>] [--json]  # read-only live check: exit 1 ONLY when an active exit is DEAD
+./router.py status --json         # machine-readable status for scripts/Hermes
+./router.py setup                  # custom setup TUI
+./router.py setup --guide all      # print Proton + WARP guides
+./router.py setup --preset         # enable OpenCode->Proton and Roblox->WARP presets
+./router.py setup --check          # validate imported profiles without networking
+./router.py setup --bridge-install # install/verify the Hermes OpenCode rotation bridge
+./router.py setup --bridge-check   # verify the installed bridge without writing
+./router.py monitor status          # read monitor state; never probes
+./router.py monitor check           # explicit one-shot ping/latency/speed sample
+./router.py monitor on              # opt in to a detached sample worker (60s default)
+./router.py monitor off             # stop the worker and remove active state
+./router.py monitor logs            # show recent JSONL samples
+./router.py init                 # write a fresh router.json (exists => refused; add --force)
+./router.py up                   # enable macOS system proxy (also ensures engine)
+./router.py down                 # disable macOS system proxy only (engine keeps running)
+```
+
+Every state-changing command takes an exclusive lock, so concurrent calls
+are safe; read-only commands (`status`, `routes`, `provider-count`, `vpn
+status`, `init`) do not.
+
+`status` and `vpn status` report the same state (exit 0 = engine up and
+matching the persisted mode; exit 1 = down, degraded, or unusable config), so
+scripts and humans can rely on either one. `status --json` adds the active
+profile, per-profile cooldowns and egress records, last rotation, and route
+table as JSON (same exit code) so automation can make decisions without
+parsing human text.
+
+## Egress health & rotation smarts
+
+Each provider exit tracks health under `state/egress/<provider>/<profile>.json`
+(atomic, mode 0600): last probe latency, consecutive failures, and an optional
+`blocked` marker. A probe is a small GET to the first domain the provider
+routes, sent THROUGH `127.0.0.1:<port>` so it exercises the real tunnel
+end-to-end (a URL matching no route would go out direct and measure the wrong
+path).
+
+Rotation is then egress-aware instead of blind round-robin:
+
+- Profiles with a fresh OK probe are preferred, fastest latency first;
+  unknown profiles come next; profiles with repeated failures (`fail_threshold`,
+  default 2) rank last.
+- Profiles with a `blocked` marker (Cloudflare 1010/403 egress-IP reputation
+  blocks, recorded by `rotate --reason 1010` or the probe itself) are skipped
+  until the marker expires (`egress.block_seconds`, default 1h) or you run
+  `rotate --force`.
+- `rotate --reason <what>` gives the CURRENT profile a longer cooldown
+  (`egress.upstream_cooldown_seconds`, default 300s) plus a recorded reason, so
+  503/429/timeout storms steer away from the exit that just failed upstream.
+- After switching, the new exit is probed; if it does not come up cleanly the
+  router restores the previous good profile (one bounded rollback step).
+- `egress probe` refreshes health on demand without rotating.
+- `egress check` is the read-only liveness view used by the keepalive self-heal
+  loop: it probes the ACTIVE exit(s) through the running tunnel and classifies
+  each one `alive` (HTTP response rode the tunnel), `degraded` (an HTTP status
+  arrived but was not ok - e.g. a Cloudflare 1010/403 reputation block or 5xx,
+  i.e. NOT a dead tunnel), or `dead` (transport-level failure, no HTTP status
+  at all - the tunnel path itself is broken). A companion DNS probe records
+  `dns_ok` in the egress record when determinable: `dead` with `dns_ok: false`
+  means resolution through the tunnel failed, `dns_ok: true` means a later
+  dial/read stage failed. Exit code is 1 only when an exit is `dead`, so
+  automation never rotates on a reputation-block HTTP status.
+- A `sing-box.json.last-good` snapshot (atomic, 0600) is written whenever a
+  freshly built config validates AND the engine demonstrably comes up with it;
+  if a later reload's config fails validation or the engine fails to come up,
+  the router restores the last-good config and reloads/starts once - never
+  looping, and failing with a clear message when no last-good exists or the
+  restore itself fails.
+
+Tunables live in `router.json` under `"egress"` (see `router.example.json`).
+
+## Error policy table (`error_policy`)
+
+What happens to a lane after an upstream failure is configurable per reason via
+a top-level `"error_policy"` table in `router.json`. Each reason maps to an
+action and a duration:
+
+```json
+"error_policy": {
+  "default": { "action": "cooldown", "seconds": 300 },
+  "429":     { "action": "exhaust", "seconds": 900 },
+  "503":     { "action": "cooldown", "seconds": 120 },
+  "timeout": { "action": "cooldown", "seconds": 60 },
+  "tls":     { "action": "cooldown", "seconds": 300 },
+  "connection": { "action": "cooldown", "seconds": 300 },
+  "1010":    { "action": "block", "seconds": 3600 },
+  "403":     { "action": "block", "seconds": 3600 }
+}
+```
+
+Semantics:
+
+- `cooldown` — normal cooldown (`mark_cooldown`): rotation skips the lane
+  until the timer resets.
+- `exhaust` — cooldown **plus** `exhausted: true`, `exhausted_at` and an
+  ISO-8601 `exhausted_until` written into the profile's egress record, so
+  `status --json` and external scripts see the lane is dead for this turn
+  (e.g. a free-tier quota lane that should not be retried for 15 minutes).
+- `block` — reputation block (`mark_blocked`): rotation skips the lane
+  entirely until the marker expires or `rotate --force` clears it (used for
+  Cloudflare 1010/403 egress-IP reputation blocks).
+
+Merge precedence (smallest merge surface, no breaking config changes): a
+per-provider `providers.<name>.error_policy` beats the global top-level
+`error_policy`, which beats the built-in defaults above. Missing reasons fall
+back to the effective `default` entry. A reason is matched loosely before
+exact lookup: `cloudflare-1010` → `1010`, `HTTP 503` / `503` → `503`,
+SSL/TLS errors → `tls`, timeouts → `timeout`, dial/connect/reset errors →
+`connection`, anything else by its slugified text (so custom reason keys like
+`"429"` overrides still work).
+
+Where it is consumed:
+
+- `rotate --reason <x>` — `_apply_upstream_failure` now applies the policy
+  entry (seconds + action) for `<x>` instead of the flat
+  `upstream_cooldown_seconds or max(...)` computation. 1010/403 text always
+  blocks regardless of the table.
+- `probe_profile` / `check_egress_live` — a transport/TLS death (no HTTP
+  status) is cooled with the policy's `tls`/`connection` seconds (built-in
+  300s, which is the merged TLS-cooldown rule). A degraded HTTP status
+  (reputation block / 5xx) is never cooled.
+- `status --json` — echoes the effective policy for every provider under the
+  top-level `"error_policy"` key, and each profile's egress record carries
+  `exhausted`/`exhausted_at`/`exhausted_until` when an exhaust policy has
+  fired, so automation can read the exact reset time.
+
+## VPN (TUN) mode
+
+`vpn on` switches the engine from a local mixed proxy (`127.0.0.1:2080`) to a
+system TUN interface. sing-box `auto_route` then captures **all** traffic at
+the IP layer — including apps that ignore system proxy settings — while the
+same route rules still decide which domains go through which provider and
+everything else exits `direct`. `vpn off` returns to proxy mode; `ensure`,
+`reload`, `add`/`remove` and `rotate` all respect whatever mode is active.
+
+Platform notes:
+
+- **Linux**: needs root for the TUN device + route table (iproute2)
+  (`sudo proxy-router vpn on`).
+- **Windows**: needs an elevated shell and `wintun.dll` next to
+  `sing-box.exe` (drop it from the official Wintun release).
+- **macOS**: needs root to create the `utun` interface. Running
+  `proxy-router vpn on` (or any engine command while TUN mode is active) as a
+  regular user in an interactive terminal re-executes itself through the
+  standard macOS admin-password dialog (`osascript` with administrator
+  privileges) and asks for permission on every run — no manual `sudo`
+  needed. State files are handed back to the invoking user automatically.
+  Background keepalive/launchd ticks never prompt (they have no TTY) and
+  keep the clear "run with sudo" error instead. Use `vpn restart` to cycle
+  the TUN with a single prompt (`vpn off && vpn on` asks twice). This is NOT
+  a System Settings VPN provider entry — that would require a signed
+  NetworkExtension app. It is a TUN interface managed from the terminal.
+
+TUN options live under `"vpn"` in `router.json`:
+`address` (CIDR list), `mtu`, `stack` (`system`, default | `gvisor`).
+
+`mtu` must fit the path to the WireGuard endpoint: if the physical network
+itself is tunneled (e.g. a school/proxy filter with a reduced inner MTU),
+the WireGuard packets fragment or get dropped, which reads as "TUN is
+slow". Measure the endpoint path with `ping -D -s <size> <endpoint>` and
+set `mtu` to `path_mtu - 80` (WireGuard overhead); 1280 is a safe
+default. `selective`/`selective_provider` is an optional IP-CIDR capture
+list from `rulesets/<name>.json` — only use it when you want TUN to
+capture exactly one site; with it set, all other domains fall out to
+direct and are NOT tunneled.
+
+Two more knobs in `"vpn"` control address-family policy:
+
+- `dns_strategy` — how domain *destinations* are resolved by the DNS module.
+  Default `ipv4_only` (the tunnels carry only the IPv4 addresses assigned in
+  each profile). Valid values: `ipv4_only`, `ipv6_only`, `ipv4_prefer`,
+  `ipv6_prefer`.
+- `prefer_ipv6_peers` — whether WireGuard *peer endpoints* that are domains
+  resolve to an IPv6 address when one exists (default `true`; some networks
+  drop the WARP IPv4 endpoint so the IPv6 one must be used). This is a
+  separate scope from `dns_strategy`: endpoints are the tunnel servers,
+  destinations are the sites you route.
+- `dns_transport` — transport for the generated `dns-<provider>` servers that
+  resolve tunneled domains. Default `udp`. Set to `https` (DoH over TCP
+  443 to 1.1.1.1) on networks that drop UDP 53 to external resolvers while
+  allowing outbound TCP 443; the same IP literal is used as the server
+  address with `server_port: 443`.
+
+## Provider setup
+
+Each profile is a sing-box-compatible WireGuard config dropped into
+`providers/<provider>/` as `<name>.conf`. The provider name (e.g. `proton`)
+becomes the sing-box endpoint tag.
+
+The easiest path is the setup wizard:
+
+```sh
+proxy-router setup                  # interactive terminal menu (item 9: Hermes rotation bridge)
+proxy-router setup --guide proton   # print the bundled Proton guide
+proxy-router setup --guide warp     # print the bundled WARP guide
+proxy-router setup --import-proton ~/Downloads/*.conf
+proxy-router setup --import-warp ~/Downloads/wgcf-profile.conf
+proxy-router setup --preset          # idempotently adds both safe route presets
+proxy-router setup --check
+proxy-router setup --bridge-install  # install/verify the Hermes OpenCode rotation bridge
+proxy-router setup --bridge-force-install  # overwrite an existing bridge file
+proxy-router setup --bridge-check    # verify the bridge without writing
+```
+
+The full provider instructions live in
+[`guides/proton-vpn-free.md`](guides/proton-vpn-free.md) and
+[`guides/cloudflare-warp.md`](guides/cloudflare-warp.md). The importer validates
+WireGuard structure, sanitizes filenames, and writes profiles as `0600`; it
+never prints private keys. Proton's flaky private resolver `10.2.0.1` is
+replaced by public DNS through the tunnel.
+
+### Config reference (`router.json`)
+
+```json
+{
+  "port": 2080,
+  "providers": {
+    "proton":     { "cooldown_seconds": 60 },
+    "cloudflare": { "cooldown_seconds": 60 }
+  },
+  "routes": [
+    { "id": "opencode-zen", "domains": ["opencode.ai"], "provider": "proton" },
+    { "id": "roblox", "domains": ["roblox.com", "rbxcdn.com", "robloxlabs.com", "rblx.com"], "provider": "cloudflare" }
+  ],
+  "rotation": { "interval_seconds": 7200, "jitter_seconds": 300 }
+}
+```
+
+`proxy-router setup --preset` adds the two routes above idempotently. Route
+choice is configurable: the current validated deployment uses the Proton pool
+for OpenCode Zen and Cloudflare WARP for Roblox, while unmatched traffic stays
+direct. If every tunnel exit is unhealthy, direct OpenCode egress remains the
+fallback; the router does not claim that a tunnel is healthy merely because a
+profile parses.
+
+- Route domains and IP CIDRs select which traffic enters a tunnel; everything
+  else matches `direct` (unmatched) traffic.
+- Every active provider injects one DNS server taken from its WireGuard
+  profile's `[Interface] DNS` (fallback `1.1.1.1`) and routed through the
+  tunnel — matching domains resolve there (strategy `ipv4_only` by default;
+  see the `vpn.dns_strategy` option if your tunnels carry IPv6).
+- A provider with no profiles is skipped entirely; its routes stay inert until
+  a profile appears.
+
+Notes on claims vs reality:
+
+- The provider `"dns"` key in `router.json` is **not read** — DNS comes from
+  each profile's `[Interface] DNS` line.
+- The setup importer chmods imported profile files `600`; manually placed
+  profiles must be secured by the operator. State files and generated
+  `sing-box.json` are also protected.
+- `router.py init` refuses to overwrite an existing `router.json` unless you
+  pass `--force`; the installer never overwrites it either.
+
+## Optional network monitoring
+
+Monitoring is completely off by default. Normal proxy traffic does not start a
+worker, timer, ping, HTTP request, or speed test. Use it only when you want a
+snapshot or a background time series:
+
+```sh
+proxy-router monitor status     # state only; no network activity
+proxy-router monitor check      # one explicit bounded sample
+proxy-router monitor on         # detached worker, 60-second samples
+proxy-router monitor logs       # bounded tail of JSONL samples
+proxy-router monitor off        # stop worker and remove enabled state
+```
+
+Each sample records HTTP latency, ICMP ping where the platform provides it, and
+bounded download/upload throughput. The worker state and samples live under
+`state/monitor/` and are mode `0600`; `monitor on` is the only command that
+starts recurring work. An optional `monitor` object in `router.json` can set
+`interval_seconds`, `ping_hosts`, URLs, `max_bytes`, and timeouts. Speed checks
+are intentionally bounded and use a conservative 1 MB default.
+
+## Self-healing
+
+On macOS: install the launchd agent to re-arm a crashed engine every 15s:
+
+```sh
+./install.sh
+examples/install-launchd.sh     # writes the plist with your paths and bootstraps
+launchctl bootout gui/$(id -u)/com.proxy-router.keepalive   # remove
+```
+
+Linux/Windows: run `examples/keepalive.sh` under a supervisor of your choice
+(systemd service / Task Scheduler / tmux).
+
+The keepalive waits `PROXY_KEEPALIVE_INTERVAL` (default 15s) between checks,
+but while `ensure` keeps failing the wait grows exponentially (15, 30, 60, ...)
+up to `PROXY_KEEPALIVE_MAX_BACKOFF` (default 300s), so a dead engine is not
+hammered; one successful check resets the wait. `sing-box.log` is also rotated
+to `sing-box.log.1` once it exceeds 10 MB (at engine start, when no engine
+holds the log).
+
+`ensure` only proves the process is alive, so the keepalive ALSO self-heals a
+dead-but-listening tunnel (WireGuard handshake/route dead while the port still
+accepts): every `PROXY_KEEPALIVE_PROBE_EVERY` successful ensures (default 4,
+roughly 60s at the base interval) it runs `router.py egress check`, which
+probes the ACTIVE exit through the tunnel. After
+`PROXY_KEEPALIVE_DEAD_STRIKES` consecutive dead checks (default 2 - a single
+transient blip never rotates) it runs `router.py rotate <provider> --reason
+timeout` (respecting cooldown/block semantics, never `--force`); a successful
+check resets the dead-counter. On start, the first successful ensure triggers
+one boot self-test: a dead tunnel logs a loud warning and gets ONE early
+rotation; a healthy tunnel logs `router: boot self-test ok`. Keepalive
+rotations are capped at `PROXY_KEEPALIVE_MAX_ROTATIONS` (default 2) per
+`PROXY_KEEPALIVE_STORM_WINDOW` seconds (default 600), so a genuinely broken
+pool can never rotation-storm.
+
+## Scheduled rotation
+
+By default the router only rotates reactively (dead tunnel, upstream
+429/503/...). With a `rotation` block in `router.json` the keepalive loop also
+rotates proactively on a fixed cadence, so the active exit's egress IP churns
+before upstream rate limits accumulate:
+
+```json
+"rotation": { "interval_seconds": 7200, "jitter_seconds": 300 }
+```
+
+- `interval_seconds` — rotate every N seconds (0 or absent = off; default
+  config enables 7200 = 2h).
+- `jitter_seconds` — spread the next rotation by ±jitter/2 around the exact
+  interval (default 300), so the switch doesn't tick in lockstep with other
+  clients on the same provider.
+- Every healthy keepalive tick runs `router.py rotate --if-due`; it reads
+  `state/<provider>.rotation` and only acts once the interval has elapsed
+  (exit 0 = rotated, 3 = not due). It is skipped automatically while the
+  engine is down or `manual-off` is set.
+- A provider with no rotation record yet is seeded as "rotated now", so a
+  fresh install waits a full interval before the first switch.
+- Scheduled switches reuse the normal `rotate` path: verify-then-switch with
+  rollback, per-provider cooldowns, and storm-guarded by nothing extra — the
+  cadence itself is the guard. The current exit is NOT marked as an upstream
+  failure (a scheduled switch is a preference, not a failure signal).
+- `router.py status --json` reports `rotation.interval_seconds`,
+  `rotation.jitter_seconds`, and `rotation.next_at` (earliest upcoming switch).
+
+Manual rotation still works as before; scheduled rotation never forces past a
+blocked/cooldown profile.
+
+## Fail-open proxy runner
+
+Apps pointed at `127.0.0.1:<port>` (hermes, curl, a cron job, ...) break when
+the engine is down. `with-proxy` wraps any command with a health check: when
+the listener answers it runs the command with `http_proxy`/`https_proxy` (and
+uppercase variants) set, otherwise it strips those vars and runs DIRECT — the
+engine is never started, so `manual-off` stays honored:
+
+```sh
+./router.py with-proxy -- hermes model@opencode "..."   # proxy when up, direct otherwise
+./router.py with-proxy --check                          # prints http://127.0.0.1:2080, exit 0 when up
+./router.py with-proxy --force-proxy -- cmd...          # refuse (exit 4) instead of running direct
+./router.py with-proxy --force-direct -- cmd...         # always direct, skip the probe
+```
+
+Flags: `--timeout-ms` (probe timeout, default 300). The child replaces the
+wrapper via exec, so exit codes and signals pass through untouched. `--check`
+is what scripts should use for one-shot health checks (exit 0/1, prints the
+URL only when up).
+
+## Hermes integration
+
+Point `hermes` at the proxy (`http://127.0.0.1:2080` via
+`https_proxy`/`http_proxy`). `examples/hermes-opencode.sh` wraps model runs:
+on rate-limit/transient-http/transport failures it rotates the provider pool
+once per profile and retries the exact same command after 15s
+(`OPENCODE_RETRY_DELAY_SECONDS` to override, `OPENCODE_MAX_ATTEMPTS` to cap,
+`OPENCODE_PROVIDER` to change the pool).
+
+The wrapper is fail-open: it pre-flights with `router.py with-proxy --check`
+and only sets the proxy env while the listener is up. When the router is
+stopped or disabled, hermes runs DIRECT (no rotation, no engine resurrection)
+so it keeps working without the tunnel — useful when the Proton egress is
+rate-limited and you just want opencode to work. Rotation on failure resumes
+automatically once the proxy is back up.
+
+The Hermes `opencode_server_rotation` plugin expects a rotation manager at
+`tools/opencode-zen-vpn/proxy-manager.sh` (its `rotate` subcommand). That
+directory was retired; ship `examples/proxy-manager.sh` to that exact path to
+bridge the plugin onto this router's `rotate` command (which provider is
+rotated is `OPENCODE_PROVIDER`, defaulting to `proton`). No plugin or Hermes
+config changes are needed.
+
+## Troubleshooting
+
+- `proxy-router: command not found` in interactive shells — the installer
+  links into `~/.local/bin`. If that isn't on your shell's PATH, add
+  `export PATH="$HOME/.local/bin:$PATH"` to `~/.zshrc` (or equivalent) and
+  open a fresh login shell.
+- `FATAL start service: bind: address already in use` — another sing-box owns
+  the port; stop it first, then `./proxy-router start`.
+- Route changes don't apply — `reload`/`add`/`remove` SIGHUP the running
+  process; a stale pid file with a dead listener needs a `start`.
+- macOS system proxy toggles use the active network service (the default
+  route's hardware port), so Wi-Fi won't be missed when on Ethernet.
+
+## Development
+
+```sh
+python3 -m unittest discover tests
+```
+
+## License
+
+[MIT](LICENSE)

--- a/tools/proxy-router/examples/com.proxy-router.tray.plist.template
+++ b/tools/proxy-router/examples/com.proxy-router.tray.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.proxy-router.tray</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>@PYTHON@</string>
+        <string>@ROOT@/examples/proxy_tray.py</string>
+        <string>--root</string>
+        <string>@ROOT@</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>@PATH@</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>@LOG_DIR@/proxy-tray.log</string>
+    <key>StandardErrorPath</key>
+    <string>@LOG_DIR@/proxy-tray.log</string>
+</dict>
+</plist>

--- a/tools/proxy-router/examples/install-tray.sh
+++ b/tools/proxy-router/examples/install-tray.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# install-tray.sh — install the proxy-router menu-bar agent as a login item.
+#
+# Fills examples/com.proxy-router.tray.plist.template, writes
+# ~/Library/LaunchAgents/com.proxy-router.tray.plist, and bootstraps it with
+# launchctl. Idempotent: refuses to double-install a live agent.
+#
+# Usage: install-tray.sh [--remove] [--root PATH]
+set -euo pipefail
+
+ROOT="${PROXY_ROUTER_ROOT:-/Users/kyson/airi/tools/proxy-router}"
+PYTHON="${PYTHON:-/opt/anaconda3/bin/python3}"
+PLIST_SRC="$ROOT/examples/com.proxy-router.tray.plist.template"
+PLIST_DST="$HOME/Library/LaunchAgents/com.proxy-router.tray.plist"
+LOG_DIR="$HOME/Library/Logs/proxy-router"
+LABEL="com.proxy-router.tray"
+
+case "${1:-}" in
+  --remove)
+    echo "unloading $LABEL..."
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+    rm -f "$PLIST_DST"
+    echo "removed $PLIST_DST"
+    exit 0
+    ;;
+  --root)
+    ROOT="${2:?--root needs a path}"
+    ;;
+esac
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "python not found at $PYTHON" >&2
+  exit 1
+fi
+
+if ! "$PYTHON" -c "import pystray, PIL" 2>/dev/null; then
+  echo "missing pystray/pillow for $PYTHON; run: $PYTHON -m pip install pystray pillow" >&2
+  exit 1
+fi
+
+mkdir -p "$LOG_DIR"
+
+if launchctl list | grep -q "$LABEL"; then
+  echo "$LABEL already loaded; refusing to stack (use --remove first)"
+  exit 1
+fi
+
+if [ ! -f "$PLIST_SRC" ]; then
+  echo "missing template: $PLIST_SRC" >&2
+  exit 1
+fi
+
+ATHOME="$HOME"
+sed -e "s|@ROOT@|$ROOT|g" \
+    -e "s|@PYTHON@|$PYTHON|g" \
+    -e "s|@LOG_DIR@|$LOG_DIR|g" \
+    -e "s|@PATH@|/opt/anaconda3/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin|g" \
+    "$PLIST_SRC" > "$PLIST_DST"
+
+chmod 644 "$PLIST_DST"
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+launchctl enable "gui/$(id -u)/$LABEL"
+echo "installed $LABEL -> $PLIST_DST"
+echo "menu-bar agent starts at next login; to force start now:"
+echo "  launchctl kickstart -k gui/$(id -u)/$LABEL"

--- a/tools/proxy-router/examples/proxy-manager.sh
+++ b/tools/proxy-router/examples/proxy-manager.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Bridge for the Hermes opencode-server-rotation plugin.
+# The plugin calls this machine-level bridge; it forwards provider failures to
+# the existing proxy-router CLI. The router remains the only engine mutator.
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+router_py() {
+  if [ -n "${PROXY_ROUTER_BIN:-}" ] && [ -x "${PROXY_ROUTER_BIN:-}" ]; then
+    printf '%s\n' "$PROXY_ROUTER_BIN"
+    return 0
+  fi
+  local candidate
+  for candidate in \
+    "$SCRIPT_DIR/router.py" \
+    "$(dirname "$SCRIPT_DIR")/router.py" \
+    "$(dirname "$SCRIPT_DIR")/proxy-router/router.py" \
+    "$HOME/.local/share/proxy-router/router.py" \
+  ; do
+    if [ -f "$candidate" ] && [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  if command -v proxy-router >/dev/null 2>&1; then
+    printf 'proxy-router\n'
+    return 0
+  fi
+  return 1
+}
+
+case "${1:-}" in
+  rotate)
+    ROUTER=$(router_py)
+    PROVIDER="${OPENCODE_PROVIDER:-proton}"
+    REASON="${2:-}"
+    case "$REASON" in
+      ""|408|425|429|500|502|503|504|1010|403|timeout|tls|connection|rate_limit|upstream_rate_limit|server_error) ;;
+      *)
+        printf 'proxy-manager: unsupported rotation reason %s\n' "$REASON" >&2
+        exit 2
+        ;;
+    esac
+    if [ -n "$REASON" ]; then
+      "$ROUTER" rotate "$PROVIDER" --reason "$REASON"
+    else
+      "$ROUTER" rotate "$PROVIDER"
+    fi
+    ;;
+  help|-h|--help|"")
+    printf 'usage: %s rotate [REASON] [OPENCODE_PROVIDER=proton]\n' "$0" >&2
+    exit 0
+    ;;
+  *)
+    printf 'proxy-manager: unknown command %s (supported: rotate)\n' "$1" >&2
+    exit 2
+    ;;
+esac

--- a/tools/proxy-router/examples/proxy_tray.py
+++ b/tools/proxy-router/examples/proxy_tray.py
@@ -1,0 +1,851 @@
+#!/usr/bin/env python3
+"""proxy_tray.py — menu-bar / taskbar control for proxy-router.
+
+Thin-client tray agent in the style of popular VPN daemons (Tailscale,
+ProtonVPN, Cloudflare WARP): a resident status icon whose menu shows live
+state and triggers the existing router CLI. It NEVER mutates engine state
+itself — every action shells out to `router.py`, so rotation ownership,
+cooldowns, and keepalive semantics stay exactly where they are.
+
+Design rules:
+- Reads: `router.py status --json` polled in a background thread (2.5s).
+- Actions: `ensure` / `stop` / `routing set --mode` / `rotate` via the CLI.
+- macOS: runs as an accessory (menu-bar only, no Dock icon).
+- Windows: pystray falls back to the taskbar notification area automatically.
+
+Usage:
+    python3 proxy_tray.py [--root /path/to/proxy-router]
+    python3 proxy_tray.py --selftest   # no GUI; validates CLI contract + dispatch
+
+Env: PROXY_ROUTER_ROOT overrides the router directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+
+try:
+    import pystray
+    from PIL import Image, ImageDraw
+except ImportError:  # --selftest and --help must work without the GUI stack
+    pystray = None
+    Image = ImageDraw = None
+
+POLL_SECONDS = 5.0  # live-enough menu state without spawning 24 CLI procs/min
+COMMAND_TIMEOUT = 20
+# osascript's admin-password dialog blocks until the user answers; a regular
+# command timeout would kill the toggle mid-prompt. Generous on purpose.
+ELEVATED_COMMAND_TIMEOUT = 120
+
+# Friendly, non-jargon labels for tray menu entries. The router CLI words
+# (safe-list / vpn-list / rotate / exit) stay in the terminal; the tray
+# speaks home / school / switch / server.
+_ROUTING_MODE_LABELS = {
+    "safe-list": "home (safe list)",
+    "vpn-list": "school (vpn list)",
+}
+
+# Built-in presets: (name, tray label). Custom presets under `presets/*.json`
+# are appended dynamically so TUI-created presets show up here too.
+_BUILTIN_PRESETS = (
+    ("opencode", "opencode — route opencode.ai via Proton"),
+    ("roblox", "roblox — route Roblox via Cloudflare"),
+    ("default", "default — opencode + roblox combo"),
+    ("school-warp", "school-warp — school sites via Cloudflare"),
+)
+
+# Raw CLI error fragments -> what a non-technical user should actually do.
+_FRIENDLY_ERRORS = (
+    ("no sing-box binary", "VPN engine not found — run Setup, then Connect"),
+    ("needs 'default_provider'", "pick a default provider first: Routing mode → home (safe list)"),
+    ("no active profile", "no VPN profile yet — add one under Setup"),
+    ("missing router.json", "no configuration yet — start under Setup"),
+    ("all profiles cooling down",
+     "no servers available right now — try again in a minute"),
+    ("no valid profiles", "no usable profiles found — re-add your .conf under Setup"),
+)
+
+
+def _friendly_egress_error(err: object) -> str:
+    """Turn a raw probe/egress error tail into a short human label.
+
+    The egress record stores Python-level failure strings (e.g.
+    ``URLError: <urlopen error [SSL: UNEXPECTED_EOF_WHILE_READING, EOF
+    occurred in violation of protocol (_ssl.c:983)]>``). Rendering that
+    verbatim in the exit picker is operator jargon; map the common classes
+    to plain language and keep the code when it is meaningful (429/403).
+    """
+    s = str(err).strip()
+    low = s.lower()
+    if not s:
+        return "offline"
+    if "ssl" in low or "certificate" in low or "unexpected_eof" in low:
+        return "offline (SSL)"
+    if "timed out" in low or "timeout" in low:
+        return "timed out"
+    if "connection refused" in low or "connection reset" in low:
+        return "offline"
+    if "dns" in low or "name or service" in low or "hostname" in low:
+        return "no route (DNS)"
+    if "rate limit" in low or "429" in s:
+        return "rate-limited"
+    if "403" in s or "1010" in s or "blocked" in low:
+        return "blocked"
+    return s[:28]
+
+
+def _humanize(out: str) -> str:
+    """Translate the last CLI line from operator jargon to user-facing text.
+
+    Success paths that only say "engine not reloaded / run router.py ensure"
+    become an actionable "Connect to apply"; known raw error fragments become
+    the concrete next step instead of the internal message.
+    """
+    if not out:
+        return ""
+    if "engine is untouched" in out or "engine was NOT reloaded" in out:
+        return "saved — Connect to apply"
+    detail = out.splitlines()[-1][:160]
+    for needle, repl in _FRIENDLY_ERRORS:
+        if needle in detail:
+            return repl
+    return detail
+
+
+@dataclass
+class RouterStatus:
+    up: bool = False
+    mode: str = "unknown"
+    port: int | None = None
+    pid: int | None = None
+    watcher: bool = False
+    active_providers: dict = field(default_factory=dict)
+    providers: dict = field(default_factory=dict)  # name -> {active, profiles, egress}
+    routing_mode: str = "default"
+    preset: str | None = None
+    error: str | None = None
+
+    @classmethod
+    def from_cli(cls, rc: int, stdout: str) -> "RouterStatus":
+        # `status --json` exits 1 whenever the engine is down OR not yet
+        # configured, but it still prints a valid JSON payload. Treating
+        # rc != 0 as an error made the tray show "! Error" on every plain
+        # disconnect and "! Error status exit 1" on a fresh install — the
+        # payload below carries the real state. Only an unparseable payload
+        # is an error now.
+        try:
+            payload = stdout[stdout.find("{"):] if "{" in stdout else stdout
+            d = json.JSONDecoder().raw_decode(payload)[0]
+        except (json.JSONDecodeError, ValueError) as e:
+            return cls(error=f"status exit {rc}" if rc else f"bad json: {e}")
+        providers = {}
+        provider_map = {}
+        for name, info in (d.get("providers") or {}).items():
+            active = info.get("active")
+            if active:
+                providers[name] = active
+            egress = {}
+            for stem, rec in (info.get("egress") or {}).items():
+                egress[stem] = {
+                    "ok": bool(rec.get("ok")),
+                    "latency_ms": rec.get("latency_ms"),
+                    "status": rec.get("status"),
+                    "error": rec.get("error") or rec.get("upstream_error"),
+                }
+            provider_map[name] = {
+                "active": active,
+                "profiles": list(info.get("profiles") or []),
+                "egress": egress,
+            }
+        routing = d.get("routing") or {}
+        watcher = d.get("watcher") or {}
+        return cls(
+            up=bool(d.get("up")),
+            mode=str(d.get("mode") or "unknown"),
+            port=d.get("port"),
+            pid=d.get("pid"),
+            watcher=bool(watcher.get("enabled") and watcher.get("running")),
+            active_providers=providers,
+            providers=provider_map,
+            routing_mode=str(routing.get("mode") or "default"),
+            preset=d.get("preset") or None,
+        )
+
+    def provider_label(self, name: str) -> str:
+        """Compact single-line label for a provider row, e.g.
+        'proton → 01-NL-FREE-140 · 164ms'. The dot reflects REAL health:
+        a probe that rode the tunnel is not enough — a persisted upstream
+        error (e.g. 429 rate-limit) or exhausted marker keeps it amber."""
+        info = self.providers.get(name, {})
+        active = info.get("active")
+        egress = (info.get("egress") or {}).get(active or "", {})
+        lat = egress.get("latency_ms")
+        if active and lat:
+            tag = f"{active} · {lat:.0f}ms" if isinstance(lat, (int, float)) else active
+        elif active:
+            tag = active
+        else:
+            tag = "no active exit"
+        ok = egress.get("ok")
+        # A lane can probe ok while the exit is actually rate-limited or
+        # exhausted upstream (record keeps `upstream_error` across probes).
+        warn = bool(egress.get("upstream_error") or egress.get("error")
+                    or egress.get("exhausted"))
+        if warn:
+            mark = "▲"
+        elif ok:
+            mark = "●"
+        elif ok is False:
+            mark = "○"
+        else:
+            mark = "·"
+        return f"{name} {mark} {tag}"
+
+    def profile_health(self, name: str, profile: str) -> str:
+        """Short health suffix for one exit, e.g. '· 164ms' or '! offline'.
+        Returns '' when nothing is known yet. `upstream_error` (a persisted
+        rotate --reason marker like 429/503) counts as an error even when
+        the last probe succeeded — the exit is rate-limited/blocked for
+        real traffic."""
+        rec = (self.providers.get(name, {}).get("egress") or {}).get(profile)
+        if not rec:
+            return ""
+        err = rec.get("error") or rec.get("upstream_error")
+        if err:
+            return " ! " + _friendly_egress_error(err)
+        lat = rec.get("latency_ms")
+        if isinstance(lat, (int, float)):
+            return f" · {lat:.0f}ms"
+        if rec.get("ok"):
+            return " · ok"
+        return ""
+
+    def headline(self) -> str:
+        if self.error:
+            return f"proxy-router: error ({self.error})"
+        state = "connected" if self.up else "disconnected"
+        detail = self.mode
+        if self.up and self.port:
+            detail = f"proxy :{self.port}"
+        watcher = "watcher on" if self.watcher else "watcher off"
+        return f"proxy {state} · {detail} · {watcher}"
+
+
+class RouterClient:
+    """Runs router.py subcommands; all mutation goes through the CLI."""
+
+    def __init__(self, root: str):
+        self.root = root
+        self.python = sys.executable or "python3"
+        self.router = os.path.join(root, "router.py")
+        self._active_provider: str | None = None
+
+    def _run(self, *args: str) -> tuple[int, str]:
+        cmd = [self.python, self.router, *args]
+        env = dict(os.environ)
+        try:
+            p = subprocess.run(
+                cmd, capture_output=True, text=True,
+                timeout=COMMAND_TIMEOUT, env=env, cwd=self.root,
+            )
+            out = (p.stdout or "") + ("\n" + p.stderr if p.stderr else "")
+            return p.returncode, out.strip()
+        except subprocess.TimeoutExpired:
+            return -1, f"timeout: {' '.join(cmd)}"
+        except FileNotFoundError as e:
+            return -2, f"missing: {e}"
+
+    def status(self) -> RouterStatus:
+        rc, out = self._run("status", "--json")
+        st = RouterStatus.from_cli(rc, out)
+        if st.active_providers:
+            # remember the carrying provider for bare "Rotate exit"
+            self._active_provider = next(iter(st.active_providers))
+        return st
+
+    def ensure(self) -> tuple[int, str]:
+        return self._run("ensure")
+
+    def start(self) -> tuple[int, str]:
+        # Explicit start: clears any manual-off marker (tray Connect).
+        return self._run("start")
+
+    def stop(self) -> tuple[int, str]:
+        return self._run("stop")
+
+    def rotate(self) -> tuple[int, str]:
+        return self._run("rotate", self._active_provider)
+
+    def rotate_to(self, provider: str, profile: str) -> tuple[int, str]:
+        return self._run("rotate", provider, "--to", profile)
+
+    def set_mode(self, mode: str, default_provider: str | None = None) -> tuple[int, str]:
+        cmd = ["routing", "set", "--mode", mode]
+        if default_provider:
+            cmd += ["--default-provider", default_provider]
+        return self._run(*cmd)
+
+    def setup_import(self, provider: str, paths) -> tuple[int, str]:
+        """Import .conf profile(s) via the setup wizard CLI (no engine touch)."""
+        flag = "--import-proton" if provider == "proton" else "--import-warp"
+        return self._run("setup", flag, *paths)
+
+    def setup_preset(self, name: str) -> tuple[int, str]:
+        """Apply a named preset (idempotent, lossless) via the setup CLI."""
+        return self._run("setup", "--preset", name)
+
+    def vpn(self, action: str) -> tuple[int, str]:
+        """Toggle full-tunnel (TUN) mode via the router CLI.
+
+        TUN mode needs root (utun creation, route table), so macOS elevates
+        through the standard admin-password dialog. The tray runs under
+        launchd with no TTY, which router.py's own isatty-gated elevation
+        explicitly refuses — so the tray drives osascript itself, with the
+        same SUDO_UID/SUDO_GID hand-back env the CLI injects.
+        """
+        if sys.platform == "darwin":
+            return self._run_elevated("vpn", action)
+        # Non-macOS: no osascript path; the CLI's clear error tells the user
+        # to run it elevated (sudo) from a terminal.
+        return self._run("vpn", action)
+
+    def _run_elevated(self, *args: str) -> tuple[int, str]:
+        """Run a router.py command as root through the macOS admin dialog.
+
+        Mirrors router.py's `_elevate_macos`: same env injection
+        (SUDO_UID/SUDO_GID for state-file hand-back, PROXY_ROUTER_ELEVATED
+        to suppress re-elevation, PATH passthrough so the bundled sing-box
+        still resolves) and the same AppleScript escaping rules.
+        """
+        env = (
+            f"SUDO_UID={os.getuid()} SUDO_GID={os.getgid()} "
+            f"PROXY_ROUTER_ELEVATED=1 "
+            f"PATH={shlex.quote(os.environ.get('PATH', ''))}"
+        )
+        cmd = shlex.join([self.python, self.router, *args])
+        shell_cmd = f"{env} {cmd}"
+        # AppleScript string literals accept only `\"` and `\\` escapes; escape
+        # the shell command's quotes/backslashes but keep the literal delimiters
+        # unescaped (a `\` at expression position is a syntax error).
+        content = shell_cmd.replace("\\", "\\\\").replace('"', '\\"')
+        script = f'do shell script "{content}" with administrator privileges'
+        try:
+            p = subprocess.run(
+                ["osascript", "-e", script], capture_output=True, text=True,
+                timeout=ELEVATED_COMMAND_TIMEOUT,
+            )
+            out = (p.stdout or "") + ("\n" + p.stderr if p.stderr else "")
+            return p.returncode, out.strip()
+        except subprocess.TimeoutExpired:
+            return -1, "timeout: admin dialog did not answer in time"
+        except FileNotFoundError:
+            return -2, "missing: osascript (this action needs macOS)"
+
+
+def make_icon(color: str, size: int = 64) -> "Image.Image":
+    """Small filled-circle status icon (green=up, red=down, orange=warn)."""
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    margin = size // 8
+    draw.ellipse(
+        [margin, margin, size - margin, size - margin],
+        fill=color, outline=(255, 255, 255, 220), width=max(2, size // 16),
+    )
+    return img
+
+
+class TrayApp:
+    def __init__(self, client: RouterClient, icon_image: "Image.Image"):
+        self.client = client
+        self.icon_image = icon_image
+        self.latest: RouterStatus = RouterStatus()
+        self.lock = threading.Lock()
+        self.last_action_result: str | None = None
+        self.quit_flag = threading.Event()
+        self.tray = None
+        self._menu_sig: str | None = None
+        self._icon_sig: str | None = None
+
+    # ---- status polling ------------------------------------------------
+    def _status_signature(self, st: RouterStatus) -> str:
+        """Stable signature of everything the menu/icon renders.
+
+        Rebuilding the pystray menu on macOS tears down the NSMenu under the
+        cursor; a rebuild racing a click loses the action handler, which is
+        exactly the 'half the buttons don't work' symptom. Rebuild ONLY when
+        the rendered state actually changed, never on a timer tick with the
+        same values.
+        """
+        health = {}
+        for name, info in (st.providers or {}).items():
+            health[name] = {
+                p: (rec.get("ok"), rec.get("error"), rec.get("latency_ms"))
+                for p, rec in (info.get("egress") or {}).items()
+            }
+        return repr({
+            "up": st.up, "error": st.error, "mode": st.mode, "port": st.port,
+            "watcher": st.watcher, "routing": st.routing_mode,
+            "active": st.active_providers, "health": health,
+            "action": self.last_action_result,
+        })
+
+    def poll_loop(self) -> None:
+        while not self.quit_flag.is_set():
+            try:
+                st = self.client.status()
+                with self.lock:
+                    self.latest = st
+                if self.tray is not None:
+                    icon_color = (
+                        "#4caf50" if st.up
+                        else ("#ff9800" if st.error else "#e53935")
+                    )
+                    if icon_color != self._icon_sig:
+                        self._icon_sig = icon_color
+                        self.tray.icon = make_icon(icon_color)
+                    sig = self._status_signature(st)
+                    if sig != self._menu_sig:
+                        self._menu_sig = sig
+                        # Rebuild the menu from the live snapshot: pystray's
+                        # update_menu() re-renders the OLD menu tree, so
+                        # without reassigning .menu the status/action labels
+                        # stay frozen at whatever was captured at startup.
+                        self.tray.menu = self.build_menu()
+            except Exception as e:  # keep the tray alive on any poll failure
+                with self.lock:
+                    self.latest = RouterStatus(error=str(e)[:80])
+            self.quit_flag.wait(POLL_SECONDS)
+
+    def _snapshot(self) -> RouterStatus:
+        with self.lock:
+            return self.latest
+
+    # ---- actions ---------------------------------------------------------
+    def _do(self, fn, label: str):
+        # Run the mutation on a worker thread: pystray invokes callbacks on
+        # its own thread, and a synchronous 20s router.py subprocess would
+        # freeze the menu (and on some macOS builds, the run loop) for the
+        # whole command. Show a "working…" line immediately, then swap in
+        # the real result when the command lands.
+        with self.lock:
+            self.last_action_result = f"{label}: working…"
+        if self.tray is not None:
+            self._menu_sig = None  # force a rebuild that shows "working…"
+            self.tray.menu = self.build_menu()
+
+        def worker():
+            try:
+                rc, out = fn()
+            except Exception as e:
+                rc, out = -1, f"{type(e).__name__}: {e}"
+            detail = _humanize(out)
+            result = f"{label}: {'done' if rc == 0 else 'failed'}"
+            if detail:
+                result += f" — {detail}"
+            try:
+                refreshed = self.client.status()
+            except Exception as e:
+                refreshed = RouterStatus(error=str(e)[:80])
+            with self.lock:
+                self.last_action_result = result
+                self.latest = refreshed
+            if self.tray is not None:
+                self._menu_sig = None
+                self.tray.menu = self.build_menu()
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def action_connect(self):
+        # start (not ensure): also clears the manual-off marker written by
+        # Disconnect, so keepalive resumes watching afterwards.
+        self._do(self.client.start, "connect")
+
+    def action_disconnect(self):
+        self._do(self.client.stop, "disconnect")
+
+    def action_toggle_vpn(self):
+        """Full-tunnel (TUN) on/off switch: click turns the tunnel on when
+        off and off when on (home/school switch)."""
+        with self.lock:
+            on = self.latest.mode == "tun"
+        self._do(lambda: self.client.vpn("off" if on else "on"),
+                 f"full tunnel {'off' if on else 'on'}")
+
+    def action_rotate(self):
+        self._do(self.client.rotate, "switch server")
+
+    def action_mode(self, mode: str):
+        provider = None
+        if mode == "safe-list":
+            # safe-list routes everything NOT on the direct list through
+            # ONE provider. If the config has no default_provider yet, fall
+            # back to the currently active provider so the click just works
+            # instead of returning a raw "needs default_provider" rc=1.
+            with self.lock:
+                active = self.latest.active_providers
+            provider = next(iter(active), None) if active else None
+        self._do(lambda: self.client.set_mode(mode, provider),
+                 f"mode {_ROUTING_MODE_LABELS.get(mode, mode)}")
+
+    def action_import_profile(self, provider: str):
+        """Native file picker → import .conf profiles (no terminal needed)."""
+        # tkinter is only imported inside the action so --selftest and --help
+        # keep working on headless machines.
+        try:
+            import tkinter as tk
+            from tkinter import filedialog
+        except ImportError:
+            self._do(lambda: (1, "file picker unavailable on this system — "
+                                  "add the profile from the terminal, see the Setup guide"),
+                     f"import {provider}")
+            return
+
+        def pick_and_import():
+            root = tk.Tk()
+            root.withdraw()
+            root.attributes("-topmost", True)
+            files = filedialog.askopenfilenames(
+                title=f"Add {provider} VPN profile (.conf)",
+                filetypes=[("WireGuard profile", "*.conf"), ("All files", "*.*")],
+            )
+            root.destroy()
+            if not files:
+                return 0, "no file selected — nothing imported"
+            return self.client.setup_import(provider, list(files))
+
+        self._do(pick_and_import, f"import {provider}")
+
+    def action_apply_preset(self, name: str):
+        """One-click preset apply (idempotent, lossless, no engine touch)."""
+        self._do(lambda: self.client.setup_preset(name), f"preset {name}")
+
+    def action_show_guide(self, provider: str):
+        """Open the bundled setup guide in the default app (macOS) so a
+        non-technical user can learn where .conf profiles come from without
+        leaving the tray. Read-only; never touches engine state."""
+        guide = os.path.join(
+            self.client.root, "guides",
+            "proton-vpn-free.md" if provider == "proton" else "cloudflare-warp.md")
+        if not os.path.isfile(guide):
+            self._do(lambda: (1, f"guide file missing ({guide})"), f"guide {provider}")
+            return
+        if sys.platform == "darwin":
+            # `open` returns immediately; the default markdown/text viewer
+            # takes over. Not a background process of ours.
+            subprocess.Popen(["open", guide])
+        else:
+            # non-macOS fallback: print the guide to stdout (best effort).
+            try:
+                with open(guide, encoding="utf-8") as f:
+                    print(f.read())
+            except OSError as e:
+                print(f"guide: cannot read {guide}: {e}", file=sys.stderr)
+
+    def action_quit(self):
+        self.quit_flag.set()
+        if self.tray is not None:
+            self.tray.stop()
+
+    # ---- menu -------------------------------------------------------------
+    def build_menu(self) -> pystray.Menu:
+        with self.lock:
+            st = self.latest
+            last_action_result = self.last_action_result
+        items = []
+
+        # Status header — compact, human-readable. A fresh install (no
+        # providers, engine never started) gets its own banner instead of a
+        # bare "Disconnected" and a first step pointing at Setup.
+        first_run = not st.providers and not st.up and not st.error
+        if first_run:
+            state = "● No VPN set up yet"
+        elif st.up:
+            state = "● Connected"
+        elif st.error:
+            state = "! Error"
+        else:
+            state = "○ Disconnected"
+        items.append(pystray.MenuItem(state, None))
+        if first_run:
+            items.append(pystray.MenuItem(
+                "Start here: Setup → Add a profile (.conf)", None))
+        if st.active_providers:
+            prov = ", ".join(f"{k} → {v}" for k, v in st.active_providers.items())
+            items.append(pystray.MenuItem(prov, None))
+        if st.routing_mode != "default":
+            items.append(pystray.MenuItem(
+                f"mode: {_ROUTING_MODE_LABELS.get(st.routing_mode, st.routing_mode)}",
+                None))
+        if st.preset:
+            items.append(pystray.MenuItem(
+                f"preset: {st.preset}", None))
+        if last_action_result:
+            items.append(pystray.MenuItem(last_action_result, None))
+
+        items.append(pystray.Menu.SEPARATOR)
+
+        # Actions — terse, no CLI flags. Connect is only offered once at
+        # least one provider exists; on a fresh install the banner above
+        # directs to Setup instead of producing a raw CLI failure.
+        items.append(pystray.MenuItem(
+            "Reconnect" if st.up else "Connect",
+            self.action_connect, enabled=bool(st.providers)))
+        items.append(pystray.MenuItem(
+            "Switch VPN server", self.action_rotate, enabled=st.up))
+
+        # Provider picker — like Tailscale/Proton: pick a provider, then an exit
+        if st.providers and st.up:
+            provider_menu = self._build_provider_menu(st)
+            items.append(pystray.MenuItem("Provider", provider_menu))
+        items.append(pystray.MenuItem(
+            "Disconnect", self.action_disconnect, enabled=st.up))
+        # Full tunnel (TUN) — checked when on. Clicking toggles it, which on
+        # macOS pops the standard admin dialog (the engine/utun needs root).
+        items.append(pystray.MenuItem(
+            "Full tunnel (WARP): on" if st.mode == "tun"
+            else "Full tunnel (WARP): off",
+            self.action_toggle_vpn,
+            checked=lambda item: st.mode == "tun"))
+
+        items.append(pystray.Menu.SEPARATOR)
+
+        # Routing mode — checked submenu
+        def mode_checked(m: str):
+            return st.routing_mode == m
+
+        items.append(pystray.MenuItem(
+            "Routing mode",
+            pystray.Menu(
+                pystray.MenuItem("safe-list (home)", lambda: self.action_mode("safe-list"),
+                                 checked=lambda item: mode_checked("safe-list")),
+                pystray.MenuItem("vpn-list (school)", lambda: self.action_mode("vpn-list"),
+                                 checked=lambda item: mode_checked("vpn-list")),
+                pystray.MenuItem("default", lambda: self.action_mode("default"),
+                                 checked=lambda item: mode_checked("default")),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Use safe-list at home, vpn-list at school",
+                                 None, enabled=False),
+            ),
+        ))
+
+        # Setup — plain-language entries for non-terminal users. The guide
+        # entries answer "where do I even get a .conf file?" before the user
+        # hits the import file-picker cold.
+        items.append(pystray.MenuItem(
+            "Setup",
+            pystray.Menu(
+                pystray.MenuItem(
+                    "New here? .conf files come from your VPN provider's website",
+                    None, enabled=False),
+                pystray.MenuItem("How to get a Proton profile (guide)",
+                                 lambda: self.action_show_guide("proton")),
+                pystray.MenuItem("How to get a Cloudflare WARP profile (guide)",
+                                 lambda: self.action_show_guide("cloudflare")),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Add Proton profile (.conf)…",
+                                 lambda: self.action_import_profile("proton")),
+                pystray.MenuItem("Add Cloudflare WARP profile (.conf)…",
+                                 lambda: self.action_import_profile("cloudflare")),
+            ),
+        ))
+
+        # Presets — top-level, one click each, active one checked. Custom
+        # presets created in the setup TUI show up here too (read from
+        # `presets/*.json`), so the tray never hides a preset the user made.
+        preset_items = []
+        for name, label in _BUILTIN_PRESETS:
+            preset_items.append(pystray.MenuItem(
+                label, lambda n=name: self.action_apply_preset(n),
+                checked=lambda item, n=name: st.preset == n))
+        for name in self._custom_preset_names():
+            preset_items.append(pystray.MenuItem(
+                self._custom_preset_label(name),
+                lambda n=name: self.action_apply_preset(n),
+                checked=lambda item, n=name: st.preset == n))
+        items.append(pystray.MenuItem("Presets", pystray.Menu(*preset_items)))
+        items.append(pystray.Menu.SEPARATOR)
+        items.append(pystray.MenuItem("Quit", self.action_quit))
+        return pystray.Menu(*items)
+
+    def _custom_preset_names(self) -> list[str]:
+        """Custom preset names from ``root/presets/*.json`` (read-only)."""
+        preset_dir = os.path.join(self.client.root, "presets")
+        try:
+            return sorted(
+                name[:-5] for name in os.listdir(preset_dir)
+                if name.endswith(".json") and name[:-5]
+            )
+        except OSError:
+            return []
+
+    def _custom_preset_label(self, name: str) -> str:
+        """One-line description for a custom preset, e.g.
+        'banana — route opencode.ai via proton (custom)'."""
+        try:
+            with open(os.path.join(self.client.root, "presets", f"{name}.json"),
+                      encoding="utf-8") as f:
+                data = json.load(f)
+            routes = data.get("routes") or []
+            if routes:
+                domains = routes[0].get("domains") or []
+                provider = routes[0].get("provider") or "?"
+                first = domains[0] if domains else "?"
+                more = f" +{len(domains) - 1} more" if len(domains) > 1 else ""
+                return f"{name} — route {first}{more} via {provider} (custom)"
+        except (OSError, json.JSONDecodeError, ValueError, IndexError):
+            pass
+        return f"{name} (custom)"
+
+    def _exit_disabled(self, st: RouterStatus, name: str, profile: str) -> bool:
+        """An exit is un-clickable only when it's genuinely dead: transport
+        failure (probe got no HTTP response) or an active block/exhaust
+        marker. A recoverable warning (e.g. stale 429 upstream_error, slow
+        latency) must NOT disable the exit — the user can still try it."""
+        rec = (st.providers.get(name, {}).get("egress") or {}).get(profile)
+        if not rec:
+            return False
+        if rec.get("blocked") or rec.get("exhausted"):
+            return True
+        if rec.get("ok") is False and rec.get("status") is None:
+            return True  # transport-level death: no HTTP status at all
+        return False
+
+    def _build_provider_menu(self, st: RouterStatus) -> pystray.Menu:
+        """Provider → exit submenu, checked on the active exit, showing health."""
+        entries = []
+        for name in sorted(st.providers):
+            info = st.providers[name]
+            active = info.get("active")
+            profiles = info.get("profiles") or []
+
+            def make_exit_action(provider=name, profile=None):
+                def action():
+                    self._do(lambda: self.client.rotate_to(provider, profile),
+                             f"switch {provider} → {profile}")
+                return action
+
+            def pick_exit_items():
+                sub = []
+                # Healthy/clickable exits first; genuinely-dead ones sink to
+                # the bottom so the picker doesn't lead with a gray wall.
+                def sort_key(p):
+                    return (self._exit_disabled(st, name, p), p)
+                for p in sorted(profiles, key=sort_key):
+                    sub.append(pystray.MenuItem(
+                        f"{p}{st.profile_health(name, p)}",
+                        make_exit_action(provider=name, profile=p),
+                        checked=lambda item, prof=p: prof == active,
+                        enabled=not self._exit_disabled(st, name, p)))
+                if not sub:
+                    sub.append(pystray.MenuItem("no exits", None, enabled=False))
+                return pystray.Menu(*sub)
+
+            def make_cycle_action(provider=name):
+                return lambda: self._do(lambda: self.client.rotate(provider),
+                                        f"switch {provider}")
+
+            label = st.provider_label(name)
+            entries.append(pystray.MenuItem(
+                label, pick_exit_items(),
+                checked=lambda item, n=name: bool(st.providers.get(n, {}).get("active"))))
+            entries.append(pystray.MenuItem(f"↻ switch {name}", make_cycle_action()))
+        entries.append(pystray.Menu.SEPARATOR)
+        entries.append(pystray.MenuItem("Click a location to switch to it", None, enabled=False))
+        return pystray.Menu(*entries)
+
+    def run(self) -> None:
+        if pystray is None:
+            print("pystray is required; pip install pystray pillow", file=sys.stderr)
+            sys.exit(2)
+
+        # macOS: menu-bar agent, no Dock icon (Tailscale/WARP-style).
+        if sys.platform == "darwin":
+            try:
+                from AppKit import (NSApplication,
+                                    NSApplicationActivationPolicyAccessory)
+                NSApplication.sharedApplication().setActivationPolicy_(
+                    NSApplicationActivationPolicyAccessory)
+            except Exception:
+                pass
+
+        def on_ready(icon):
+            # Custom setup replaces pystray's default setup; explicitly show
+            # the status item or the agent runs invisibly on macOS.
+            icon.visible = True
+            threading.Thread(target=self.poll_loop, daemon=True).start()
+
+        self.tray = pystray.Icon(
+            "proxy-router", self.icon_image, "proxy-router",
+            menu=self.build_menu(),
+        )
+        # NOTE: use blocking run(), NOT run_detached(). On the Darwin backend
+        # run_detached() only marks the icon ready and never starts the
+        # NSApplication event loop, so the status item is created but never
+        # painted and the tray runs invisibly. run() blocks on the main
+        # thread driving the Cocoa loop until stop() is called.
+        self.tray.run(setup=on_ready)
+
+
+def selftest(root: str) -> int:
+    """CLI-contract check: status parses, dispatch targets exist, no GUI."""
+    print(f"selftest root: {root}")
+    if not os.path.isfile(os.path.join(root, "router.py")):
+        print(f"FAIL: router.py not found in {root}")
+        return 1
+    client = RouterClient(root)
+    st = client.status()
+    rc = 0 if not st.error else 1
+    print(f"parsed: up={st.up} mode={st.mode} watcher={st.watcher} "
+          f"routing={st.routing_mode} exits={st.active_providers}")
+    if st.error:
+        print(f"status parse FAIL: {st.error}")
+        return 1
+    # verify every menu action's CLI entry exists (--help exits 0)
+    for label, args in [
+        ("ensure", ["ensure", "--help"]),
+        ("stop", ["stop", "--help"]),
+        ("rotate", ["rotate", "--help"]),
+        ("routing set", ["routing", "set", "--help"]),
+        ("vpn", ["vpn", "--help"]),
+    ]:
+        r, o = client._run(*args)
+        status = "OK" if r == 0 else f"FAIL rc={r}"
+        print(f"  {label}: {status}")
+    print("SELFTEST DONE")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="proxy-router tray agent")
+    ap.add_argument("--root", default=os.environ.get(
+        "PROXY_ROUTER_ROOT",
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    ap.add_argument("--selftest", action="store_true",
+                    help="validate CLI contract, no GUI")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest(args.root)
+
+    if pystray is None or Image is None:
+        print("pystray + pillow required (pip install pystray pillow)",
+              file=sys.stderr)
+        return 2
+
+    client = RouterClient(args.root)
+    client.latest = client.status()  # warm first status for the menu
+    app = TrayApp(client, make_icon("#e53935"))
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/proxy-router/guides/cloudflare-warp.md
+++ b/tools/proxy-router/guides/cloudflare-warp.md
@@ -1,0 +1,121 @@
+# Cloudflare WARP — WireGuard Profile for proxy-router
+
+> Cloudflare WARP can be used as a WireGuard provider for proxy-router via the
+> official WARP client **or** a standalone WireGuard `.conf` profile generated
+> with `wgcf`. This guide covers both approaches. **WARP is optional** —
+> proxy-router does not need both Proton and WARP enabled simultaneously.
+
+## Option A: Official WARP client (not recommended for proxy-router)
+
+The official Cloudflare WARP client runs as a system service and manages its
+own WireGuard tunnel. proxy-router cannot rotate or manage its profiles
+directly. Use this only if you want WARP for general system-wide traffic
+outside of proxy-router's routing.
+
+Docs: <https://developers.cloudflare.com/warp-client/get-started/>
+
+## Option B: wgcf profile (recommended)
+
+`wgcf` generates a standard WireGuard `.conf` from your WARP account. This is
+the approach proxy-router supports — you get a normal `.conf` file that
+proxy-router can manage alongside Proton profiles.
+
+### Step 1: Install wgcf
+
+```sh
+# macOS (Homebrew)
+brew install wgcf
+
+# Linux (manual download)
+# See https://github.com/ViRb3/wgcf/releases for your platform
+```
+
+Official docs: <https://github.com/ViRb3/wgcf>
+
+### Step 2: Generate account and profile
+
+```sh
+# Create a WARP account and register your device
+wgcf register
+# This creates wgcf-account.toml with your account/license details
+
+# Generate the WireGuard profile
+wgcf generate
+# This creates wgcf-profile.conf
+```
+
+> **Note:** The generated profile uses Cloudflare's DNS (`1.1.1.1`), which
+> works well with proxy-router.
+
+### Step 3: Import into proxy-router
+
+```sh
+# Create the provider directory
+mkdir -p providers/cloudflare
+
+# Copy the generated profile
+cp wgcf-profile.conf providers/cloudflare/warp.conf
+
+# Set safe permissions
+chmod 600 providers/cloudflare/*.conf
+```
+
+Or use the setup wizard:
+
+```sh
+proxy-router setup --import-warp wgcf-profile.conf
+```
+
+### Step 4: Verify
+
+```sh
+ls -la providers/cloudflare/
+# Should show 0600 permissions
+
+proxy-router setup --check
+```
+
+## Multiple WARP profiles
+
+For rotation, you can register multiple devices with wgcf (each `wgcf register`
+creates a new device) and import each as a separate `.conf`:
+
+```sh
+# First device
+wgcf register
+wgcf generate
+cp wgcf-profile.conf providers/cloudflare/warp1.conf
+
+# Second device (new registration)
+rm wgcf-account.toml  # reset to create fresh registration
+wgcf register
+wgcf generate
+cp wgcf-profile.conf providers/cloudflare/warp2.conf
+
+chmod 600 providers/cloudflare/*.conf
+```
+
+## When to use WARP
+
+- **Roblox routing:** WARP is the validated provider for Roblox domains.
+  The `roblox` route in `router.example.json` targets `cloudflare` by default.
+- **As a fallback:** If all Proton profiles are cooling down, WARP provides
+  an alternate exit path.
+- **Standalone:** You can use WARP-only without Proton. Just import WARP
+  profiles and create routes targeting the `cloudflare` provider.
+
+## Security notes
+
+- **Never** paste private keys into chat, email, or commit them to git.
+- `.conf` files contain your WireGuard private key — treat them like passwords.
+- proxy-router writes `sing-box.json` with private keys inline at mode `0600`.
+- Keep `wgcf-account.toml` private — it contains your WARP license key.
+
+## Troubleshooting
+
+- **`wgcf register` fails:** Check your network connection. Cloudflare may
+  rate-limit registrations from the same IP.
+- **Profile import rejected:** Ensure the `.conf` file has a `[Interface]`
+  and `[Peer]` section. Run `proxy-router setup --check` for details.
+- **`setup --check` fails:** Verify files are in `providers/cloudflare/` with
+  `0600` permissions and contain valid WireGuard configuration.

--- a/tools/proxy-router/guides/proton-vpn-free.md
+++ b/tools/proxy-router/guides/proton-vpn-free.md
@@ -1,0 +1,88 @@
+# Proton VPN Free — WireGuard Configuration Export
+
+> This guide walks you through exporting standard WireGuard `.conf` files from
+> your **Proton VPN Free** account and importing them into proxy-router. You do
+> **not** need a paid plan — Free servers support WireGuard.
+
+## Prerequisites
+
+- A Proton VPN account (free tier is fine): <https://account.protonvpn.com>
+- A browser to download configuration files
+
+## Step 1: Open the WireGuard configuration page
+
+Go to **<https://protonvpn.com/support/wireguard-configurations>** and follow
+the official instructions, or navigate directly to:
+
+> **Settings → WireGuard → Configuration** in the Proton VPN dashboard.
+
+Official docs: <https://protonvpn.com/support/wireguard-configurations>
+
+## Step 2: Select servers
+
+1. In the configuration page, you will see a list of available servers.
+2. Select **multiple Free servers** — choose 3–9 servers in different countries
+   for the best rotation pool. Free servers are labeled with a **free** tag.
+3. For each server, download the `.conf` file. They will arrive as files like
+   `protonvpn-ch-free-1.conf`.
+
+> **Tip:** Choose servers from different regions. If one is slow or unavailable,
+> proxy-router automatically rotates to the next.
+
+## Step 3: Import into proxy-router
+
+Copy the downloaded `.conf` files into the provider directory:
+
+```sh
+# Create the provider directory if it does not exist
+mkdir -p providers/proton
+
+# Copy all downloaded configs (adjust path to where your browser saved them)
+cp ~/Downloads/protonvpn-*.conf providers/proton/
+
+# Set safe permissions (required — configs contain private keys)
+chmod 600 providers/proton/*.conf
+```
+
+Or use the setup wizard:
+
+```sh
+proxy-router setup --import-proton ~/Downloads/protonvpn-*.conf
+```
+
+The wizard validates each file and sets mode `0600` automatically.
+
+## Step 4: Verify
+
+```sh
+ls -la providers/proton/
+# Should show 0600 permissions on each .conf file
+
+proxy-router setup --check
+# Validates that at least one provider profile is loadable
+```
+
+## DNS caveat
+
+Proton's WireGuard configs set `DNS = 10.2.0.1` (their private tunnel
+resolver). This resolver intermittently blackholes DNS on macOS. proxy-router
+**automatically overrides this** by routing DNS through Cloudflare `1.1.1.1`
+over the same WireGuard tunnel. You do not need to edit the `.conf` files.
+
+## Security notes
+
+- **Never** paste private keys into chat, email, or commit them to git.
+- The `.conf` files contain your WireGuard private key — treat them like
+  passwords. Mode `0600` ensures only your user can read them.
+- proxy-router generates `sing-box.json` with private keys inline; this file
+  is also written mode `0600` and should never be committed.
+- `.conf` files and generated configs are listed in `.gitignore` by default.
+
+## Troubleshooting
+
+- **No Free servers showing:** Ensure you are logged into a Free-tier account.
+  Free servers may rotate; re-download if a specific server goes offline.
+- **All profiles cooling down:** proxy-router marks used profiles for cooldown.
+  Wait the cooldown period (default 60s) or add more servers to the pool.
+- **`setup --check` fails:** Ensure `.conf` files are in `providers/proton/`
+  and have `0600` permissions. Run `proxy-router setup` for interactive guidance.

--- a/tools/proxy-router/hermes-opencode.sh
+++ b/tools/proxy-router/hermes-opencode.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Bounded one-shot Hermes runner over the proxy router: on rate-limit/transient
+# signals it rotates the Proton pool, waits 15s, then retries the same command.
+# Fail-open: the proxy is only used while its listener is actually up
+# (`router.py with-proxy --check`); when it is down (stopped / manual-off) the
+# attempt runs DIRECT with the proxy env stripped, so hermes keeps working
+# with the router disabled. Rotation is skipped in direct mode - it would
+# resurrect the engine.
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# The scripts ship under examples/ next to router.py; locate the prefix either
+# from the examples dir (parent) or from a standalone copy of the script.
+if [ ! -f "$ROOT/router.py" ] && [ -f "$(dirname "$ROOT")/router.py" ]; then
+  ROOT="$(dirname "$ROOT")"
+fi
+ROUTER="$ROOT/router.py"
+HERMES_BIN="${HERMES_BIN:-hermes}"
+MAX_ATTEMPTS="${OPENCODE_MAX_ATTEMPTS:-}"
+RETRY_DELAY="${OPENCODE_RETRY_DELAY_SECONDS:-15}"
+PROVIDER="${OPENCODE_PROVIDER:-proton}"
+TMP_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/hermes-opencode.XXXXXX")
+trap 'rm -f "$TMP_OUTPUT"' EXIT
+
+# Pre-flight health check: non-empty PROXY_URL means the listener answers and
+# the attempt should go through the tunnel; empty means run direct.
+PROXY_URL=$("$ROUTER" with-proxy --check 2>/dev/null || true)
+profile_count=$("$ROUTER" provider-count "$PROVIDER" 2>/dev/null || echo 2)
+[[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || MAX_ATTEMPTS="$profile_count"
+((MAX_ATTEMPTS < 1)) && MAX_ATTEMPTS=1
+
+retry_kind() {
+  local file="$1"
+  if grep -Eiq 'rate[[:space:]]*-limit|too many requests|quota[^[:alnum:]]*(exceeded|exhausted)' "$file"; then
+    printf '%s\n' "rate-limit"
+    return 0
+  fi
+  # Cloudflare egress-IP reputation block (1010/403 "Access denied"): the exit
+  # itself is unusable for this zone, so block it and pick a different one.
+  if grep -Eiq 'error[[:space:]]*code[[:space:]]*[:=]?[[:space:]]*1010|1010[^[:alnum:]]*(block|denied|error)|access[[:space:]]*denied' "$file"; then
+    printf '%s\n' "blocked"
+    return 0
+  fi
+  if grep -Eiq 'HTTP[[:space:]/:-]+(408|425|429|500|502|503|504)([^0-9]|$)|(status|status_code|response_code|http_code)[[:space:]]*[=:][[:space:]]*(408|425|429|500|502|503|504)([^0-9]|$)|(408|425|429|500|502|503|504)[[:space:]]-+(request timeout|too early|too many requests|internal server error|bad gateway|service unavailable|gateway timeout)' "$file"; then
+    printf '%s\n' "transient-http"
+    return 0
+  fi
+  if grep -Eiq 'timed[[:space:]]+out|timeout|connection[[:space:]]+(reset|refused|closed)|broken pipe|network[[:space:]]+error|temporary failure|ECONNRESET|ECONNREFUSED' "$file"; then
+    printf '%s\n' "transport"
+    return 0
+  fi
+  return 1
+}
+
+summaries=()
+attempt=0
+while ((attempt < MAX_ATTEMPTS)); do
+  : > "$TMP_OUTPUT"
+
+  if [ -n "$PROXY_URL" ]; then
+    export http_proxy="$PROXY_URL" https_proxy="$PROXY_URL" HTTP_PROXY="$PROXY_URL" HTTPS_PROXY="$PROXY_URL"
+  else
+    unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+  fi
+
+  set +e
+  "$HERMES_BIN" "$@" >"$TMP_OUTPUT" 2>&1
+  rc=$?
+  set -e
+
+  if ((rc == 0)) && ! retry_kind "$TMP_OUTPUT" >/dev/null 2>&1; then
+    cat "$TMP_OUTPUT"
+    exit 0
+  fi
+
+  if ! kind=$(retry_kind "$TMP_OUTPUT"); then
+    printf '[opencode] request failed; no failover signal (exit=%s)\n' "$rc" >&2
+    exit "${rc:-1}"
+  fi
+
+  summaries+=("$kind")
+  ((attempt += 1))
+  if ((attempt >= MAX_ATTEMPTS)); then
+    printf '[opencode] failover exhausted after %s attempt(s): %s\n' "$attempt" "${summaries[*]}" >&2
+    ((rc != 0)) && exit "$rc"
+    exit 75
+  fi
+
+  if [ -z "$PROXY_URL" ]; then
+    # Direct mode: rotation cannot help (and would resurrect the engine);
+    # retry the same command direct after the delay instead.
+    printf '[opencode] %s; proxy-router is down, retrying direct (%s/%s)\n' "$kind" "$attempt" "$MAX_ATTEMPTS" >&2
+  else
+    printf '[opencode] %s; rotating %s provider (%s/%s)\n' "$kind" "$PROVIDER" "$attempt" "$MAX_ATTEMPTS" >&2
+    # Tell the router WHY the current exit failed: it applies a longer
+    # cooldown (and a blocked marker for egress-IP reputation blocks) before
+    # switching.
+    if ! "$ROUTER" rotate "$PROVIDER" --reason "$kind" >/dev/null 2>&1; then
+      printf '[opencode] failover exhausted: no eligible alternate profile\n' >&2
+      ((rc != 0)) && exit "$rc"
+      exit 75
+    fi
+  fi
+
+  # Wait a fixed 15s (override with OPENCODE_RETRY_DELAY_SECONDS) before
+  # retrying the exact same model command on the freshly rotated server.
+  printf '[opencode] waiting %ss before retrying %s on the rotated server\n' "$RETRY_DELAY" "$*" >&2
+  sleep "$RETRY_DELAY"
+done
+
+printf '[opencode] failover exhausted\n' >&2
+exit 75

--- a/tools/proxy-router/keepalive.sh
+++ b/tools/proxy-router/keepalive.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Keeps the proxy router's sing-box listener alive on 127.0.0.1:2080.
+#
+# Runs indefinitely as a launchd agent: every CHECK_INTERVAL seconds it calls
+# `router.py ensure`, which starts the engine when the listener is missing.
+# This resurrects a silently-died proxy without waiting for the next login or
+# for a Hermes process to be restarted.
+#
+# Backoff: while `ensure` keeps failing (broken config, missing sing-box, ...)
+# the wait grows exponentially (INTERVAL, 2x, 4x, ...) up to MAX_BACKOFF
+# seconds, so a dead engine is not hammered every INTERVAL; a single
+# successful ensure resets the wait back to INTERVAL.
+#
+# Dead-tunnel self-heal: `ensure` only proves the PROCESS is alive - a
+# WireGuard tunnel whose route/handshake is dead still "passes ensure" while
+# every request times out upstream. On a slower cadence the loop therefore
+# also runs `router.py egress check` (a read-only probe of the ACTIVE exit
+# through the running tunnel) and auto-rotates the provider pool when the
+# exit is genuinely dead: after PROXY_KEEPALIVE_DEAD_STRIKES consecutive dead
+# checks (a single transient blip never rotates), and never more than
+# PROXY_KEEPALIVE_MAX_ROTATIONS times per PROXY_KEEPALIVE_STORM_WINDOW
+# seconds, so a broken pool cannot storm. A boot self-test runs once on the
+# first successful ensure (one early rotation, same storm guard).
+#
+# Scheduled rotation: when router.json has a "rotation" block, the loop also
+# calls `router.py rotate --if-due` on every healthy tick - the CLI reads the
+# configured interval/jitter and only rotates once the interval has elapsed
+# (exit 3 = not due, nothing logged), so the active exit churns on a cadence
+# and upstream rate limits see a fresh egress IP. The verify-then-switch
+# rollback path and per-provider cooldowns apply exactly as for a manual
+# rotate; `state/<provider>.rotation` tracks the last switch time.
+#
+# Knobs (env vars, defaults):
+#   PROXY_KEEPALIVE_INTERVAL       base wait between ensures           (15)
+#   PROXY_KEEPALIVE_MAX_BACKOFF    cap for exponential backoff         (300)
+#   PROXY_KEEPALIVE_PROBE_EVERY    egress check per N successful ensures (4)
+#   PROXY_KEEPALIVE_DEAD_STRIKES   consecutive dead checks before rotate (2)
+#   PROXY_KEEPALIVE_STORM_WINDOW   rotation-guard window in seconds    (600)
+#   PROXY_KEEPALIVE_MAX_ROTATIONS  max keepalive rotations per window  (2)
+set -uo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# The scripts ship under examples/ next to router.py; locate the prefix either
+# from the examples dir (parent) or from a standalone copy of the script.
+if [ ! -f "$ROOT/router.py" ] && [ -f "$(dirname "$ROOT")/router.py" ]; then
+  ROOT="$(dirname "$ROOT")"
+fi
+INTERVAL="${PROXY_KEEPALIVE_INTERVAL:-15}"
+MAX_BACKOFF="${PROXY_KEEPALIVE_MAX_BACKOFF:-300}"
+PROBE_EVERY="${PROXY_KEEPALIVE_PROBE_EVERY:-4}"
+DEAD_STRIKES="${PROXY_KEEPALIVE_DEAD_STRIKES:-2}"
+STORM_WINDOW="${PROXY_KEEPALIVE_STORM_WINDOW:-600}"
+MAX_ROTATIONS="${PROXY_KEEPALIVE_MAX_ROTATIONS:-2}"
+
+backoff="$INTERVAL"
+boot=1
+checks=0
+strikes=0
+rotations=0
+window_start=0
+
+# Allow at most MAX_ROTATIONS keepalive rotations per STORM_WINDOW seconds.
+rotation_allowed() {
+  now=$(date +%s)
+  if [ "$window_start" -eq 0 ] || [ $((now - window_start)) -ge "$STORM_WINDOW" ]; then
+    window_start="$now"
+    rotations=0
+  fi
+  [ "$rotations" -lt "$MAX_ROTATIONS" ]
+}
+
+# One bounded auto-rotation for the provider `egress check` reported dead.
+# `egress check` prints "dead: <provider>" as its last stdout line (and exits
+# 1) when an active exit is dead; without that line nothing is rotated.
+rotate_dead() {
+  provider="$1"
+  if [ -z "$provider" ]; then
+    # egress check failed before it could name a dead provider (e.g. TUN
+    # mode, or the engine itself is down): never rotate on an ambiguous
+    # signal - ensure already handles the engine-down case.
+    echo "router: egress check dead but no provider identified; skipping rotation" >&2
+    strikes=0
+    return
+  fi
+  if ! rotation_allowed; then
+    echo "router: rotation skipped (storm guard: $rotations rotations in the last ${STORM_WINDOW}s)" >&2
+    strikes=0
+    return
+  fi
+  echo "router: rotating '$provider' after dead tunnel checks" >&2
+  if "$ROOT/router.py" rotate "$provider" --reason timeout; then
+    :
+  else
+    echo "router: rotate '$provider' failed; will retry after the next dead check" >&2
+  fi
+  rotations=$((rotations + 1))
+  strikes=0
+}
+
+while true; do
+  # Manual disconnect (tray Disconnect / `router.py stop`) writes
+  # state/manual-off; while it exists the user wants the engine DOWN, so
+  # skip ensure entirely instead of resurrecting it 15s later. `router.py
+  # start` (tray Connect) removes the marker.
+  if [ -f "$ROOT/state/manual-off" ]; then
+    sleep "$INTERVAL"
+    continue
+  fi
+  if "$ROOT/router.py" ensure >/dev/null 2>&1; then
+    backoff="$INTERVAL"
+    if [ "$boot" -eq 1 ]; then
+      boot=0
+      # Boot self-test: one live egress check on the first successful ensure.
+      # A dead tunnel gets ONE early rotation (storm guard applies); a
+      # healthy one is logged and the normal loop continues.
+      if out=$("$ROOT/router.py" egress check 2>&1); then
+        echo "router: boot self-test ok"
+      else
+        echo "router: boot self-test: active tunnel is dead - rotating once ($(printf '%s\n' "$out" | tail -n 1))" >&2
+        rotate_dead "$(printf '%s\n' "$out" | sed -n 's/^dead: //p')"
+      fi
+    else
+      checks=$((checks + 1))
+      if [ "$checks" -ge "$PROBE_EVERY" ]; then
+        checks=0
+        if out=$("$ROOT/router.py" egress check 2>&1); then
+          strikes=0
+        else
+          strikes=$((strikes + 1))
+          echo "router: egress check: dead exit ($strikes/$DEAD_STRIKES strikes): $(printf '%s\n' "$out" | tail -n 1)" >&2
+          if [ "$strikes" -ge "$DEAD_STRIKES" ]; then
+            rotate_dead "$(printf '%s\n' "$out" | sed -n 's/^dead: //p')"
+          fi
+        fi
+      fi
+      # Scheduled rotation: `rotate --if-due` self-gates on the configured
+      # interval (exit 0 = rotated, 3 = not due); never logs when quiet.
+      if "$ROOT/router.py" rotate --if-due >/dev/null 2>&1; then
+        echo "router: scheduled rotation: rotated provider(s)" >&2
+      fi
+    fi
+  else
+    backoff=$((backoff * 2))
+    ((backoff < INTERVAL)) && backoff="$INTERVAL"
+    ((backoff > MAX_BACKOFF)) && backoff="$MAX_BACKOFF"
+  fi
+  sleep "$backoff"
+done

--- a/tools/proxy-router/monitor.py
+++ b/tools/proxy-router/monitor.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Opt-in network monitor for proxy-router.
+
+The monitor is deliberately separate from the routing engine. Nothing here runs
+unless the user invokes ``monitor check`` or starts the detached worker with
+``monitor on``. Samples are bounded JSONL records under ``state/monitor``.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import platform
+import re
+import signal
+import shlex
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+
+ROOT = Path(os.environ.get("PROXY_ROUTER_ROOT") or Path(__file__).resolve().parent).resolve()
+DEFAULT_INTERVAL = 60
+DEFAULT_HTTP_URL = "https://www.cloudflare.com/cdn-cgi/trace"
+DEFAULT_DOWNLOAD_URL = "https://speed.cloudflare.com/__down?bytes=1000000"
+DEFAULT_UPLOAD_URL = "https://speed.cloudflare.com/__up"
+DEFAULT_PING_HOSTS = ("1.1.1.1", "8.8.8.8")
+DEFAULT_MAX_BYTES = 1_000_000
+DEFAULT_TIMEOUT = 10
+MAX_LOG_LINES = 100
+# Rotate the samples file once it grows past either bound (F11): the worker
+# appends a line every interval, so without a cap samples.jsonl grows forever.
+MAX_SAMPLE_LINES = 10_000
+MAX_SAMPLE_BYTES = 5_000_000
+DEFAULT_HEADERS = {
+    "User-Agent": "proxy-router-monitor/1.0",
+    "Accept": "*/*",
+}
+
+
+def _open(opener, url: str, timeout: float):
+    """Use browser-like headers for real urllib; leave injected test openers simple."""
+    if opener is urllib.request.urlopen:
+        return opener(urllib.request.Request(url, headers=DEFAULT_HEADERS), timeout=timeout)
+    return opener(url, timeout=timeout)
+
+
+def monitor_dir(root: Path | None = None) -> Path:
+    return (Path(root) if root is not None else ROOT) / "state" / "monitor"
+
+
+def pid_file(root: Path | None = None) -> Path:
+    return monitor_dir(root) / "pid"
+
+
+def enabled_file(root: Path | None = None) -> Path:
+    return monitor_dir(root) / "enabled"
+
+
+def samples_file(root: Path | None = None) -> Path:
+    return monitor_dir(root) / "samples.jsonl"
+
+
+def _error(message: str, **extra) -> dict:
+    result = {"error": message}
+    result.update(extra)
+    return result
+
+
+def _network_error(exc: Exception, url: str, **extra) -> dict:
+    """Keep exception details useful without persisting a credential-bearing URL."""
+    url_text = str(url)
+    message = str(exc).replace(url_text, "[REDACTED_URL]")
+    message = re.sub(r"https?://[^\s'\"]+", "[REDACTED_URL]", message)
+    return _error(f"{type(exc).__name__}: {message}", **extra)
+
+
+def _close(response) -> None:
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
+
+
+def parse_ping_output(text: str) -> dict:
+    """Parse macOS/Linux or Windows ping output without assuming locale details."""
+    match = re.search(
+        r"(?:min/avg/max/(?:stddev|mdev)|Minimum\s*=)\s*=?\s*"
+        r"([0-9.]+)[/\s]+([0-9.]+)[/\s]+([0-9.]+)",
+        text,
+        re.IGNORECASE,
+    )
+    if match:
+        return {
+            "min_ms": float(match.group(1)),
+            "avg_ms": float(match.group(2)),
+            "max_ms": float(match.group(3)),
+        }
+    windows = re.search(
+        r"Minimum\s*=\s*(\d+)ms,\s*Maximum\s*=\s*(\d+)ms,\s*Average\s*=\s*(\d+)ms",
+        text,
+        re.IGNORECASE,
+    )
+    if windows:
+        return {
+            "min_ms": float(windows.group(1)),
+            "avg_ms": float(windows.group(3)),
+            "max_ms": float(windows.group(2)),
+        }
+    return {"min_ms": None, "avg_ms": None, "max_ms": None, "error": "ping result unavailable"}
+
+
+def _safe_target(url: str) -> str:
+    try:
+        parsed = urlsplit(str(url))
+        return parsed.hostname or "configured-target"
+    except (TypeError, ValueError):
+        return "configured-target"
+
+
+def measure_http_latency(url: str = DEFAULT_HTTP_URL, *, opener=urllib.request.urlopen,
+                         clock=time.monotonic, timeout: float = 5) -> dict:
+    started = clock()
+    response = None
+    try:
+        response = _open(opener, url, timeout)
+        response.read(1)
+        result = {
+            "target": _safe_target(url),
+            "status": int(getattr(response, "status", getattr(response, "code", 200))),
+            "latency_ms": round((clock() - started) * 1000, 2),
+        }
+        return result
+    except Exception as exc:  # network errors are data, not monitor crashes
+        return _network_error(exc, url, target=_safe_target(url))
+    finally:
+        if response is not None:
+            _close(response)
+
+
+def _throughput(bytes_read: int, elapsed: float) -> float | None:
+    if elapsed <= 0:
+        return None
+    return round(bytes_read * 8 / elapsed / 1_000_000, 3)
+
+
+def measure_download(url: str = DEFAULT_DOWNLOAD_URL, *, max_bytes: int = DEFAULT_MAX_BYTES,
+                     opener=urllib.request.urlopen, clock=time.monotonic,
+                     timeout: float = DEFAULT_TIMEOUT) -> dict:
+    max_bytes = max(1, int(max_bytes))
+    started = clock()
+    response = None
+    total = 0
+    try:
+        response = _open(opener, url, timeout)
+        while total < max_bytes:
+            chunk = response.read(min(64 * 1024, max_bytes - total))
+            if not chunk:
+                break
+            total += len(chunk)
+        elapsed = clock() - started
+        return {"bytes": total, "mbps": _throughput(total, elapsed)}
+    except Exception as exc:
+        return _network_error(exc, url, bytes=total)
+    finally:
+        if response is not None:
+            _close(response)
+
+
+def measure_upload(url: str = DEFAULT_UPLOAD_URL, *, max_bytes: int = DEFAULT_MAX_BYTES,
+                   opener=urllib.request.urlopen, clock=time.monotonic,
+                   timeout: float = DEFAULT_TIMEOUT) -> dict:
+    max_bytes = max(1, int(max_bytes))
+    payload = b"0" * max_bytes
+    started = clock()
+    response = None
+    try:
+        request = urllib.request.Request(url, data=payload, headers=DEFAULT_HEADERS, method="POST")
+        response = opener(request, timeout=timeout)
+        response.read(1)
+        elapsed = clock() - started
+        return {"bytes": max_bytes, "mbps": _throughput(max_bytes, elapsed),
+                "status": int(getattr(response, "status", getattr(response, "code", 200)))}
+    except Exception as exc:
+        return _network_error(exc, url, bytes=max_bytes)
+    finally:
+        if response is not None:
+            _close(response)
+
+
+def measure_ping(host: str, *, command_runner=subprocess.run,
+                 system: str | None = None, timeout: float = 8) -> dict:
+    system = system or platform.system()
+    if system == "Windows":
+        command = ["ping", "-n", "3", "-w", "2000", host]
+    elif system == "Darwin":
+        # macOS: -W is in milliseconds.
+        command = ["ping", "-c", "3", "-W", "2000", host]
+    else:
+        # Linux: -W is in SECONDS; 2000 would be an ~33-minute dead wait (F9).
+        command = ["ping", "-c", "3", "-W", "2", host]
+    try:
+        result = command_runner(command, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        return _error("ping command unavailable", host=host)
+    except Exception as exc:
+        return _error(f"{type(exc).__name__}: {exc}", host=host)
+    parsed = parse_ping_output((result.stdout or "") + "\n" + (result.stderr or ""))
+    parsed["host"] = host
+    if getattr(result, "returncode", 0) != 0 and parsed.get("avg_ms") is None:
+        parsed.setdefault("error", "ping failed")
+    return parsed
+
+
+def _monitor_settings(root: Path) -> dict:
+    settings = {
+        "interval_seconds": DEFAULT_INTERVAL,
+        "http_url": DEFAULT_HTTP_URL,
+        "download_url": DEFAULT_DOWNLOAD_URL,
+        "upload_url": DEFAULT_UPLOAD_URL,
+        "ping_hosts": list(DEFAULT_PING_HOSTS),
+        "max_bytes": DEFAULT_MAX_BYTES,
+        "timeout_seconds": DEFAULT_TIMEOUT,
+    }
+    config = root / "router.json"
+    try:
+        data = json.loads(config.read_text())
+        custom = data.get("monitor", {}) if isinstance(data, dict) else {}
+        if isinstance(custom, dict):
+            for key in settings:
+                if key in custom:
+                    settings[key] = custom[key]
+    except (OSError, json.JSONDecodeError):
+        pass
+    for key in ("http_url", "download_url", "upload_url"):
+        value = settings[key]
+        try:
+            parsed = urlsplit(value) if isinstance(value, str) else None
+        except ValueError:
+            parsed = None
+        if parsed is None or parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            settings[key] = {
+                "http_url": DEFAULT_HTTP_URL,
+                "download_url": DEFAULT_DOWNLOAD_URL,
+                "upload_url": DEFAULT_UPLOAD_URL,
+            }[key]
+    try:
+        settings["interval_seconds"] = max(5, int(settings["interval_seconds"]))
+    except (TypeError, ValueError):
+        settings["interval_seconds"] = DEFAULT_INTERVAL
+    try:
+        settings["max_bytes"] = min(max(1, int(settings["max_bytes"])), 10_000_000)
+    except (TypeError, ValueError):
+        settings["max_bytes"] = DEFAULT_MAX_BYTES
+    try:
+        settings["timeout_seconds"] = min(max(1, float(settings["timeout_seconds"])), 60)
+    except (TypeError, ValueError):
+        settings["timeout_seconds"] = DEFAULT_TIMEOUT
+    hosts = settings["ping_hosts"]
+    if not isinstance(hosts, (list, tuple)):
+        hosts = DEFAULT_PING_HOSTS
+    settings["ping_hosts"] = [str(x) for x in hosts if str(x)][:8]
+    return settings
+
+
+def collect_sample(root: Path | None = None, *, opener=urllib.request.urlopen,
+                   command_runner=subprocess.run, clock=time.monotonic,
+                   include_speed: bool = True) -> dict:
+    """Collect one bounded sample; this function is only called by check/worker."""
+    root = Path(root) if root is not None else ROOT
+    settings = _monitor_settings(root)
+    sample = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "http": measure_http_latency(settings["http_url"], opener=opener, clock=clock,
+                                      timeout=settings["timeout_seconds"]),
+        "ping": [measure_ping(host, command_runner=command_runner) for host in settings["ping_hosts"]],
+    }
+    if include_speed:
+        sample["download"] = measure_download(
+            settings["download_url"], max_bytes=settings["max_bytes"], opener=opener,
+            clock=clock, timeout=settings["timeout_seconds"],
+        )
+        sample["upload"] = measure_upload(
+            settings["upload_url"], max_bytes=settings["max_bytes"], opener=opener,
+            clock=clock, timeout=settings["timeout_seconds"],
+        )
+    return sample
+
+
+def _pid_matches(pid: int, root: Path) -> bool:
+    """Confirm a PID belongs to this monitor worker before trusting/killing it."""
+    if pid <= 0:
+        return False
+    root = Path(root).resolve()
+    try:
+        if os.name == "nt":
+            command = [
+                "powershell", "-NoProfile", "-Command",
+                f"(Get-CimInstance Win32_Process -Filter \"ProcessId={pid}\").CommandLine",
+            ]
+        else:
+            command = ["ps", "-p", str(pid), "-o", "command="]
+        result = subprocess.run(command, capture_output=True, text=True, timeout=3)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    command_line = result.stdout or ""
+    try:
+        tokens = shlex.split(command_line)
+    except ValueError:
+        tokens = command_line.split()
+    script_ok = any(Path(token).name == "monitor.py" for token in tokens)
+    root_arg = None
+    if "--root" in tokens:
+        index = tokens.index("--root")
+        if index + 1 < len(tokens):
+            root_arg = tokens[index + 1]
+    return (
+        result.returncode == 0
+        and script_ok
+        and "--worker" in tokens
+        and root_arg == str(root)
+    )
+
+
+def _pid_running(pid: int, root: Path | None = None) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return root is None or _pid_matches(pid, Path(root))
+
+
+
+def _read_pid(root: Path) -> int | None:
+    try:
+        return int(pid_file(root).read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def status(root: Path | None = None, *, pid_checker=None) -> dict:
+    """Read state only; never performs network probes."""
+    root = Path(root) if root is not None else ROOT
+    pid = _read_pid(root)
+    if pid_checker is None:
+        running = bool(pid and _pid_running(pid, root))
+    else:
+        running = bool(pid and pid_checker(pid))
+    return {
+        "enabled": enabled_file(root).is_file(),
+        "running": running,
+        "pid": pid,
+        "samples": samples_file(root).is_file(),
+    }
+
+
+def worker_command(root: Path, interval: int) -> list[str]:
+    return [sys.executable, str(Path(__file__).resolve()), "--worker", "--root", str(root),
+            "--interval", str(int(interval))]
+
+
+def start(root: Path | None = None, *, interval: int | None = None) -> dict:
+    root = Path(root) if root is not None else ROOT
+    current = status(root)
+    if current["running"]:
+        return {"started": False, "already_running": True, "pid": current["pid"]}
+    interval = max(5, int(interval or _monitor_settings(root)["interval_seconds"]))
+    directory = monitor_dir(root)
+    directory.mkdir(parents=True, exist_ok=True)
+    command = worker_command(root, interval)
+    try:
+        proc = subprocess.Popen(
+            command, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, start_new_session=True,
+        )
+    except OSError as exc:
+        return {"started": False, "error": f"could not start monitor: {exc}"}
+    pid_file(root).write_text(str(proc.pid))
+    enabled_file(root).write_text("enabled\n")
+    os.chmod(pid_file(root), 0o600)
+    os.chmod(enabled_file(root), 0o600)
+    return {"started": True, "pid": proc.pid, "interval_seconds": interval}
+
+
+def stop(root: Path | None = None) -> dict:
+    root = Path(root) if root is not None else ROOT
+    pid = _read_pid(root)
+    if pid and _pid_running(pid, root):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    pid_file(root).unlink(missing_ok=True)
+    enabled_file(root).unlink(missing_ok=True)
+    return {"stopped": True, "pid": pid}
+
+
+def _rotate_samples_if_needed(path: Path) -> None:
+    """Archive a too-large/too-long samples file to ``samples.jsonl.1``."""
+    try:
+        size = path.stat().st_size
+        with path.open() as handle:
+            lines = sum(1 for _ in handle)
+    except OSError:
+        return
+    if size < MAX_SAMPLE_BYTES and lines < MAX_SAMPLE_LINES:
+        return
+    archive = path.with_suffix(path.suffix + ".1")
+    archive.unlink(missing_ok=True)
+    try:
+        path.rename(archive)
+    except OSError:
+        pass
+
+
+def append_sample(root: Path, sample: dict) -> None:
+    path = samples_file(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_samples_if_needed(path)
+    with path.open("a") as handle:
+        handle.write(json.dumps(sample, separators=(",", ":")) + "\n")
+    os.chmod(path, 0o600)
+
+
+def worker(root: Path, interval: int) -> int:
+    """Worker entrypoint. It exits naturally when monitor off removes enabled."""
+    root = Path(root)
+    enabled_file(root).parent.mkdir(parents=True, exist_ok=True)
+    enabled_file(root).touch(mode=0o600, exist_ok=True)
+    while enabled_file(root).is_file():
+        try:
+            append_sample(root, collect_sample(root))
+        except Exception as exc:  # keep the worker alive but record no secrets
+            append_sample(root, {"timestamp": datetime.now(timezone.utc).isoformat(),
+                                 "error": f"{type(exc).__name__}: {exc}"})
+        time.sleep(max(5, int(interval)))
+    return 0
+
+
+def tail_logs(root: Path | None = None, *, lines: int = 20) -> str:
+    path = samples_file(Path(root) if root is not None else ROOT)
+    if not path.is_file():
+        return ""
+    lines = min(max(1, int(lines)), MAX_LOG_LINES)
+    with path.open() as handle:
+        return "".join(collections.deque(handle, maxlen=lines))
+
+
+def _print_json(data: dict) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def main(argv=None, root=None) -> int:
+    global ROOT
+    if root is not None:
+        ROOT = Path(root).resolve()
+    argv = list(argv or sys.argv[1:])
+    if argv and argv[0] == "monitor":
+        argv = argv[1:]
+    parser = argparse.ArgumentParser(prog="proxy-router monitor")
+    parser.add_argument("action", nargs="?", choices=["check", "on", "off", "status", "logs"])
+    parser.add_argument("--root", default=None)
+    parser.add_argument("--interval", type=int, default=None)
+    parser.add_argument("--lines", type=int, default=20)
+    parser.add_argument("--worker", action="store_true")
+    args = parser.parse_args(argv)
+    target = Path(args.root).resolve() if args.root else ROOT
+    if args.worker:
+        return worker(target, args.interval or _monitor_settings(target)["interval_seconds"])
+    if args.action == "check":
+        _print_json(collect_sample(target))
+        return 0
+    if args.action == "on":
+        _print_json(start(target, interval=args.interval))
+        return 0
+    if args.action == "off":
+        _print_json(stop(target))
+        return 0
+    if args.action == "status":
+        _print_json(status(target))
+        return 0
+    if args.action == "logs":
+        text = tail_logs(target, lines=args.lines)
+        print(text, end="" if text.endswith("\n") or not text else "\n")
+        return 0
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/proxy-router/route_watcher.py
+++ b/tools/proxy-router/route_watcher.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Standalone watcher for domains observed through proxy-router.
+
+This process is deliberately independent from Hermes. It tails sing-box's
+connection log, records which routed targets are active, attributes current
+localhost:2080 clients when macOS exposes them through ``lsof``, and probes a
+critical routed domain after it is observed. It rotates the provider only for
+persistent destination-specific transport failures.
+
+Scope is intentionally honest: HTTP-proxy mode can observe traffic that uses
+127.0.0.1:2080, not applications that bypass the proxy. Full-device coverage
+requires sing-box TUN or a macOS Network Extension and is a separate mode.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Iterable
+
+ROOT = Path(os.environ.get("PROXY_ROUTER_ROOT") or Path(__file__).resolve().parent).resolve()
+LOG_FILE_NAME = "sing-box.log"
+STATE_DIR_NAME = "state/route-watcher"
+PID_NAME = "pid"
+ENABLED_NAME = "enabled"
+EVENTS_NAME = "events.jsonl"
+DEFAULT_INTERVAL = 2.0
+TARGET_IDLE_SECONDS = 60.0
+PROBE_EVERY_SECONDS = 10.0
+CLIENT_SNAPSHOT_EVERY_SECONDS = 5.0
+FAILURE_WINDOW_SECONDS = 60.0
+MIN_TRANSPORT_FAILURES = 2
+ROTATE_COOLDOWN_SECONDS = 120.0
+EVENT_MAX_LINES = 5000
+EVENT_MAX_BYTES = 2_000_000
+TARGET_RE = re.compile(
+    r"(?:inbound connection to|outbound connection to|open connection to)\s+"
+    r"(?P<host>[^\s:]+)(?::(?P<port>\d+))?",
+    re.IGNORECASE,
+)
+CLIENT_RE = re.compile(r"inbound connection from\s+(?P<host>[^\s:]+)", re.IGNORECASE)
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+FAILURE_RE = re.compile(
+    r"\b(?:timeout|timed out|connection refused|connection reset|unexpected eof|"
+    r"tls|ssl|eof|network is unreachable|no route to host|i/o timeout)\b",
+    re.IGNORECASE,
+)
+
+
+def state_dir(root: Path | None = None) -> Path:
+    return (Path(root) if root is not None else ROOT) / STATE_DIR_NAME
+
+
+def pid_file(root: Path | None = None) -> Path:
+    return state_dir(root) / PID_NAME
+
+
+def enabled_file(root: Path | None = None) -> Path:
+    return state_dir(root) / ENABLED_NAME
+
+
+def events_file(root: Path | None = None) -> Path:
+    return state_dir(root) / EVENTS_NAME
+
+
+def normalize_host(host: str) -> str:
+    return host.rstrip(".").lower().strip("[]")
+
+
+def domain_matches(host: str, domain: str) -> bool:
+    host = normalize_host(host)
+    domain = normalize_host(domain)
+    return host == domain or host.endswith("." + domain)
+
+
+def parse_line(line: str) -> dict | None:
+    """Parse a sing-box connection line without retaining ANSI decoration."""
+    clean = ANSI_RE.sub("", line).strip()
+    target = TARGET_RE.search(clean)
+    if target:
+        return {
+            "kind": "target",
+            "host": normalize_host(target.group("host")),
+            "port": int(target.group("port") or 443),
+            "failure": bool("open connection to" in clean.lower() and FAILURE_RE.search(clean)),
+            "line": clean[-400:],
+        }
+    client = CLIENT_RE.search(clean)
+    if client:
+        return {"kind": "client", "source": client.group("host"), "line": clean[-300:]}
+    return None
+
+
+def critical_domains(root: Path) -> tuple[str, ...]:
+    """Read target domains from routes; opencode.ai is the default critical lane."""
+    domains: list[str] = []
+    try:
+        config = json.loads((Path(root) / "router.json").read_text())
+        for route in config.get("routes", []):
+            route_id = str(route.get("id", "")).lower()
+            for domain in route.get("domains", []):
+                domain = normalize_host(str(domain))
+                if domain and ("opencode" in route_id or domain_matches(domain, "opencode.ai")):
+                    domains.append(domain)
+    except (OSError, ValueError, TypeError):
+        pass
+    return tuple(dict.fromkeys(domains or ["opencode.ai"]))
+
+
+def _owned_pid(root: Path) -> int | None:
+    try:
+        return int((Path(root) / "sing-box.pid").read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def client_snapshot(root: Path, runner: Callable = subprocess.run) -> list[dict]:
+    """Return current processes with sockets attached to the local proxy.
+
+    ``lsof -F`` is macOS-native and keeps this dependency-free. Command names
+    only are persisted; command lines may contain secrets and are never saved.
+    """
+    if sys.platform != "darwin":
+        return []
+    try:
+        result = runner(
+            ["lsof", "-nP", "-a", "-iTCP:2080", "-F", "pcn"],
+            capture_output=True, text=True, timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    owned = _owned_pid(root)
+    records: list[dict] = []
+    current: dict | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("p"):
+            if current and current.get("pid") != owned:
+                records.append(current)
+            try:
+                current = {"pid": int(line[1:]), "command": "", "connections": []}
+            except ValueError:
+                current = None
+        elif current is not None and line.startswith("c"):
+            current["command"] = line[1:]
+        elif current is not None and line.startswith("n"):
+            current["connections"].append(line[1:])
+    if current and current.get("pid") != owned:
+        records.append(current)
+    return records
+
+
+def _rotate_events(path: Path) -> None:
+    try:
+        if path.stat().st_size < EVENT_MAX_BYTES:
+            return
+        archive = Path(str(path) + ".1")
+        archive.unlink(missing_ok=True)
+        path.rename(archive)
+    except OSError:
+        pass
+
+
+def append_event(root: Path, event: dict) -> None:
+    path = events_file(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _rotate_events(path)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, separators=(",", ":")) + "\n")
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+
+class RotationGuard:
+    """Persistent-failure guard used by the standalone worker."""
+
+    def __init__(self) -> None:
+        self.failure_times: collections.deque[float] = collections.deque()
+        self.last_rotate = 0.0
+
+    def record_transport_failure(self, now: float) -> bool:
+        while self.failure_times and now - self.failure_times[0] > FAILURE_WINDOW_SECONDS:
+            self.failure_times.popleft()
+        self.failure_times.append(now)
+        if len(self.failure_times) < MIN_TRANSPORT_FAILURES:
+            return False
+        if self.last_rotate and now - self.last_rotate < ROTATE_COOLDOWN_SECONDS:
+            self.failure_times.clear()
+            return False
+        self.last_rotate = now
+        self.failure_times.clear()
+        return True
+
+
+def probe_target(root: Path, host: str, *, runner: Callable = subprocess.run) -> dict:
+    """Probe the exact routed target through the local proxy.
+
+    HTTP responses prove the route reached the destination, even 401/429/5xx.
+    A curl transport failure (exit code != 0) is the signal used for rotation;
+    upstream HTTP errors are recorded but do not cause blind exit churn.
+    """
+    url = f"https://{host}/zen/v1/models" if domain_matches(host, "opencode.ai") else f"https://{host}/"
+    try:
+        result = runner(
+            ["curl", "--proxy", "http://127.0.0.1:2080", "--noproxy", "",
+             "--silent", "--show-error", "--output", "/dev/null",
+             "--write-out", "%{http_code}", "--connect-timeout", "4",
+             "--max-time", "8", url],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "transport_failure": True, "error": "curl timeout", "host": host}
+    except OSError as exc:
+        return {"ok": False, "transport_failure": True, "error": type(exc).__name__, "host": host}
+    code = (result.stdout or "").strip()
+    if result.returncode != 0:
+        return {"ok": False, "transport_failure": True, "error": (result.stderr or "curl failed")[-200:], "host": host}
+    try:
+        status = int(code)
+    except ValueError:
+        status = 0
+    return {
+        "ok": 100 <= status < 600,
+        "transport_failure": False,
+        "status": status,
+        "blocked": status in {403, 1010},
+        "host": host,
+    }
+
+
+def rotate_provider(root: Path, provider: str = "proton", *, runner: Callable = subprocess.run) -> dict:
+    """Ask proxy-router itself to rotate; Hermes is not involved."""
+    try:
+        result = runner(
+            [sys.executable, str(Path(root) / "router.py"), "rotate", provider,
+             "--reason", "timeout"],
+            cwd=str(root), capture_output=True, text=True, timeout=50,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"rotated": False, "error": type(exc).__name__}
+    return {"rotated": result.returncode == 0, "returncode": result.returncode,
+            "output": (result.stderr or result.stdout or "")[-300:]}
+
+
+def _read_new_lines(path: Path, offset: int) -> tuple[int, list[str]]:
+    try:
+        size = path.stat().st_size
+        if size < offset:
+            offset = 0
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            handle.seek(offset)
+            lines = handle.readlines()
+            return handle.tell(), lines
+    except OSError:
+        return offset, []
+
+
+def worker(root: Path, interval: float = DEFAULT_INTERVAL, *, sleep: Callable = time.sleep) -> int:
+    root = Path(root).resolve()
+    state_dir(root).mkdir(parents=True, exist_ok=True)
+    pid_file(root).write_text(str(os.getpid()), encoding="ascii")
+    enabled_file(root).write_text("enabled\n", encoding="ascii")
+    os.chmod(pid_file(root), 0o600)
+    os.chmod(enabled_file(root), 0o600)
+    log_path = root / LOG_FILE_NAME
+    offset = log_path.stat().st_size if log_path.exists() else 0
+    domains = critical_domains(root)
+    last_target: dict[str, float] = {}
+    last_probe: dict[str, float] = {}
+    clients: list[dict] = []
+    clients_at = 0.0
+    guard = RotationGuard()
+    try:
+        while enabled_file(root).is_file():
+            offset, lines = _read_new_lines(log_path, offset)
+            for line in lines:
+                event = parse_line(line)
+                if not event:
+                    continue
+                now = time.monotonic()
+                host = event.get("host", "")
+                if event["kind"] == "target":
+                    is_critical = any(domain_matches(host, d) for d in domains)
+                    if now - clients_at >= CLIENT_SNAPSHOT_EVERY_SECONDS:
+                        clients = client_snapshot(root)
+                        clients_at = now
+                    event.update({
+                        "critical": is_critical,
+                        "observed_at": time.time(),
+                        "clients": clients,
+                    })
+                    append_event(root, event)
+                    if is_critical:
+                        last_target[host] = now
+                        if event.get("failure") and guard.record_transport_failure(now):
+                            result = rotate_provider(root)
+                            append_event(root, {"kind": "rotation", "observed_at": time.time(), **result})
+                elif event["kind"] == "client":
+                    # Client lines are retained only as a bounded observation;
+                    # exact app attribution is captured on target events.
+                    append_event(root, {**event, "observed_at": time.time()})
+            now = time.monotonic()
+            for host, seen_at in list(last_target.items()):
+                if now - seen_at > TARGET_IDLE_SECONDS or now - last_probe.get(host, 0) < PROBE_EVERY_SECONDS:
+                    continue
+                last_probe[host] = now
+                result = probe_target(root, host)
+                append_event(root, {"kind": "probe", "observed_at": time.time(), **result})
+                if result.get("transport_failure") and guard.record_transport_failure(now):
+                    rotation = rotate_provider(root)
+                    append_event(root, {"kind": "rotation", "observed_at": time.time(), **rotation})
+            sleep(max(0.5, float(interval)))
+    finally:
+        pid_file(root).unlink(missing_ok=True)
+        enabled_file(root).unlink(missing_ok=True)
+    return 0
+
+
+def _pid_matches(root: Path, pid: int) -> bool:
+    """Reject recycled/foreign PIDs before status or stop signals them."""
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    command = result.stdout.strip()
+    return "--worker" in command and str(Path(root).resolve()) in command and Path(__file__).resolve().name in command
+
+
+def _pid_running(pid: int, root: Path | None = None) -> bool:
+    root = Path(root) if root is not None else ROOT
+    if not _pid_matches(root, pid):
+        return False
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+def status(root: Path | None = None) -> dict:
+    root = Path(root) if root is not None else ROOT
+    try:
+        pid = int(pid_file(root).read_text().strip())
+    except (OSError, ValueError):
+        pid = None
+    return {"enabled": enabled_file(root).is_file(), "running": bool(pid and _pid_running(pid, root)), "pid": pid,
+            "events": events_file(root).is_file(), "scope": "proxy-observable only", "targets": list(critical_domains(root))}
+
+
+def start(root: Path | None = None, *, interval: float = DEFAULT_INTERVAL) -> dict:
+    root = Path(root) if root is not None else ROOT
+    current = status(root)
+    if current["running"]:
+        return {"started": False, "already_running": True, "pid": current["pid"]}
+    state_dir(root).mkdir(parents=True, exist_ok=True)
+    command = [sys.executable, str(Path(__file__).resolve()), "--worker", "--root", str(root), "--interval", str(interval)]
+    try:
+        proc = subprocess.Popen(command, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL, start_new_session=True)
+    except OSError as exc:
+        return {"started": False, "error": f"{type(exc).__name__}: {exc}"}
+    pid_file(root).write_text(str(proc.pid), encoding="ascii")
+    enabled_file(root).write_text("enabled\n", encoding="ascii")
+    os.chmod(pid_file(root), 0o600)
+    os.chmod(enabled_file(root), 0o600)
+    return {"started": True, "pid": proc.pid, "interval": interval}
+
+
+def stop(root: Path | None = None) -> dict:
+    root = Path(root) if root is not None else ROOT
+    try:
+        pid = int(pid_file(root).read_text().strip())
+    except (OSError, ValueError):
+        pid = None
+    if pid and _pid_running(pid, root):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    pid_file(root).unlink(missing_ok=True)
+    enabled_file(root).unlink(missing_ok=True)
+    return {"stopped": True, "pid": pid}
+
+
+def main(argv: Iterable[str] | None = None, root: Path | None = None) -> int:
+    global ROOT
+    if root is not None:
+        ROOT = Path(root).resolve()
+    parser = argparse.ArgumentParser(prog="proxy-router watcher")
+    parser.add_argument("action", nargs="?", choices=["status", "on", "off", "logs"])
+    parser.add_argument("--root", default=None)
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL)
+    parser.add_argument("--lines", type=int, default=20)
+    parser.add_argument("--worker", action="store_true")
+    argv = list(argv) if argv is not None else sys.argv[1:]
+    if argv and argv[0] == "watcher":
+        argv = argv[1:]
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve() if args.root else ROOT
+    if args.worker:
+        return worker(root, args.interval)
+    if args.action in (None, "status"):
+        print(json.dumps(status(root), indent=2, sort_keys=True))
+        return 0
+    if args.action == "on":
+        print(json.dumps(start(root, interval=args.interval), indent=2, sort_keys=True))
+        return 0
+    if args.action == "off":
+        print(json.dumps(stop(root), indent=2, sort_keys=True))
+        return 0
+    path = events_file(root)
+    if path.is_file():
+        try:
+            with path.open(encoding="utf-8") as handle:
+                print("".join(collections.deque(handle, maxlen=max(1, min(args.lines, 100)))))
+        except OSError:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/proxy-router/router.example.json
+++ b/tools/proxy-router/router.example.json
@@ -1,0 +1,97 @@
+{
+  "port": 2080,
+  "providers": {
+    "proton": {
+      "directory": "providers/proton",
+      "cooldown_seconds": 60
+    },
+    "cloudflare": {
+      "directory": "providers/cloudflare",
+      "cooldown_seconds": 60,
+      "error_policy": {
+        "429": {
+          "action": "cooldown",
+          "seconds": 300
+        }
+      }
+    }
+  },
+  "routes": [
+    {
+      "id": "opencode-zen",
+      "domains": [
+        "opencode.ai"
+      ],
+      "provider": "proton"
+    },
+    {
+      "id": "roblox",
+      "domains": [
+        "roblox.com",
+        "rbxcdn.com",
+        "robloxlabs.com",
+        "rblx.com"
+      ],
+      "provider": "cloudflare"
+    }
+  ],
+  "routing": {
+    "mode": "vpn-list",
+    "vpn_domains": []
+  },
+  "vpn": {
+    "address": [
+      "172.19.0.1/30"
+    ],
+    "mtu": 1500,
+    "stack": "system",
+    "dns_transport": "udp"
+  },
+  "egress": {
+    "probe_url": "https://www.cloudflare.com/cdn-cgi/trace",
+    "probe_timeout": 8,
+    "block_seconds": 3600,
+    "upstream_cooldown_seconds": 300,
+    "fail_threshold": 2,
+    "slow_latency_ms": 1200,
+    "ok_window": 86400
+  },
+  "error_policy": {
+    "default": {
+      "action": "cooldown",
+      "seconds": 300
+    },
+    "429": {
+      "action": "exhaust",
+      "seconds": 900
+    },
+    "503": {
+      "action": "cooldown",
+      "seconds": 120
+    },
+    "timeout": {
+      "action": "cooldown",
+      "seconds": 60
+    },
+    "tls": {
+      "action": "cooldown",
+      "seconds": 300
+    },
+    "connection": {
+      "action": "cooldown",
+      "seconds": 300
+    },
+    "1010": {
+      "action": "block",
+      "seconds": 3600
+    },
+    "403": {
+      "action": "block",
+      "seconds": 3600
+    }
+  },
+  "rotation": {
+    "interval_seconds": 7200,
+    "jitter_seconds": 300
+  }
+}

--- a/tools/proxy-router/router.py
+++ b/tools/proxy-router/router.py
@@ -1,0 +1,3334 @@
+#!/usr/bin/env python3
+"""Proxy router: domain/IP -> provider (WireGuard) selective routing.
+
+Reads ``router.json`` (routes + providers), generates a sing-box config with one
+WireGuard endpoint per provider, and hot-reloads it via SIGHUP so route changes
+do not drop existing connections. Providers are pools of ``*.conf`` WireGuard
+profiles (Proton, Cloudflare WARP, ...) with per-profile cooldown and rotation.
+
+The generated ``sing-box.json`` contains the private keys of every active
+profile, so it is written mode 0600 alongside the input profiles.
+"""
+from __future__ import annotations
+
+import argparse
+import configparser
+import datetime
+import json
+import os
+import random
+import re
+import shlex
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(os.environ.get("PROXY_ROUTER_ROOT") or Path(__file__).resolve().parent).resolve()
+CONFIG_FILE = ROOT / "router.json"
+SING_BOX_CONFIG = ROOT / "sing-box.json"
+LAST_GOOD_FILE = ROOT / "sing-box.json.last-good"
+PID_FILE = ROOT / "sing-box.pid"
+LOG_FILE = ROOT / "sing-box.log"
+LOCK_FILE = ROOT / "state" / "engine.lock"
+MODE_FILE = ROOT / "state" / "mode"
+# Written by `router.py stop` (and the tray Disconnect); respected by
+# keepalive.sh so a manual disconnect is NOT resurrected on the next
+# ensure tick. Removed by `router.py start` / tray Connect.
+MANUAL_OFF_FILE = ROOT / "state" / "manual-off"
+DEFAULT_PORT = 2080
+DEFAULT_TUN_ADDRESS = ["172.19.0.1/30"]
+DEFAULT_TUN_MTU = 1500
+DEFAULT_TUN_STACK = "system"
+DEFAULT_PROBE_URL = "https://www.cloudflare.com/cdn-cgi/trace"
+DEFAULT_EGRESS_SETTINGS = {
+    "probe_url": DEFAULT_PROBE_URL,
+    "probe_timeout": 8.0,
+    "block_seconds": 3600,
+    "upstream_cooldown_seconds": 300,
+    "fail_threshold": 2,
+    "slow_latency_ms": 1200.0,
+    "ok_window": 86400,
+}
+# Optional scheduled rotation (router.json top-level ``rotation``): churn the
+# active provider's exit every ``interval_seconds`` (0/absent = off) with
+# ``jitter_seconds`` spread (default 300) instead of only rotating reactively
+# on failures, so upstream rate limits see a fresh egress IP on a cadence.
+DEFAULT_ROTATION_SETTINGS = {"interval_seconds": 0, "jitter_seconds": 300}
+
+_rotation: dict = {}
+# Per-reason upstream-error policy (router.json top-level ``error_policy``,
+# then per-provider ``providers.<name>.error_policy``, then these built-in
+# defaults; closest scope wins). action: cooldown (rotate skips the lane until
+# reset), exhaust (cooldown + ``exhausted``/``exhausted_until`` marker with a
+# machine-readable reset time in the egress record), block (reputation block:
+# rotate skips the lane entirely until expiry or --force).
+DEFAULT_ERROR_POLICY = {
+    "default": {"action": "cooldown", "seconds": 300},
+    "429": {"action": "exhaust", "seconds": 900},
+    "503": {"action": "cooldown", "seconds": 120},
+    "timeout": {"action": "cooldown", "seconds": 60},
+    "tls": {"action": "cooldown", "seconds": 300},
+    "connection": {"action": "cooldown", "seconds": 300},
+    "1010": {"action": "block", "seconds": 3600},
+    "403": {"action": "block", "seconds": 3600},
+}
+# Rotate sing-box.log once it outgrows this (mirrors monitor.py sample
+# rotation); the live log grows a line per connection and is unbounded.
+LOG_MAX_BYTES = 10_000_000
+
+_sing_box_cache: str | None = None
+_sing_box_resolved = False
+
+
+def resolve_sing_box() -> str | None:
+    """Resolve the sing-box executable, cached.
+
+    Priority: ``SING_BOX`` env var, then ``<root>/bin/sing-box(.exe)`` (bundled
+    releases), then ``sing-box`` on ``PATH``. Returns None when not found.
+    """
+    global _sing_box_cache, _sing_box_resolved
+    if _sing_box_resolved:
+        return _sing_box_cache
+    bundled = ROOT / "bin" / ("sing-box.exe" if os.name == "nt" else "sing-box")
+    for candidate in (os.environ.get("SING_BOX"), str(bundled)):
+        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            _sing_box_cache = candidate
+            _sing_box_resolved = True
+            return candidate
+    _sing_box_cache = shutil.which("sing-box")
+    _sing_box_resolved = True
+    return _sing_box_cache
+
+
+def _sing_box_missing_message() -> str:
+    """One-line message naming every location the resolver checks."""
+    bundled = ROOT / "bin" / ("sing-box.exe" if os.name == "nt" else "sing-box")
+    return f"sing-box not found; set SING_BOX, bundle it at {bundled}, or install it on PATH"
+
+
+# The generated sing-box.json uses features that do not exist before sing-box
+# 1.12.0 (dialer `domain_resolver`, route `default_domain_resolver`, and the
+# dns `hijack-dns` rule action - verified against the 1.12 and 1.11 release
+# binaries). An older binary fails `check` with a cryptic "unknown field"
+# error, so we reject it up front with a clear message (M8).
+MIN_SING_BOX_VERSION = (1, 12, 0)
+
+_sing_box_version_cache: tuple[int, int, int] | None = None
+_sing_box_version_resolved = False
+
+
+def sing_box_version() -> tuple[int, int, int] | None:
+    """Parse `sing-box version` output into a (major, minor, patch) tuple.
+
+    Returns None when the binary cannot be run or the banner does not contain
+    a parseable version (callers then fall back to `sing-box check`, which
+    still reports the concrete schema error instead of guessing)."""
+    global _sing_box_version_cache, _sing_box_version_resolved
+    if _sing_box_version_resolved:
+        return _sing_box_version_cache
+    version = None
+    sing_box = resolve_sing_box()
+    if sing_box is not None:
+        try:
+            result = subprocess.run(
+                [sing_box, "version"], capture_output=True, text=True, timeout=10
+            )
+            match = re.search(r"version\s+[vV]?(\d+)\.(\d+)\.(\d+)", result.stdout)
+            if match:
+                version = tuple(int(g) for g in match.groups())
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    _sing_box_version_cache = version
+    _sing_box_version_resolved = True
+    return version
+
+
+def sing_box_at_least(minimum: tuple[int, int, int]) -> bool:
+    """True when sing-box satisfies ``minimum``; an unknown version is not
+    rejected here (the generated config's `check` still catches real schema
+    problems, and refusing on a parse failure could lock out beta builds)."""
+    version = sing_box_version()
+    return version is None or version >= minimum
+
+
+def _sing_box_version_message(required: tuple[int, int, int]) -> str:
+    version = sing_box_version()
+    if version is None:
+        return f"cannot determine sing-box version; need >= {'.'.join(map(str, required))}"
+    return f"sing-box {'.'.join(map(str, version))} is too old (need >= {'.'.join(map(str, required))}); install a newer sing-box or point SING_BOX at one"
+
+_providers: dict = {}
+_routes: list = []
+_port: int = DEFAULT_PORT
+_vpn: dict = {}
+_routing: dict = {}
+_egress_settings: dict = {}
+_error_policy: dict | None = None
+_PROVIDER_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,63}")
+
+
+def fail(message: str) -> int:
+    print(f"router: {message}", file=sys.stderr)
+    return 1
+
+
+def current_mode() -> str:
+    """'proxy' (default) or 'tun'. Persisted in state/mode so ensure/reload
+    keep running whatever the user last selected."""
+    try:
+        if MODE_FILE.is_file():
+            mode = MODE_FILE.read_text().strip()
+            if mode in ("proxy", "tun"):
+                return mode
+    except OSError:
+        # Root-owned mode file (written by a sudo run whose ownership was
+        # not handed back) must not crash the regular-user CLI/keepalive.
+        return "proxy"
+    return "proxy"
+
+
+def _hand_back_ownership(path: Path) -> None:
+    """Chown a state file back to the user who invoked sudo.
+
+    tun mode needs root, so `sudo vpn on` writes state files as root with
+    0600; the regular-user keepalive/CLI then cannot read them and treats
+    a live engine as dead (garbage pid file H6, unreadable mode/config),
+    churning restarts. SUDO_UID/SUDO_GID identify who to hand back to."""
+    if os.geteuid() != 0:
+        return
+    uid = os.environ.get("SUDO_UID")
+    gid = os.environ.get("SUDO_GID")
+    if not uid or not gid:
+        return
+    try:
+        os.chown(path, int(uid), int(gid))
+    except (OSError, ValueError):
+        pass
+
+
+def set_mode(mode: str) -> None:
+    MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    MODE_FILE.write_text(mode)
+    os.chmod(MODE_FILE, 0o600)
+    _hand_back_ownership(MODE_FILE)
+
+
+def _atomic_write(path: Path, text: str, mode: int = 0o600) -> None:
+    """Write ``text`` to ``path`` atomically (temp file + os.replace) with
+    ``mode`` permissions, so a crash mid-write never leaves a truncated
+    config and the file is never world-readable (F5)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=path.parent,
+            prefix=f".{path.name}.", suffix=".tmp", delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(text)
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+        temporary = None
+        _hand_back_ownership(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def load_config() -> int:
+    global _providers, _routes, _port, _vpn, _routing
+    if not CONFIG_FILE.is_file():
+        return fail(f"missing {CONFIG_FILE.name}; run 'router.py init' first")
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+        if not isinstance(data, dict):
+            return fail(f"bad {CONFIG_FILE.name}: top level must be an object")
+        port = int(data.get("port", DEFAULT_PORT))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        return fail(f"bad {CONFIG_FILE.name}: {exc}")
+    if not 1 <= port <= 65535:
+        return fail(f"bad {CONFIG_FILE.name}: port must be between 1 and 65535")
+    providers = data.get("providers", {})
+    routes = data.get("routes", [])
+    vpn = data.get("vpn", {})
+    if not isinstance(providers, dict) or not providers:
+        return fail("no providers configured")
+    if not all(isinstance(name, str) and _PROVIDER_NAME.fullmatch(name) and isinstance(entry, dict)
+               for name, entry in providers.items()):
+        return fail(f"bad {CONFIG_FILE.name}: provider names/entries are invalid")
+    for name, entry in providers.items():
+        directory = entry.get("directory", f"providers/{name}")
+        if not isinstance(directory, str):
+            return fail(f"bad {CONFIG_FILE.name}: provider '{name}' directory must be a string")
+        try:
+            (ROOT / directory).resolve().relative_to(ROOT)
+        except ValueError:
+            return fail(f"bad {CONFIG_FILE.name}: provider '{name}' directory escapes the router root")
+    if not isinstance(routes, list) or not all(isinstance(route, dict) for route in routes) or not isinstance(vpn, dict):
+        return fail(f"bad {CONFIG_FILE.name}: providers/routes/vpn have invalid types")
+    routing = data.get("routing", {})
+    if routing is None:
+        routing = {}
+    if not isinstance(routing, dict):
+        return fail(f"bad {CONFIG_FILE.name}: routing must be an object")
+    known_providers = set(providers)
+    for route in routes:
+        if not isinstance(route.get("provider"), str):
+            return fail(f"bad {CONFIG_FILE.name}: every route needs a provider")
+        # F3: an unknown provider must be rejected at load, never silently
+        # dropped, or matching domains would fall through to direct.
+        if route["provider"] not in known_providers:
+            return fail(
+                f"bad {CONFIG_FILE.name}: route '{route.get('id', '<unnamed>')}' "
+                f"references unknown provider '{route['provider']}'"
+            )
+        for key in ("domains", "ip_cidr"):
+            if key in route and (not isinstance(route[key], list) or not all(isinstance(v, str) for v in route[key])):
+                return fail(f"bad {CONFIG_FILE.name}: route '{route.get('id', '<unnamed>')}' {key} must be a string list")
+    # Routing modes (safe-list / vpn-list): validated eagerly so a malformed
+    # section fails load with a precise message, never a silent guess. Shared
+    # with the `routing` CLI writer so both paths enforce the same rules.
+    routing_error = _routing_error(routing, known_providers)
+    if routing_error is not None:
+        return fail(f"bad {CONFIG_FILE.name}: {routing_error}")
+    try:
+        _load_error_policy(data, providers)
+        _load_rotation_settings(data)
+    except ValueError as exc:
+        return fail(f"bad {CONFIG_FILE.name}: {exc}")
+    _load_egress_settings(data)
+    _port = port
+    _providers = providers
+    _routes = routes
+    _vpn = vpn
+    _routing = dict(routing)
+    return 0
+
+
+def write_default_config(force: bool = False) -> int:
+    if CONFIG_FILE.is_file() and not force:
+        return fail(f"{CONFIG_FILE.name} already exists; use 'init --force' to overwrite")
+    example = ROOT / "router.example.json"
+    if example.is_file():
+        data = json.loads(example.read_text())
+    else:
+        data = {
+            "port": DEFAULT_PORT,
+            "providers": {
+                "proton": {"directory": "providers/proton", "cooldown_seconds": 60},
+                "cloudflare": {"directory": "providers/cloudflare", "cooldown_seconds": 60,
+                               "error_policy": {"429": {"action": "cooldown", "seconds": 300}}},
+            },
+            "routes": [
+                {
+                    "id": "opencode-zen",
+                    "domains": ["opencode.ai"],
+                    "provider": "proton",
+                },
+                {
+                    "id": "roblox",
+                    "domains": ["roblox.com", "rbxcdn.com", "robloxlabs.com", "rblx.com"],
+                    "provider": "cloudflare",
+                },
+            ],
+            # vpn-list with an empty list is the safe default: route.final
+            # stays "direct" and nothing is tunneled unless listed.
+            "routing": {"mode": "vpn-list", "vpn_domains": []},
+            "vpn": {
+                "address": DEFAULT_TUN_ADDRESS,
+                "mtu": DEFAULT_TUN_MTU,
+                "stack": DEFAULT_TUN_STACK,
+            },
+            "egress": {
+                "probe_url": DEFAULT_PROBE_URL,
+                "probe_timeout": 8,
+                "block_seconds": 3600,
+                "upstream_cooldown_seconds": 300,
+                "fail_threshold": 2,
+                "slow_latency_ms": 1200,
+                "ok_window": 86400,
+            },
+            # Scheduled rotation: churn the active exits every 2h (with
+            # ±150s jitter) so upstream rate limits see a fresh egress IP.
+            "rotation": {"interval_seconds": 7200, "jitter_seconds": 300},
+            "error_policy": {
+                "default": {"action": "cooldown", "seconds": 300},
+                "429": {"action": "exhaust", "seconds": 900},
+                "503": {"action": "cooldown", "seconds": 120},
+                "timeout": {"action": "cooldown", "seconds": 60},
+                "tls": {"action": "cooldown", "seconds": 300},
+                "connection": {"action": "cooldown", "seconds": 300},
+                "1010": {"action": "block", "seconds": 3600},
+                "403": {"action": "block", "seconds": 3600},
+            },
+        }
+    _atomic_write(CONFIG_FILE, json.dumps(data, indent=2) + "\n", 0o600)
+    print(f"wrote {CONFIG_FILE}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# provider pools
+# ---------------------------------------------------------------------------
+
+def provider_dir(name: str) -> Path:
+    entry = _providers.get(name, {})
+    if not isinstance(entry, dict):
+        raise ValueError(f"provider '{name}' entry must be an object")
+    configured = entry.get("directory", f"providers/{name}")
+    if not isinstance(configured, str):
+        raise ValueError(f"provider '{name}' directory must be a string")
+    path = (ROOT / configured).resolve()
+    try:
+        path.relative_to(ROOT)
+    except ValueError as exc:
+        raise ValueError(f"provider '{name}' directory escapes the router root") from exc
+    return path
+
+
+def provider_files(name: str) -> list[Path]:
+    return sorted(provider_dir(name).glob("*.conf"))
+
+
+def is_cooled_down(name: str, profile: Path) -> bool:
+    path = ROOT / "state" / "cooldowns" / name / f"{profile.stem}.until"
+    if not path.is_file():
+        return False
+    try:
+        return int(path.read_text().strip()) > int(time.time())
+    except ValueError:
+        return False
+
+
+def mark_cooldown(name: str, profile: Path, seconds: int) -> None:
+    path = ROOT / "state" / "cooldowns" / name / f"{profile.stem}.until"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(int(time.time()) + seconds))
+    os.chmod(path, 0o600)
+
+
+# ---------------------------------------------------------------------------
+# egress health per profile
+# ---------------------------------------------------------------------------
+
+def egress_settings() -> dict:
+    """Effective egress-tuning settings (router.json top-level ``egress``
+    merged over module defaults). Rotation consults these to avoid
+    known-blocked/slow exits without hardcoding thresholds."""
+    return _egress_settings or DEFAULT_EGRESS_SETTINGS
+
+
+def _parse_error_policy(supplied) -> dict:
+    """Validate one error-policy table: {reason: {action, seconds}}. Returns
+    the cleaned table ({} when absent). Raises ValueError with a precise
+    message on malformed input so load_config rejects the config instead of
+    silently guessing."""
+    if supplied is None:
+        return {}
+    if not isinstance(supplied, dict):
+        raise ValueError("'error_policy' must be an object of reason -> {\"action\", \"seconds\"}")
+    cleaned: dict[str, dict] = {}
+    for key, entry in supplied.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"'error_policy.{key}' must be an object with 'action' and 'seconds'")
+        action = entry.get("action", "cooldown")
+        if action not in ("cooldown", "exhaust", "block"):
+            raise ValueError(f"'error_policy.{key}.action' must be 'cooldown'|'exhaust'|'block' (got {action!r})")
+        try:
+            seconds = max(0, int(entry.get("seconds", 300)))
+        except (TypeError, ValueError):
+            raise ValueError(f"'error_policy.{key}.seconds' must be a non-negative integer") from None
+        cleaned[str(key)] = {"action": action, "seconds": seconds}
+    return cleaned
+
+
+def _load_error_policy(data: dict, providers: dict) -> None:
+    """Store the validated top-level ``error_policy`` table and each provider's
+    ``providers.<name>.error_policy`` override. Raises ValueError on malformed
+    entries; load_config turns that into a hard config failure so a policy
+    mistake can never silently change rotation behavior."""
+    global _error_policy
+    _error_policy = _parse_error_policy(data.get("error_policy") if isinstance(data, dict) else None)
+    for name, entry in providers.items():
+        if isinstance(entry, dict) and "error_policy" in entry:
+            entry["error_policy"] = _parse_error_policy(entry["error_policy"])
+
+
+def error_policy_for(name: str) -> dict:
+    """Effective error-policy table for provider ``name``.
+
+    Merge precedence (closest scope wins): ``providers.<name>.error_policy``
+    beats the top-level ``error_policy`` beats the built-in defaults in
+    DEFAULT_ERROR_POLICY. Returns a fresh independent table each call so
+    callers can never mutate module state."""
+    policy = {key: dict(entry) for key, entry in DEFAULT_ERROR_POLICY.items()}
+    for scope in (_error_policy, _provider_error_policy(name)):
+        if not isinstance(scope, dict):
+            continue
+        for key, entry in scope.items():
+            if isinstance(entry, dict):
+                policy[key] = dict(entry)
+    return policy
+
+
+def _provider_error_policy(name: str) -> dict | None:
+    """Per-provider ``error_policy`` override (None when unset)."""
+    entry = _providers.get(name) if isinstance(_providers, dict) else None
+    if not isinstance(entry, dict):
+        return None
+    supplied = entry.get("error_policy")
+    return supplied if isinstance(supplied, dict) else None
+
+
+def _normalize_reason(reason) -> str:
+    """Map a failure reason string to the policy key it governs: HTTP status
+    codes (1010/403/429/503) and transport classes (tls/connection/timeout).
+    Unrecognized reasons keep their slugified text so exact-match overrides
+    still work; empty/unknown reasons fall back to ``default``."""
+    text = str(reason or "").lower()
+    for code in ("1010", "403", "429", "503"):
+        if re.search(rf"\b{code}\b", text):
+            return code
+    if any(token in text for token in ("tls", "ssl", "handshake", "certificate")):
+        return "tls"
+    if "timed out" in text or "timeout" in text:
+        return "timeout"
+    if any(token in text for token in ("connection", "refused", "reset", "unreachable", "eof")):
+        return "connection"
+    slug = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return slug or "default"
+
+
+def policy_action(name: str, reason) -> tuple[str, int]:
+    """(action, seconds) for a failure ``reason`` under provider ``name``'s
+    effective policy: normalized reason key, then ``default``, then the
+    built-in cooldown 300s fallback."""
+    policy = error_policy_for(name)
+    entry = policy.get(_normalize_reason(reason))
+    if entry is None:
+        entry = policy.get("default") or dict(DEFAULT_ERROR_POLICY["default"])
+    return entry["action"], int(entry["seconds"])
+
+
+def _iso_ts(epoch: int) -> str:
+    """ISO-8601 UTC timestamp for machine-readable egress markers."""
+    return datetime.datetime.fromtimestamp(epoch, datetime.timezone.utc).isoformat()
+
+
+def _transport_reason(error_text) -> str:
+    """Classify a transport-level probe failure (no HTTP status) into a policy
+    reason: TLS/SSL/handshake/certificate errors are ``tls``, everything else
+    (dial/connect/reset/read) is ``connection``."""
+    text = str(error_text or "").lower()
+    if any(token in text for token in ("tls", "ssl", "handshake", "certificate", "eof", "alert")):
+        return "tls"
+    return "connection"
+
+
+def _load_egress_settings(data: dict) -> None:
+    """Merge router.json's optional top-level ``egress`` dict over defaults
+    with the same bounded leniency monitor.py applies to its settings."""
+    global _egress_settings
+    settings = dict(DEFAULT_EGRESS_SETTINGS)
+    supplied = data.get("egress") if isinstance(data, dict) else None
+    if isinstance(supplied, dict):
+        for key in DEFAULT_EGRESS_SETTINGS:
+            if key in supplied:
+                settings[key] = supplied[key]
+    try:
+        settings["probe_timeout"] = min(max(1.0, float(settings["probe_timeout"])), 60.0)
+    except (TypeError, ValueError):
+        settings["probe_timeout"] = DEFAULT_EGRESS_SETTINGS["probe_timeout"]
+    for key in ("block_seconds", "upstream_cooldown_seconds", "ok_window"):
+        try:
+            settings[key] = max(0, int(settings[key]))
+        except (TypeError, ValueError):
+            settings[key] = DEFAULT_EGRESS_SETTINGS[key]
+    try:
+        settings["fail_threshold"] = min(max(1, int(settings["fail_threshold"])), 20)
+    except (TypeError, ValueError):
+        settings["fail_threshold"] = DEFAULT_EGRESS_SETTINGS["fail_threshold"]
+    try:
+        settings["slow_latency_ms"] = max(0.0, float(settings["slow_latency_ms"]))
+    except (TypeError, ValueError):
+        settings["slow_latency_ms"] = DEFAULT_EGRESS_SETTINGS["slow_latency_ms"]
+    url = settings["probe_url"]
+    try:
+        parsed = urllib.parse.urlsplit(str(url))
+        sane = parsed.scheme in ("http", "https") and bool(parsed.hostname)
+    except (TypeError, ValueError):
+        sane = False
+    if not sane:
+        settings["probe_url"] = DEFAULT_EGRESS_SETTINGS["probe_url"]
+    _egress_settings = settings
+
+
+def _load_rotation_settings(data: dict) -> None:
+    """Merge router.json's optional top-level ``rotation`` dict; raises
+    ValueError on invalid values so load_config rejects the config."""
+    global _rotation
+    supplied = data.get("rotation") if isinstance(data, dict) else None
+    interval = DEFAULT_ROTATION_SETTINGS["interval_seconds"]
+    jitter = DEFAULT_ROTATION_SETTINGS["jitter_seconds"]
+    if isinstance(supplied, dict):
+        interval = int(supplied.get("interval_seconds", interval))
+        jitter = int(supplied.get("jitter_seconds", jitter))
+    if interval < 0 or jitter < 0:
+        raise ValueError("rotation interval_seconds/jitter_seconds must be >= 0")
+    _rotation = {"interval_seconds": interval, "jitter_seconds": jitter}
+
+
+def egress_record_path(name: str, profile: Path) -> Path:
+    """state/egress/<provider>/<profile>.json with a path-traversal guard."""
+    stem = profile.stem
+    if not _PROVIDER_NAME.fullmatch(stem):
+        raise ValueError(f"profile name '{stem}' is invalid")
+    return ROOT / "state" / "egress" / name / f"{stem}.json"
+
+
+def read_egress(name: str, profile: Path) -> dict:
+    path = egress_record_path(name, profile)
+    if not path.is_file():
+        return {}
+    try:
+        record = json.loads(path.read_text())
+        return record if isinstance(record, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def write_egress(name: str, profile: Path, record: dict) -> None:
+    _atomic_write(egress_record_path(name, profile), json.dumps(record, indent=2, sort_keys=True) + "\n", 0o600)
+
+
+def record_egress(name: str, profile: Path, *, ok: bool, latency_ms: float | None = None,
+                  status: int | None = None, error: str | None = None,
+                  dns_ok: bool | None = None) -> dict:
+    """Merge one probe outcome into the profile's egress record. A passing
+    probe clears the fail streak and any blocked marker; a failure bumps the
+    streak so rotation deprioritizes the exit. ``dns_ok`` (True/False from the
+    tunnel-DNS companion check) is persisted when it could be determined."""
+    record = read_egress(name, profile)
+    now = int(time.time())
+    record["ok"] = bool(ok)
+    record["checked_at"] = now
+    if ok:
+        record["fails"] = 0
+        record["last_ok_at"] = now
+        record["latency_ms"] = round(float(latency_ms), 2) if latency_ms is not None else None
+        record["status"] = status
+        record["error"] = None
+        record["blocked"] = False
+        record["block_reason"] = None
+        record["blocked_at"] = None
+        record["blocked_until"] = None
+        record["exhausted"] = False
+        record["exhausted_at"] = None
+        record["exhausted_until"] = None
+        # A passing probe heals a stale upstream_error marker (e.g. a 429
+        # from `rotate --reason` hours ago): the exit recovered, so the
+        # tray must stop warning/disable it.
+        record["upstream_error"] = None
+        record["upstream_error_at"] = None
+    else:
+        record["fails"] = int(record.get("fails") or 0) + 1
+        record["latency_ms"] = None
+        record["status"] = status
+        record["error"] = error or record.get("error")
+    if dns_ok is not None:
+        record["dns_ok"] = bool(dns_ok)
+    write_egress(name, profile, record)
+    return record
+
+
+def clear_blocked(name: str, profile: Path) -> None:
+    """Drop a blocked marker (rotate --force, or a fresh passing probe)."""
+    record = read_egress(name, profile)
+    if not record:
+        return
+    record["blocked"] = False
+    record["block_reason"] = None
+    record["blocked_at"] = None
+    record["blocked_until"] = None
+    write_egress(name, profile, record)
+
+
+def mark_blocked(name: str, profile: Path, reason: str, seconds: int | None = None) -> dict:
+    """Persist a blocked-exit marker (Cloudflare 1010/403 egress-IP
+    reputation block) so rotation skips the profile until the marker expires
+    or an explicit rotate --force."""
+    seconds = int(seconds) if seconds is not None else int(egress_settings()["block_seconds"])
+    now = int(time.time())
+    record = read_egress(name, profile)
+    record["blocked"] = True
+    record["block_reason"] = str(reason)
+    record["blocked_at"] = now
+    record["blocked_until"] = now + max(0, seconds)
+    write_egress(name, profile, record)
+    return record
+
+
+def egress_is_blocked(name: str, profile: Path, now: int | None = None) -> bool:
+    record = read_egress(name, profile)
+    if not record.get("blocked"):
+        return False
+    until = record.get("blocked_until")
+    if until is None:
+        return True  # no expiry recorded: blocked until cleared
+    return (now if now is not None else int(time.time())) < int(until)
+
+
+def _is_block_reason(reason: str) -> bool:
+    """True when an upstream failure reason describes an egress-IP reputation
+    block (Cloudflare 1010/403) rather than a transient error."""
+    text = str(reason).lower()
+    return "1010" in text or "403" in text or "blocked" in text or "cloudflare" in text
+
+
+def _egress_error_text(exc: Exception) -> str:
+    text = str(exc)
+    text = re.sub(r"https?://[^\s'\"]+", "[REDACTED_URL]", text)
+    return f"{type(exc).__name__}: {text}" if text else type(exc).__name__
+
+
+def _open_probe(opener, request, timeout: float):
+    """Open ``request`` through an opener that may be a urllib OpenerDirector
+    (use .open) or a plain callable injected by tests, mirroring monitor.py."""
+    open_method = getattr(opener, "open", None)
+    if callable(open_method):
+        return open_method(request, timeout=timeout)
+    return opener(request, timeout=timeout)
+
+
+def probe_url_for(name: str) -> str | None:
+    """Probe target for a provider: the first routed domain of that provider,
+    so the probe actually rides the tunnel end-to-end (a URL that matches no
+    route would go out direct and measure the wrong path). None when the
+    provider has no route domain to probe through.
+
+    An explicit ``probe_url`` on the provider entry wins over the route
+    pick: some routed domains (e.g. roblox.com's bot-protection landing
+    page) hang or redirect even on a healthy tunnel, which would
+    false-mark the exit dead. Operators pin a light, reliable target
+    (e.g. https://www.roblox.com/robots.txt) when that happens.
+
+    In safe-list routing mode, domains whitelisted as ``direct_domains`` are
+    sent DIRECT by the route table; probing such a host would measure the
+    direct path, not the tunnel, and false-alive a dead exit — so those are
+    skipped here and the next tunneled route domain is picked (only in
+    safe-list mode: in default/vpn-list the list is not pinned direct). When
+    every route domain of the provider is direct-whitelisted there is no
+    tunneled path to probe; None is returned (egress check then skips the
+    provider instead of trusting a direct-path result).
+    """
+    entry = _providers.get(name)
+    if isinstance(entry, dict):
+        pinned = entry.get("probe_url")
+        if isinstance(pinned, str) and pinned.startswith("https://"):
+            return pinned
+    direct = frozenset((routing_state().get("direct_domains") or [])) \
+        if routing_state().get("mode") == "safe-list" else frozenset()
+    for route in _routes:
+        if route.get("provider") != name:
+            continue
+        for host in route.get("domains", []):
+            host = host.lstrip("*.").strip()
+            if host and "." in host and not host.startswith("."):
+                if host in direct:
+                    continue  # safe-list mode: routed direct, not the tunnel
+                return f"https://{host}"
+    return None
+
+
+def probe_egress(*, port: int | None = None, url: str | None = None, timeout: float | None = None,
+                 opener=None, clock=time.monotonic) -> dict:
+    """One small HTTP GET through the router's proxy listener (the tunnel) and
+    a parsed outcome: ok, latency, status, error. ``opener``/``clock`` are
+    injectable for tests, mirroring monitor.py."""
+    port = port or _port
+    url = url or egress_settings()["probe_url"]
+    timeout = timeout if timeout is not None else egress_settings()["probe_timeout"]
+    if opener is None:
+        proxy = f"http://127.0.0.1:{port}"
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({"http": proxy, "https": proxy})
+        )
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "proxy-router-egress/1.0", "Accept": "*/*"}
+    )
+    started = clock()
+    response = None
+    try:
+        response = _open_probe(opener, request, timeout)
+        body = response.read(4096)
+        latency = (clock() - started) * 1000.0
+        status = int(getattr(response, "status", getattr(response, "code", 200)))
+        text = body.decode("utf-8", "replace")
+        reason = None
+        if re.search(r"error\s*code\s*[:=]?\s*1010|cloudflare.{0,20}1010", text, re.IGNORECASE):
+            reason = "cloudflare-1010"
+        elif (status in (403, 1010)) and "cloudflare" in text.lower():
+            reason = "cloudflare-403"
+        return {
+            "ok": reason is None,
+            "latency_ms": round(latency, 2),
+            "status": status,
+            "error": reason,
+            "block_reason": reason,
+        }
+    except Exception as exc:  # network errors are data, never a crash
+        return {
+            "ok": False,
+            "latency_ms": None,
+            "status": None,
+            "error": _egress_error_text(exc),
+            "block_reason": None,
+        }
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+
+
+def probe_profile(name: str, profile: Path, *, port: int | None = None) -> tuple[bool, dict | None]:
+    """Probe egress for ``profile`` (the provider's active exit) through the
+    tunnel, persist the outcome, and add a blocked marker when the probe itself
+    hit a Cloudflare reputation block. Returns (ok, record); record is None
+    when the provider has no routed domain to probe through."""
+    url = probe_url_for(name)
+    if url is None:
+        return True, None
+    result = probe_egress(port=port, url=url)
+    record = record_egress(name, profile, ok=result["ok"], latency_ms=result["latency_ms"],
+                           status=result["status"], error=result["error"])
+    if result["block_reason"]:
+        mark_blocked(name, profile, result["block_reason"])
+    elif not result["ok"] and result["status"] is None and not is_cooled_down(name, profile):
+        # Transport-level failure (TLS/connection/read) with no HTTP status:
+        # the exit is failed for real traffic. Cool it so rotation and
+        # resolve_active avoid it instead of re-picking the same dead exit.
+        # Seconds come from the effective error policy for the reason class
+        # (tls/connection; built-in default matches the merged 300s rule).
+        reason = _transport_reason(result["error"])
+        _action, seconds = policy_action(name, reason)
+        mark_cooldown(name, profile, seconds)
+        print(f"router: marked {profile.stem} failed (transport/{reason}; cooldown {seconds}s)", file=sys.stderr)
+    return result["ok"], record
+
+
+_DNS_ERROR_RE = re.compile(
+    r"(getaddrinfo|no such host|nodename nor servname|name or service not known|"
+    r"temporary failure in name resolution|could not resolve|servfail)",
+    re.IGNORECASE,
+)
+
+
+def _dns_error_markers(text: str) -> bool:
+    """True when an error string describes a failed DNS resolution rather than
+    a transport/connect failure (used to classify probe failures)."""
+    return bool(text) and bool(_DNS_ERROR_RE.search(text))
+
+
+def _bounded_getaddrinfo(host: str, port: int, timeout: float) -> list[str] | None:
+    """Resolve ``host`` on a daemon worker so a broken resolver can never
+    stall the check (mirrors resolve_host's bounded pattern). None on
+    failure/timeout."""
+    resolved: list[str] = []
+
+    def _resolve() -> None:
+        try:
+            infos = socket.getaddrinfo(host, port, socket.AF_UNSPEC)
+        except (socket.gaierror, OSError):
+            return
+        for info in infos:
+            resolved.append(info[4][0])
+
+    worker = threading.Thread(target=_resolve, name=f"dnscheck-{host}", daemon=True)
+    worker.start()
+    worker.join(timeout=timeout)
+    return resolved or None
+
+
+def egress_dns_probe(host: str, *, port: int | None = None, timeout: float | None = None,
+                     opener=None) -> bool | None:
+    """Secondary tunnel-DNS signal for the egress live check: does resolution
+    of ``host`` work THROUGH the tunnel?
+
+    - Direct-resolver baseline first: if the hostname does not resolve
+      directly at all, nothing can be attributed to the tunnel (None).
+    - Then a tiny proxied GET forces the engine to resolve+connect ``host``
+      through the tunnel; a response proves the resolution path worked
+      (True), a DNS-flavored error (getaddrinfo/no such host/...) means the
+      tunnel's resolution path is dead (False), and any other transport
+      error is inconclusive (None).
+
+    Bounded (getaddrinfo worker timeout + short request timeout), injectable
+    openers for tests, no new dependencies.
+    """
+    timeout = timeout if timeout is not None else max(2.0, min(egress_settings()["probe_timeout"], 5.0))
+    if _bounded_getaddrinfo(host, 443, min(timeout, 3.0)) is None:
+        return None  # hostname itself unresolvable: not a tunnel signal
+    result = probe_egress(port=port, url=f"http://{host}/", timeout=timeout, opener=opener)
+    if result["ok"] or result["status"] is not None:
+        return True  # a response rode the tunnel: resolution worked
+    if _dns_error_markers(result["error"]):
+        return False
+    return None
+
+
+def check_egress_live(name: str, profile: Path, *, port: int | None = None) -> tuple[str, dict | None]:
+    """Live check of ``profile`` (provider ``name``'s active exit) THROUGH the
+    running tunnel. Returns (status, record):
+
+    - ``alive``: the HTTPS probe got an HTTP response through the tunnel.
+    - ``degraded``: an HTTP response arrived but was not ok (e.g. Cloudflare
+      1010/403 reputation block or 5xx). The tunnel path works, so this is
+      NOT a dead tunnel and keepalive must not rotate on it.
+    - ``dead``: the probe failed at transport level (no HTTP status at all),
+      i.e. the tunnel path itself is broken. The DNS signal sharpens the
+      reason: ``dns_ok is False`` means resolution through the tunnel failed,
+      otherwise a later dial/read stage failed.
+
+    The outcome is persisted in the normal egress health record (including
+    ``dns_ok`` when determined) and reputation-block reasons still raise a
+    blocked marker, exactly like probe_profile.
+    """
+    url = probe_url_for(name)
+    if url is None:
+        return "alive", None
+    probe = probe_egress(port=port, url=url)
+    if probe["ok"]:
+        status, dns_ok = "alive", True
+    elif probe["status"] is not None:
+        status, dns_ok = "degraded", True  # HTTP response rode the tunnel
+    else:
+        status = "dead"
+        host = urllib.parse.urlsplit(url).hostname or ""
+        dns_ok = egress_dns_probe(host, port=port) if host else None
+    record = record_egress(name, profile, ok=probe["ok"], latency_ms=probe["latency_ms"],
+                           status=probe["status"], error=probe["error"], dns_ok=dns_ok)
+    if probe["block_reason"]:
+        mark_blocked(name, profile, probe["block_reason"])
+    elif status == "dead" and not is_cooled_down(name, profile):
+        # TLS/transport-level death (no HTTP status): the exit is failed for
+        # real traffic. Cool it so resolve_active/rotation stop re-picking the
+        # same dead exit. Seconds come from the effective error policy for the
+        # reason class (tls/connection; built-in default is the merged 300s
+        # rule for TLS/transport deaths).
+        reason = _transport_reason(probe["error"])
+        _action, seconds = policy_action(name, reason)
+        mark_cooldown(name, profile, seconds)
+        print(f"router: marked {profile.stem} dead (cooldown {seconds}s)", file=sys.stderr)
+    return status, record
+
+
+def _egress_rank(record: dict, now: int | None = None) -> tuple[int, float]:
+    """Rotation preference: lower is better. Recently-OK profiles rank by
+    latency (fastest first); known-slow-but-OK and unknown profiles rank
+    second; profiles with repeated failures rank last."""
+    if not record:
+        return (1, float("inf"))
+    now = int(now if now is not None else time.time())
+    ok = record.get("ok")
+    last_ok = record.get("last_ok_at") or record.get("checked_at")
+    fails = int(record.get("fails") or 0)
+    settings = egress_settings()
+    if ok and last_ok and now - int(last_ok) < int(settings["ok_window"]):
+        latency = float(record.get("latency_ms") or float("inf"))
+        if latency < float(settings["slow_latency_ms"]):
+            return (0, latency)
+        return (2, latency)
+    if fails >= int(settings["fail_threshold"]):
+        return (3, float("inf"))
+    return (1, float("inf"))
+
+
+def record_rotation(name: str, profile: Path) -> None:
+    """Persist the last switch (profile + epoch) for status --json."""
+    record = {"profile": profile.stem, "at": int(time.time())}
+    _atomic_write(ROOT / "state" / f"{name}.rotation", json.dumps(record, indent=2, sort_keys=True) + "\n", 0o600)
+
+
+def scheduled_interval() -> int:
+    """Configured scheduled-rotation interval in seconds (0 = off)."""
+    try:
+        return int(_rotation.get("interval_seconds", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def last_rotation_at(name: str) -> int | None:
+    """Epoch of the last recorded rotation for ``name``
+    (state/<name>.rotation "at"), or None when there is no record."""
+    record = ROOT / "state" / f"{name}.rotation"
+    if not record.is_file():
+        return None
+    try:
+        return int(json.loads(record.read_text())["at"])
+    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def next_rotation_at(name: str) -> int | None:
+    """Epoch of the next scheduled rotation for ``name``, or None when
+    rotation is disabled or no rotation has ever been recorded."""
+    interval = scheduled_interval()
+    if interval <= 0:
+        return None
+    at = last_rotation_at(name)
+    if at is None:
+        return None
+    jitter = int(_rotation.get("jitter_seconds", DEFAULT_ROTATION_SETTINGS["jitter_seconds"]) or 0)
+    # Deterministic per-rotation jitter: seeded by the last rotation time, so
+    # repeated checks agree instead of re-rolling every tick and potentially
+    # deferring forever at the boundary.
+    offset = random.Random(at).randint(-(jitter // 2), jitter // 2) if jitter > 0 else 0
+    return at + interval + offset
+
+
+def rotate_due(provider: str | None = None) -> int:
+    """Scheduled rotation pass: rotate every provider whose interval elapsed.
+
+    Read-only when nothing is due (exit 3). Rotates via the normal ``rotate``
+    path (verify-then-switch, rollback, cooldowns); the current exit is NOT
+    marked as an upstream failure — a scheduled switch is a preference, not a
+    failure signal. Providers without a rotation record are seeded with now
+    (first rotation waits a full interval). Returns 0 when a provider was
+    rotated or seeded, 3 otherwise.
+    """
+    interval = scheduled_interval()
+    if interval <= 0:
+        return 3
+    if provider is not None:
+        names = [provider]
+    else:
+        suffix = ".active"
+        names = sorted(
+            p.name[: -len(suffix)]
+            for p in (ROOT / "state").glob(f"*{suffix}")
+            if p.name.endswith(suffix) and p.name[: -len(suffix)] in _providers
+        )
+    if not names:
+        return 3
+    now = int(time.time())
+    handled = False
+    for name in names:
+        at = last_rotation_at(name)
+        if at is None:
+            active = persisted_active(name)
+            if active is not None:
+                record_rotation(name, active)
+            else:
+                _atomic_write(
+                    ROOT / "state" / f"{name}.rotation",
+                    json.dumps({"profile": None, "at": now}, sort_keys=True) + "\n",
+                )
+            handled = True
+            continue
+        next_at = next_rotation_at(name)
+        if next_at is None or now < next_at:
+            continue
+        handled = rotate(name) == 0 or handled
+    return 0 if handled else 3
+
+
+def _clear_cooldown(name: str, profile: Path) -> None:
+    """Drop a profile's persisted cooldown (last-good rollback restore)."""
+    (ROOT / "state" / "cooldowns" / name / f"{profile.stem}.until").unlink(missing_ok=True)
+
+
+def _apply_upstream_failure(name: str, profile: Path | None, reason: str, cooldown_seconds: int) -> None:
+    """rotate --reason: the CURRENT profile just failed upstream (429/503/
+    timeout/1010...). Apply the configured error policy for the reason:
+    cooldown (rotation skips until reset), exhaust (cooldown + an
+    ``exhausted`` marker with a machine-readable reset time in the egress
+    record, so status --json/external scripts see the lane is dead for this
+    turn), or block (reputation block: rotation skips the exit entirely until
+    the marker expires or --force). ``cooldown_seconds`` is the legacy per-
+    provider rotate hint and is kept for call compatibility; policy seconds
+    are authoritative when configured."""
+    if profile is None:
+        return
+    action, seconds = policy_action(name, reason)
+    if action != "block" and _is_block_reason(reason):
+        action = "block"  # 1010/403 text always blocks, matching the old rule
+    mark_cooldown(name, profile, seconds)
+    record = read_egress(name, profile)
+    record["upstream_error"] = str(reason)
+    record["upstream_error_at"] = int(time.time())
+    record["error"] = f"upstream:{reason}"
+    if action == "exhaust":
+        record["exhausted"] = True
+        record["exhausted_at"] = int(time.time())
+        record["exhausted_until"] = _iso_ts(int(time.time()) + seconds)
+    else:
+        record["exhausted"] = False
+        record["exhausted_at"] = None
+        record["exhausted_until"] = None
+    write_egress(name, profile, record)
+    if action == "block":
+        mark_blocked(name, profile, reason, seconds)
+    print(f"router: marked {profile.stem} upstream error '{reason}' ({action} {seconds}s)", file=sys.stderr)
+
+
+def persisted_active(name: str) -> Path | None:
+    """The profile the running tunnel was last configured with
+    (state/<name>.active), regardless of cooldown/block state.
+
+    Cooldown marks and blocked markers never reload the engine: the live
+    tunnel keeps routing via the persisted active profile even after a probe
+    cools it. Attribution/probing therefore must use THIS profile —
+    ``resolve_active`` skips cooled profiles and would blame a different
+    exit for the tunnel's health (one dead exit poisoning the whole pool's
+    records). Returns the profile from the state file, or None when there is
+    no state file / the stem has no matching *.conf (callers fall back to
+    resolve_active without a preference).
+    """
+    profiles = provider_files(name)
+    if not profiles:
+        return None
+    live = configured_profile(name) if engine_alive() else None
+    if live is not None:
+        state = ROOT / "state" / f"{name}.active"
+        try:
+            marker = state.read_text().strip() if state.is_file() else ""
+        except OSError:
+            marker = ""
+        if marker != live.stem:
+            # The engine is the source of truth for a tunnel that is already
+            # running. Repair stale state before probes can blame the wrong exit.
+            set_active(name, live)
+        return live
+    state = ROOT / "state" / f"{name}.active"
+    if state.is_file():
+        stem = state.read_text().strip()
+        return next((p for p in profiles if p.stem == stem), None)
+    return None
+
+
+def configured_profile(name: str) -> Path | None:
+    """Return the provider profile represented by the generated sing-box config.
+
+    The active marker is desired state, not proof of what sing-box loaded.
+    Compare endpoint payloads in memory; never print or persist private keys.
+    """
+    if not SING_BOX_CONFIG.is_file():
+        return None
+    try:
+        config = json.loads(SING_BOX_CONFIG.read_text())
+        endpoint = next(
+            item for item in config.get("endpoints", [])
+            if item.get("tag") == name and item.get("type") == "wireguard"
+        )
+    except (json.JSONDecodeError, OSError, StopIteration, AttributeError, TypeError):
+        return None
+
+    def identity(value: dict) -> dict:
+        return {key: item for key, item in value.items() if key not in {"tag", "domain_resolver"}}
+
+    target = identity(endpoint)
+    for profile in provider_files(name):
+        try:
+            if identity(parse_wireguard(profile)) == target:
+                return profile
+        except (SystemExit, KeyError, ValueError, configparser.Error, OSError):
+            continue
+    return None
+
+
+def resolve_active(name: str) -> Path | None:
+    profiles = provider_files(name)
+    if not profiles:
+        return None
+    state = ROOT / "state" / f"{name}.active"
+    if state.is_file():
+        stem = state.read_text().strip()
+        match = next((p for p in profiles if p.stem == stem), None)
+        if match is not None and not is_cooled_down(name, match):
+            return match
+    return next((p for p in profiles if not is_cooled_down(name, p)), None)
+
+
+def set_active(name: str, profile: Path) -> None:
+    state = ROOT / "state" / f"{name}.active"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(profile.stem)
+    os.chmod(state, 0o600)
+
+
+def _profile_error(profile: Path) -> str | None:
+    """Return an error message when ``profile`` cannot be parsed, else None.
+
+    The engine's parser raises (SystemExit for bad Endpoints/missing
+    AllowedIPs, KeyError/ValueError for missing/typed sections) on malformed
+    files; converting that into a string lets callers skip one bad profile
+    without losing the whole provider or producing a traceback (F2/F6).
+    """
+    try:
+        parse_wireguard(profile)
+        dns_server_for(profile)
+        return None
+    except (SystemExit, KeyError, ValueError, configparser.Error, OSError) as exc:
+        return str(exc) or type(exc).__name__
+
+
+def _usable_profile(name: str, preferred: Path | None = None) -> Path | None:
+    """Profile for ``name`` that builds cleanly: the persisted active one when
+    valid, else the first non-cooled valid profile. Malformed profiles are
+    logged and skipped so one bad file never disables the provider (F6)."""
+    profiles = provider_files(name)
+    if not profiles:
+        return None
+    active = preferred or resolve_active(name)
+    if active is not None:
+        error = _profile_error(active)
+        if error is None:
+            return active
+        print(f"router: skipping bad active profile {active.name} for '{name}': {error}", file=sys.stderr)
+    for profile in profiles:
+        if active is not None and profile == active:
+            continue  # already logged above
+        error = _profile_error(profile)
+        if error is not None:
+            print(f"router: skipping bad profile {profile.name} for '{name}': {error}", file=sys.stderr)
+            continue
+        if not is_cooled_down(name, profile):
+            return profile
+    return None
+
+
+# ---------------------------------------------------------------------------
+# sing-box config generation
+# ---------------------------------------------------------------------------
+
+def resolve_host(host: str) -> str:
+    """Resolve a WireGuard peer host to an IP literal.
+
+    IPv6 literals (with or without brackets) and IPv4 literals pass through;
+    domains are resolved with a preference for IPv6: the network this machine
+    runs on silently drops the WARP IPv4 endpoint (handshake never completes)
+    while the IPv6 endpoint answers.
+
+    Note (M10): this preference is deliberately independent of the DNS
+    ``strategy`` in the generated config. `dns.strategy` governs how domain
+    *destinations* are resolved: the tunnels in this router are IPv4-only
+    (profiles assign e.g. 10.2.0.2/32), so destinations default to
+    ``ipv4_only``. Peer *endpoints*, on the other hand, may be IPv6 because
+    that is the only family some networks route to the WARP server. Both are
+    tunable via ``vpn.dns_strategy`` / ``vpn.prefer_ipv6_peers`` so a
+    deployment can express one consistent policy.
+    """
+    host = host.strip().strip("[]")
+    try:
+        socket.inet_pton(socket.AF_INET6, host)
+        return host
+    except OSError:
+        pass
+    try:
+        socket.inet_aton(host)
+        return host  # already an IPv4 literal
+    except OSError:
+        pass
+    prefer_ipv6 = bool(_vpn.get("prefer_ipv6_peers", True))
+    resolved: list[str] = []
+
+    def _resolve() -> None:
+        # Runs on a daemon worker so a slow/broken resolver can never stall
+        # config build indefinitely (F7).
+        try:
+            infos = socket.getaddrinfo(host, None, socket.AF_UNSPEC)
+        except (socket.gaierror, OSError):
+            return
+        for info in infos:
+            if prefer_ipv6 and info[0] == socket.AF_INET6:
+                resolved.append(info[4][0])
+                return
+            if not prefer_ipv6 and info[0] == socket.AF_INET:
+                resolved.append(info[4][0])
+                return
+        if infos:
+            resolved.append(infos[0][4][0])
+
+    worker = threading.Thread(target=_resolve, name=f"dns-{host}", daemon=True)
+    worker.start()
+    worker.join(timeout=5.0)
+    if resolved:
+        return resolved[0]
+    # Bounded DNS failed (timeout/unresolvable): pass the hostname through and
+    # let sing-box's own resolver deal with it (previous gaierror behavior).
+    return host
+
+
+def _bad_endpoint(endpoint: str) -> None:
+    raise SystemExit(f"bad Endpoint '{endpoint}' (expected host:port or [v6]:port)")
+
+
+def parse_endpoint(endpoint: str) -> tuple[str, str]:
+    """Split a WireGuard ``host:port`` (or ``[v6]:port``) Endpoint into
+    (host, port) without breaking on IPv6 colons."""
+    endpoint = endpoint.strip()
+    if endpoint.startswith("["):
+        host, _, rest = endpoint[1:].partition("]")
+        port = rest.lstrip(":")
+    else:
+        host, sep, port = endpoint.rpartition(":")
+        if not sep:
+            _bad_endpoint(endpoint)
+    if not host or not port:
+        _bad_endpoint(endpoint)
+    port_number = 0
+    try:
+        port_number = int(port)
+    except ValueError:
+        _bad_endpoint(endpoint)
+    if not 1 <= port_number <= 65535:
+        _bad_endpoint(endpoint)
+    return host, str(port_number)
+
+
+def parse_wireguard(profile: Path) -> dict:
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read(profile)
+    interface, peer = parser["Interface"], parser["Peer"]
+    host, port = parse_endpoint(peer["Endpoint"].strip())
+    host = resolve_host(host)
+    allowed_ips = [a.strip() for a in re.split(r"[,\s]+", peer.get("AllowedIPs", "").strip()) if a]
+    if not allowed_ips:
+        raise SystemExit(f"missing AllowedIPs in {profile.name}")
+    endpoint = {
+        "type": "wireguard",
+        "tag": "",  # set by caller to the provider name
+        "address": [a.strip() for a in re.split(r"[,\s]+", interface["Address"].strip()) if a],
+        "private_key": interface["PrivateKey"].strip(),
+        "peers": [{"address": host.strip(), "port": int(port), "public_key": peer["PublicKey"].strip(), "allowed_ips": allowed_ips}],
+    }
+    if peer.get("PresharedKey", "").strip():
+        endpoint["peers"][0]["pre_shared_key"] = peer["PresharedKey"].strip()
+    if peer.get("PersistentKeepalive", "").strip():
+        endpoint["peers"][0]["persistent_keepalive_interval"] = int(peer["PersistentKeepalive"].strip())
+    if interface.get("MTU", "").strip():
+        endpoint["mtu"] = int(interface["MTU"].strip())
+    return endpoint
+
+
+def dns_server_for(profile: Path) -> str:
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read(profile)
+    dns = parser.get("Interface", "DNS", fallback="").strip()
+    if dns:
+        dns = re.split(r"[,\s]+", dns)[0]
+    # Proton's private tunnel resolver intermittently blackholes DNS on macOS
+    # (10.2.0.1 / 2a07:b944::). Resolve through Cloudflare DNS over the same
+    # WireGuard endpoint instead; the destination traffic remains provider-routed.
+    if dns.startswith("10.") or dns.lower().startswith("2a07:b944:"):
+        return "1.1.1.1"
+    return dns or "1.1.1.1"
+
+
+_DNS_STRATEGIES = ("ipv4_only", "ipv6_only", "ipv4_prefer", "ipv6_prefer")
+
+
+def dns_strategy() -> str:
+    """Address-family strategy for DNS resolution of domain *destinations*.
+
+    Defaults to ``ipv4_only`` because the WireGuard tunnels this router builds
+    carry only the IPv4 addresses assigned in each profile (e.g. 10.2.0.2/32).
+    Tunable per-machine with ``vpn.dns_strategy`` in router.json (see
+    resolve_host for why peer endpoints are handled separately, M10).
+    """
+    strategy = _vpn.get("dns_strategy", "ipv4_only")
+    if strategy not in _DNS_STRATEGIES:
+        return "ipv4_only"
+    return strategy
+
+
+def dns_transport() -> str:
+    """DNS server transport for provider-pinned resolution.
+
+    Some networks drop UDP 53 to external resolvers (captive-portal/school
+    firewalls) while allowing DoH (TCP 443). ``vpn.dns_transport`` switches
+    the generated ``dns-<provider>`` servers between ``udp`` (default) and
+    ``https`` (DoH, 1.1.1.1) so tunneled domains still resolve there.
+    """
+    transport = _vpn.get("dns_transport", "udp")
+    if transport not in ("udp", "https"):
+        return "udp"
+    return transport
+
+
+def build_singbox_config(active_overrides: dict[str, Path] | None = None) -> tuple[dict, dict[str, Path]]:
+    active: dict[str, dict] = {}
+    selected: dict[str, Path] = {}
+    dns_map: dict[str, str] = {}
+    for name in _providers:
+        preferred = active_overrides.get(name) if active_overrides else None
+        profile = _usable_profile(name, preferred=preferred)
+        if profile is None:
+            continue
+        try:
+            endpoint = parse_wireguard(profile)
+            dns_map[name] = dns_server_for(profile)
+        except (SystemExit, KeyError, ValueError, configparser.Error, OSError) as exc:
+            # Defensive: _usable_profile already validated, but a file changed
+            # between the check and the build must never kill the config.
+            print(f"router: skipping bad profile {profile.name} for '{name}': {exc}", file=sys.stderr)
+            continue
+        endpoint["tag"] = name
+        # sing-box 1.12+: provider endpoint routed through this endpoint is
+        # resolved with an explicit per-endpoint resolver instead of the
+        # deprecated implicit DNS rule path. DialerOptions is embedded flat.
+        endpoint["domain_resolver"] = f"dns-{name}"
+        active[name] = endpoint
+        selected[name] = profile
+
+    # DNS resolution must NOT ride the tunnel: a WireGuard blip would then
+    # take down resolution for the very request we're trying to route, which
+    # surfaces as "Connection error" storms upstream. DNS queries go out the
+    # direct physical path (no detour; sing-box 1.13 rejects detouring a DNS
+    # server to the "direct" outbound with "empty direct outbound" at start).
+    # The resolved IP still gets dialed through the provider's endpoint
+    # outbound, so the destination traffic stays provider-routed.
+    dns_servers = [
+        {
+            "type": dns_transport(),
+            "tag": f"dns-{name}",
+            "server": dns_map[name],
+            **({"server_port": 443} if dns_transport() == "https" else {}),
+        }
+        for name in active
+    ]
+    # sing-box 1.12+: any dial without an explicit resolver needs
+    # route.default_domain_resolver; the system (local) transport keeps
+    # non-routed domains away from the tunnels and silences the deprecated
+    # implicit fallback. Route DNS rules still pin tunneled domains to the
+    # provider's own server.
+    dns_servers.append({"type": "local", "tag": "dns-local"})
+    routing = routing_state()
+    routing_mode = routing["mode"]
+    dns_rules = []
+    if routing_mode == "safe-list" and routing["direct_domains"]:
+        # Safe-list: trusted domains go DIRECT, so their DNS must resolve via
+        # the local resolver, never a provider's DNS server - pinning them to
+        # a provider resolver would leak direct traffic's DNS through the
+        # tunnel. The rule comes first so a domain listed both here and in a
+        # provider route always wins the direct resolver.
+        dns_rules.append({"domain_suffix": list(routing["direct_domains"]), "server": "dns-local"})
+    vpn_domains = frozenset(routing["vpn_domains"])
+    for route in _routes:
+        if route["provider"] not in active or not route.get("domains"):
+            continue
+        domains = route["domains"]
+        if routing_mode == "vpn-list":
+            domains = [
+                domain for domain in domains
+                if any(domain == vpn or domain.endswith("." + vpn) for vpn in vpn_domains)
+            ]
+        if domains:
+            dns_rules.append({"domain_suffix": domains, "server": f"dns-{route['provider']}"})
+
+    # Route rules: safe-list direct-domain pins first (a trusted domain is
+    # never tunneled even if a provider route also mentions it), then the
+    # per-domain provider routes, then the loopback/localhost pins. With no
+    # routing section (default mode) direct_pins is empty and the rule list
+    # is byte-identical to the pre-routing-modes output.
+    provider_rules = []
+    for route in _routes:
+        if route["provider"] not in active:
+            continue
+        rule = {"outbound": route["provider"]}
+        if route.get("domains"):
+            domains = route["domains"]
+            if routing_mode == "vpn-list":
+                domains = [
+                    domain for domain in domains
+                    if any(domain == vpn or domain.endswith("." + vpn) for vpn in vpn_domains)
+                ]
+            if domains:
+                rule["domain_suffix"] = domains
+            elif not route.get("ip_cidr"):
+                continue
+        if route.get("ip_cidr"):
+            if routing_mode == "vpn-list":
+                continue
+            rule["ip_cidr"] = route["ip_cidr"]
+        provider_rules.append(rule)
+    direct_pins: list[dict] = []
+    if routing_mode == "safe-list" and routing["direct_domains"]:
+        direct_pins.append({"domain_suffix": list(routing["direct_domains"]), "outbound": "direct"})
+    rules = direct_pins + provider_rules + [
+        {"domain": ["localhost"], "outbound": "direct"},
+        {"ip_cidr": ["127.0.0.0/8", "::1/128"], "outbound": "direct"},
+    ]
+
+    mode = current_mode()
+    rule_sets: list[dict] = []
+    if mode == "tun":
+        tun: dict = {
+            "type": "tun",
+            "tag": "tun-in",
+            "address": _vpn.get("address", DEFAULT_TUN_ADDRESS),
+            "mtu": int(_vpn.get("mtu", DEFAULT_TUN_MTU)),
+            "stack": _vpn.get("stack", DEFAULT_TUN_STACK),
+            "strict_route": False,
+        }
+        # Selective TUN: sing-box installs only the routes from
+        # ``route_address_set`` while leaving unmatched destinations on the
+        # OS route table. ``auto_route`` must remain enabled on macOS; the
+        # selective address-set is what prevents a default-route detour.
+        selective = _vpn.get("selective")
+        rule_sets: list[dict] = []
+        if selective:
+            if not isinstance(selective, str) or not _PROVIDER_NAME.fullmatch(selective):
+                raise SystemExit("selective tun: name must contain only letters, digits, dots, underscores, or hyphens")
+            ruleset_path = ROOT / "rulesets" / f"{selective}.json"
+            try:
+                selective_data = json.loads(ruleset_path.read_text())
+            except FileNotFoundError:
+                raise SystemExit(f"selective tun: missing ruleset {ruleset_path}") from None
+            except (OSError, json.JSONDecodeError) as exc:
+                raise SystemExit(f"selective tun: could not read {ruleset_path}: {exc}") from None
+            if not isinstance(selective_data, dict) or not isinstance(selective_data.get("ip_cidr"), list):
+                raise SystemExit(f"selective tun: {ruleset_path} needs an ip_cidr string list")
+            cidrs = selective_data["ip_cidr"]
+            if not cidrs or not all(isinstance(cidr, str) and cidr for cidr in cidrs):
+                raise SystemExit(f"selective tun: {ruleset_path} has no valid ip_cidr entries")
+            provider = selective_data.get("provider", _vpn.get("selective_provider", "cloudflare"))
+            if provider not in active:
+                raise SystemExit(f"selective tun: provider '{provider}' has no active profile")
+            tag = f"ruleset-{selective}"
+            rule_sets.append({
+                "type": "inline",
+                "tag": tag,
+                "rules": [{"ip_cidr": cidrs}],
+            })
+            tun["auto_route"] = True
+            tun["route_address_set"] = [tag]
+            # Once a matching packet enters the TUN, send it through the
+            # selected provider. The TUN field only controls OS capture.
+            rules.insert(0, {"rule_set": [tag], "outbound": provider})
+        else:
+            tun["auto_route"] = True
+        inbounds = [tun]
+        route_final = "direct"
+        # In tun mode the OS resolver's queries enter the tunnel; hijack them
+        # into sing-box's DNS module so dns.rules still pin routed domains to
+        # the provider's own resolver instead of leaking through the physical
+        # network. The hijack must come FIRST (before the domain/outbound
+        # rules): routes match DNS queries too, and a query sent to 'proton'
+        # outbound would bypass dns.rules. hijack-dns is a rule action added
+        # in sing-box 1.12 (confirmed against the 1.12 binary), so the tun
+        # config needs the same 1.12 minimum as proxy mode.
+        rules.insert(0, {"protocol": "dns", "action": "hijack-dns"})
+    else:
+        inbounds = [{"type": "mixed", "tag": "local-proxy", "listen": "127.0.0.1", "listen_port": _port}]
+        route_final = "direct"
+
+    if routing_mode == "safe-list":
+        # route.final must be a live outbound tag: everything not pinned
+        # direct rides the default provider. Fail the build with a precise
+        # error when that provider has no active profile - never emit a
+        # dangling final.
+        default_provider = routing["default_provider"]
+        if default_provider not in active:
+            raise SystemExit(
+                f"routing mode 'safe-list': default_provider '{default_provider}' has no active profile; "
+                "cannot emit a dangling route.final (drop *.conf into providers/<name>/ first)"
+            )
+        route_final = default_provider
+
+    config = {
+        "log": {"level": "info"},
+        "inbounds": inbounds,
+        "endpoints": list(active.values()),
+        "outbounds": [{"type": "direct", "tag": "direct"}],
+        "dns": {"servers": dns_servers, "rules": dns_rules, "strategy": dns_strategy()},
+        "route": {
+            "auto_detect_interface": True,
+            "default_domain_resolver": "dns-local",
+            "rules": rules,
+            "rule_set": rule_sets,
+            "final": route_final,
+        },
+    }
+    return config, selected
+
+
+def write_sing_box(config: dict) -> None:
+    SING_BOX_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=SING_BOX_CONFIG.parent,
+            prefix=f".{SING_BOX_CONFIG.name}.", suffix=".tmp", delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(json.dumps(config, indent=2) + "\n")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, SING_BOX_CONFIG)
+        temporary = None
+        os.chmod(SING_BOX_CONFIG, 0o600)
+        _hand_back_ownership(SING_BOX_CONFIG)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def validate_config() -> bool:
+    sing_box = resolve_sing_box()
+    if sing_box is None:
+        print(_sing_box_missing_message(), file=sys.stderr)
+        return False
+    try:
+        result = subprocess.run(
+            [sing_box, "check", "-c", str(SING_BOX_CONFIG)],
+            capture_output=True, text=True, timeout=20,
+        )
+    except subprocess.TimeoutExpired:
+        print("router: sing-box config check timed out", file=sys.stderr)
+        return False
+    except OSError as exc:
+        print(f"router: could not run sing-box config check: {exc}", file=sys.stderr)
+        return False
+    if result.returncode == 0:
+        return True
+    print(result.stderr or result.stdout, file=sys.stderr)
+    return False
+
+
+def write_last_good() -> None:
+    """Snapshot the current generated config as ``sing-box.json.last-good``.
+
+    Only called after the engine demonstrably came up with a freshly built +
+    validated config, so last-good is always a config the engine HAS RUN (a
+    config that fails validation/start is never snapshotted). Atomic write,
+    mode 0600, same as every other config write."""
+    try:
+        content = SING_BOX_CONFIG.read_text()
+    except OSError:
+        return
+    _atomic_write(LAST_GOOD_FILE, content, 0o600)
+
+
+def restore_last_good() -> int:
+    """Restore ``sing-box.json.last-good`` and get the engine back up on it.
+
+    Called when a freshly generated config fails validation or the engine
+    fails to come up after it was written. One bounded restore, never a
+    loop: a missing last-good, or a last-good that also fails validation or
+    refuses to start, fails with a clear message."""
+    if not LAST_GOOD_FILE.is_file():
+        return fail(f"no {LAST_GOOD_FILE.name} to restore; leaving the engine alone")
+    try:
+        content = LAST_GOOD_FILE.read_text()
+    except OSError as exc:
+        return fail(f"could not read {LAST_GOOD_FILE.name}: {exc}")
+    _atomic_write(SING_BOX_CONFIG, content, 0o600)
+    if not validate_config():
+        return fail(f"restored {LAST_GOOD_FILE.name} failed sing-box check; engine not started")
+    pid = None
+    try:
+        if PID_FILE.is_file():
+            pid = int(PID_FILE.read_text().strip())
+    except (ValueError, OSError):
+        pid = None
+    if pid is not None and _pid_matches(pid):
+        reload_log_from = log_offset()
+        try:
+            os.kill(pid, signal.SIGHUP)  # hot-reload the restored config in place
+        except PermissionError:
+            print("router: engine runs as root (started via sudo); restored config will apply on the next sudo start", file=sys.stderr)
+            return 1
+        except ProcessLookupError:
+            return engine_start(use_existing_config=True)
+        if wait_engine(2.0, log_from=reload_log_from):
+            return 0
+    print("router: starting engine with the restored last-good config", file=sys.stderr)
+    return engine_start(use_existing_config=True)
+
+
+def listener_up() -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex(("127.0.0.1", _port)) == 0
+
+
+def _any_our_engine_running() -> bool:
+    """True when ANY sing-box process is running with our generated config
+    path in its command line.
+
+    Used when the pid file itself is unreadable (root-owned after a
+    `sudo vpn on`): same identity check as ``_pid_matches``, minus the pid."""
+    try:
+        if os.name == "nt":
+            out = subprocess.run(
+                ["powershell", "-NoProfile", "-Command",
+                 "(Get-CimInstance Win32_Process -Filter \"Name='sing-box.exe'\").CommandLine"],
+                capture_output=True, text=True, timeout=5,
+            ).stdout
+            if out:
+                return str(SING_BOX_CONFIG) in out
+            out = subprocess.run(
+                ["tasklist", "/FI", "IMAGENAME eq sing-box.exe", "/FO", "CSV", "/NH"],
+                capture_output=True, text=True, timeout=3,
+            ).stdout
+            return "sing-box" in out.lower()
+        out = subprocess.run(
+            ["ps", "-ax", "-o", "command="],
+            capture_output=True, text=True, timeout=3,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return f"sing-box run" in out and str(SING_BOX_CONFIG) in out
+
+
+def _pid_matches(pid: int) -> bool:
+    """True when PID is a sing-box we launched (cmdline contains our config,
+    so a recycled/foreign PID with the same number can never be killed)."""
+    try:
+        if os.name == "nt":
+            # tasklist only names the process, so any sing-box.exe with a
+            # recycled PID would pass; read the real command line first and
+            # require our generated config path in it (H3).
+            try:
+                out = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command",
+                     f"(Get-CimInstance Win32_Process -Filter \"ProcessId={pid}\").CommandLine"],
+                    capture_output=True, text=True, timeout=5,
+                ).stdout
+            except (OSError, subprocess.TimeoutExpired):
+                out = ""
+            if out:
+                return "sing-box" in out.lower() and str(SING_BOX_CONFIG) in out
+            out = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+                capture_output=True, text=True, timeout=3,
+            ).stdout
+            return "sing-box" in out.lower()
+        out = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=3,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return f"sing-box run" in out and str(SING_BOX_CONFIG) in out
+
+
+def engine_alive() -> bool:
+    """True when a sing-box started by us is still running (tun mode has no
+    TCP listener to probe, so process liveness is the health check). Also
+    refuses foreign/recycled PIDs so a stale pid file can't claim liveness."""
+    if not PID_FILE.is_file():
+        return False
+    try:
+        pid = int(PID_FILE.read_text().strip())
+    except PermissionError:
+        # Root-owned pid file (started via `sudo vpn on`): cannot read the
+        # pid, but liveness is verifiable from the process table; declaring
+        # the engine dead here churns a doomed regular-user restart that
+        # clobbers the pid file.
+        return _any_our_engine_running()
+    except (ValueError, OSError):
+        return False
+    if not _pid_matches(pid):
+        return False
+    trim_live_log_if_needed()
+    try:
+        if os.name == "nt":
+            out = subprocess.run(["tasklist", "/FI", f"PID eq {pid}"], capture_output=True, text=True, timeout=3).stdout
+            return str(pid) in out
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        # Engine started via `sudo vpn on` runs as root: we may not probe
+        # it, but the pid file is ours and the process exists, so it is our
+        # engine (H3 foreign-PID check still holds — a recycled foreign pid
+        # file would never have been written by us).
+        return True
+    except (ProcessLookupError, ValueError, OSError):
+        return False
+
+
+def engine_mode_consistent() -> bool:
+    """True when the running engine's config actually matches current_mode.
+
+    Prevents the H2 false-positive: a proxy-mode engine running while
+    state/mode says 'tun' (or vice versa) is NOT the state we claim."""
+    if not SING_BOX_CONFIG.is_file():
+        return False
+    try:
+        config = json.loads(SING_BOX_CONFIG.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    inbounds = config.get("inbounds", [])
+    if current_mode() == "tun":
+        return any(i.get("type") == "tun" for i in inbounds)
+    return any(i.get("type") in ("mixed", "socks", "http") for i in inbounds)
+
+
+def log_offset() -> int:
+    try:
+        return LOG_FILE.stat().st_size
+    except OSError:
+        return 0
+
+
+def log_has_fatal(after: int) -> bool:
+    """True when sing-box.log contains a FATAL line after byte offset ``after``.
+
+    tun mode fails fast with 'FATAL ... operation not permitted' when it lacks
+    root/wintun; the process can be alive for a few ms before dying, so the
+    log is the only reliable failure signal within the settle window."""
+    try:
+        with LOG_FILE.open("rb") as fh:
+            fh.seek(after)
+            tail = fh.read(64 * 1024).decode("utf-8", "replace")
+    except OSError:
+        return False
+    return "FATAL" in tail or "fatal" in tail
+
+
+def wait_engine(timeout: float = 8.0, log_from: int = 0) -> bool:
+    """Mode-aware readiness: the engine must come up AND survive a settle
+    window without a FATAL in the log.
+
+    - proxy mode is ready when OUR process listens (engine_alive + the
+      listener probe): a foreign process answering on the port while our
+      sing-box dies on `bind: address already in use` is NOT a healthy
+      start (H2).
+    - tun mode is ready when OUR process survives the launch window
+      (interface setup has no socket to poll, and a broken tun dies
+      instantly with FATAL - no root / no wintun.dll).
+
+    Either way the first "up" poll just opens a 0.5s settle window instead of
+    returning immediately, because sing-box can emit its FATAL a moment after
+    the first successful poll (e.g. bind conflict or interface setup)."""
+    deadline = time.time() + timeout
+    first = True
+    while time.time() < deadline:
+        if log_has_fatal(log_from):
+            return False
+        if current_mode() == "tun":
+            ok = engine_alive() and engine_mode_consistent()
+        else:
+            ok = listener_up() and engine_alive()
+        if ok:
+            if first:
+                first = False
+                time.sleep(0.5)
+                continue
+            if not log_has_fatal(log_from):
+                return True
+        time.sleep(0.2)
+    return False
+
+
+def wait_listener(timeout: float = 8.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if listener_up():
+            return True
+        time.sleep(0.2)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# engine lifecycle
+# ---------------------------------------------------------------------------
+
+def route_watcher_start() -> None:
+    """Start the independent routed-connection watcher best-effort."""
+    if current_mode() == "tun":
+        route_watcher_stop()
+        return
+    try:
+        import route_watcher
+
+        result = route_watcher.start(ROOT)
+        if result.get("error"):
+            print(f"router: route watcher unavailable: {result['error']}", file=sys.stderr)
+    except Exception as exc:  # watcher failure must not take down the proxy
+        print(f"router: route watcher unavailable: {type(exc).__name__}", file=sys.stderr)
+
+
+def route_watcher_stop() -> None:
+    """Stop only our watcher; never signal arbitrary processes."""
+    try:
+        import route_watcher
+
+        route_watcher.stop(ROOT)
+    except Exception as exc:
+        print(f"router: route watcher stop warning: {type(exc).__name__}", file=sys.stderr)
+
+
+def rotate_log_if_needed() -> None:
+    """Archive an oversized sing-box.log to sing-box.log.1 (mirrors monitor.py's
+    samples rotation). Called from engine_start only, when no engine holds the
+    log fd."""
+    try:
+        if LOG_FILE.stat().st_size < LOG_MAX_BYTES:
+            os.chmod(LOG_FILE, 0o600)
+            return
+    except OSError:
+        return
+    archive = Path(str(LOG_FILE) + ".1")
+    archive.unlink(missing_ok=True)
+    try:
+        LOG_FILE.rename(archive)
+        os.chmod(archive, 0o600)
+    except OSError:
+        pass
+    try:
+        os.chmod(LOG_FILE, 0o600)
+    except OSError:
+        pass
+
+
+def trim_live_log_if_needed() -> None:
+    """Bound a live log without renaming the inode sing-box has open."""
+    try:
+        if LOG_FILE.stat().st_size < LOG_MAX_BYTES:
+            os.chmod(LOG_FILE, 0o600)
+            return
+        keep = LOG_MAX_BYTES - 256
+        with LOG_FILE.open("r+b") as handle:
+            handle.seek(-keep, os.SEEK_END)
+            tail = handle.read()
+            handle.seek(0)
+            handle.write(b"router: log trimmed; older entries archived by size\n")
+            handle.write(tail)
+            handle.truncate()
+        os.chmod(LOG_FILE, 0o600)
+    except (OSError, ValueError):
+        pass
+
+
+def engine_start(use_existing_config: bool = False, *, recover: bool = True) -> int:
+    sing_box = resolve_sing_box()
+    if sing_box is None:
+        return fail(_sing_box_missing_message())
+    if not sing_box_at_least(MIN_SING_BOX_VERSION):
+        return fail(f"{_sing_box_version_message(MIN_SING_BOX_VERSION)}")
+    active: dict[str, Path] = {}
+    if use_existing_config:
+        # restore_last_good path: boot the sing-box.json file as it now
+        # stands (already validated + written from last-good), without
+        # regenerating it from router.json/profiles (which produced the
+        # config that just failed).
+        if not SING_BOX_CONFIG.is_file():
+            return fail(f"no {SING_BOX_CONFIG.name} to start (use_existing_config)")
+    else:
+        try:
+            config, active = build_singbox_config()
+        except (SystemExit, KeyError, ValueError, OSError, configparser.Error) as exc:
+            return fail(f"could not build sing-box config: {exc}")
+        if not active:
+            return fail("no provider profile available (drop *.conf into providers/<name>/)")
+        write_sing_box(config)
+        if not validate_config():
+            if LAST_GOOD_FILE.is_file():
+                print("router: generated config failed validation; restoring last-good", file=sys.stderr)
+                return restore_last_good()
+            return fail("sing-box config check failed")
+    stop_rc = engine_stop()
+    if stop_rc != 0:
+        # The engine is root-owned (started via `sudo vpn on`) and could not
+        # be stopped: starting a second engine would clobber the pid file and
+        # strand the live root engine untracked.
+        return stop_rc
+    # Only rotate here, with the old engine already stopped: renaming a live
+    # engine's log would detach its (still open) fd and growth would continue
+    # invisibly instead of being bounded.
+    rotate_log_if_needed()
+    log_handle = None
+    try:
+        log_handle = LOG_FILE.open("ab")
+        popen_kwargs = {"stdout": log_handle, "stderr": subprocess.STDOUT, "cwd": ROOT}
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+        process = subprocess.Popen([sing_box, "run", "-c", str(SING_BOX_CONFIG)], **popen_kwargs)
+    except OSError as exc:
+        if recover and not use_existing_config and LAST_GOOD_FILE.is_file():
+            print("router: could not start generated config; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return fail(f"could not start sing-box: {exc}")
+    finally:
+        if log_handle is not None:
+            log_handle.close()
+    PID_FILE.write_text(str(process.pid))
+    os.chmod(PID_FILE, 0o600)
+    _hand_back_ownership(PID_FILE)
+    if not wait_engine(log_from=log_offset()):
+        engine_stop()
+        if recover and not use_existing_config and LAST_GOOD_FILE.is_file():
+            print("router: generated config failed to come up; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return fail("sing-box failed to come up")
+    if not use_existing_config:
+        # The engine demonstrably runs this config: snapshot it as last-good
+        # (a later failed reload/start can restore from it) and persist the
+        # exact profile selection that was actually launched.
+        write_last_good()
+        for provider, profile in active.items():
+            set_active(provider, profile)
+    else:
+        # A last-good restore is also allowed to repair stale marker state.
+        for provider in _providers:
+            live = configured_profile(provider)
+            if live is not None:
+                set_active(provider, live)
+    return 0
+
+
+def engine_ensure() -> int:
+    if MANUAL_OFF_FILE.is_file():
+        # The user disconnected manually (tray Disconnect / `router.py
+        # stop`). keepalive.sh also skips its ensure tick while the marker
+        # exists, but a stray direct `router.py ensure` must not resurrect
+        # the engine either.
+        print("router: manually disconnected (manual-off marker present); "
+              "run 'router.py start' to reconnect", file=sys.stderr)
+        return 0
+    if current_mode() == "tun":
+        # A proxy engine running while state/mode says tun is NOT healthy
+        # (status/vpn status report it as down); restart into the persisted
+        # mode instead of declaring victory (M13).
+        if engine_alive() and engine_mode_consistent():
+            return 0
+        return engine_start()
+    # Proxy mode: only a listener owned by OUR engine is "up". A foreign
+    # process answering the port while our pid is dead/mismatched is NOT
+    # healthy (F1): start the engine instead of declaring victory.
+    if listener_up() and engine_alive():
+        return 0
+    return engine_start()
+
+
+def engine_stop() -> int:
+    if PID_FILE.is_file():
+        try:
+            pid = int(PID_FILE.read_text().strip())
+        except PermissionError:
+            # Root-owned pid file (started via `sudo vpn on`): the engine may
+            # be alive; keep the pid file and fail loudly (mirror of the kill
+            # PermissionError below) instead of unlinking a live engine's pid
+            # as "garbage" (H6).
+            print("router: engine runs as root (started via sudo); stop it with `sudo python3 router.py vpn off`", file=sys.stderr)
+            return 1
+        except (ValueError, OSError):
+            # Garbage pid file (H6): treat as stale, clean it up, carry on.
+            PID_FILE.unlink(missing_ok=True)
+            return 0
+        if not _pid_matches(pid):
+            # Foreign/recycled PID (H3): never signal a process we don't own.
+            # Remove the stale pid file so a later start can proceed.
+            PID_FILE.unlink(missing_ok=True)
+            return 0
+        try:
+            if os.name == "nt":
+                # taskkill /T /F is a hard kill (TerminateProcess on the whole
+                # tree); the process may already be gone, so ignore its exit code.
+                subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], capture_output=True)
+            else:
+                os.kill(pid, signal.SIGTERM)
+                time.sleep(0.4)
+                os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, ValueError):
+            pass
+        except PermissionError:
+            # Engine was started via `sudo vpn on` and runs as root; a
+            # regular-user stop cannot signal it. Keep the pid file (the
+            # engine IS alive) and tell the user to stop with sudo.
+            print("router: engine runs as root (started via sudo); stop it with `sudo python3 router.py vpn off`", file=sys.stderr)
+            return 1
+        PID_FILE.unlink(missing_ok=True)
+    return 0
+
+
+def engine_reload(active_overrides: dict[str, Path] | None = None) -> int:
+    sing_box = resolve_sing_box()
+    if sing_box is None:
+        return fail(_sing_box_missing_message())
+    if not sing_box_at_least(MIN_SING_BOX_VERSION):
+        return fail(f"{_sing_box_version_message(MIN_SING_BOX_VERSION)}")
+    try:
+        config, active = build_singbox_config(active_overrides)
+    except (SystemExit, KeyError, ValueError, OSError, configparser.Error) as exc:
+        # Nothing was written or reloaded, so the running engine keeps its
+        # old in-memory config; fail cleanly (no last-good restore needed).
+        return fail(f"could not build sing-box config: {exc}")
+    if not active:
+        return fail("no provider endpoint available")
+    write_sing_box(config)
+    if not validate_config():
+        # The bad config is already on disk; restore the last known-good one
+        # so a crash/restart can never boot it (F2: bad generated config must
+        # not leave the proxy dead while a known-good config exists).
+        print("router: new sing-box config failed validation; restoring last-good", file=sys.stderr)
+        return restore_last_good()
+    if not PID_FILE.is_file():
+        if engine_start(recover=False) != 0:
+            print("router: engine failed to start with new config; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return 0
+    try:
+        pid = int(PID_FILE.read_text().strip())
+    except (ValueError, OSError):
+        PID_FILE.unlink(missing_ok=True)
+        if engine_start(recover=False) != 0:
+            print("router: engine failed to start with new config; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return 0
+    if not _pid_matches(pid):
+        PID_FILE.unlink(missing_ok=True)
+        if engine_start(recover=False) != 0:
+            print("router: engine failed to start with new config; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return 0
+    if os.name == "nt":
+        # Windows has no SIGHUP; stop+start applies the fresh config.
+        if engine_stop() != 0:
+            return fail("engine stop failed during reload")
+        if engine_start(recover=False) != 0:
+            print("router: engine failed to start with new config; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return 0
+    reload_log_from = log_offset()
+    try:
+        os.kill(pid, signal.SIGHUP)  # SIGHUP: sing-box hot-reloads the config in place
+    except PermissionError:
+        return fail("engine runs as root (started via sudo); reload it with `sudo python3 router.py reload`")
+    except ProcessLookupError:
+        if engine_start(recover=False) != 0:
+            print("router: engine failed to start with new config; restoring last-good", file=sys.stderr)
+            return restore_last_good()
+        return 0
+    if wait_engine(2.0, log_from=reload_log_from):
+        # The new config demonstrably runs: snapshot it as last-good.
+        write_last_good()
+        return 0
+    # SIGHUP did not come up cleanly; try a full (re)start of the new config
+    # before giving up and restoring last-good.
+    print("router: engine did not come up after SIGHUP; trying a full start", file=sys.stderr)
+    if engine_start(recover=False) != 0:
+        print("router: engine failed to start with new config; restoring last-good", file=sys.stderr)
+        return restore_last_good()
+    return 0
+
+
+def rotate(name: str, *, reason: str | None = None, force: bool = False, probe: bool = True,
+           to: str | None = None) -> int:
+    """Switch to the next healthy profile for ``name``.
+
+    - Egress-aware selection: cooled-down profiles are skipped as before, and
+      blocked exits (Cloudflare 1010/403) too unless ``force``; the remaining
+      candidates are ranked so recently-OK, lower-latency exits are preferred
+      over unknown ones and known-failing ones.
+    - ``reason`` (rotate --reason): the CURRENT profile just failed upstream;
+      it gets a longer cooldown + recorded reason (and a blocked marker for
+      reputation-block reasons) so the next rotation prefers a different exit.
+    - ``to`` (rotate --to PROFILE): switch to this exact exit instead of the
+      ranked next one (used by the tray provider picker). The profile must
+      exist and parse; blocked exits are honored unless ``force``, so a manual
+      pick can still be refused when the exit is reputation-blocked.
+    - Last-good rollback: after switching, the new exit is probed through the
+      tunnel (proxy mode); if it fails to come up cleanly, the previous good
+      profile is restored.
+    """
+    profiles = provider_files(name)
+    if not profiles:
+        return fail(f"provider '{name}' has no profiles")
+    # Keep only parseable profiles so one bad *.conf cannot wedge rotation
+    # (F6); log every skipped filename (F2).
+    valid: list[Path] = []
+    for profile in profiles:
+        error = _profile_error(profile)
+        if error is not None:
+            print(f"router: skipping bad profile {profile.name} of '{name}': {error}", file=sys.stderr)
+            continue
+        valid.append(profile)
+    if not valid:
+        return fail(f"provider '{name}' has no valid profiles (all *.conf are malformed)")
+    try:
+        seconds = int(_providers.get(name, {}).get("cooldown_seconds", 60))
+    except (TypeError, ValueError):
+        return fail(f"provider '{name}': cooldown_seconds must be an integer")
+    current = persisted_active(name) or resolve_active(name)
+    chosen = None
+    if to is not None:
+        chosen = next((p for p in valid if p.stem == to), None)
+        if chosen is None:
+            return fail(f"provider '{name}': no valid profile named '{to}' (have {', '.join(p.stem for p in valid)})")
+        # Re-selecting the already-active exit is a no-op. It must NOT
+        # cooldown the current profile or fail on its own cooldown state
+        # -- the old code marked the current exit cooling, then refused
+        # the pick with "exit is cooling down", a nonsense error for a
+        # click that should just confirm "already on it".
+        if not force and chosen == current:
+            print(f"already on {name} -> {chosen.stem}")
+            return 0
+    if reason is not None:
+        _apply_upstream_failure(name, current, reason, seconds)
+    elif current is not None and not is_cooled_down(name, current) and not force:
+        mark_cooldown(name, current, seconds)
+    if to is not None:
+        assert chosen is not None  # resolved and validated in the block above
+        if not force and egress_is_blocked(name, chosen):
+            return fail(f"provider '{name}': exit '{to}' is blocked (use 'rotate --force' to override)")
+        if not force and current is not None and is_cooled_down(name, chosen) and chosen == current:
+            mark_cooldown(name, current, seconds)  # keep the manual pick from pinning a cooling exit
+        if not force and is_cooled_down(name, chosen):
+            return fail(f"provider '{name}': exit '{to}' is cooling down (use 'rotate --force' to override)")
+    else:
+        if current in valid:
+            start = valid.index(current) + 1
+            ordered = valid[start:] + valid[:start]
+        else:
+            ordered = valid
+        if force:
+            chosen = ordered[0]
+        else:
+            cooled = [p for p in ordered if not is_cooled_down(name, p)]
+            if not cooled:
+                return fail(f"provider '{name}': all profiles cooling down")
+            unblocked = [p for p in cooled if not egress_is_blocked(name, p)]
+            if not unblocked:
+                return fail(f"provider '{name}': no unblocked profile available (use 'rotate --force' to override)")
+            chosen = min(unblocked, key=lambda p: _egress_rank(read_egress(name, p)))
+    if force:
+        clear_blocked(name, chosen)
+    previous = current
+    rc = engine_reload({name: chosen})
+    if rc != 0:
+        # The old marker remains intact, so a failed reload cannot claim the
+        # candidate is live. engine_reload restores last-good when possible.
+        return rc
+    set_active(name, chosen)
+    record_rotation(name, chosen)
+    print(f"switched {name} -> {chosen.stem}")
+    if probe and current_mode() != "proxy":
+        probe = False  # tun mode has no 127.0.0.1 listener to probe through
+    if not probe:
+        return 0
+    ok, _ = probe_profile(name, chosen)
+    if ok:
+        return 0
+    # The new exit did not come up cleanly: restore the last good profile
+    # (one bounded step, never a loop) so the listener keeps working.
+    print(f"router: egress probe failed for {chosen.stem}; restoring '{name}' to previous profile", file=sys.stderr)
+    if previous is None or previous == chosen or previous not in valid or egress_is_blocked(name, previous):
+        print("router: no usable previous profile to roll back to", file=sys.stderr)
+        return 0
+    mark_cooldown(name, chosen, max(seconds * 2, int(egress_settings()["upstream_cooldown_seconds"])))
+    if reason is None:
+        # Plain rotations cooldown the previous profile only as a mild
+        # preference; restoring it must undo that so the last-good exit is
+        # immediately usable again. A --reason rotation marks the previous
+        # profile as FAILED upstream (429/503/TLS...); its cooldown is the
+        # whole point of the mark and must survive the rollback, otherwise
+        # we ping-pong A -> B -> A -> C -> A forever, burning the pool while
+        # the tunnel keeps returning to the broken exit.
+        _clear_cooldown(name, previous)
+    rc = engine_reload({name: previous})
+    if rc == 0:
+        set_active(name, previous)
+        record_rotation(name, previous)
+        print(f"switched {name} -> {previous.stem} (rollback)")
+    return rc
+
+
+def provider_count(name: str) -> int:
+    """Number of rotation candidates for a provider (used as a retry budget by
+    hermes-opencode.sh); at least 1 so callers always attempt once."""
+    return max(1, len(provider_files(name)))
+
+
+# ---------------------------------------------------------------------------
+# route table management
+# ---------------------------------------------------------------------------
+
+def save_config() -> int:
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+        data["routes"] = _routes
+        CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=CONFIG_FILE.parent,
+                prefix=f".{CONFIG_FILE.name}.", suffix=".tmp", delete=False,
+            ) as handle:
+                temporary = Path(handle.name)
+                handle.write(json.dumps(data, indent=2) + "\n")
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, CONFIG_FILE)
+            temporary = None
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+        os.chmod(CONFIG_FILE, 0o600)
+    except (json.JSONDecodeError, OSError, TypeError) as exc:
+        return fail(f"could not save {CONFIG_FILE.name}: {exc}")
+    return 0
+
+
+def routes_list() -> int:
+    for route in _routes:
+        targets = ",".join(route.get("domains", []) + route.get("ip_cidr", []))
+        print(f"  {route['id']:<16} {targets:<52} -> {route['provider']}")
+    return 0
+
+
+def _routes_add_entry(target: str, key: str, id_: str | None, provider: str) -> tuple[str, str] | None:
+    """Add or update a route in the in-memory table.
+
+    Merges into the existing entry's list (appending unique values) instead of
+    overwriting, so ``routes add`` never drops previously configured targets
+    (F4). Returns (key, id) on success, or None when the target is empty or
+    the provider is unknown.
+    """
+    if not target or provider not in _providers:
+        return None
+    id_ = id_ or re.sub(r"[^a-z0-9-]", "-", target.lower())
+    existing = next((r for r in _routes if r.get("id") == id_), None)
+    if existing is None:
+        existing = {"id": id_, "provider": provider}
+        _routes.append(existing)
+    entries = existing.get(key)
+    if not isinstance(entries, list):
+        entries = []
+    if target not in entries:
+        entries.append(target)
+    existing[key] = entries
+    existing["provider"] = provider
+    return key, id_
+
+
+def routes_add(args) -> int:
+    # Honor BOTH --domain and --ip when provided (F4).
+    targets: list[tuple[str, str]] = []
+    if args.domain:
+        targets.append(("domains", args.domain))
+    if args.ip:
+        targets.append(("ip_cidr", args.ip))
+    if not targets:
+        return fail("need --domain or --ip")
+    if args.provider not in _providers:
+        return fail(f"unknown provider '{args.provider}' (have {', '.join(_providers)})")
+    for key, target in targets:
+        _routes_add_entry(target, key, args.id, args.provider)
+    if save_config() != 0:
+        return 1
+    if engine_reload() != 0:
+        return fail("route saved but engine reload failed")
+    routes_list()
+    return 0
+
+
+def _routes_remove_entry(id_: str) -> bool:
+    """Remove the route with the given id from the in-memory table."""
+    before = len(_routes)
+    _routes[:] = [r for r in _routes if r.get("id") != id_]
+    return len(_routes) != before
+
+
+def routes_remove(id_: str) -> int:
+    if not _routes_remove_entry(id_):
+        return fail(f"no route with id '{id_}'")
+    if save_config() != 0:
+        return 1
+    if engine_reload() != 0:
+        return fail("route removed but engine reload failed")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# routing modes (safe-list / vpn-list)
+# ---------------------------------------------------------------------------
+
+ROUTING_MODES = ("safe-list", "vpn-list")
+
+
+def routing_state() -> dict:
+    """Effective routing-mode view: ``mode`` (default|safe-list|vpn-list),
+    ``direct_domains``, ``vpn_domains``, ``default_provider``.
+
+    An absent ``routing`` section means 'default' mode (per-domain provider
+    routes, ``route.final`` = direct) - the pre-routing-modes behavior.
+    """
+    routing = _routing if isinstance(_routing, dict) else {}
+    return {
+        "mode": routing.get("mode", "default"),
+        "direct_domains": list(routing.get("direct_domains", []) or []),
+        "vpn_domains": list(routing.get("vpn_domains", []) or []),
+        "default_provider": routing.get("default_provider"),
+    }
+
+
+def _routing_error(routing: dict, known_providers: set) -> str | None:
+    """Precise error for a malformed routing section, else None.
+
+    Shared by ``load_config`` and the ``routing`` CLI writer so both paths
+    enforce exactly the same schema - malformed config fails loudly, never a
+    silent guess. ``mode`` "default" is the explicit spelling of the absent
+    (pre-existing) behavior; ``default_provider`` is only meaningful (and only
+    required/validated against known providers) in safe-list mode.
+    """
+    mode = routing.get("mode", "default")
+    if mode not in ("default", "safe-list", "vpn-list"):
+        return f"routing.mode must be 'safe-list', 'vpn-list', or absent (default); got '{mode}'"
+    for key in ("direct_domains", "vpn_domains"):
+        value = routing.get(key)
+        if value is not None and (not isinstance(value, list) or not all(isinstance(v, str) for v in value)):
+            return f"routing.{key} must be a string list"
+    default_provider = routing.get("default_provider")
+    if default_provider is not None and not isinstance(default_provider, str):
+        return "routing.default_provider must be a provider name string"
+    if mode == "safe-list":
+        if not default_provider:
+            return "routing mode 'safe-list' needs 'default_provider' (everything not on the direct list goes through it)"
+        if default_provider not in known_providers:
+            return (f"routing.default_provider '{default_provider}' is not a known provider "
+                    f"(have {', '.join(sorted(known_providers))})")
+    return None
+
+
+def _routing_mutate(routing: dict) -> int:
+    """Persist a routing section into router.json atomically (temp + replace,
+    mode 0600, same convention as every other config write) and refresh the
+    in-memory state. Never touches the engine - the operator runs
+    ensure/reload separately."""
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+        if not isinstance(data, dict):
+            return fail(f"bad {CONFIG_FILE.name}: top level must be an object")
+        data["routing"] = routing
+        _atomic_write(CONFIG_FILE, json.dumps(data, indent=2) + "\n", 0o600)
+    except (json.JSONDecodeError, OSError, TypeError) as exc:
+        return fail(f"could not save routing in {CONFIG_FILE.name}: {exc}")
+    global _routing
+    _routing = dict(routing)
+    return 0
+
+
+def _routing_print(state: dict, *, note: bool = False) -> None:
+    """Print an effective routing state: JSON on stdout (machine-readable),
+    one human summary line on stderr. ``note`` adds the no-reload reminder
+    (mutating commands only)."""
+    print(json.dumps(state, indent=2, sort_keys=True))
+    if state["mode"] == "safe-list":
+        direct = ", ".join(state["direct_domains"]) or "(none)"
+        print(f"mode safe-list: direct {direct}; everything else via {state['default_provider']}", file=sys.stderr)
+    elif state["mode"] == "vpn-list":
+        vpn = ", ".join(state["vpn_domains"]) or "(none)"
+        print(f"mode vpn-list: tunnel {vpn}; everything else direct", file=sys.stderr)
+    else:
+        print("mode default: per-domain provider routes, route.final = direct", file=sys.stderr)
+    if note:
+        print("config saved; the engine was NOT reloaded - run 'router.py ensure' (or 'router.py reload') to apply", file=sys.stderr)
+
+
+def routing_cli_show() -> int:
+    _routing_print(routing_state())
+    return 0
+
+
+def routing_cli_set(mode: str, default_provider: str | None) -> int:
+    routing = dict(_routing if isinstance(_routing, dict) else {})
+    routing["mode"] = mode
+    if default_provider is not None:
+        routing["default_provider"] = default_provider
+    error = _routing_error(routing, set(_providers))
+    if error is not None:
+        return fail(error)
+    if _routing_mutate(routing) != 0:
+        return 1
+    _routing_print(routing_state(), note=True)
+    return 0
+
+
+def routing_cli_add(mode: str, domain: str) -> int:
+    key = "direct_domains" if mode == "safe-list" else "vpn_domains"
+    routing = dict(_routing if isinstance(_routing, dict) else {})
+    entries = list(routing.get(key, []) or [])
+    if domain in entries:
+        print(f"routing: '{domain}' is already on the {key} list (no change)", file=sys.stderr)
+        _routing_print(routing_state(), note=True)
+        return 0
+    entries.append(domain)
+    routing[key] = entries
+    error = _routing_error(routing, set(_providers))
+    if error is not None:
+        return fail(error)
+    if _routing_mutate(routing) != 0:
+        return 1
+    _routing_print(routing_state(), note=True)
+    return 0
+
+
+def routing_cli_remove(mode: str, domain: str) -> int:
+    key = "direct_domains" if mode == "safe-list" else "vpn_domains"
+    routing = dict(_routing if isinstance(_routing, dict) else {})
+    entries = list(routing.get(key, []) or [])
+    if domain not in entries:
+        print(f"routing: '{domain}' is not on the {key} list (no change)", file=sys.stderr)
+        _routing_print(routing_state(), note=True)
+        return 0
+    entries.remove(domain)
+    routing[key] = entries
+    if _routing_mutate(routing) != 0:
+        return 1
+    _routing_print(routing_state(), note=True)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# VPN (TUN) toggle
+# ---------------------------------------------------------------------------
+
+def vpn_note() -> None:
+    """Per-OS caveats when switching to tun mode; prints to stderr, not an error."""
+    if current_mode() != "tun":
+        return
+    if sys.platform == "darwin":
+        print("router: tun mode on macOS needs root (create utun interface); run with sudo", file=sys.stderr)
+        print("router: tun mode on macOS is NOT a System Settings VPN entry (requires a signed NE app); it is a utun interface", file=sys.stderr)
+    elif os.name == "nt":
+        print("router: tun mode on Windows needs an elevated shell (admin) and wintun.dll next to sing-box.exe", file=sys.stderr)
+
+
+def vpn_on() -> int:
+    if current_mode() == "tun":
+        if engine_alive() and engine_mode_consistent():
+            print("vpn: tun already up")
+            # Idempotent re-entry must leave the same surface state as a
+            # fresh start: tun mode has no local listener, so the system
+            # proxy must be off (a stale proxy points at the dead port).
+            if sys.platform == "darwin":
+                system_proxy_off()
+            return 0
+        # state says tun but nothing consistent is running: reset to proxy so a
+        # failed start below can't wedge a phantom tun, then fall through.
+        set_mode("proxy")
+
+    old_mode = current_mode()
+    sing_box = resolve_sing_box()
+    if sing_box is None:
+        return fail(_sing_box_missing_message())
+    if not sing_box_at_least(MIN_SING_BOX_VERSION):
+        return fail(f"{_sing_box_version_message(MIN_SING_BOX_VERSION)}")
+
+    # Pre-flight BEFORE persisting mode (H5): build + validate the tun config
+    # with the current providers. On failure, state/mode is restored and the
+    # keepalive keeps running the proxy instead of hammering a broken tun.
+    set_mode("tun")
+    ok = False
+    try:
+        config, active = build_singbox_config()
+        if not active:
+            return fail("no provider profile available (drop *.conf into providers/<name>/)")
+        write_sing_box(config)
+        if not validate_config():
+            return fail("sing-box config check failed for tun mode")
+        ok = True
+    except SystemExit as exc:
+        return fail(str(exc) or "config build failed")
+    except Exception as exc:  # noqa: BLE001 - CLI boundary: report, don't crash
+        return fail(f"tun pre-flight failed: {exc}")
+    finally:
+        if not ok:
+            set_mode(old_mode)
+
+    vpn_note()
+    rc = engine_start()
+    if rc != 0:
+        # Engine failed to come up (e.g. no root for utun on macOS): restore
+        # the previous mode. engine_start already stopped whatever proxy was
+        # running, so bring the proxy engine back immediately instead of
+        # leaving the user without connectivity until keepalive re-arms it.
+        set_mode(old_mode)
+        if old_mode == "proxy" and not listener_up():
+            engine_start()
+        return rc
+    # Tun mode replaces the local proxy entirely: the OS routes traffic into
+    # the utun interface and no 127.0.0.1:<port> listener exists here.
+    # Leaving the macOS system proxy enabled would send the browser to a
+    # dead port ("connection was reset"), so disable it once tun is up.
+    if sys.platform == "darwin":
+        system_proxy_off()
+    return rc
+
+
+def vpn_off() -> int:
+    set_mode("proxy")
+    rc = engine_stop()
+    if rc != 0:
+        return rc
+    # Returning to proxy mode should leave the user with working connectivity
+    # (M11): start the proxy engine so 127.0.0.1:<port> answers again.
+    rc = engine_start()
+    # Back on the proxy: re-point the macOS system proxy at the listener so
+    # the browser keeps working without manual networksetup (mirror of the
+    # disable above; tun mode has no listener to point at).
+    if rc == 0 and sys.platform == "darwin":
+        system_proxy_on()
+    return rc
+
+
+def vpn_restart() -> int:
+    """Stop the current engine and bring TUN back up in a single operation.
+
+    One elevated invocation means one macOS admin-password prompt for the
+    whole cycle, instead of two with `vpn off && vpn on`."""
+    rc = engine_stop()
+    if rc != 0:
+        return rc
+    return vpn_on()
+
+
+def _status_report() -> tuple[int, str]:
+    """Single liveness check shared by `status` and `vpn status` (M13): both
+    commands must report the same up/down state and exit code so automation
+    cannot disagree with a human reading one or the other.
+
+    Returns (rc, line) with rc == 0 only when the engine is running AND its
+    generated config matches the persisted mode (tun engine for tun mode,
+    proxy listener for proxy mode); anything else is a degraded/down state
+    with rc == 1.
+    """
+    mode = current_mode()
+    if mode == "tun":
+        if engine_alive() and engine_mode_consistent():
+            return 0, "up (tun)"
+        if engine_alive():
+            return 1, "down (running engine does not match tun mode; run 'vpn on')"
+        return 1, "down (mode set to tun; run 'vpn on')"
+    if listener_up() and engine_alive():
+        return 0, "up (proxy 127.0.0.1:{})".format(_port)
+    if listener_up():
+        # F1: something answers the port but it is not our engine (stale pid
+        # file or a recycled/foreign process); never report that as up.
+        return 1, "down (foreign listener on 127.0.0.1:{}; run 'start')".format(_port)
+    return 1, "down (proxy mode; run 'vpn on' for tun, 'start' for proxy)"
+
+
+def vpn_status() -> int:
+    rc, line = _status_report()
+    print(f"vpn: {line}")
+    return rc
+
+
+def _provider_status(name: str) -> dict:
+    """Machine-readable view of one provider: profiles, active, cooldowns,
+    last rotation, and persisted egress records."""
+    profiles = [p.stem for p in provider_files(name)]
+    # Report the PERSISTED active profile (what the engine is configured with)
+    # rather than resolve_active(), which skips a cooled-down active when
+    # picking the next candidate.
+    active_profile = persisted_active(name)
+    active_stem = active_profile.stem if active_profile is not None else None
+    entry = {"profiles": profiles, "active": active_stem}
+    cooldowns = {}
+    for stem in profiles:
+        path = ROOT / "state" / "cooldowns" / name / f"{stem}.until"
+        try:
+            if path.is_file():
+                cooldowns[stem] = int(path.read_text().strip())
+        except (ValueError, OSError):
+            pass
+    if cooldowns:
+        entry["cooldown_until"] = cooldowns
+    rotation = ROOT / "state" / f"{name}.rotation"
+    try:
+        if rotation.is_file():
+            entry["last_rotation"] = json.loads(rotation.read_text())
+    except (json.JSONDecodeError, OSError):
+        pass
+    egress = {}
+    for stem in profiles:
+        record = read_egress(name, Path(stem + ".conf"))
+        if record:
+            egress[stem] = record
+    if egress:
+        entry["egress"] = egress
+    return entry
+
+
+def status_json() -> dict:
+    """Full machine-readable status for `status --json`."""
+    rc, line = _status_report()
+    data = {"up": rc == 0, "state": line, "mode": current_mode(), "port": _port}
+    try:
+        if PID_FILE.is_file():
+            data["pid"] = int(PID_FILE.read_text().strip())
+    except (ValueError, OSError):
+        pass
+    data["providers"] = {name: _provider_status(name) for name in _providers}
+    data["error_policy"] = {name: error_policy_for(name) for name in _providers}
+    data["routes"] = [{
+        "id": route.get("id"),
+        "provider": route.get("provider"),
+        "domains": route.get("domains", []),
+        "ip_cidr": route.get("ip_cidr", []),
+    } for route in _routes]
+    data["routing"] = routing_state()
+    try:
+        cfg = json.loads(CONFIG_FILE.read_text())
+        data["preset"] = cfg.get("preset")
+    except (OSError, json.JSONDecodeError):
+        data["preset"] = None
+    try:
+        import route_watcher
+
+        data["watcher"] = route_watcher.status(ROOT)
+    except Exception:
+        data["watcher"] = {"running": False, "enabled": False, "scope": "proxy-observable only"}
+    rotation = {
+        "interval_seconds": scheduled_interval(),
+        "jitter_seconds": int(_rotation.get("jitter_seconds", DEFAULT_ROTATION_SETTINGS["jitter_seconds"]) or 0),
+    }
+    if rotation["interval_seconds"] > 0:
+        next_times = [n for n in (next_rotation_at(name) for name in _providers) if n is not None]
+        if next_times:
+            rotation["next_at"] = min(next_times)
+    data["rotation"] = rotation
+    return data
+
+
+def egress_probe(name: str | None = None) -> int:
+    """Probe the active exit of every provider (or just ``name``) through the
+    tunnel, persist the outcome, print it as JSON; exit 1 when any probe
+    failed."""
+    if current_mode() != "proxy":
+        return fail("egress probe requires proxy mode (tun has no 127.0.0.1 listener)")
+    if not listener_up():
+        return fail(f"engine not listening on 127.0.0.1:{_port}; start it first")
+    providers = [name] if name is not None else list(_providers)
+    results = {}
+    any_failed = False
+    for provider in providers:
+        if provider not in _providers:
+            results[provider] = {"error": "unknown provider"}
+            any_failed = True
+            continue
+        active = persisted_active(provider) or resolve_active(provider)
+        if active is None:
+            results[provider] = {"error": "no active profile"}
+            any_failed = True
+            continue
+        ok, _record = probe_profile(provider, active)
+        results[provider] = {"profile": active.stem, "ok": ok}
+        any_failed = any_failed or not ok
+    print(json.dumps(results, indent=2, sort_keys=True))
+    return 1 if any_failed else 0
+
+
+def egress_check(name: str | None = None, as_json: bool = False) -> int:
+    """Read-only liveness check of the ACTIVE exit of every provider (or just
+    ``name``) through the running tunnel.
+
+    Unlike `egress probe` (which exits 1 on any probe failure), this
+    classifies each exit alive/degraded/dead (see check_egress_live) and
+    exits 1 only when an exit is DEAD - i.e. the tunnel path itself is broken
+    - so a caller like keepalive can auto-rotate on a genuinely dead tunnel
+    without reacting to reputation-block HTTP statuses (403/1010), TUN mode,
+    or a temporarily down engine.
+
+    Never rotates, never touches the engine; the only write is the normal
+    egress health record. Bounded probes make it safe to run every 30-60s.
+    Stops at the first dead provider. In human mode a trailing ``dead:
+    <provider>`` line (and exit code 1) is the machine contract keepalive
+    parses; ``--json`` emits the same data as one JSON document.
+    """
+    mode = current_mode()
+    if mode != "proxy":
+        return fail(f"egress check requires proxy mode (mode is '{mode}'; no 127.0.0.1 tunnel listener)")
+    if not listener_up():
+        return fail(f"engine not listening on 127.0.0.1:{_port}; tunnel is down")
+    if name is not None and name not in _providers:
+        return fail(f"unknown provider '{name}' (have {', '.join(_providers)})")
+    providers = [name] if name is not None else list(_providers)
+    results: dict[str, dict] = {}
+    dead: list[str] = []
+    for provider in providers:
+        active = persisted_active(provider) or resolve_active(provider)
+        if active is None:
+            results[provider] = {"profile": None, "ok": True, "status": "skipped",
+                                 "detail": "no active profile"}
+            continue
+        status, record = check_egress_live(provider, active)
+        entry: dict = {"profile": active.stem, "ok": status != "dead", "status": status}
+        if record is not None and record.get("dns_ok") is not None:
+            entry["dns_ok"] = record["dns_ok"]
+        if status == "dead":
+            entry["detail"] = "dns" if entry.get("dns_ok") is False else "probe connection"
+            dead.append(provider)
+        elif status == "degraded" and record is not None and record.get("status") is not None:
+            entry["detail"] = f"HTTP {record['status']}"
+        results[provider] = entry
+        if dead:
+            break  # stop at the first dead provider so keepalive rotates it
+    if as_json:
+        print(json.dumps({"dead": dead, "results": results}, indent=2, sort_keys=True))
+    else:
+        for provider, entry in results.items():
+            status = entry["status"]
+            if status == "skipped":
+                print(f"{provider}: skipped (no active profile)")
+            elif status == "alive":
+                print(f"{provider}: alive ({entry['profile']})")
+            elif status == "degraded":
+                print(f"{provider}: degraded ({entry['profile']}; {entry.get('detail', 'HTTP response')})")
+            else:
+                print(f"{provider}: dead ({entry['profile']}; {entry.get('detail', 'probe connection')})")
+        if dead:
+            print(f"dead: {dead[0]}")
+    return 1 if dead else 0
+
+
+def egress_show(name: str | None = None) -> int:
+    """Print persisted egress records (state/egress/**) as JSON."""
+    providers = [name] if name is not None else list(_providers)
+    if name is not None and name not in _providers:
+        return fail(f"unknown provider '{name}' (have {', '.join(_providers)})")
+    records = {}
+    for provider in providers:
+        records[provider] = {}
+        for profile in provider_files(provider):
+            record = read_egress(provider, profile)
+            if record:
+                records[provider][profile.stem] = record
+    print(json.dumps(records, indent=2, sort_keys=True))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# macOS system proxy toggle
+# ---------------------------------------------------------------------------
+
+def active_service_name() -> str | None:
+    try:
+        iface = None
+        out = subprocess.run(
+            ["route", "-n", "get", "default"], capture_output=True, text=True, timeout=5,
+        ).stdout
+        for line in out.splitlines():
+            if "interface:" in line:
+                iface = line.split()[-1]
+        if not iface:
+            return None
+        service = None
+        out = subprocess.run(
+            ["networksetup", "-listallhardwareports"], capture_output=True, text=True, timeout=5,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    for line in out.splitlines():
+        if line.startswith("Hardware Port:"):
+            service = line.split(":", 1)[1].strip()
+        elif line.startswith("Device:") and line.split()[-1] == iface:
+            return service
+    return None
+
+
+def system_proxy_on() -> int:
+    service = active_service_name()
+    if not service:
+        return fail("could not determine the active network service")
+    commands = [
+        ["networksetup", "-setwebproxy", service, "127.0.0.1", str(_port)],
+        ["networksetup", "-setsecurewebproxy", service, "127.0.0.1", str(_port)],
+        ["networksetup", "-setwebproxystate", service, "on"],
+        ["networksetup", "-setsecurewebproxystate", service, "on"],
+        ["networksetup", "-setproxybypassdomains", service, "*.local", "localhost", "127.0.0.1", "::1"],
+    ]
+    try:
+        for command in commands:
+            subprocess.run(command, check=True, capture_output=True, timeout=10)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return fail(f"could not enable system proxy: {exc}")
+    print(f"system proxy enabled on '{service}' -> 127.0.0.1:{_port}")
+    return 0
+
+
+def system_proxy_off() -> int:
+    service = active_service_name()
+    if not service:
+        return fail("could not determine the active network service")
+    try:
+        subprocess.run(
+            ["networksetup", "-setwebproxystate", service, "off"],
+            check=True, capture_output=True, timeout=10,
+        )
+        subprocess.run(
+            ["networksetup", "-setsecurewebproxystate", service, "off"],
+            check=True, capture_output=True, timeout=10,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return fail(f"could not disable system proxy: {exc}")
+    print(f"system proxy disabled ({service})")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-open proxy runner
+# ---------------------------------------------------------------------------
+
+PROXY_ENV_VARS = ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY")
+
+
+def _config_port() -> int:
+    """Read the mixed-proxy port from router.json without full validation so
+    with-proxy stays usable even with a broken/missing config."""
+    try:
+        if CONFIG_FILE.is_file():
+            port = int(json.loads(CONFIG_FILE.read_text()).get("port", DEFAULT_PORT))
+            if 1 <= port <= 65535:
+                return port
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+    return DEFAULT_PORT
+
+
+def _listener_healthy(port: int, timeout: float) -> bool:
+    """True when a TCP listener answers on 127.0.0.1:port. Read-only probe:
+    never starts the engine, never touches state."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def with_proxy(cmd: list[str], *, timeout_ms: int = 300,
+               force_proxy: bool = False, force_direct: bool = False,
+               check: bool = False) -> int:
+    """Fail-open command runner: exec ``cmd`` through the local proxy when the
+    listener is up, otherwise strip the proxy env and run direct.
+
+    Use when:
+    - Wrapping apps pointed at 127.0.0.1:<port> (hermes, curl, ...) so they
+      keep working when the engine is stopped / manual-off.
+    - Health checks: ``--check`` prints the proxy URL and exits 0 when the
+      listener answers, exits 1 when it does not.
+
+    Expects:
+    - ``cmd``: argv to exec via os.execvpe (child replaces this process; exit
+      code flows through).
+    - ``--force-proxy`` refuses to run (exit 4) when the listener is down;
+      ``--force-direct`` skips the probe and always strips the proxy env.
+    - ``--check`` ignores ``cmd``.
+
+    Returns:
+    - Child exit code (exec path), 4 for a refused --force-proxy run, 1 for
+      --check when the listener is down, 1 for a missing command.
+    """
+    timeout = max(0.001, timeout_ms / 1000.0)
+    if check:
+        port = _config_port()
+        if _listener_healthy(port, timeout):
+            print(f"http://127.0.0.1:{port}")
+            return 0
+        return 1
+    if not cmd:
+        return fail("with-proxy: no command given (usage: router.py with-proxy [flags] -- <cmd...>)")
+    if force_proxy and force_direct:
+        return fail("with-proxy: --force-proxy and --force-direct are mutually exclusive")
+    port = _config_port()
+    healthy = _listener_healthy(port, timeout)
+    if force_proxy and not healthy:
+        print(f"router: proxy listener 127.0.0.1:{port} is down; refusing --force-proxy run", file=sys.stderr)
+        return 4
+    env = dict(os.environ)
+    if (healthy and not force_direct) or force_proxy:
+        url = f"http://127.0.0.1:{port}"
+        for var in PROXY_ENV_VARS:
+            env[var] = url
+    else:
+        for var in PROXY_ENV_VARS:
+            env.pop(var, None)
+    try:
+        os.execvpe(cmd[0], cmd, env)
+    except OSError as exc:
+        return fail(f"with-proxy: cannot execute {cmd[0]}: {exc}")
+    return 127  # unreachable: execvpe only returns on error
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _needs_elevation(args) -> bool:
+    """Whether this invocation must re-run as root before doing anything.
+
+    TUN mode needs root (utun creation, route table) and the engine then
+    runs as root, so `vpn on` and tun-mode engine commands cannot run as a
+    regular user. Only interactive macOS sessions elevate: launchd/keepalive
+    ticks have no TTY and must never pop a password dialog on every interval
+    (they keep the existing clear-error behavior instead).
+    """
+    if sys.platform != "darwin" or os.geteuid() == 0:
+        return False
+    if os.environ.get("PROXY_ROUTER_ELEVATED"):
+        return False
+    if not sys.stdin.isatty():
+        return False
+    mode = current_mode()
+    if args.cmd == "vpn":
+        return args.action in ("on", "restart") or (args.action == "off" and mode == "tun")
+    return (args.cmd in ("start", "stop", "ensure", "reload", "rotate", "add", "remove")
+            and mode == "tun")
+
+
+def _elevate_macos() -> int:
+    """Re-run the current command with administrator privileges (macOS).
+
+    Instead of requiring the user to type `sudo python3 router.py vpn on`,
+    re-exec the exact same CLI through the standard macOS "… wants to make
+    changes" password dialog (osascript `do shell script … with administrator
+    privileges`), which asks for permission on every run.
+
+    SUDO_UID/SUDO_GID are injected so `_hand_back_ownership` hands state
+    files back to the invoking user; PROXY_ROUTER_ELEVATED prevents
+    recursion; PATH is passed through so the bundled sing-box still resolves.
+    """
+    env = (
+        f"SUDO_UID={os.getuid()} SUDO_GID={os.getgid()} "
+        f"PROXY_ROUTER_ELEVATED=1 "
+        f"PATH={shlex.quote(os.environ.get('PATH', ''))}"
+    )
+    cmd = shlex.join([sys.executable, os.path.abspath(__file__), *sys.argv[1:]])
+    shell_cmd = f"{env} {cmd}"
+    # AppleScript string literals accept only `\"` and `\\` escapes; escape
+    # the shell command's quotes/backslashes but keep the literal delimiters
+    # unescaped (a `\` at expression position is a syntax error).
+    content = shell_cmd.replace("\\", "\\\\").replace('"', '\\"')
+    script = f'do shell script "{content}" with administrator privileges'
+    proc = subprocess.run(["osascript", "-e", script], text=True)
+    if proc.returncode != 0:
+        print("router: elevation canceled or failed; run with sudo manually if needed",
+              file=sys.stderr)
+    return proc.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="router", description="selective WireGuard proxy router")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("ensure")
+    sub.add_parser("start")
+    sub.add_parser("stop")
+    status = sub.add_parser("status")
+    status.add_argument("--json", action="store_true", help="machine-readable status (JSON)")
+    sub.add_parser("reload")
+    sub.add_parser("routes")
+    sub.add_parser("up")
+    sub.add_parser("down")
+
+    routing = sub.add_parser("routing", help="routing modes (safe-list / vpn-list): show|set|add|remove")
+    routing_sub = routing.add_subparsers(dest="routing_action")
+    routing_sub.add_parser("show", help="show the effective routing mode and lists (JSON + human)")
+    routing_set = routing_sub.add_parser("set", help="switch routing mode (safe-list / vpn-list / default)")
+    routing_set.add_argument("--mode", required=True, choices=list(ROUTING_MODES) + ["default"])
+    routing_set.add_argument("--default-provider", default=None,
+                             help="provider carrying everything not pinned direct (safe-list)")
+    for action in ("add", "remove"):
+        routing_mut = routing_sub.add_parser(action, help=f"{action} a domain on a routing list")
+        routing_mut.add_argument("--mode", required=True, choices=list(ROUTING_MODES))
+        routing_mut.add_argument("--domain", required=True)
+
+    egress = sub.add_parser("egress", help="egress health for provider exits")
+    egress.add_argument("action", choices=["probe", "show", "check"])
+    egress.add_argument("provider", nargs="?", default=None,
+                        help="provider name (positional, for probe/show)")
+    egress.add_argument("--provider", dest="provider_opt", default=None,
+                        help="provider name to check (egress check)")
+    egress.add_argument("--json", action="store_true",
+                        help="egress check: machine-readable JSON output")
+
+    init = sub.add_parser("init")
+    init.add_argument("--force", action="store_true", help="overwrite an existing router.json")
+
+    vpn = sub.add_parser("vpn", help="toggle TUN mode (vpn on|off|restart|status)")
+    vpn.add_argument("action", choices=["on", "off", "restart", "status"])
+
+    setup = sub.add_parser("setup", help="interactive Proton/WARP setup wizard")
+    setup.add_argument("setup_args", nargs=argparse.REMAINDER)
+
+    monitor = sub.add_parser("monitor", help="opt-in network monitoring")
+    monitor.add_argument("monitor_args", nargs=argparse.REMAINDER)
+
+    watcher = sub.add_parser("watcher", help="standalone routed-connection watcher")
+    watcher.add_argument("watcher_args", nargs=argparse.REMAINDER)
+
+    r_add = sub.add_parser("add")
+    r_add.add_argument("--id")
+    r_add.add_argument("--domain")
+    r_add.add_argument("--ip")
+    r_add.add_argument("--provider", required=True)
+
+    r_rm = sub.add_parser("remove")
+    r_rm.add_argument("id")
+
+    r_rot = sub.add_parser("rotate")
+    r_rot.add_argument("provider", nargs="?", help="provider name (optional with --if-due)")
+    r_rot.add_argument("--if-due", action="store_true",
+                       help="scheduled rotation: only rotate when the configured interval elapsed (exit 3 when not due)")
+    r_rot.add_argument("--to", default=None,
+                       help="switch to this exact exit profile instead of the ranked next one (e.g. 01-NL-FREE-140)")
+    r_rot.add_argument("--reason", default=None,
+                       help="mark the current profile with an upstream error/cooldown before rotating (e.g. 503, 429, timeout, 1010)")
+    r_rot.add_argument("--force", action="store_true",
+                       help="ignore cooldowns and blocked-exit markers and switch anyway")
+    r_rot.add_argument("--no-probe", action="store_true",
+                       help="skip the post-switch egress probe")
+
+    w_proxy = sub.add_parser("with-proxy", help="run a command through the proxy when up, else direct (fail-open)")
+    w_proxy.add_argument("--timeout-ms", type=int, default=300, help="listener probe timeout (default 300)")
+    w_proxy_group = w_proxy.add_mutually_exclusive_group()
+    w_proxy_group.add_argument("--force-proxy", action="store_true",
+                               help="fail (exit 4) instead of running direct when the listener is down")
+    w_proxy_group.add_argument("--force-direct", action="store_true",
+                               help="skip the probe and always run direct")
+    w_proxy.add_argument("--check", action="store_true",
+                         help="print the proxy URL and exit 0 if the listener answers, else exit 1")
+    w_proxy.add_argument("cmd_tail", nargs=argparse.REMAINDER,
+                         help="-- <cmd...> (argv after a leading --)")
+
+    r_count = sub.add_parser("provider-count")
+    r_count.add_argument("provider")
+
+    args, passthrough = parser.parse_known_args()
+    if _needs_elevation(args):
+        return _elevate_macos()
+    if args.cmd == "setup":
+        import setup_tui
+
+        return setup_tui.main(["setup", *passthrough, *args.setup_args], root=ROOT)
+    if args.cmd == "monitor":
+        import monitor
+
+        return monitor.main(["monitor", *args.monitor_args, *passthrough], root=ROOT)
+    if args.cmd == "watcher":
+        import route_watcher
+
+        return route_watcher.main(["watcher", *args.watcher_args, *passthrough], root=ROOT)
+    if passthrough:
+        parser.error("unrecognized arguments: " + " ".join(passthrough))
+    if args.cmd == "with-proxy":
+        # Fail-open must work even with a broken/missing router.json, so it
+        # bypasses the load_config gate below (it only reads the port).
+        tail = args.cmd_tail
+        if tail and tail[0] == "--":
+            tail = tail[1:]
+        return with_proxy(tail, timeout_ms=args.timeout_ms, force_proxy=args.force_proxy,
+                          force_direct=args.force_direct, check=args.check)
+    if args.cmd == "init":
+        return write_default_config(force=getattr(args, "force", False))
+    if args.cmd is None:
+        # Bare `proxy-router` opens the interactive TUI (settings, presets,
+        # routing modes, health). The wizard never starts or reloads the
+        # engine on its own — the only lifecycle action is menu item 8,
+        # operator-initiated. Help stays available via `router.py --help`
+        # (argparse handles that before we get here).
+        import setup_tui
+
+        return setup_tui.main([], root=ROOT)
+
+    if args.cmd == "up":
+        if sys.platform != "darwin":
+            return fail("up requires macOS (v1 scope)")
+        rc = load_config()
+        if rc == 0 and engine_start() == 0:
+            route_watcher_start()
+            return system_proxy_on()
+        return rc
+    if args.cmd == "down" and sys.platform != "darwin":
+        return fail("down requires macOS (v1 scope)")
+
+    rc = load_config()
+    if rc:
+        # A broken/missing router.json is a degraded state: `status` and
+        # `vpn status` still print a state line and exit 1 (M13); the reason
+        # is already on stderr from load_config.
+        if args.cmd == "status":
+            if args.json:
+                print(json.dumps({"up": False, "state": "down (unusable config; see error above)",
+                                  "mode": None, "port": None, "providers": {}, "routes": [],
+                                  "routing": {"mode": None, "direct_domains": [], "vpn_domains": [],
+                                              "default_provider": None}},
+                                 indent=2, sort_keys=True))
+            else:
+                print("down (unusable config; see error above)")
+            return 1
+        if args.cmd == "vpn":
+            print("vpn: down (unusable config; see error above)")
+            return 1
+        return rc
+
+    if args.cmd == "ensure":
+        rc = _with_lock(engine_ensure)
+        if rc == 0:
+            route_watcher_start()
+        else:
+            route_watcher_stop()
+        return rc
+    if args.cmd == "start":
+        # Explicit start (tray Connect / CLI) cancels any manual-off state.
+        MANUAL_OFF_FILE.unlink(missing_ok=True)
+        route_watcher_stop()
+        rc = _with_lock(engine_start)
+        if rc == 0:
+            route_watcher_start()
+        return rc
+    if args.cmd == "stop":
+        route_watcher_stop()
+        rc = _with_lock(engine_stop)
+        if rc == 0:
+            # Manual disconnect: tell keepalive.sh to leave the engine down.
+            # Without this marker the keepalive's next `ensure` tick
+            # resurrects the proxy within 15s and the tray's Disconnect
+            # looks broken.
+            try:
+                MANUAL_OFF_FILE.write_text(
+                    f"manual stop {datetime.datetime.now(datetime.timezone.utc).isoformat(timespec='seconds')}\n",
+                    encoding="utf-8",
+                )
+                try:
+                    MANUAL_OFF_FILE.chmod(0o600)
+                except OSError:
+                    pass
+            except OSError as e:
+                print(f"router: warning: could not write manual-off marker: {e}",
+                      file=sys.stderr)
+        return rc
+    if args.cmd == "status":
+        if resolve_sing_box() is None:
+            print(f"router: {_sing_box_missing_message()}", file=sys.stderr)
+        rc, line = _status_report()
+        if args.json:
+            print(json.dumps(status_json(), indent=2, sort_keys=True))
+        else:
+            print(line)
+        return rc
+    if args.cmd == "reload":
+        rc = _with_lock(engine_reload)
+        if rc == 0:
+            route_watcher_start()
+        return rc
+    if args.cmd == "rotate":
+        if args.if_due:
+            return _with_lock(lambda: rotate_due(args.provider))
+        if not args.provider:
+            parser.error("rotate needs a provider (or use --if-due for scheduled rotation)")
+        return _with_lock(lambda: rotate(args.provider, reason=args.reason, force=args.force,
+                                         probe=not args.no_probe, to=args.to))
+    if args.cmd == "egress":
+        if args.action == "probe":
+            return egress_probe(args.provider)
+        if args.action == "check":
+            return egress_check(args.provider_opt or args.provider, as_json=args.json)
+        return egress_show(args.provider)
+    if args.cmd == "provider-count":
+        print(provider_count(args.provider))
+        return 0
+    if args.cmd == "routes":
+        return routes_list()
+    if args.cmd == "routing":
+        if args.routing_action == "show":
+            return routing_cli_show()
+        if args.routing_action == "set":
+            return routing_cli_set(args.mode, args.default_provider)
+        if args.routing_action == "add":
+            return routing_cli_add(args.mode, args.domain)
+        if args.routing_action == "remove":
+            return routing_cli_remove(args.mode, args.domain)
+        parser.error("routing needs an action: show | set | add | remove")
+    if args.cmd == "vpn":
+        if args.action == "on":
+            route_watcher_stop()
+            return _with_lock(vpn_on)
+        if args.action == "restart":
+            route_watcher_stop()
+            return _with_lock(vpn_restart)
+        if args.action == "off":
+            route_watcher_stop()
+            rc = _with_lock(vpn_off)
+            if rc == 0:
+                route_watcher_start()
+            return rc
+        return vpn_status()
+    if args.cmd == "add":
+        return _with_lock(lambda: routes_add(args))
+    if args.cmd == "remove":
+        return _with_lock(lambda: routes_remove(args.id))
+    if args.cmd == "down":
+        if sys.platform != "darwin":
+            return fail("down requires macOS (v1 scope)")
+        return system_proxy_off()
+    parser.print_help()
+    return 2
+
+
+class _EngineLock:
+    """Exclusive lock on ``state/engine.lock``.
+
+    Uses ``fcntl.flock`` on POSIX and ``msvcrt.locking`` on Windows so the
+    same CLI surface works on macOS, Linux, and Windows.
+    """
+
+    def __init__(self) -> None:
+        self._path = LOCK_FILE
+        self._file = None
+
+    def __enter__(self) -> "_EngineLock":
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self._path.open("w")
+        if os.name == "nt":
+            import msvcrt
+
+            # msvcrt.locking cannot lock an empty file, so seed one byte.
+            self._file.write("0")
+            self._file.flush()
+            self._file.seek(0)
+            msvcrt.locking(self._file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(self._file.fileno(), fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        if self._file is not None:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    self._file.seek(0)
+                    msvcrt.locking(self._file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(self._file.fileno(), fcntl.LOCK_UN)
+            finally:
+                self._file.close()
+        return False
+
+
+def _with_lock(action) -> int:
+    with _EngineLock():
+        return action()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/proxy-router/rulesets/roblox.json
+++ b/tools/proxy-router/rulesets/roblox.json
@@ -1,0 +1,13 @@
+{
+  "provider": "cloudflare",
+  "description": "Roblox AS22697 announced IPv4/IPv6 ranges for selective UDP/TUN routing",
+  "source": "RIPE RIS announced-prefixes, queried 2026-08-12",
+  "ip_cidr": [
+    "128.116.0.0/17",
+    "103.140.28.0/23",
+    "141.193.3.0/24",
+    "205.201.62.0/24",
+    "2620:135:6000::/40",
+    "2620:2b:e000::/48"
+  ]
+}

--- a/tools/proxy-router/setup_tui.py
+++ b/tools/proxy-router/setup_tui.py
@@ -1,0 +1,1748 @@
+#!/usr/bin/env python3
+"""Setup wizard for proxy-router: guides, profile imports, route presets, checks.
+
+Stdlib only. Owns the non-engine half of ``proxy-router setup``:
+
+- ``guide_text``      - bundled provider guides (Proton VPN Free, Cloudflare WARP)
+- ``import_profiles`` - validates/dedupes/copies WireGuard ``.conf`` files
+- ``apply_presets``   - idempotent safe route presets (opencode.ai, Roblox)
+- ``check``           - reports provider profile availability (no network)
+- ``bridge``          - installs/verifies the Hermes OpenCode auto-rotation
+  bridge (``proxy-manager.sh``) at the path the Hermes plugin expects
+- ``main`` / ``wizard`` - non-interactive CLI flags and a full-screen TUI
+  (alternate screen, arrow-key navigation; plain line menu when not a TTY)
+
+This module never starts sing-box, enables TUN, or touches networking on its
+own. The only engine lifecycle call (menu item 8) shells out to the existing
+``router.py ensure`` command, and only when the user explicitly selects it.
+"""
+from __future__ import annotations
+
+import argparse
+import configparser
+import contextlib
+import copy
+import dataclasses
+import glob
+import io
+import json
+import os
+import re
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+_PRESET_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,63}")
+
+try:
+    import termios
+    import tty
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    termios = None
+    tty = None
+
+_HAVE_TERMIOS = termios is not None and tty is not None
+
+ROOT = Path(os.environ.get("PROXY_ROUTER_ROOT") or Path(__file__).resolve().parent).resolve()
+
+# Default Hermes config path for the bridge check (resolved via env at call
+# time so tests can override; defaults to this module-level value).
+_HERMES_CONFIG_DEFAULT = "~/.hermes/config.yaml"
+
+# Guides live next to this module in the checkout/installed prefix. They are
+# resolved from the module location (not ROOT) because the test harness
+# relocates ROOT per-suite while the bundled guides are fixed files.
+_GUIDES = {
+    "proton": "proton-vpn-free.md",
+    "warp": "cloudflare-warp.md",
+}
+
+# Idempotent safe presets: only ever added when their route id is absent,
+# never merged into or replacing unrelated routes/providers.
+_PRESET_ROUTES = {
+    "opencode-zen": {
+        "id": "opencode-zen",
+        "domains": ["opencode.ai"],
+        "provider": "proton",
+    },
+    "roblox": {
+        "id": "roblox",
+        "domains": ["roblox.com", "rbxcdn.com", "robloxlabs.com", "rblx.com"],
+        "provider": "cloudflare",
+    },
+    "school": {
+        "id": "school",
+        "domains": [
+            "discord.com",
+            "discord.gg",
+            "discordapp.com",
+            "twitch.tv",
+            "facebook.com",
+            "fbcdn.net",
+            "instagram.com",
+            "cdninstagram.com",
+            "youtube.com",
+            "googlevideo.com",
+            "ytimg.com",
+            "x.com",
+            "twitter.com",
+            "cdn.sstatic.net",
+        ],
+        "provider": "cloudflare",
+    },
+}
+
+# Built-in preset definitions: name -> {"routes": [..], "routing": {...}}.
+# A preset is a NAMED bundle of routes (domains -> provider) plus an optional
+# routing-mode section, applied by name with `setup --preset <name>`. Users
+# add their own with `setup --preset-add NAME --provider P --domain ...`.
+_BUILTIN_PRESETS: dict = {
+    "opencode": {
+        "routes": [_PRESET_ROUTES["opencode-zen"]],
+        "routing": {"mode": "default"},
+    },
+    "roblox": {
+        "routes": [_PRESET_ROUTES["roblox"]],
+        "routing": {"mode": "default"},
+    },
+    "default": {  # the classic combo: opencode via proton + roblox via warp
+        "routes": [_PRESET_ROUTES["opencode-zen"], _PRESET_ROUTES["roblox"]],
+        "routing": {"mode": "default"},
+    },
+    "school-warp": {
+        "routes": [_PRESET_ROUTES["school"]],
+        "routing": {"mode": "vpn-list",
+                    "vpn_domains": list(_PRESET_ROUTES["school"]["domains"])},
+    },
+}
+
+ANSI = sys.stdout.isatty() and sys.stdin.isatty() and os.environ.get("NO_COLOR") is None
+
+
+class _Ansi:
+    RESET = "\x1b[0m"
+    BOLD = "\x1b[1m"
+    DIM = "\x1b[2m"
+    RED = "\x1b[31m"
+    GREEN = "\x1b[32m"
+    YELLOW = "\x1b[33m"
+    CYAN = "\x1b[36m"
+    MAGENTA = "\x1b[35m"
+    REVERSE = "\x1b[7m"
+    # 256-color: true orange/purple (brand-ish, readable on light+dark).
+    PURPLE = "\x1b[38;5;141m"
+    ORANGE = "\x1b[38;5;208m"
+
+
+def _style(text: str, *codes: str) -> str:
+    return "".join(codes) + text + _Ansi.RESET if ANSI else text
+
+
+_PROVIDER_RE = re.compile(r"\b(proton|cloudflare|warp)\b", re.IGNORECASE)
+
+
+def _tint_provider(text: str) -> str:
+    """Color provider names: Proton/WARP = purple, Cloudflare = orange.
+
+    Applies AFTER width fitting so ANSI bytes never affect layout math.
+    No-op when ANSI is disabled (NO_COLOR / non-TTY).
+    """
+    if not ANSI:
+        return text
+
+    def _repl(match: re.Match) -> str:
+        word = match.group(0)
+        color = _Ansi.PURPLE if word.lower() in ("proton", "warp") else _Ansi.ORANGE
+        return color + word + _Ansi.RESET
+
+    return _PROVIDER_RE.sub(_repl, text)
+
+
+# ---------------------------------------------------------------------------
+# validation
+# ---------------------------------------------------------------------------
+
+def _valid_endpoint(endpoint: str) -> bool:
+    """Basic host:port endpoint shape (bracketed IPv6 allowed, no DNS lookups)."""
+    endpoint = endpoint.strip()
+    if not endpoint:
+        return False
+    if endpoint.startswith("["):
+        return re.fullmatch(r"\[[0-9a-fA-F:.%]+\]:\d+", endpoint) is not None
+    host, sep, port = endpoint.rpartition(":")
+    return bool(sep) and bool(host) and port.isdigit()
+
+
+def inspect_profile(conf_path: Path) -> tuple[bool, str]:
+    """Validate the minimum WireGuard structure of a ``.conf`` file.
+
+    Returns (ok, reason). Checks ``[Interface]`` Address/PrivateKey,
+    ``[Peer]`` PublicKey/Endpoint/AllowedIPs, and a parseable Endpoint -
+    the same surface the engine's parser needs. Never returns file contents.
+    """
+    try:
+        parser = configparser.ConfigParser(interpolation=None)
+        if not parser.read(conf_path):
+            return False, "unreadable file"
+        if not parser.has_section("Interface"):
+            return False, "missing [Interface] section"
+        interface = parser["Interface"]
+        for key in ("Address", "PrivateKey"):
+            if not str(interface.get(key, "")).strip():
+                return False, f"missing Interface.{key}"
+        if not parser.has_section("Peer"):
+            return False, "missing [Peer] section"
+        peer = parser["Peer"]
+        for key in ("PublicKey", "Endpoint", "AllowedIPs"):
+            if not str(peer.get(key, "")).strip():
+                return False, f"missing Peer.{key}"
+        if not _valid_endpoint(str(peer["Endpoint"])):
+            return False, "bad Peer.Endpoint (expected host:port or [v6]:port)"
+        return True, "ok"
+    except configparser.Error as exc:
+        return False, f"not a parseable config: {exc}"
+    except OSError as exc:
+        return False, f"cannot read file: {exc}"
+
+
+def validate_profile(conf_path: Path) -> bool:
+    """Default single-file validator: True for a structurally valid profile."""
+    ok, _ = inspect_profile(conf_path)
+    return ok
+
+
+def sanitize_name(name: str) -> str:
+    """Lowercase, safe filename preserving a trailing ``.conf`` extension."""
+    name = name.strip()
+    stem = name[:-5] if name.lower().endswith(".conf") else name
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "-", stem)
+    stem = stem.strip("._-").lower()
+    if not stem:
+        stem = "profile"
+    return stem + ".conf"
+
+
+def _unique_target(destination: Path, name: str) -> Path:
+    target = destination / name
+    if not target.exists():
+        return target
+    stem = name[:-5] if name.lower().endswith(".conf") else Path(name).stem
+    for index in range(2, 10_000):
+        candidate = destination / f"{stem}-{index}.conf"
+        if not candidate.exists():
+            return candidate
+    raise OSError(f"could not find a unique destination name for {name}")
+
+
+def import_profiles(source, destination, validator=None) -> dict:
+    """Copy valid WireGuard ``.conf`` profiles from ``source`` into ``destination``.
+
+    ``source`` is a single ``.conf`` file or a directory of ``.conf`` files.
+    Each profile is validated, given a sanitized, collision-free name, and
+    written with mode 0600. Nothing about the contents is printed.
+
+    Returns::
+
+        {"imported": n, "rejected": n, "files": [names],
+         "rejected_files": [{"name": ..., "reason": ...}]}
+    """
+    source = Path(source)
+    destination = Path(destination)
+    if source.is_dir():
+        candidates = sorted(
+            p for p in source.iterdir() if p.is_file() and p.suffix.lower() == ".conf"
+        )
+    else:
+        candidates = [source]
+    destination.mkdir(parents=True, exist_ok=True)
+
+    files: list[str] = []
+    rejected_files: list[dict] = []
+    for candidate in candidates:
+        name = candidate.name
+        if not candidate.is_file():
+            rejected_files.append({"name": name, "reason": "no such file"})
+            continue
+        if validator is None or validator is validate_profile:
+            ok, reason = inspect_profile(candidate)
+        else:
+            try:
+                ok = bool(validator(candidate))
+            except Exception as exc:  # noqa: BLE001 - a broken custom validator
+                ok, reason = False, f"validator error: {exc}"
+            else:
+                reason = "" if ok else "rejected by custom validator"
+        if not ok:
+            rejected_files.append({"name": name, "reason": reason or "invalid WireGuard profile"})
+            continue
+        try:
+            target = _unique_target(destination, sanitize_name(name))
+            shutil.copyfile(candidate, target)
+            os.chmod(target, 0o600)
+        except OSError as exc:
+            rejected_files.append({"name": name, "reason": f"copy failed: {exc}"})
+            continue
+        files.append(target.name)
+
+    return {
+        "imported": len(files),
+        "rejected": len(rejected_files),
+        "files": files,
+        "rejected_files": rejected_files,
+    }
+
+
+# ---------------------------------------------------------------------------
+# guides
+# ---------------------------------------------------------------------------
+
+def guide_text(provider: str) -> str:
+    """Return the bundled markdown guide; ``all`` combines them; unknown -> ""."""
+    if provider == "all":
+        return "\n\n".join(part for part in (guide_text("proton"), guide_text("warp")) if part)
+    if provider not in _GUIDES:
+        return ""
+    try:
+        return (Path(__file__).resolve().parent / "guides" / _GUIDES[provider]).read_text()
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# presets
+# ---------------------------------------------------------------------------
+
+def _default_config() -> dict:
+    example = Path(__file__).resolve().parent / "router.example.json"
+    if example.is_file():
+        return json.loads(example.read_text())
+    return {
+        "port": 2080,
+        "providers": {},
+        "routes": [],
+        "vpn": {"address": ["172.19.0.1/30"], "mtu": 1500, "stack": "system"},
+    }
+
+
+def apply_presets(config_path, opencode=True, warp_roblox=True) -> dict:
+    """Add the safe route presets to ``router.json`` (idempotent, lossless).
+
+    Adds providers ``proton``/``cloudflare`` and routes ``opencode-zen``
+    (opencode.ai -> proton) and ``roblox`` (Roblox domains -> cloudflare) when
+    missing, leaving every other key, provider, route, and value untouched.
+    Returns ``{"added": [route ids created this call]}``.
+    """
+    config_path = Path(config_path)
+    if config_path.is_file():
+        data = json.loads(config_path.read_text())
+    else:
+        data = _default_config()
+    providers = data.setdefault("providers", {})
+    routes = data.setdefault("routes", [])
+
+    added: list[str] = []
+    if opencode:
+        providers.setdefault("proton", {"directory": "providers/proton", "cooldown_seconds": 60})
+        if not any(r.get("id") == "opencode-zen" for r in routes):
+            routes.append(dict(_PRESET_ROUTES["opencode-zen"]))
+            added.append("opencode-zen")
+    if warp_roblox:
+        providers.setdefault(
+            "cloudflare", {"directory": "providers/cloudflare", "cooldown_seconds": 60}
+        )
+        if not any(r.get("id") == "roblox" for r in routes):
+            routes.append(dict(_PRESET_ROUTES["roblox"]))
+            added.append("roblox")
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(data, indent=2) + "\n")
+    os.chmod(config_path, 0o600)
+    return {"added": added}
+
+
+def custom_preset_path(root: Path, name: str) -> Path:
+    """Path of the custom preset file for ``name`` under ``root/presets/``.
+
+    Preset names are validated like provider names (letters/digits/._-), so a
+    name can never escape the presets directory.
+    """
+    if not _PRESET_NAME.fullmatch(name):
+        raise ValueError(
+            f"invalid preset name '{name}' (use letters, digits, '.', '_', '-'; max 64)"
+        )
+    return root / "presets" / f"{name}.json"
+
+
+def preset_names(root: Path) -> list[str]:
+    """All available preset names: built-ins first, then custom files."""
+    names = sorted(_BUILTIN_PRESETS)
+    try:
+        custom_dir = root / "presets"
+        if custom_dir.is_dir():
+            names += sorted(p.stem for p in custom_dir.glob("*.json"))
+    except OSError:
+        pass
+    result: list[str] = []
+    for name in names:
+        if name not in result:
+            result.append(name)
+    return result
+
+
+def load_preset(root: Path, name: str) -> dict:
+    """Load a preset definition (built-in or custom) as
+    ``{"routes": [...], "routing": {...}, "providers": {...}}``."""
+    if name in _BUILTIN_PRESETS:
+        return dict(_BUILTIN_PRESETS[name])
+    path = custom_preset_path(root, name)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"preset '{name}' is not loadable: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"preset '{name}' must be a JSON object")
+    return data
+
+
+def apply_preset_by_name(root: Path, name: str) -> dict:
+    """Apply the preset ``name`` to ``root/router.json`` (idempotent, lossless).
+
+    Adds the preset's routes/providers and merges its ``routing`` section
+    (mode switch when the preset defines one; a ``default`` routing is left
+    untouched). Never starts the engine.
+    Returns ``{"added": [...], "mode": ..., "preset": name}``.
+    """
+    config_path = root / "router.json"
+    if config_path.is_file():
+        data = json.loads(config_path.read_text())
+    else:
+        data = _default_config()
+    preset = load_preset(root, name)
+    providers = data.setdefault("providers", {})
+    routes = data.setdefault("routes", [])
+    for provider in preset.get("providers", {}):
+        providers.setdefault(provider, dict(preset["providers"][provider]))
+    added: list[str] = []
+    for route in preset.get("routes", []):
+        if route.get("provider") and route["provider"] not in providers:
+            providers.setdefault(route["provider"], {
+                "directory": f"providers/{route['provider']}", "cooldown_seconds": 60})
+        if not any(r.get("id") == route.get("id") for r in routes):
+            routes.append(dict(route))
+            added.append(str(route.get("id")))
+    routing = preset.get("routing") or {}
+    mode = routing.get("mode", "default")
+    if mode != "default":
+        data["routing"] = data.get("routing") or {}
+        data["routing"].update({k: v for k, v in routing.items() if v is not None})
+        # never clobber an explicitly-set default_provider with None
+        if routing.get("default_provider"):
+            data["routing"]["default_provider"] = routing["default_provider"]
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    # record the applied preset so `status` (and the tray) can show it
+    data["preset"] = name
+    config_path.write_text(json.dumps(data, indent=2) + "\n")
+    os.chmod(config_path, 0o600)
+    return {"added": added, "mode": mode, "preset": name}
+
+
+def add_custom_preset(root: Path, name: str, provider: str, domains: list[str],
+                      mode: str = "vpn-list", default_provider: str | None = None) -> Path:
+    """Create a custom named preset file under ``root/presets/``.
+
+    Custom presets are the "make it yours" path: pick a name, a provider
+    (proton, cloudflare, or any configured exit), and the domains that ride
+    it. The remaining routing mode defaults to vpn-list (only these domains
+    tunneled) — the configurable inverse of safe-list.
+    """
+    domain_list = [d for d in domains if d]
+    if not domain_list:
+        raise ValueError("preset needs at least one domain")
+    routing: dict = {"mode": mode}
+    if mode == "vpn-list":
+        routing["vpn_domains"] = domain_list
+    elif mode == "safe-list":
+        routing["direct_domains"] = domain_list
+        if default_provider:
+            routing["default_provider"] = default_provider
+    elif mode == "default":
+        routing = {"mode": "default"}
+    preset = {
+        "routes": [{"id": name, "domains": domain_list, "provider": provider}],
+        "routing": routing,
+    }
+    path = custom_preset_path(root, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(preset, indent=2) + "\n")
+    os.chmod(path, 0o600)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# non-interactive commands
+# ---------------------------------------------------------------------------
+
+def check(root) -> dict:
+    """Report provider profile availability from ``root/router.json``.
+
+    Network-free: every configured provider needs at least one valid
+    ``*.conf`` profile in its directory. Returns ``{"ok": bool, "issues": []}``.
+    """
+    root = Path(root)
+    config_file = root / "router.json"
+    if not config_file.is_file():
+        return {"ok": False, "issues": [f"missing {config_file}"]}
+    try:
+        data = json.loads(config_file.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"ok": False, "issues": [f"bad {config_file.name}: {exc}"]}
+    providers = data.get("providers") or {}
+    if not providers:
+        return {"ok": False, "issues": ["no providers configured in router.json"]}
+    issues: list[str] = []
+    for name, entry in providers.items():
+        directory = root / (entry or {}).get("directory", f"providers/{name}")
+        if not directory.is_dir():
+            issues.append(f"provider '{name}': missing directory {directory}")
+            continue
+        if not any(validate_profile(p) for p in directory.glob("*.conf")):
+            issues.append(f"provider '{name}': no valid .conf profile in {directory}")
+    return {"ok": not issues, "issues": issues}
+
+
+def _expand_paths(paths) -> list[Path]:
+    """Expand ~ and glob patterns into a de-duplicated list of paths."""
+    expanded: list[Path] = []
+    seen: set[str] = set()
+    for raw in paths:
+        raw = os.path.expanduser(raw)
+        if any(ch in raw for ch in "*?["):
+            matches = sorted(glob.glob(raw))
+            candidates = matches or [raw]
+        else:
+            candidates = [raw]
+        for candidate in candidates:
+            key = os.path.abspath(candidate)
+            if key not in seen:
+                seen.add(key)
+                expanded.append(Path(candidate))
+    return expanded
+
+
+def _merge_results(results: list[dict]) -> dict:
+    return {
+        "imported": sum(r["imported"] for r in results),
+        "rejected": sum(r["rejected"] for r in results),
+        "files": [f for r in results for f in r["files"]],
+        "rejected_files": [f for r in results for f in r["rejected_files"]],
+    }
+
+
+def _cmd_guide(provider: str) -> int:
+    text = guide_text(provider)
+    if not text:
+        print(f"setup: no guide available for '{provider}'", file=sys.stderr)
+        return 1
+    print(_style(f"--- {_tint_provider(provider)} setup guide ---", _Ansi.BOLD, _Ansi.CYAN))
+    print(text)
+    return 0
+
+
+def _cmd_check(root: Path) -> int:
+    result = check(root)
+    if result["ok"]:
+        print(_style("setup: ok - every provider has at least one valid profile", _Ansi.GREEN))
+        return 0
+    for issue in result["issues"]:
+        print(_style(f"setup: {issue}", _Ansi.RED), file=sys.stderr)
+    print(_style("setup: check failed", _Ansi.RED), file=sys.stderr)
+    return 1
+
+
+def _cmd_import(root: Path, provider: str, paths) -> int:
+    destination = root / "providers" / provider
+    sources = _expand_paths(paths) or [Path(paths[0])]
+    merged = _merge_results([import_profiles(src, destination) for src in sources])
+    if merged["imported"]:
+        print(_style(
+            f"setup: imported {merged['imported']} profile(s) into providers/{provider}",
+            _Ansi.GREEN,
+        ))
+        for name in merged["files"]:
+            print(_style(f"  + {name}", _Ansi.DIM))
+    for entry in merged["rejected_files"]:
+        print(_style(f"  - {entry['name']}: {entry['reason']}", _Ansi.YELLOW))
+    if merged["rejected"]:
+        print(_style(f"setup: rejected {merged['rejected']} file(s)", _Ansi.YELLOW))
+    return 0 if merged["imported"] else 1
+
+
+def _cmd_preset(root: Path) -> int:
+    config_path = root / "router.json"
+    try:
+        result = apply_presets(config_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(_style(f"setup: preset failed: {exc}", _Ansi.RED), file=sys.stderr)
+        return 1
+    if result["added"]:
+        print(_style(_tint_provider("setup: added route preset(s): " + ", ".join(result["added"])), _Ansi.GREEN))
+    else:
+        print(_style(_tint_provider("setup: route presets already applied (nothing to add)"), _Ansi.GREEN))
+    print(f"setup: wrote {config_path}")
+    return 0
+
+
+def _cmd_preset_prompt(root: Path) -> int:
+    """Line-menu flow: pick a preset by name (built-in or custom) and apply it,
+    or create a new custom preset interactively."""
+    names = preset_names(root)
+    if not names:
+        print(_style("  no presets available", _Ansi.RED), file=sys.stderr)
+        return 1
+    print(_style("  available presets: " + ", ".join(names), _Ansi.BOLD))
+    print(_style("  create a new one with:  new", _Ansi.BOLD))
+    name = input("  preset name (empty cancels, 'new' creates): ").strip().lower()
+    if not name:
+        return 1
+    if name == "new":
+        return _cmd_preset_create_prompt(root)
+    if name not in names:
+        print(_style(f"  unknown preset '{name}' — use one of: {', '.join(names)}", _Ansi.RED), file=sys.stderr)
+        return 1
+    try:
+        result = apply_preset_by_name(root, name)
+    except (ValueError, json.JSONDecodeError, OSError) as exc:
+        print(_style(f"  preset apply failed: {exc}", _Ansi.RED), file=sys.stderr)
+        return 1
+    label = f"preset '{result['preset']}' applied — routing={result['mode']}"
+    if result["added"]:
+        label += f", added route(s): {', '.join(result['added'])}"
+    else:
+        label += " (already present, nothing added)"
+    print(_style(_tint_provider(label), _Ansi.GREEN))
+    print("  run menu item 8 (`ensure`) to apply; engine untouched for now.")
+    return 0
+
+
+def _cmd_preset_create_prompt(root: Path) -> int:
+    """Line-menu create flow: name -> provider -> comma-separated domains.
+    Writes the preset file only; the engine is never started here."""
+    try:
+        name = input("  new preset name (empty cancels): ").strip().lower()
+        if not name:
+            return 1
+        try:
+            custom_preset_path(root, name)  # validates the name
+        except ValueError as exc:
+            print(_style(f"  {exc}", _Ansi.RED), file=sys.stderr)
+            return 1
+        if name in preset_names(root):
+            print(_style(f"  preset '{name}' already exists — pick another name", _Ansi.RED), file=sys.stderr)
+            return 1
+        provider = input("  provider for this preset (proton / cloudflare / other): ").strip()
+        if not provider:
+            print(_style("  provider cannot be empty", _Ansi.RED), file=sys.stderr)
+            return 1
+        domain_text = input("  domains to tunnel, comma-separated (e.g. opencode.ai,roblox.com): ").strip()
+        if not domain_text:
+            print(_style("  at least one domain is required", _Ansi.RED), file=sys.stderr)
+            return 1
+        path = add_custom_preset(root, name, provider,
+                                 [d.strip() for d in domain_text.split(",") if d.strip()])
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return 130
+    except (ValueError, OSError) as exc:
+        print(_style(f"  preset create failed: {exc}", _Ansi.RED), file=sys.stderr)
+        return 1
+    print(_style(f"  custom preset '{name}' written to {path.relative_to(root or Path('.'))} (not applied)", _Ansi.GREEN))
+    print("  apply it now with 's', or from the tray: Presets → your name")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Hermes OpenCode auto-rotation bridge
+# ---------------------------------------------------------------------------
+
+def bridge_root() -> Path:
+    """Machine-level VPN root that the Hermes rotation plugin expects.
+
+    Mirrors the plugin's lookup exactly: ``OPENCODE_ZEN_VPN_ROOT`` env
+    override, else the plugin's compiled-in default (hardcoded here only).
+    ``expanduser`` so ``~`` prefixes work in the env value.
+    """
+    return Path(
+        os.environ.get("OPENCODE_ZEN_VPN_ROOT", "/Users/kyson/airi/tools/opencode-zen-vpn")
+    ).expanduser()
+
+
+def _hermes_config_path() -> Path:
+    """Hermes config path, resolved from env at call time (default module global)."""
+    return Path(os.environ.get("HERMES_CONFIG", _HERMES_CONFIG_DEFAULT)).expanduser()
+
+
+def _hermes_plugin_enabled() -> bool:
+    """Best-effort: is ``opencode-server-rotation`` listed under a plugins: block?
+
+    Read-only and never fatal: an unreadable/missing config reports not
+    enabled. A simple scan of parsed lines keeps this dependency-free.
+    """
+    try:
+        lines = _hermes_config_path().read_text().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return False
+    section = ""
+    for line in lines:
+        if line and not line[0].isspace():
+            section = line.split(":", 1)[0].strip()
+        if section == "plugins" and "opencode-server-rotation" in line:
+            return True
+    return False
+
+
+def _cmd_bridge_check(root: Path | None = None) -> int:
+    """Verify the Hermes rotation bridge; no side effects, one line per check.
+
+    ``root`` is accepted for CLI symmetry but placement always comes from
+    ``OPENCODE_ZEN_VPN_ROOT`` (this is a machine-level Hermes integration,
+    not a repo file). The Hermes plugin-enabled line is informational only
+    and does not affect the exit code.
+    """
+    manager = bridge_root() / "proxy-manager.sh"
+    ok = True
+
+    if manager.is_file():
+        print(_style(f"bridge: manager present ({manager})", _Ansi.GREEN))
+    else:
+        print(_style(f"bridge: manager missing ({manager})", _Ansi.RED))
+        ok = False
+
+    if os.access(manager, os.X_OK):
+        print(_style("bridge: executable", _Ansi.GREEN))
+    else:
+        print(_style("bridge: not executable", _Ansi.RED))
+        ok = False
+
+    if manager.is_file():
+        try:
+            result = subprocess.run(["bash", "-n", str(manager)], capture_output=True, text=True)
+        except OSError as exc:
+            print(_style(f"bridge: syntax check skipped (bash unavailable: {exc})", _Ansi.YELLOW))
+        else:
+            if result.returncode == 0:
+                print(_style("bridge: syntax ok", _Ansi.GREEN))
+            else:
+                print(_style(f"bridge: syntax error: {result.stderr.strip() or result.stdout.strip()}", _Ansi.RED))
+                ok = False
+    else:
+        print(_style("bridge: syntax check skipped (manager missing)", _Ansi.YELLOW))
+
+    vpn_root = bridge_root()
+    if os.environ.get("OPENCODE_ZEN_VPN_ROOT"):
+        print(f"bridge: vpn root {vpn_root} (env OPENCODE_ZEN_VPN_ROOT)")
+    else:
+        print(f"bridge: vpn root {vpn_root} (default)")
+
+    if _hermes_plugin_enabled():
+        print(_style("bridge: hermes plugin enabled (opencode-server-rotation)", _Ansi.GREEN))
+    else:
+        print(_style("bridge: hermes plugin NOT enabled (add plugins: - opencode-server-rotation)", _Ansi.YELLOW))
+    return 0 if ok else 1
+
+
+def _cmd_bridge_install(root: Path, force: bool = False) -> int:
+    """Install the Hermes OpenCode auto-rotation bridge and validate it.
+
+    Copies ``examples/proxy-manager.sh`` to ``OPENCODE_ZEN_VPN_ROOT/
+    proxy-manager.sh`` (a machine-level Hermes integration, not a repo
+    config file), chmod 0755, then runs ``bash -n`` and removes the file
+    on failure. Idempotent when content is already identical; refuses to
+    overwrite a differing existing file unless ``force`` is set.
+    """
+    source = Path(__file__).resolve().parent / "examples" / "proxy-manager.sh"
+    target_dir = bridge_root()
+    target = target_dir / "proxy-manager.sh"
+
+    try:
+        payload = source.read_bytes()
+    except OSError as exc:
+        print(f"bridge: cannot read source {source}: {exc}", file=sys.stderr)
+        return 1
+
+    if target.is_file():
+        try:
+            if target.read_bytes() == payload:
+                print(_style(f"bridge: already up to date ({target})", _Ansi.GREEN))
+                return 0
+        except OSError as exc:
+            if not force:
+                print(_style(f"bridge: existing {target} not readable ({exc})", _Ansi.RED), file=sys.stderr)
+                return 1
+        if not force:
+            print(
+                _style(
+                    f"bridge: refusing to overwrite existing {target} "
+                    "(use --bridge-force-install)",
+                    _Ansi.YELLOW,
+                ),
+                file=sys.stderr,
+            )
+            return 1
+    elif target.exists():
+        if not force:
+            print(_style(f"bridge: refusing to replace non-file path {target}", _Ansi.YELLOW), file=sys.stderr)
+            return 1
+
+    created_dir = not target_dir.is_dir()
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        if created_dir:
+            os.chmod(target_dir, 0o700)
+        shutil.copy2(source, target)
+        os.chmod(target, 0o755)
+    except OSError as exc:
+        print(f"bridge: install failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = subprocess.run(["bash", "-n", str(target)], capture_output=True, text=True)
+    except OSError as exc:
+        print(f"bridge: bash unavailable after install ({exc})", file=sys.stderr)
+        return 1
+    if result.returncode != 0:
+        try:
+            target.unlink(missing_ok=True)
+        except OSError:
+            pass
+        print(
+            f"bridge: syntax check failed, removed {target}: "
+            f"{result.stderr.strip() or result.stdout.strip()}",
+            file=sys.stderr,
+        )
+        return 1
+    print(_style(f"bridge: installed -> {target}", _Ansi.GREEN))
+    return 0
+
+
+def _router_command(root: Path, *args: str) -> int:
+    """Run the existing router CLI against ``root`` (never enabled implicitly)."""
+    script = Path(__file__).resolve().parent / "router.py"
+    env = dict(os.environ, PROXY_ROUTER_ROOT=str(root))
+    try:
+        return subprocess.call([sys.executable, str(script), *args], env=env)
+    except OSError as exc:
+        print(f"setup: could not run {script}: {exc}", file=sys.stderr)
+        return 1
+
+
+def _read_routing_state(root: Path) -> dict:
+    """Read-only view of the persisted routing section (no mutation, no
+    subprocess): the TUI renders from this; every change goes through the
+    ``router.py routing`` CLI writer below."""
+    try:
+        data = json.loads((Path(root) / "router.json").read_text())
+        routing = data.get("routing") or {}
+        if not isinstance(routing, dict):
+            routing = {}
+    except (OSError, json.JSONDecodeError):
+        routing = {}
+    return {
+        "mode": routing.get("mode", "default"),
+        "direct_domains": list(routing.get("direct_domains", []) or []),
+        "vpn_domains": list(routing.get("vpn_domains", []) or []),
+        "default_provider": routing.get("default_provider"),
+    }
+
+
+def _routing_lines(root: Path) -> list[str]:
+    state = _read_routing_state(root)
+    direct = ", ".join(state["direct_domains"]) or "(none)"
+    vpn = ", ".join(state["vpn_domains"]) or "(none)"
+    return [
+        f"mode: {state['mode']}",
+        f"direct_domains: {direct}",
+        f"vpn_domains: {vpn}",
+        f"default_provider: {state['default_provider'] or '(none)'}",
+    ]
+
+
+def _cmd_routing(root: Path) -> None:
+    """Line-menu flow for routing modes. Every mutation shells out to the
+    existing ``router.py routing`` CLI - one config writer, never a second
+    mutation path - and the engine is never started or reloaded here."""
+    while True:
+        _router_command(root, "routing", "show")
+        print(_style("  [1] set vpn-list   [2] set safe-list   [3] add direct   [4] remove direct"
+                     "   [5] add vpn   [6] remove vpn   [b] back", _Ansi.BOLD))
+        try:
+            choice = input(_style("routing> ", _Ansi.BOLD)).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if choice in ("b", "back", "q"):
+            return
+        if choice == "1":
+            _router_command(root, "routing", "set", "--mode", "vpn-list")
+        elif choice == "2":
+            provider = input("  default provider (empty keeps the current one): ").strip()
+            args = ["routing", "set", "--mode", "safe-list"]
+            if provider:
+                args += ["--default-provider", provider]
+            _router_command(root, "routing", *args)
+        elif choice == "3":
+            domain = input("  domain to go DIRECT: ").strip()
+            if domain:
+                _router_command(root, "routing", "add", "--mode", "safe-list", "--domain", domain)
+        elif choice == "4":
+            domain = input("  domain to remove from the direct list: ").strip()
+            if domain:
+                _router_command(root, "routing", "remove", "--mode", "safe-list", "--domain", domain)
+        elif choice == "5":
+            domain = input("  domain to TUNNEL: ").strip()
+            if domain:
+                _router_command(root, "routing", "add", "--mode", "vpn-list", "--domain", domain)
+        elif choice == "6":
+            domain = input("  domain to remove from the vpn list: ").strip()
+            if domain:
+                _router_command(root, "routing", "remove", "--mode", "vpn-list", "--domain", domain)
+        else:
+            print(f"  unknown choice '{choice}'")
+
+
+# ---------------------------------------------------------------------------
+# interactive wizard
+# ---------------------------------------------------------------------------
+
+_BANNER = """
+  proxy-router setup wizard
+  -------------------------
+  Guides, profile imports, route presets and health checks.
+  The engine is never started unless you explicitly pick item 8.
+"""
+
+_MENU = [
+    ("1", "Show Proton VPN guide"),
+    ("2", "Show Cloudflare WARP guide"),
+    ("3", "Show both guides"),
+    ("4", "Import Proton VPN profiles (.conf file or directory)"),
+    ("5", "Import Cloudflare WARP profiles (.conf file or directory)"),
+    ("6", "Apply route presets (opencode.ai -> proton, roblox -> cloudflare)"),
+    ("7", "Check provider health"),
+    ("8", "Start / reload the proxy engine (explicit action)"),
+    ("9", "Install / verify OpenCode auto-rotation bridge (Hermes)"),
+    ("r", "Routing modes (safe-list / vpn-list / default)"),
+    ("s", "Presets: apply, browse, or create (built-in + custom)"),
+    ("q", "Quit"),
+]
+
+
+def _print_menu() -> None:
+    print(_style(_BANNER, _Ansi.CYAN))
+    for key, label in _MENU:
+        print(f"  {_style(key, _Ansi.BOLD)}  {_tint_provider(label)}")
+    print()
+
+
+def _prompt_import(root: Path, provider: str) -> None:
+    label = "Proton VPN" if provider == "proton" else "Cloudflare WARP"
+    try:
+        answer = input(f"  path to .conf file or directory ({_tint_provider(label)}): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+    if not answer:
+        return
+    _cmd_import(root, provider, [answer])
+
+
+def _line_wizard(root: Path) -> int:
+    """Line-based fallback: used whenever either stream is not a real TTY."""
+    while True:
+        _print_menu()
+        try:
+            choice = input(_style("setup> ", _Ansi.BOLD)).strip().lower()
+        except EOFError:
+            print()
+            return 0
+        except KeyboardInterrupt:
+            print()
+            return 130
+        if choice in ("q", "quit"):
+            return 0
+        if choice == "1":
+            _cmd_guide("proton")
+        elif choice == "2":
+            _cmd_guide("warp")
+        elif choice == "3":
+            _cmd_guide("all")
+        elif choice == "4":
+            _prompt_import(root, "proton")
+        elif choice == "5":
+            _prompt_import(root, "cloudflare")
+        elif choice == "6":
+            _cmd_preset(root)
+        elif choice == "7":
+            _cmd_check(root)
+        elif choice == "8":
+            print(_style("  starting/reloading the proxy engine (router ensure)...", _Ansi.YELLOW))
+            rc = _router_command(root, "ensure")
+            if rc == 0:
+                print(_style("  engine up", _Ansi.GREEN))
+            else:
+                print(_style("  engine failed to start (see router output above)", _Ansi.RED))
+        elif choice == "9":
+            _cmd_bridge_install(root)
+        elif choice == "r":
+            _cmd_routing(root)
+        elif choice == "s":
+            _cmd_preset_prompt(root)
+        else:
+            print(f"  unknown choice '{choice}' (enter a number or 'q')")
+
+
+# ---------------------------------------------------------------------------
+# full-screen TUI: state, pure key handling and frame rendering
+# ---------------------------------------------------------------------------
+
+# TUI menu keeps the same actions plus Quit (digit 0; q/Q/ESC also quit).
+TUI_MENU = [
+    ("1", "Show Proton guide"),
+    ("2", "Show Cloudflare guide"),
+    ("3", "Show both guides"),
+    ("4", "Import Proton profiles"),
+    ("5", "Import Cloudflare profiles"),
+    ("6", "Apply route presets (opencode.ai -> proton, roblox -> cloudflare)"),
+    ("7", "Check provider health"),
+    ("8", "Start/reload the proxy engine"),
+    ("9", "Install / verify OpenCode auto-rotation bridge (Hermes)"),
+    ("r", "Routing modes (show / switch / add-remove domain)"),
+    ("s", "Presets: apply by name / create custom (built-in + custom)"),
+    ("0", "Quit"),
+]
+TUI_MENU_INDEX = {key: index for index, (key, _) in enumerate(TUI_MENU)}
+
+UP = "\x1b[A"
+DOWN = "\x1b[B"
+ESC = "\x1b"
+ENTER = "\r"
+BACKSPACE = "\x7f"
+
+_ANSI_ESC_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI SGR sequences so captured action output stays box-safe."""
+    return _ANSI_ESC_RE.sub("", text)
+
+
+@dataclasses.dataclass
+class TuiState:
+    """Pure TUI state; view is one of "menu" | "guide" | "import" |
+    "routing" | "routing_prompt"."""
+
+    view: str = "menu"
+    cursor: int = 0
+    guide_provider: str = "proton"
+    guide_lines: list = dataclasses.field(default_factory=list)
+    guide_scroll: int = 0
+    import_provider: str = "proton"
+    import_text: str = ""
+    routing_lines: list = dataclasses.field(default_factory=list)
+    routing_prompt_label: str = ""
+    routing_prompt_text: str = ""
+    routing_prompt_args: tuple = ()
+    preset_browser: bool = False          # routing view showing presets (s), not routing actions
+    preset_step: int = 0                  # 0=name, 1=provider, 2=domains
+    preset_name: str = ""
+    preset_provider: str = ""
+    status: str = ""
+    status_ok: bool = True
+    action: tuple | None = None  # recorded machine action for the wizard loop
+    quit: bool = False
+    cols: int = 80
+    rows: int = 24
+    root: Path = ROOT
+
+
+def _initial_state(root: Path | None = None) -> TuiState:
+    size = shutil.get_terminal_size((80, 24))
+    state = TuiState(cols=max(size.columns, 40), rows=max(size.lines, 18))
+    if root is not None:
+        state.root = Path(root).resolve()
+    return state
+
+
+def _fit(text: str, width: int) -> str:
+    """Truncate/pad ``text`` to exactly ``width`` columns."""
+    if len(text) > width:
+        if width <= 1:
+            return text[:width]
+        return text[: width - 1] + "\u2026"  # horizontal ellipsis
+    return text + " " * (width - len(text))
+
+
+def _wrap_guide(text: str, width: int) -> list[str]:
+    """Split guide markdown into screen lines wrapped to ``width``."""
+    width = max(width, 10)
+    lines: list[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            lines.append("")
+        else:
+            lines.extend(textwrap.wrap(line, width) or [""])
+    return lines
+
+
+def _render_menu(state: TuiState) -> list[str]:
+    inner = max(state.cols - 2, 30)
+    lines = ["\u250c" + "\u2500" * inner + "\u2510"]
+    header = _style(_fit(" proxy-router setup ", inner), _Ansi.BOLD, _Ansi.CYAN)
+    lines.append("\u2502" + header + "\u2502")
+    lines.append("\u2502" + _fit(" Guides \u00b7 imports \u00b7 presets \u00b7 health checks ", inner) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    for index, (key, label) in enumerate(TUI_MENU):
+        right = f" {key} "
+        prefix = f"  {key}  "
+        fitted = _fit(prefix + label, inner - len(right))
+        label_plain = fitted[len(prefix):]
+        label_tint = _tint_provider(label_plain)
+        if index == state.cursor:
+            row = "\u2502" + prefix + label_tint + right + "\u2502"
+            lines.append(_style(row, _Ansi.REVERSE))
+        else:
+            lines.append("\u2502" + _style(prefix, _Ansi.CYAN) + label_tint + right + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    status_lines = [ln for ln in state.status.splitlines() if ln.strip()] or ["Ready \u2014 pick an item."]
+    for ln in status_lines[-2:]:
+        plain = _strip_ansi(ln)
+        if plain.strip() == "Ready \u2014 pick an item.":
+            styled = _style(_fit(" " + plain, inner), _Ansi.DIM)
+        elif state.status_ok:
+            styled = _style(_fit(" " + plain, inner), _Ansi.GREEN)
+        else:
+            styled = _style(_fit(" " + plain, inner), _Ansi.RED)
+        lines.append("\u2502" + styled + "\u2502")
+    lines.append("\u2502" + _style(_fit(" \u2191\u2193 navigate \u00b7 Enter select \u00b7 q/ESC quit ", inner), _Ansi.DIM) + "\u2502")
+    lines.append("\u2514" + "\u2500" * inner + "\u2518")
+    return lines
+
+
+def _render_guide(state: TuiState) -> list[str]:
+    inner = max(state.cols - 2, 30)
+    titles = {
+        "proton": "Show Proton VPN guide",
+        "warp": "Show Cloudflare WARP guide",
+        "all": "Show both guides",
+    }
+    title = titles.get(state.guide_provider, "Guide")
+    lines = ["\u250c" + "\u2500" * inner + "\u2510"]
+    title_fit = _fit(f" {title} ", inner)
+    lines.append("\u2502" + _style(_tint_provider(title_fit), _Ansi.BOLD, _Ansi.CYAN) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    visible = max(state.rows - 5, 1)
+    scroll = min(state.guide_scroll, max(0, len(state.guide_lines) - visible))
+    for index in range(visible):
+        src = state.guide_lines[scroll + index] if scroll + index < len(state.guide_lines) else ""
+        lines.append("\u2502" + _fit(src, inner) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    total = len(state.guide_lines)
+    shown = min(scroll + 1, total) if total else 0
+    lines.append("\u2502" + _style(_fit(f" line {shown}/{total} \u00b7 \u2191\u2193 scroll \u00b7 q back ", inner), _Ansi.DIM) + "\u2502")
+    lines.append("\u2514" + "\u2500" * inner + "\u2518")
+    return lines
+
+
+def _render_import(state: TuiState) -> list[str]:
+    inner = max(state.cols - 2, 30)
+    title = (
+        "Import Proton VPN profiles"
+        if state.import_provider == "proton"
+        else "Import Cloudflare WARP profiles"
+    )
+    lines = ["\u250c" + "\u2500" * inner + "\u2510"]
+    title_fit = _fit(f" {title} ", inner)
+    lines.append("\u2502" + _style(_tint_provider(title_fit), _Ansi.BOLD, _Ansi.CYAN) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    path_display = state.import_text or "no path yet"
+    lines.append("\u2502" + _fit(" path: " + path_display, inner) + "\u2502")
+    lines.append("\u2502" + _style(_fit(" Enter submits \u00b7 ESC cancels \u00b7 backspace edits ", inner), _Ansi.DIM) + "\u2502")
+    lines.append("\u2514" + "\u2500" * inner + "\u2518")
+    return lines
+
+
+_ROUTING_ACTIONS = [
+    ("1", "switch to vpn-list (only listed domains tunneled)"),
+    ("2", "switch to safe-list (everything else via default_provider)"),
+    ("3", "add domain to the direct list"),
+    ("4", "remove domain from the direct list"),
+    ("5", "add domain to the vpn list"),
+    ("6", "remove domain from the vpn list"),
+    ("7", "apply a preset by name (built-in or custom)"),
+]
+_PRESET_ACTIONS = [
+    ("1", "apply a preset by name (built-in or custom)"),
+    ("2", "create a new preset (name, provider, domain)"),
+]
+_PRESET_PROMPT_LABEL = "preset name to apply (built-in or custom):"
+_PRESET_CREATE_LABELS = [
+    "new preset name (e.g. banana):",
+    "provider for the preset (proton / cloudflare):",
+    "domain(s) to route (comma-separated, e.g. opencode.ai):",
+]
+
+
+def _render_routing(state: TuiState) -> list[str]:
+    """Routing-modes view (r) or presets browser (s). Rendered read-only;
+    every change is executed by the wizard loop through the router CLI
+    (routing) or add_custom_preset (preset create)."""
+    inner = max(state.cols - 2, 30)
+    if state.preset_browser:
+        title = " presets "
+        lines = ["\u250c" + "\u2500" * inner + "\u2510"]
+        lines.append("\u2502" + _style(_fit(title, inner), _Ansi.BOLD, _Ansi.CYAN) + "\u2502")
+        lines.append("\u251c" + "\u2500" * inner + "\u2524")
+        for ln in state.routing_lines:
+            lines.append("\u2502" + _fit(" " + ln, inner) + "\u2502")
+        lines.append("\u251c" + "\u2500" * inner + "\u2524")
+        for key, label in _PRESET_ACTIONS:
+            lines.append("\u2502" + _style(_fit(f"  {key}  {label}", inner), _Ansi.CYAN) + "\u2502")
+        lines.append("\u251c" + "\u2500" * inner + "\u2524")
+        lines.append("\u2502" + _style(_fit(" 1-2 change \u00b7 ESC back ", inner), _Ansi.DIM) + "\u2502")
+        lines.append("\u2514" + "\u2500" * inner + "\u2518")
+        return lines
+    lines = ["\u250c" + "\u2500" * inner + "\u2510"]
+    lines.append("\u2502" + _style(_fit(" routing modes ", inner), _Ansi.BOLD, _Ansi.CYAN) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    for ln in state.routing_lines:
+        lines.append("\u2502" + _fit(" " + ln, inner) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    for key, label in _ROUTING_ACTIONS:
+        lines.append("\u2502" + _style(_fit(f"  {key}  {label}", inner), _Ansi.CYAN) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    lines.append("\u2502" + _style(_fit(" 1-7 change \u00b7 writes go through the router CLI \u00b7 ESC back ", inner), _Ansi.DIM) + "\u2502")
+    lines.append("\u2514" + "\u2500" * inner + "\u2518")
+    return lines
+
+
+def _render_routing_prompt(state: TuiState) -> list[str]:
+    """Single-field text input for routing mutations (domain/provider)."""
+    inner = max(state.cols - 2, 30)
+    lines = ["\u250c" + "\u2500" * inner + "\u2510"]
+    lines.append("\u2502" + _style(_fit(" routing input ", inner), _Ansi.BOLD, _Ansi.CYAN) + "\u2502")
+    lines.append("\u251c" + "\u2500" * inner + "\u2524")
+    lines.append("\u2502" + _fit(" " + (state.routing_prompt_label or "input:"), inner) + "\u2502")
+    display = state.routing_prompt_text or "no input yet"
+    lines.append("\u2502" + _fit(" input: " + display, inner) + "\u2502")
+    lines.append("\u2502" + _style(_fit(" Enter submits \u00b7 ESC cancels \u00b7 backspace edits ", inner), _Ansi.DIM) + "\u2502")
+    lines.append("\u2514" + "\u2500" * inner + "\u2518")
+    return lines
+
+
+def render_frame(state: TuiState) -> list[str]:
+    """Build the full frame (header, body, footer) as a list of screen lines."""
+    if state.view == "guide":
+        return _render_guide(state)
+    if state.view == "import":
+        return _render_import(state)
+    if state.view == "routing":
+        return _render_routing(state)
+    if state.view == "routing_prompt":
+        return _render_routing_prompt(state)
+    return _render_menu(state)
+
+
+def _open_guide(state: TuiState, provider: str) -> None:
+    text = guide_text(provider)
+    if not text:
+        state.status = f"no {provider} guide available"
+        state.status_ok = False
+        return
+    state.view = "guide"
+    state.guide_provider = provider
+    state.guide_lines = _wrap_guide(text, max(state.cols - 4, 20))
+    state.guide_scroll = 0
+
+
+def _select_item(state: TuiState, index: int) -> TuiState:
+    """Enter/digit selection: switch view or record a machine action."""
+    key, _ = TUI_MENU[index]
+    if key == "0":
+        state.quit = True
+    elif key == "1":
+        _open_guide(state, "proton")
+    elif key == "2":
+        _open_guide(state, "warp")
+    elif key == "3":
+        _open_guide(state, "all")
+    elif key == "4":
+        state.view, state.import_provider, state.import_text = "import", "proton", ""
+    elif key == "5":
+        state.view, state.import_provider, state.import_text = "import", "cloudflare", ""
+    elif key == "6":
+        state.action = ("preset",)
+    elif key == "7":
+        state.action = ("check",)
+    elif key == "8":
+        state.action = ("engine",)
+    elif key == "9":
+        state.action = ("bridge_install",)
+    elif key == "r":
+        # Read-only rendering; mutations flow through the router CLI via
+        # state.action, exactly like every other TUI action.
+        state.view = "routing"
+        state.preset_browser = False
+        state.routing_lines = _routing_lines(state.root) or ["routing modes"]
+        state.routing_prompt_text = ""
+    elif key == "s":
+        # Preset browser: renders read-only, mutation flows through
+        # state.action like routing changes.
+        state.view = "routing"
+        state.preset_browser = True
+        try:
+            names = preset_names(state.root)
+            state.routing_lines = ["presets: " + (", ".join(names) if names else "(none)")]
+        except OSError:
+            state.routing_lines = ["presets: (unreadable)"]
+        state.routing_prompt_text = ""
+    return state
+
+
+def apply_key(state: TuiState, key: str) -> TuiState:
+    """Advance the TUI by one key event; returns a new state.
+
+    Pure with respect to the terminal: never writes to the screen and never
+    runs machine actions directly. Imports/presets/check/engine record
+    ``state.action`` for the wizard loop to execute through the existing
+    ``_cmd_*`` helpers, keeping business logic identical to today.
+    """
+    state = copy.copy(state)
+    state.action = None
+
+    if state.view == "guide":
+        if key in ("q", "Q", ESC, ENTER, "\n"):
+            state.view = "menu"
+        elif key in (UP, "k", "K"):
+            state.guide_scroll = max(0, state.guide_scroll - 1)
+        elif key in (DOWN, "j", "J"):
+            visible = max(1, state.rows - 5)
+            max_scroll = max(0, len(state.guide_lines) - visible)
+            state.guide_scroll = min(state.guide_scroll + 1, max_scroll)
+        return state
+
+    if state.view == "import":
+        if key == ESC:
+            state.view = "menu"
+        elif key in (ENTER, "\n"):
+            path = state.import_text.strip()
+            state.view = "menu"
+            if not path:
+                state.status = "import cancelled: empty path"
+                state.status_ok = False
+            else:
+                state.action = ("import", state.import_provider, path)
+        elif key in (BACKSPACE, "\x08"):
+            state.import_text = state.import_text[:-1]
+        elif key and len(key) == 1 and ord(key) >= 32:
+            if len(state.import_text) < max(state.cols * 4, 256):
+                state.import_text += key
+        return state
+
+    if state.view == "routing":
+        if key in (ESC, "q", "Q"):
+            state.view = "menu"
+        elif state.preset_browser:
+            if key == "1":
+                state.view = "routing_prompt"
+                state.routing_prompt_label = _PRESET_PROMPT_LABEL
+                state.routing_prompt_args = ("preset_by_name", "{TEXT}")
+            elif key == "2":
+                state.view = "routing_prompt"
+                state.preset_step = 0
+                state.preset_name = state.preset_provider = ""
+                state.routing_prompt_label = _PRESET_CREATE_LABELS[0]
+            return state
+        elif key == "1":
+            state.action = ("routing", "set", "--mode", "vpn-list")
+        elif key == "2":
+            if _read_routing_state(state.root).get("default_provider"):
+                state.action = ("routing", "set", "--mode", "safe-list")
+            else:
+                state.view = "routing_prompt"
+                state.routing_prompt_label = "default provider for safe-list (e.g. proton):"
+                state.routing_prompt_args = ("routing", "set", "--mode", "safe-list",
+                                             "--default-provider", "{TEXT}")
+        elif key == "3":
+            state.view = "routing_prompt"
+            state.routing_prompt_label = "domain to go DIRECT (safe-list):"
+            state.routing_prompt_args = ("routing", "add", "--mode", "safe-list", "--domain", "{TEXT}")
+        elif key == "4":
+            state.view = "routing_prompt"
+            state.routing_prompt_label = "domain to remove from the DIRECT list (safe-list):"
+            state.routing_prompt_args = ("routing", "remove", "--mode", "safe-list", "--domain", "{TEXT}")
+        elif key == "5":
+            state.view = "routing_prompt"
+            state.routing_prompt_label = "domain to TUNNEL (vpn-list):"
+            state.routing_prompt_args = ("routing", "add", "--mode", "vpn-list", "--domain", "{TEXT}")
+        elif key == "6":
+            state.view = "routing_prompt"
+            state.routing_prompt_label = "domain to remove from the VPN list (vpn-list):"
+            state.routing_prompt_args = ("routing", "remove", "--mode", "vpn-list", "--domain", "{TEXT}")
+        elif key == "7":
+            state.view = "routing_prompt"
+            state.routing_prompt_label = _PRESET_PROMPT_LABEL
+            state.routing_prompt_args = ("preset_by_name", "{TEXT}")
+        return state
+
+    if state.view == "routing_prompt":
+        if key == ESC:
+            state.view = "routing" if state.preset_browser else "menu"
+            state.preset_step = 0
+        elif key in (ENTER, "\n"):
+            text = state.routing_prompt_text.strip()
+            if state.preset_browser and state.preset_step < 2:
+                # create-preset flow: name (0) -> provider (1) -> domains (2)
+                if not text:
+                    state.status = "preset create cancelled: empty input"
+                    state.status_ok = False
+                elif state.preset_step == 0:
+                    state.preset_name = text
+                    state.preset_step = 1
+                    state.routing_prompt_label = _PRESET_CREATE_LABELS[1]
+                elif state.preset_step == 1:
+                    state.preset_provider = text
+                    state.preset_step = 2
+                    state.routing_prompt_label = _PRESET_CREATE_LABELS[2]
+                state.routing_prompt_text = ""
+            elif state.preset_browser and state.preset_step == 2:
+                # final create-flow step: domains -> fire preset_create action
+                state.view = "routing"
+                state.preset_step = 0
+                if not text:
+                    state.status = "preset create cancelled: empty domain"
+                    state.status_ok = False
+                else:
+                    state.action = ("preset_create", state.preset_name,
+                                    state.preset_provider, text)
+            else:
+                state.view = "routing" if state.preset_browser else "menu"
+                if not text:
+                    state.status = "routing change cancelled: empty input"
+                    state.status_ok = False
+                else:
+                    state.action = tuple(text if part == "{TEXT}" else part for part in state.routing_prompt_args)
+        elif key in (BACKSPACE, "\x08"):
+            state.routing_prompt_text = state.routing_prompt_text[:-1]
+        elif key and len(key) == 1 and ord(key) >= 32:
+            if len(state.routing_prompt_text) < max(state.cols * 4, 256):
+                state.routing_prompt_text += key
+        return state
+
+    # menu view
+    if key in (UP, "k", "K"):
+        state.cursor = (state.cursor - 1) % len(TUI_MENU)
+    elif key in (DOWN, "j", "J"):
+        state.cursor = (state.cursor + 1) % len(TUI_MENU)
+    elif key in ("q", "Q", ESC, "\x03", "\x04"):
+        state.quit = True
+    elif key in (ENTER, "\n"):
+        return _select_item(state, state.cursor)
+    elif key in TUI_MENU_INDEX:
+        state.cursor = TUI_MENU_INDEX[key]
+        return _select_item(state, state.cursor)
+    return state
+
+
+@contextlib.contextmanager
+def _capture_output():
+    """Capture parent prints and child-process fd output into one buffer."""
+    buf = io.StringIO()
+    saved_out = saved_err = None
+    sys.stdout.flush()
+    sys.stderr.flush()
+    try:
+        saved_out, saved_err = os.dup(1), os.dup(2)
+        with tempfile.TemporaryFile() as tmp:
+            os.dup2(tmp.fileno(), 1)
+            os.dup2(tmp.fileno(), 2)
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                yield buf
+            tmp.seek(0)
+            buf.write(tmp.read().decode("utf-8", errors="replace"))
+    finally:
+        if saved_out is not None:
+            os.dup2(saved_out, 1)
+            os.close(saved_out)
+        if saved_err is not None:
+            os.dup2(saved_err, 2)
+            os.close(saved_err)
+
+
+def _execute_action(action: tuple, root: Path) -> tuple[str, int]:
+    """Run a recorded action through the existing helpers, capturing output.
+
+    Exactly the same helpers and call shapes as the non-interactive CLI and
+    the line wizard use; the screen simply stays up and the result lands in
+    the status area instead of the terminal scrollback.
+    """
+    kind = action[0]
+    with _capture_output() as buf:
+        if kind == "import":
+            rc = _cmd_import(root, action[1], [action[2]])
+        elif kind == "preset":
+            rc = _cmd_preset(root)
+        elif kind == "preset_by_name":
+            try:
+                result = apply_preset_by_name(root, action[1])
+                buf.write(f"preset '{result['preset']}' applied — routing={result['mode']}"
+                          + (f"; added {', '.join(result['added'])}" if result["added"] else "; nothing to add"))
+                rc = 0
+            except (ValueError, json.JSONDecodeError, OSError) as exc:
+                buf.write(f"preset apply failed: {exc}")
+                rc = 1
+        elif kind == "preset_create":
+            # write the preset file only; the engine is never started here
+            try:
+                _, name, provider, domain_text = action
+                domains = [d.strip() for d in domain_text.split(",") if d.strip()]
+                path = add_custom_preset(root, name, provider, domains)
+                buf.write(f"custom preset '{name}' written to {path.relative_to(root or Path('.'))} (not applied)")
+                rc = 0
+            except (ValueError, OSError) as exc:
+                buf.write(f"preset create failed: {exc}")
+                rc = 1
+        elif kind == "check":
+            rc = _cmd_check(root)
+        elif kind == "engine":
+            rc = _router_command(root, "ensure")
+            if rc == 0:
+                buf.write("engine up")
+            else:
+                buf.write("engine failed to start (see output above)")
+        elif kind == "bridge_install":
+            rc = _cmd_bridge_install(root)
+        elif kind == "routing":
+            # One writer: the `router.py routing` CLI. Never starts the engine -
+            # the output tells the operator to run ensure/reload separately.
+            rc = _router_command(root, "routing", *action[1:])
+            if rc == 0:
+                buf.write("routing config saved (engine NOT reloaded - run 'router.py ensure' to apply)")
+            else:
+                buf.write("routing change failed (see router output above)")
+        else:  # pragma: no cover - defensive
+            rc = 0
+    return _strip_ansi(buf.getvalue()).strip(), rc
+
+
+def _paint(state: TuiState) -> None:
+    """Paint one full frame: home + lines + home, single write burst."""
+    out = sys.stdout
+    frame = render_frame(state)
+    if len(frame) < state.rows:
+        frame = frame + [""] * (state.rows - len(frame))
+    out.write("\x1b[H")
+    out.write("\r\n".join(frame))
+    out.write("\x1b[H")
+    if state.view == "import":
+        row = 4  # 1-based line of the " path: " input row (frame index 3)
+        col = min(1 + len(" path: ") + len(state.import_text), state.cols - 1)
+        out.write(f"\x1b[{row};{col}H\x1b[?25h")
+    else:
+        out.write("\x1b[?25l")
+    out.flush()
+
+
+def _read_key(timeout: float = 0.05) -> str:
+    """Read one key event from raw stdin; resolves ESC-prefixed sequences."""
+    fd = sys.stdin.fileno()
+
+    def _read1() -> str:
+        try:
+            data = os.read(fd, 1)
+        except OSError:
+            return ""
+        if not data:
+            return "\x04"  # EOF behaves like quit
+        return data.decode("utf-8", errors="replace")
+
+    ch = _read1()
+    if ch != ESC:
+        return ch
+    # ESC: possibly the start of an arrow/function sequence; peek for more.
+    try:
+        ready, _, _ = select.select([fd], [], [], timeout)
+    except (OSError, ValueError):
+        ready = []
+    if not ready:
+        return ESC
+    seq = _read1()
+    if seq in ("[", "O"):
+        try:
+            ready, _, _ = select.select([fd], [], [], timeout)
+        except (OSError, ValueError):
+            ready = []
+        if ready:
+            seq += _read1()
+    return ESC + seq
+
+
+def _tui_wizard(root: Path) -> int:
+    """Full-screen alternate-screen wizard (both streams must be TTYs)."""
+    state = _initial_state(root)
+    fd = sys.stdin.fileno()
+    try:
+        saved = termios.tcgetattr(fd)
+    except (termios.error, OSError, ValueError):
+        saved = None
+    interrupted = False
+    try:
+        try:
+            tty.setraw(fd)
+        except Exception:
+            return _line_wizard(root)
+        sys.stdout.write("\x1b[?1049h\x1b[?25l\x1b[2J")
+        sys.stdout.flush()
+        while not state.quit:
+            _paint(state)
+            key = _read_key()
+            state = apply_key(state, key)
+            if state.action is not None:
+                text, rc = _execute_action(state.action, root)
+                state.action = None
+                state.view = "menu"
+                state.status = text or ("command finished" if rc == 0 else "command failed")
+                state.status_ok = rc == 0
+    except KeyboardInterrupt:
+        interrupted = True
+    finally:
+        # Always restore the terminal, even on errors or Ctrl-C.
+        try:
+            sys.stdout.write("\x1b[?25h\x1b[?1049l\n\n")
+            sys.stdout.flush()
+        except Exception:
+            pass
+        if saved is not None:
+            try:
+                termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+            except Exception:
+                pass
+    return 130 if interrupted else 0
+
+
+def wizard(root=None) -> int:
+    """Interactive setup: full-screen TUI on a real TTY, line fallback otherwise.
+
+    Falls back to the plain line menu when stdin or stdout is not a TTY
+    (pipes, CI, tests) or when POSIX raw mode (termios/tty) is unavailable.
+    """
+    root = Path(root) if root is not None else ROOT
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return _line_wizard(root)
+    if not _HAVE_TERMIOS:
+        return _line_wizard(root)
+    return _tui_wizard(root)
+
+
+def main(argv=None, root=None) -> int:
+    """CLI entry point: non-interactive flags, or the wizard when run bare.
+
+    ``root`` is the repository root to operate on (tests and the router CLI
+    pass it explicitly); it redirects every path this module resolves.
+    """
+    global ROOT
+    if root is not None:
+        ROOT = Path(root).resolve()
+    if argv and argv[0] == "setup":
+        argv = argv[1:]
+
+    parser = argparse.ArgumentParser(
+        prog="proxy-router setup",
+        description="setup wizard: guides, profile import, presets, health check",
+    )
+    parser.add_argument("--guide", choices=["proton", "warp", "all"], metavar="PROVIDER",
+                        help="print a setup guide (proton, warp, or all)")
+    parser.add_argument("--check", action="store_true",
+                        help="verify router.json and provider profiles")
+    parser.add_argument("--import-proton", nargs="+", metavar="PATH",
+                        help="import WireGuard .conf file(s)/directory into providers/proton")
+    parser.add_argument("--import-warp", nargs="+", metavar="PATH",
+                        help="import WireGuard .conf file(s)/directory into providers/cloudflare")
+    parser.add_argument("--preset", metavar="NAME", nargs="?",
+                        const="default",
+                        help="apply a preset by name (built-in or custom; bare --preset applies 'default')")
+    parser.add_argument("--preset-list", action="store_true",
+                        help="list available presets (built-in and custom)")
+    parser.add_argument("--preset-add", metavar="NAME",
+                        help="create a custom preset file under presets/")
+    parser.add_argument("--provider", metavar="PROVIDER",
+                        help="provider for --preset-add (e.g. proton, cloudflare)")
+    parser.add_argument("--domain", action="append", default=[], metavar="DOMAIN",
+                        help="domain for --preset-add (repeatable)")
+    parser.add_argument("--preset-route-mode", choices=["vpn-list", "safe-list", "default"],
+                        default="vpn-list",
+                        help="routing mode for --preset-add (default vpn-list)")
+    parser.add_argument("--preset-default-provider", metavar="PROVIDER",
+                        help="default_provider for --preset-add safe-list mode")
+    parser.add_argument("--bridge-install", action="store_true",
+                        help="install the Hermes OpenCode auto-rotation bridge")
+    parser.add_argument("--bridge-force-install", action="store_true",
+                        help="install the bridge, overwriting an existing file")
+    parser.add_argument("--bridge-check", action="store_true",
+                        help="verify the installed OpenCode auto-rotation bridge")
+    args = parser.parse_args(argv)
+
+    rc = 0
+    if args.guide:
+        rc = max(rc, _cmd_guide(args.guide))
+    if args.check:
+        rc = max(rc, _cmd_check(ROOT))
+    if args.import_proton:
+        rc = max(rc, _cmd_import(ROOT, "proton", args.import_proton))
+    if args.import_warp:
+        rc = max(rc, _cmd_import(ROOT, "cloudflare", args.import_warp))
+    if args.preset:
+        try:
+            result = apply_preset_by_name(ROOT, args.preset)
+            label = f"setup: preset '{result['preset']}' applied — routing={result['mode']}"
+            if result["added"]:
+                label += f", added route(s): {', '.join(result['added'])}"
+            else:
+                label += " (already present, nothing added)"
+            print(_style(_tint_provider(label), _Ansi.GREEN))
+            print("setup: run `proxy-router ensure` (or reload) to apply; the engine is untouched.")
+        except (ValueError, json.JSONDecodeError, OSError) as exc:
+            print(_style(f"setup: preset apply failed: {exc}", _Ansi.RED), file=sys.stderr)
+            rc = max(rc, 1)
+    if args.preset_list:
+        print("setup: available presets:")
+        for name in preset_names(ROOT):
+            source = "built-in" if name in _BUILTIN_PRESETS else "custom"
+            print(f"  {name:16s} ({source})")
+    if args.preset_add:
+        try:
+            if not args.provider:
+                raise ValueError("--preset-add needs --provider (e.g. proton, cloudflare)")
+            path = add_custom_preset(ROOT, args.preset_add, args.provider, args.domain,
+                                     mode=args.preset_route_mode,
+                                     default_provider=args.preset_default_provider)
+            print(_style(f"setup: custom preset '{args.preset_add}' written to {path}", _Ansi.GREEN))
+            print("setup: apply it with `setup --preset <name>`, or from the TUI preset menu.")
+        except ValueError as exc:
+            print(_style(f"setup: {exc}", _Ansi.RED), file=sys.stderr)
+            rc = max(rc, 1)
+    if args.bridge_install:
+        rc = max(rc, _cmd_bridge_install(ROOT))
+    if args.bridge_force_install:
+        rc = max(rc, _cmd_bridge_install(ROOT, force=True))
+    if args.bridge_check:
+        rc = max(rc, _cmd_bridge_check(ROOT))
+    if not (args.guide or args.check or args.import_proton or args.import_warp or args.preset
+            or args.bridge_install or args.bridge_force_install or args.bridge_check):
+        rc = wizard(ROOT)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/proxy-router/tests/test_router_regressions.py
+++ b/tools/proxy-router/tests/test_router_regressions.py
@@ -1,0 +1,1020 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_router(tmp_path):
+    sys.path.insert(0, str(ROOT))
+    spec = importlib.util.spec_from_file_location("proxy_router_under_test", ROOT / "router.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.ROOT = tmp_path
+    module.CONFIG_FILE = tmp_path / "router.json"
+    module.SING_BOX_CONFIG = tmp_path / "sing-box.json"
+    module.LAST_GOOD_FILE = tmp_path / "sing-box.json.last-good"
+    module.PID_FILE = tmp_path / "sing-box.pid"
+    module.LOG_FILE = tmp_path / "sing-box.log"
+    module.LOCK_FILE = tmp_path / "state" / "engine.lock"
+    module.MODE_FILE = tmp_path / "state" / "mode"
+    return module
+
+
+def test_vpn_list_filters_provider_routes_to_vpn_domains(tmp_path):
+    router = load_router(tmp_path)
+    profile = tmp_path / "proton.conf"
+    router._providers = {"proton": {}}
+    router._routes = [{
+        "id": "mixed",
+        "provider": "proton",
+        "domains": ["blocked.example", "ordinary.example"],
+    }]
+    router._routing = {"mode": "vpn-list", "vpn_domains": ["blocked.example"]}
+    router._port = 2080
+    router.current_mode = lambda: "proxy"
+    router._usable_profile = lambda name, preferred=None: profile
+    router.parse_wireguard = lambda path: {
+        "type": "wireguard", "tag": "", "address": ["10.0.0.2/32"],
+        "private_key": "secret", "peers": [{"address": "192.0.2.1", "port": 1,
+        "public_key": "public", "allowed_ips": ["0.0.0.0/0"]}],
+    }
+    router.dns_server_for = lambda path: "1.1.1.1"
+
+    config, _active = router.build_singbox_config()
+
+    provider_rules = [r for r in config["route"]["rules"] if r.get("outbound") == "proton"]
+    assert provider_rules == [{"outbound": "proton", "domain_suffix": ["blocked.example"]}]
+    assert config["route"]["final"] == "direct"
+
+
+def test_selective_tun_uses_address_set_and_keeps_auto_route(tmp_path):
+    router = load_router(tmp_path)
+    rulesets = tmp_path / "rulesets"
+    rulesets.mkdir()
+    (rulesets / "roblox.json").write_text(json.dumps({
+        "provider": "cloudflare",
+        "ip_cidr": ["128.116.0.0/17", "2620:135:6000::/40"],
+    }))
+    profile = tmp_path / "cloudflare.conf"
+    router._providers = {"cloudflare": {}}
+    router._routes = []
+    router._vpn = {"selective": "roblox", "selective_provider": "cloudflare"}
+    router._routing = {}
+    router._port = 2080
+    router.current_mode = lambda: "tun"
+    router._usable_profile = lambda name, preferred=None: profile
+    router.parse_wireguard = lambda path: {
+        "type": "wireguard", "tag": "", "address": ["10.0.0.2/32"],
+        "private_key": "secret", "peers": [{"address": "192.0.2.1", "port": 1,
+        "public_key": "public", "allowed_ips": ["0.0.0.0/0"]}],
+    }
+    router.dns_server_for = lambda path: "1.1.1.1"
+
+    config, _active = router.build_singbox_config()
+    tun = config["inbounds"][0]
+
+    assert tun["auto_route"] is True
+    assert tun["route_address_set"] == ["ruleset-roblox"]
+    assert config["route"]["rule_set"] == [{
+        "type": "inline", "tag": "ruleset-roblox",
+        "rules": [{"ip_cidr": ["128.116.0.0/17", "2620:135:6000::/40"]}],
+    }]
+    assert config["route"]["rules"][1] == {
+        "rule_set": ["ruleset-roblox"], "outbound": "cloudflare",
+    }
+
+
+def test_configured_profile_matches_live_endpoint_without_using_marker(tmp_path):
+    router = load_router(tmp_path)
+    provider_dir = tmp_path / "providers" / "proton"
+    provider_dir.mkdir(parents=True)
+    profile = provider_dir / "01-NL-FREE-140.conf"
+    profile.write_text("[Interface]\nAddress = 10.0.0.2/32\nPrivateKey = secret\n\n[Peer]\nEndpoint = 192.0.2.55:51820\nPublicKey = public\nAllowedIPs = 0.0.0.0/0\n")
+    router._providers = {"proton": {"directory": "providers/proton"}}
+    router.SING_BOX_CONFIG.write_text(json.dumps({"endpoints": [{
+        "type": "wireguard", "tag": "proton", "address": ["10.0.0.2/32"],
+        "private_key": "secret", "peers": [{"address": "192.0.2.55", "port": 51820,
+        "public_key": "public", "allowed_ips": ["0.0.0.0/0"]}],
+        "domain_resolver": "dns-proton",
+    }]}))
+    (tmp_path / "state").mkdir()
+    (tmp_path / "state" / "proton.active").write_text("00-US-FREE-108")
+
+    assert router.configured_profile("proton") == profile
+
+
+def test_rotate_to_current_profile_is_noop_does_not_cooldown(tmp_path, monkeypatch):
+    """Re-selecting the already-active exit must succeed and must NOT mark
+    the current profile cooling; the old code cooled it then refused the
+    pick with a nonsense 'exit is cooling down' error."""
+    router = load_router(tmp_path)
+    provider_dir = tmp_path / "providers" / "proton"
+    provider_dir.mkdir(parents=True)
+    profile = provider_dir / "00-US-FREE-108.conf"
+    profile.write_text("[Interface]\nAddress = 10.0.0.2/32\nPrivateKey = secret\n\n[Peer]\nEndpoint = 192.0.2.55:51820\nPublicKey = public\nAllowedIPs = 0.0.0.0/0\n")
+    router._providers = {"proton": {"directory": "providers/proton", "cooldown_seconds": 60}}
+    router.persisted_active = lambda name: profile
+    router.is_cooled_down = lambda name, p: False
+    marked = {}
+    router.mark_cooldown = lambda name, p, seconds: marked.setdefault(name, p)
+    router.egress_is_blocked = lambda name, p: False
+    router.engine_reload = lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not reload"))
+    router.set_active = lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not set_active"))
+    router.record_rotation = lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not record_rotation"))
+
+    rc = router.rotate("proton", to="00-US-FREE-108")
+
+    assert rc == 0
+    assert "proton" not in marked
+
+
+# ---------------------------------------------------------------------------
+# tray UX regressions (examples/proxy_tray.py)
+# ---------------------------------------------------------------------------
+
+import types  # noqa: E402
+
+
+def load_tray(tmp_path):
+    """Load the tray module with deterministic pystray/PIL stubs.
+
+    Stubs are injected into ``sys.modules`` BEFORE the module body runs, so
+    ``import pystray`` inside the tray resolves to the stub regardless of
+    whether a real pystray is installed in the test interpreter. The stub
+    mirrors pystray's Menu-as-second-argument-is-a-submenu behaviour.
+    """
+    stub_pystray = types.ModuleType("pystray")
+
+    class _StubMenu:
+        SEPARATOR = None
+
+        def __init__(self, *items):
+            self.items = items
+            self._items = items
+
+    class _StubMenuItem:
+        def __init__(self, text, action=None, enabled=True, checked=None, submenu=None):
+            if isinstance(action, _StubMenu):
+                submenu, action = action, None
+            self.text = text
+            self.action = action
+            self.enabled = enabled
+            self._checked = checked
+            self._submenu = submenu
+
+        @property
+        def submenu(self):
+            if callable(self._submenu) and not isinstance(self._submenu, _StubMenu):
+                return self._submenu()
+            return self._submenu
+
+        def is_checked(self):
+            return bool(self._checked and self._checked(_StubMenuItem("probe")))
+
+    stub_pystray.Menu = _StubMenu
+    stub_pystray.MenuItem = _StubMenuItem
+
+    stub_pil = types.ModuleType("PIL")
+    stub_pil.Image = object
+    stub_pil.ImageDraw = object
+
+    saved = {}
+    for name in ("pystray", "PIL"):
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = {"pystray": stub_pystray, "PIL": stub_pil}[name]
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "proxy_tray_under_test", ROOT / "examples" / "proxy_tray.py")
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        # Register before exec: the module uses `from __future__ import
+        # annotations`, and dataclasses resolves the string annotations via
+        # sys.modules[cls.__module__] — an unregistered module crashes there.
+        sys.modules["proxy_tray_under_test"] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name in ("pystray", "PIL"):
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+def _tray_app(module, root, *, up=False, providers=None, preset=None, error=None,
+              routing="default", action=None, mode="proxy"):
+    client = module.RouterClient(str(root))
+    app = module.TrayApp.__new__(module.TrayApp)
+    app.client = client
+    app.latest = module.RouterStatus(
+        up=up, mode=mode, providers=providers or {}, routing_mode=routing,
+        preset=preset, error=error, active_providers={})
+    app.last_action_result = action
+    app.lock = __import__("threading").Lock()
+    app.tray = None
+    return app
+
+
+def _flatten(menu_items, depth=0):
+    """Flatten a stub menu tree into (depth, text, enabled, checked) tuples."""
+    out = []
+    for item in menu_items:
+        if item is None:
+            out.append((depth, "---", True, False))
+            continue
+        sub = item.submenu
+        out.append((depth, item.text, item.enabled, item.is_checked() if sub is None else False))
+        if sub:
+            out.extend(_flatten(sub.items, depth + 1))
+    return out
+
+
+def test_tray_down_status_is_disconnected_not_error(tmp_path):
+    """ROOT CAUSE: `RouterStatus.from_cli` short-circuited on rc != 0, so a
+    plain disconnect (status --json exits 1 with a valid payload) rendered as
+    "! Error" in the tray header. The JSON payload carries the real state.
+
+    Before: error='status exit 1' on any down state.
+    After: the payload is parsed and up=False is reported; error stays None.
+    """
+    module = load_tray(tmp_path)
+    down = json.dumps({
+        "up": False, "state": "down (proxy mode; run 'vpn on' for tun, 'start' for proxy)",
+        "mode": "proxy", "port": 2080, "pid": None,
+        "providers": {"proton": {"profiles": ["01-NL-FREE-140"], "active": "01-NL-FREE-140",
+                                 "egress": {}}},
+        "routing": {"mode": "default", "direct_domains": [], "vpn_domains": [],
+                    "default_provider": None},
+        "watcher": {"enabled": True, "running": False}, "preset": "opencode",
+    })
+    st = module.RouterStatus.from_cli(1, down)
+    assert st.up is False
+    assert st.error is None
+    assert st.preset == "opencode"
+    assert st.providers["proton"]["active"] == "01-NL-FREE-140"
+
+
+def test_tray_fresh_install_is_not_error_and_shows_setup_banner(tmp_path):
+    """A fresh install (no router.json) must NOT show "! Error status exit 1";
+    the menu should point the user at Setup and leave Connect disabled."""
+    module = load_tray(tmp_path)
+    fresh = json.dumps({
+        "up": False, "state": "down (unusable config; see error above)", "mode": None,
+        "port": None, "providers": {}, "routes": [],
+        "routing": {"mode": None, "direct_domains": [], "vpn_domains": [],
+                    "default_provider": None},
+    })
+    st = module.RouterStatus.from_cli(1, fresh)
+    assert st.error is None
+    assert st.up is False
+    assert st.providers == {}
+
+    app = _tray_app(module, tmp_path)
+    rows = _flatten(app.build_menu().items)
+    labels = [text for _, text, _, _ in rows]
+    assert "● No VPN set up yet" in labels
+    assert "Start here: Setup → Add a profile (.conf)" in labels
+    # Connect must be disabled until at least one provider exists
+    connect_row = next(r for r in rows if r[1] in ("Connect", "Reconnect"))
+    assert connect_row[2] is False
+
+
+def test_tray_unparseable_status_is_error(tmp_path):
+    """A status payload that fails to parse is the only thing that should
+    surface as an error in the tray."""
+    module = load_tray(tmp_path)
+    st = module.RouterStatus.from_cli(1, "router: boom")
+    assert st.error is not None
+    assert st.up is False
+
+
+def test_tray_presets_menu_includes_custom_presets(tmp_path):
+    """Custom presets created in the setup TUI (presets/<name>.json) must
+    appear in the tray Presets menu, checked when active."""
+    module = load_tray(tmp_path)
+    (tmp_path / "presets").mkdir()
+    (tmp_path / "presets" / "banana.json").write_text(json.dumps({
+        "routes": [{"id": "banana", "domains": ["opencode.ai"], "provider": "proton"}],
+        "routing": {"mode": "vpn-list", "vpn_domains": ["opencode.ai"]},
+    }))
+    app = _tray_app(module, tmp_path, up=True, preset="banana",
+                    providers={"proton": {"active": "01-NL-FREE-140",
+                                          "profiles": ["01-NL-FREE-140"], "egress": {}}})
+    rows = _flatten(app.build_menu().items)
+    preset_rows = [(d, t, c) for d, t, e, c in rows if t.startswith("banana")]
+    assert preset_rows, "custom preset missing from tray Presets menu"
+    depth, label, checked = preset_rows[0]
+    assert "opencode.ai via proton" in label
+    assert checked is True  # active preset shows the checkmark
+
+
+def test_tray_humanize_cli_output(tmp_path):
+    """Raw CLI success/failure lines become user-facing text in the menu."""
+    module = load_tray(tmp_path)
+    assert module._humanize(
+        "setup: run `proxy-router ensure` (or reload) to apply; the engine is untouched."
+    ) == "saved — Connect to apply"
+    assert module._humanize(
+        "config saved; the engine was NOT reloaded - run 'router.py ensure' to apply"
+    ) == "saved — Connect to apply"
+    assert module._humanize(
+        "router: no sing-box binary found at /usr/local/bin/sing-box"
+    ) == "VPN engine not found — run Setup, then Connect"
+    assert module._humanize(
+        "routing mode 'safe-list' needs 'default_provider'"
+    ) == "pick a default provider first: Routing mode → home (safe list)"
+    assert module._humanize(
+        "router: provider 'cloudflare': all profiles cooling down"
+    ) == "no servers available right now — try again in a minute"
+
+
+def test_tray_friendly_egress_error_mapping(tmp_path):
+    """Raw probe error tails must become plain-language labels in the exit
+    picker — an SSL URLError tail is operator jargon, not a menu item."""
+    module = load_tray(tmp_path)
+    f = module._friendly_egress_error
+    assert f("URLError: <urlopen error [SSL: UNEXPECTED_EOF_WHILE_READING, "
+             "EOF occurred in violation of protocol (_ssl.c:983)]>") == "offline (SSL)"
+    assert f("URLError: timed out") == "timed out"
+    assert f("URLError: connection refused") == "offline"
+    assert f("URLError: [Errno -5] No address associated with hostname") == "no route (DNS)"
+    assert f("429") == "rate-limited"
+    assert f("HTTP 403") == "blocked"
+    # unknown but short tails still truncate, not explode
+    assert len(f("weird exotic failure mode")) <= 28
+
+
+def test_tray_exit_picker_humanizes_raw_error(tmp_path):
+    """profile_health must render a raw SSL/URLError as '! offline (SSL)',
+    not the Python error tail (the screenshot bug)."""
+    module = load_tray(tmp_path)
+    bad = {"ok": False, "status": None, "latency_ms": None,
+           "error": "URLError: <urlopen error [SSL: UNEXPECTED_EOF_WHILE_READING, "
+                    "EOF occurred in violation of protocol (_ssl.c:983)]>",
+           "blocked": False, "exhausted": False}
+    app = _tray_app(module, tmp_path, up=True,
+                    providers={"proton": {
+                        "active": "01-NL-FREE-140",
+                        "profiles": ["01-NL-FREE-140"],
+                        "egress": {"01-NL-FREE-140": bad}}})
+    health = app.latest.profile_health("proton", "01-NL-FREE-140")
+    assert "offline (SSL)" in health, f"raw error tail leaked: {health!r}"
+    assert "urlopen" not in health.lower(), f"Python error leaked: {health!r}"
+
+
+def test_tray_provider_row_no_manual_checkmark_duplication(tmp_path):
+    """The active provider row gets ONE checkmark from pystray's `checked=`;
+    the old code ALSO appended '  ✓' to the label, rendering two checkmarks
+    ('✓ cloudflare ● warp · 593ms ✓')."""
+    module = load_tray(tmp_path)
+    app = _tray_app(module, tmp_path, up=True,
+                    providers={"proton": {
+                        "active": "01-NL-FREE-140",
+                        "profiles": ["01-NL-FREE-140"],
+                        "egress": {"01-NL-FREE-140": {
+                            "ok": True, "status": 200,
+                            "latency_ms": 164.0, "error": None}}}})
+    rows = _flatten(app.build_menu().items)
+    provider_rows = [t for _, t, _, _ in rows if t.startswith("proton")]
+    assert provider_rows, "provider row missing"
+    label = provider_rows[0]
+    assert label.count("✓") == 0, f"manual checkmark duplicated in label: {label!r}"
+    # the footer must be plain language, not the 'exit' jargon
+    footer = [t for _, t, _, _ in rows if "Click a" in t]
+    assert footer and "location" in footer[0], f"footer jargon: {footer!r}"
+
+
+def test_tray_upstream_error_shows_warning_not_green(tmp_path):
+    """F1: a probe can ride the tunnel (ok=true) while the exit is actually
+    rate-limited upstream (429 from rotate --reason). The tray must NOT show
+    a healthy green dot — it should warn, but the exit stays CLICKABLE (a
+    stale upstream_error is recoverable, not dead)."""
+    module = load_tray(tmp_path)
+    egress_ok_but_429 = {"ok": True, "status": 200, "latency_ms": 1203.26,
+                         "error": None, "upstream_error": "429",
+                         "exhausted": False}
+    app = _tray_app(module, tmp_path, up=True,
+                    providers={"proton": {
+                        "active": "01-NL-FREE-140",
+                        "profiles": ["01-NL-FREE-140"],
+                        "egress": {"01-NL-FREE-140": egress_ok_but_429}}})
+    # provider_label: warning marker (▲), never the green ●
+    label = app.latest.provider_label("proton")
+    assert "▲" in label, f"expected warning marker in {label!r}"
+    assert "●" not in label, f"rate-limited exit shown as healthy: {label!r}"
+    # profile_health: the 429 must surface in the exit picker as plain
+    # language (raw "429" would be fine too, but "rate-limited" reads better)
+    health = app.latest.profile_health("proton", "01-NL-FREE-140")
+    assert "!" in health, f"upstream 429 not surfaced: {health!r}"
+    assert "rate-limited" in health, f"429 not humanized: {health!r}"
+    # but the exit stays clickable — recoverable warning ≠ dead
+    assert not app._exit_disabled(app.latest, "proton", "01-NL-FREE-140"), \
+        "recoverable 429 warning must not disable the exit"
+    # a genuinely healthy lane keeps the green dot
+    healthy = _tray_app(module, tmp_path, up=True,
+                        providers={"proton": {
+                            "active": "01-NL-FREE-140",
+                            "profiles": ["01-NL-FREE-140"],
+                            "egress": {"01-NL-FREE-140": {
+                                "ok": True, "status": 200,
+                                "latency_ms": 164.0, "error": None}}}})
+    healthy_label = healthy.latest.provider_label("proton")
+    assert "●" in healthy_label, f"healthy lane lost green dot: {healthy_label!r}"
+
+
+def test_tray_transport_dead_exit_is_disabled(tmp_path):
+    """An exit that died at transport level (no HTTP status) IS disabled —
+    clicking it would just fail. This is the 'genuinely dead' case, distinct
+    from a recoverable upstream_error warning."""
+    module = load_tray(tmp_path)
+    dead = {"ok": False, "status": None, "latency_ms": None,
+            "error": "URLError: connection refused", "blocked": False,
+            "exhausted": False}
+    app = _tray_app(module, tmp_path, up=True,
+                    providers={"proton": {
+                        "active": "01-NL-FREE-140",
+                        "profiles": ["01-NL-FREE-140", "02-NL-FREE-149"],
+                        "egress": {"01-NL-FREE-140": dead,
+                                   "02-NL-FREE-149": {
+                                       "ok": True, "status": 200,
+                                       "latency_ms": 164.0, "error": None}}}})
+    assert app._exit_disabled(app.latest, "proton", "01-NL-FREE-140")
+    assert not app._exit_disabled(app.latest, "proton", "02-NL-FREE-149")
+
+
+def test_tray_exit_picker_sorts_healthy_first(tmp_path):
+    """Dead exits sink to the bottom of the provider picker — the menu
+    shouldn't lead with a wall of grayed-out 'offline (SSL)' rows."""
+    module = load_tray(tmp_path)
+    dead = {"ok": False, "status": None, "latency_ms": None,
+            "error": "URLError: <urlopen error [SSL: UNEXPECTED_EOF_WHILE_READING]>",
+            "blocked": False, "exhausted": False}
+    healthy = {"ok": True, "status": 200, "latency_ms": 164.0, "error": None}
+    app = _tray_app(module, tmp_path, up=True,
+                    providers={"proton": {
+                        "active": "02-NL-FREE-149",
+                        "profiles": ["00-US-FREE-108", "01-NL-FREE-140",
+                                     "02-NL-FREE-149"],
+                        "egress": {"00-US-FREE-108": dead,
+                                   "01-NL-FREE-140": dead,
+                                   "02-NL-FREE-149": healthy}}})
+    rows = _flatten(app.build_menu().items)
+    # Provider submenu rows are at depth 2; grab the exit entries under proton
+    exit_rows = [t for d, t, e, _ in rows if d == 2 and "FREE" in t]
+    assert exit_rows[0].startswith("02-NL-FREE-149"), \
+        f"healthy exit should sort first: {exit_rows}"
+    # both dead exits sink to the bottom (alphabetical among themselves)
+    assert all(not r.startswith("02-NL-FREE-149") for r in exit_rows[1:]), \
+        f"dead exits should all sort after healthy: {exit_rows}"
+    # disabled flags still correct after sorting
+    enabled = [e for d, t, e, _ in rows if d == 2 and "FREE" in t]
+    assert enabled[0] is True and enabled[-1] is False
+
+
+def test_record_egress_heals_stale_upstream_error(tmp_path):
+    """A passing probe must clear a stale upstream_error marker (e.g. 429
+    from `rotate --reason` hours ago). Without this, the tray keeps showing
+    a warning/disable on an exit that already recovered."""
+    router = load_router(tmp_path)
+    (tmp_path / "state" / "egress" / "proton").mkdir(parents=True)
+    profile = Path("01-NL-FREE-140.conf")
+    router.record_egress("proton", profile, ok=False, status=None,
+                         error="URLError: timeout")
+    router.record_egress("proton", profile, ok=True, status=200,
+                         latency_ms=120.0, error=None)
+    rec = router.read_egress("proton", profile)
+    assert rec["ok"] is True
+    assert rec["upstream_error"] is None
+    assert rec["upstream_error_at"] is None
+    assert rec["error"] is None
+
+
+class _UnreadableModeFile:
+    def is_file(self):
+        return True
+
+    def read_text(self):
+        raise PermissionError(1, "operation not permitted")
+
+
+def test_vpn_on_disables_system_proxy_after_tun_start(tmp_path, monkeypatch):
+    """ROOT CAUSE: `vpn on` switched the engine to tun mode (no
+    127.0.0.1:2080 listener) but left the macOS system proxy enabled, so
+    browsers sent traffic to a dead port and every site failed with a
+    connection reset. A successful tun start must disable the system proxy."""
+    router = load_router(tmp_path)
+    router.current_mode = lambda: "proxy"
+    router.set_mode = lambda m: None
+    router.resolve_sing_box = lambda: Path("/bin/true")
+    router.sing_box_at_least = lambda v: True
+    router.build_singbox_config = lambda: ({"inbounds": [{"type": "tun"}]}, {"proton": Path("p")})
+    router.write_sing_box = lambda c: None
+    router.validate_config = lambda: True
+    router.vpn_note = lambda: None
+    router.engine_start = lambda: 0
+    calls = []
+    router.system_proxy_off = lambda: calls.append("off") or 0
+    monkeypatch.setattr("sys.platform", "darwin")
+
+    assert router.vpn_on() == 0
+    assert calls == ["off"]
+
+
+def test_vpn_on_already_up_still_disables_system_proxy(tmp_path, monkeypatch):
+    """Re-entering `vpn on` while tun is already up must be idempotent:
+    a stale system proxy (left on by an older version) must be cleared
+    even when the engine is not restarted."""
+    router = load_router(tmp_path)
+    router.current_mode = lambda: "tun"
+    router.engine_alive = lambda: True
+    router.engine_mode_consistent = lambda: True
+    calls = []
+    router.system_proxy_off = lambda: calls.append("off") or 0
+    monkeypatch.setattr("sys.platform", "darwin")
+
+    assert router.vpn_on() == 0
+    assert calls == ["off"]
+
+
+def test_vpn_off_reenables_system_proxy_in_proxy_mode(tmp_path, monkeypatch):
+    """Returning to proxy mode restores the listener-based system proxy,
+    mirroring the tun-mode disable; without it the browser stays broken
+    after `vpn off`."""
+    router = load_router(tmp_path)
+    router.set_mode = lambda m: None
+    router.engine_stop = lambda: 0
+    router.engine_start = lambda: 0
+    calls = []
+    router.system_proxy_on = lambda: calls.append("on") or 0
+    monkeypatch.setattr("sys.platform", "darwin")
+
+    assert router.vpn_off() == 0
+    assert calls == ["on"]
+
+
+def test_engine_alive_permission_error_means_our_engine(tmp_path, monkeypatch):
+    """ROOT CAUSE: an engine started via `sudo vpn on` runs as root; the
+    regular-user liveness probe os.kill(pid, 0) raises PermissionError,
+    which was swallowed by the generic OSError catch and misread as
+    "process gone", so the keepalive kept restarting a live engine and
+    deleted its pid file. PermissionError means the process EXISTS and our
+    pid file names it -> it is alive and ours."""
+    router = load_router(tmp_path)
+    router.PID_FILE.write_text("4242")
+    router._pid_matches = lambda pid: True
+
+    def deny_kill(pid, sig):
+        raise PermissionError(1, "operation not permitted")
+
+    monkeypatch.setattr(router.os, "kill", deny_kill)
+    assert router.engine_alive() is True
+
+
+def test_engine_stop_permission_error_keeps_pid_file(tmp_path, monkeypatch):
+    """A regular-user engine_stop on a sudo-started (root) engine cannot
+    signal it: it must fail loudly and keep the pid file (the engine IS
+    alive), not delete the pid file and pretend it stopped."""
+    router = load_router(tmp_path)
+    router.PID_FILE.write_text("4242")
+    router._pid_matches = lambda pid: True
+
+    def deny_kill(pid, sig):
+        raise PermissionError(1, "operation not permitted")
+
+    monkeypatch.setattr(router.os, "kill", deny_kill)
+    assert router.engine_stop() == 1
+    assert router.PID_FILE.is_file()
+
+
+def test_current_mode_unreadable_mode_file_defaults_to_proxy(tmp_path, monkeypatch):
+    """A root-owned mode file (from a sudo run) must not crash the
+    regular-user CLI/keepalive; unreadable state defaults to proxy mode."""
+    router = load_router(tmp_path)
+    router.MODE_FILE = _UnreadableModeFile()
+    assert router.current_mode() == "proxy"
+
+
+def test_hand_back_ownership_chowns_when_sudo_invoked(tmp_path, monkeypatch):
+    """When running as root under sudo, state files must be handed back to
+    the invoking user (SUDO_UID/SUDO_GID) so the regular-user keepalive/CLI
+    can read them."""
+    router = load_router(tmp_path)
+    target = tmp_path / "state-file"
+    target.write_text("x")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 0)
+    monkeypatch.setenv("SUDO_UID", "501")
+    monkeypatch.setenv("SUDO_GID", "20")
+    chowned = []
+    monkeypatch.setattr(router.os, "chown", lambda path, uid, gid: chowned.append((str(path), uid, gid)))
+
+    router._hand_back_ownership(target)
+    assert chowned == [(str(target), 501, 20)]
+
+
+def test_hand_back_ownership_noop_for_regular_user(tmp_path, monkeypatch):
+    """A non-root run must never chown state files."""
+    router = load_router(tmp_path)
+    target = tmp_path / "state-file"
+    target.write_text("x")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    chowned = []
+    monkeypatch.setattr(router.os, "chown", lambda *args: chowned.append(args))
+
+    router._hand_back_ownership(target)
+    assert chowned == []
+
+
+class _TTY:
+    """Stands in for sys.stdin so elevation TTY checks can be controlled."""
+
+    def __init__(self, isatty):
+        self._isatty = isatty
+
+    def isatty(self):
+        return self._isatty
+
+
+def test_needs_elevation_vpn_on_interactive_darwin_nonroot(tmp_path, monkeypatch):
+    """`vpn on` as a regular user on macOS must re-run elevated so the
+    standard admin-password dialog asks permission instead of a manual sudo."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(router.sys, "stdin", _TTY(True))
+    monkeypatch.delenv("PROXY_ROUTER_ELEVATED", raising=False)
+    args = type("A", (), {"cmd": "vpn", "action": "on"})()
+    assert router._needs_elevation(args) is True
+
+
+def test_needs_elevation_vpn_off_only_in_tun_mode(tmp_path, monkeypatch):
+    """`vpn off` needs root only while TUN is active (engine runs as root);
+    in proxy mode the engine is user-owned so no elevation is needed."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(router.sys, "stdin", _TTY(True))
+    monkeypatch.delenv("PROXY_ROUTER_ELEVATED", raising=False)
+    args = type("A", (), {"cmd": "vpn", "action": "off"})()
+    router.MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    router.MODE_FILE.write_text("tun")
+    assert router._needs_elevation(args) is True
+    router.MODE_FILE.write_text("proxy")
+    assert router._needs_elevation(args) is False
+
+
+def test_needs_elevation_engine_commands_only_in_tun_mode(tmp_path, monkeypatch):
+    """start/stop/ensure/reload/rotate/add/remove touch the engine, which in
+    tun mode runs as root -> elevate; in proxy mode they stay user-level."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(router.sys, "stdin", _TTY(True))
+    monkeypatch.delenv("PROXY_ROUTER_ELEVATED", raising=False)
+    router.MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    router.MODE_FILE.write_text("tun")
+    for cmd in ("start", "stop", "ensure", "reload", "rotate", "add", "remove"):
+        args = type("A", (), {"cmd": cmd})()
+        assert router._needs_elevation(args) is True, cmd
+    router.MODE_FILE.write_text("proxy")
+    for cmd in ("start", "stop", "ensure", "reload", "rotate", "add", "remove"):
+        args = type("A", (), {"cmd": cmd})()
+        assert router._needs_elevation(args) is False, cmd
+
+
+def test_needs_elevation_skips_readonly_and_status_commands(tmp_path, monkeypatch):
+    """Read-only commands (status, routes, vpn status) never elevate."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(router.sys, "stdin", _TTY(True))
+    monkeypatch.delenv("PROXY_ROUTER_ELEVATED", raising=False)
+    router.MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    router.MODE_FILE.write_text("tun")
+    for cmd, action in (("status", None), ("routes", None), ("vpn", "status")):
+        args = type("A", (), {"cmd": cmd, "action": action})()
+        assert router._needs_elevation(args) is False, cmd
+
+
+def test_needs_elevation_skips_noninteractive_keepalive(tmp_path, monkeypatch):
+    """keepalive/launchd ticks run without a TTY and must never pop the
+    admin-password dialog on every 15s interval."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(router.sys, "stdin", _TTY(False))
+    monkeypatch.delenv("PROXY_ROUTER_ELEVATED", raising=False)
+    router.MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    router.MODE_FILE.write_text("tun")
+    args = type("A", (), {"cmd": "vpn", "action": "on"})()
+    assert router._needs_elevation(args) is False
+
+
+def test_needs_elevation_skips_root_and_elevated_child(tmp_path, monkeypatch):
+    """Already-root runs (sudo, or the elevated child) never re-elevate."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.sys, "stdin", _TTY(True))
+    args = type("A", (), {"cmd": "vpn", "action": "on"})()
+    monkeypatch.setattr(router.os, "geteuid", lambda: 0)
+    assert router._needs_elevation(args) is False
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setenv("PROXY_ROUTER_ELEVATED", "1")
+    assert router._needs_elevation(args) is False
+
+
+def test_elevate_macos_runs_osascript_with_admin_privileges(tmp_path, monkeypatch):
+    """The elevated child must be the same CLI, with SUDO_UID/SUDO_GID and
+    PATH injected so ownership hand-back and sing-box resolution work."""
+    router = load_router(tmp_path)
+    calls = []
+    monkeypatch.setattr(router.os, "getuid", lambda: 501)
+    monkeypatch.setattr(router.os, "getgid", lambda: 20)
+    monkeypatch.setattr(router.os, "environ", {"PATH": "/usr/bin:/bin"}, raising=False)
+    monkeypatch.setattr(router.sys, "argv", ["router.py", "vpn", "on"])
+    monkeypatch.setattr(router.sys, "executable", "/usr/bin/python3")
+    monkeypatch.setattr(router.subprocess, "run",
+                        lambda *a, **k: calls.append((a, k)) or type("P", (), {"returncode": 0})())
+
+    router._elevate_macos()
+    assert calls, "osascript was never invoked"
+    (pos, kwargs), = calls
+    argv = pos[0]
+    assert argv[:2] == ["osascript", "-e"]
+    script = argv[2]
+    assert "with administrator privileges" in script
+    assert "SUDO_UID=501" in script
+    assert "SUDO_GID=20" in script
+    assert "PROXY_ROUTER_ELEVATED=1" in script
+    assert "PATH=/usr/bin:/bin" in script
+    assert "vpn" in script and "on" in script
+
+
+def test_elevate_macos_escapes_applescript_specials(tmp_path, monkeypatch):
+    """Quotes/backslashes in args must survive the AppleScript string literal
+    (e.g. an --id with quotes): content `\"`/`\\` escapes, literal delimiters
+    stay unescaped (a `\` at expression position is a -2741 syntax error)."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.os, "getuid", lambda: 501)
+    monkeypatch.setattr(router.os, "getgid", lambda: 20)
+    monkeypatch.setattr(router.os, "environ", {"PATH": "/usr/bin"}, raising=False)
+    monkeypatch.setattr(router.sys, "argv", ["router.py", "add", "--id", 'we"ird\\id', "--domain", "x.example"])
+    monkeypatch.setattr(router.sys, "executable", "/usr/bin/python3")
+    captured = []
+    monkeypatch.setattr(router.subprocess, "run",
+                        lambda *a, **k: captured.append(a[0]) or type("P", (), {"returncode": 0})())
+
+    router._elevate_macos()
+    script = captured[0][2]
+    assert script.startswith('do shell script "')
+    assert 'we\\"ird\\\\id' in script
+    assert script.endswith('" with administrator privileges')
+
+
+def test_needs_elevation_vpn_restart_always(tmp_path, monkeypatch):
+    """`vpn restart` stops the engine and re-enters tun; it always needs root
+    so the whole cycle gets ONE admin prompt instead of two."""
+    router = load_router(tmp_path)
+    monkeypatch.setattr(router.sys, "platform", "darwin")
+    monkeypatch.setattr(router.os, "geteuid", lambda: 501)
+    monkeypatch.setattr(router.sys, "stdin", _TTY(True))
+    monkeypatch.delenv("PROXY_ROUTER_ELEVATED", raising=False)
+    router.MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    router.MODE_FILE.write_text("proxy")
+    args = type("A", (), {"cmd": "vpn", "action": "restart"})()
+    assert router._needs_elevation(args) is True
+
+
+def test_vpn_restart_stops_then_brings_tun_up(tmp_path, monkeypatch):
+    """vpn_restart = engine_stop then vpn_on; a failed stop short-circuits."""
+    router = load_router(tmp_path)
+    calls = []
+    monkeypatch.setattr(router, "engine_stop", lambda: calls.append("stop") or 0)
+    monkeypatch.setattr(router, "vpn_on", lambda: calls.append("on") or 0)
+    assert router.vpn_restart() == 0
+    assert calls == ["stop", "on"]
+    calls.clear()
+    monkeypatch.setattr(router, "engine_stop", lambda: calls.append("stop") or 1)
+    assert router.vpn_restart() == 1
+    assert calls == ["stop"]
+
+
+class _UnreadablePidFile:
+    """Pid file a regular user cannot read (root-owned, mode 0600 after a
+    `sudo vpn on` batch)."""
+
+    def __init__(self):
+        self.unlink_calls = 0
+
+    def is_file(self):
+        return True
+
+    def read_text(self):
+        raise PermissionError(1, "operation not permitted")
+
+    def unlink(self, missing_ok=False):
+        self.unlink_calls += 1
+
+
+def test_engine_start_aborts_when_engine_stop_fails(tmp_path, monkeypatch):
+    """ROOT CAUSE: engine_start ignored engine_stop()'s failure and started
+    a second engine on top of a live root-owned one. The doomed Popen then
+    failed (no utun access), wait_engine failed, engine_stop unlinked the
+    pid file, and the root engine was left running untracked. A failed stop
+    must abort the start."""
+    router = load_router(tmp_path)
+    router.resolve_sing_box = lambda: Path("/bin/true")
+    router.sing_box_at_least = lambda v: True
+    router.build_singbox_config = lambda overrides=None: ({"inbounds": []}, {"proton": Path("p")})
+    router.write_sing_box = lambda c: None
+    router.validate_config = lambda: True
+    router.engine_stop = lambda: 1
+    popen_calls = []
+    monkeypatch.setattr(router.subprocess, "Popen", lambda *a, **k: popen_calls.append(a) or object())
+    assert router.engine_start() == 1
+    assert popen_calls == []
+
+
+def test_engine_stop_unreadable_pid_keeps_pid_file(tmp_path, monkeypatch):
+    """ROOT CAUSE: engine_stop's garbage branch caught PermissionError
+    (an OSError subclass) on the pid-file read and unlinked the file, which
+    for a root-owned live engine destroys the only ownership record. An
+    unreadable pid file must fail loudly and stay in place."""
+    router = load_router(tmp_path)
+    pid_file = _UnreadablePidFile()
+    router.PID_FILE = pid_file
+    assert router.engine_stop() == 1
+    assert pid_file.unlink_calls == 0
+
+
+def test_engine_alive_unreadable_pid_uses_ps_scan_fallback(tmp_path, monkeypatch):
+    """ROOT CAUSE: engine_alive read PermissionError as "process gone", so
+    the keepalive kept restarting a live root-owned engine and deleted its
+    pid file. An unreadable pid file must fall back to a process-table scan
+    instead of declaring the engine dead."""
+    router = load_router(tmp_path)
+    router.PID_FILE = _UnreadablePidFile()
+    monkeypatch.setattr(router, "_any_our_engine_running", lambda: True)
+    assert router.engine_alive() is True
+    monkeypatch.setattr(router, "_any_our_engine_running", lambda: False)
+    assert router.engine_alive() is False
+
+
+def test_any_our_engine_running_scans_posix_process_table(tmp_path, monkeypatch):
+    """_any_our_engine_running matches a live sing-box by our generated
+    config path in its command line, so a foreign/unrelated process can
+    never claim liveness."""
+    router = load_router(tmp_path)
+
+    class _RunResult:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    router.os = type("_Os", (), {"name": "posix"})()
+    dead_cmd = "some other process -c /etc/sing-box/config.json"
+    live_cmd = f"sing-box run -c {router.SING_BOX_CONFIG}"
+    monkeypatch.setattr(router.subprocess, "run", lambda *a, **k: _RunResult(live_cmd))
+    assert router._any_our_engine_running() is True
+    monkeypatch.setattr(router.subprocess, "run", lambda *a, **k: _RunResult(dead_cmd))
+    assert router._any_our_engine_running() is False
+
+
+def test_engine_reload_permission_error_on_sighup_only(tmp_path, monkeypatch):
+    """ROOT CAUSE: engine_reload caught only ProcessLookupError around the
+    SIGHUP, so a regular-user reload of a root-owned engine crashed with an
+    unhandled PermissionError traceback. It must fail with the sudo hint
+    and leave the pid file alone."""
+    router = load_router(tmp_path)
+    router.resolve_sing_box = lambda: Path("/bin/true")
+    router.sing_box_at_least = lambda v: True
+    router.build_singbox_config = lambda overrides=None: ({"inbounds": []}, {"proton": Path("p")})
+    router.write_sing_box = lambda c: None
+    router.validate_config = lambda: True
+    router.PID_FILE.write_text("4242")
+    router._pid_matches = lambda pid: True
+    start_calls = []
+    monkeypatch.setattr(router, "engine_start", lambda **k: start_calls.append(k) or 0)
+
+    def deny_sighup(pid, sig):
+        raise PermissionError(1, "operation not permitted")
+
+    monkeypatch.setattr(router.os, "kill", deny_sighup)
+    assert router.engine_reload() == 1
+    assert start_calls == []
+    assert router.PID_FILE.read_text() == "4242"
+
+
+def test_restore_last_good_permission_error_on_sighup_only(tmp_path, monkeypatch):
+    """restore_last_good must not crash on a root-owned engine either: a
+    SIGHUP PermissionError fails the restore (rc 1) without touching the
+    pid file or attempting a doomed regular-user start."""
+    router = load_router(tmp_path)
+    router.LAST_GOOD_FILE.write_text("{}")
+    router.validate_config = lambda: True
+    router.PID_FILE.write_text("4242")
+    router._pid_matches = lambda pid: True
+    start_calls = []
+    monkeypatch.setattr(router, "engine_start", lambda **k: start_calls.append(k) or 0)
+
+    def deny_sighup(pid, sig):
+        raise PermissionError(1, "operation not permitted")
+
+    monkeypatch.setattr(router.os, "kill", deny_sighup)
+    assert router.restore_last_good() == 1
+    assert start_calls == []
+    assert router.PID_FILE.read_text() == "4242"
+
+
+def test_tray_full_tunnel_toggle_checked_when_tun(tmp_path):
+    """The tray must expose the full-tunnel (TUN) state as a checked menu
+    item so the user can see "on" and click to turn it off from the menu."""
+    module = load_tray(tmp_path)
+    app = _tray_app(module, tmp_path, up=True, mode="tun")
+    rows = _flatten(app.build_menu().items)
+    labels = [text for _, text, _, _ in rows]
+    assert "Full tunnel (WARP): on" in labels
+    toggle = next(r for r in rows if r[1].startswith("Full tunnel (WARP)"))
+    assert toggle[3] is True  # checked
+
+
+def test_tray_full_tunnel_toggle_unchecked_when_proxy(tmp_path):
+    """In proxy mode the toggle renders off/unchecked; clicking it turns
+    the full tunnel back on."""
+    module = load_tray(tmp_path)
+    app = _tray_app(module, tmp_path, up=True, mode="proxy")
+    rows = _flatten(app.build_menu().items)
+    toggle = next(r for r in rows if r[1].startswith("Full tunnel (WARP)"))
+    assert toggle[1] == "Full tunnel (WARP): off"
+    assert toggle[3] is False
+
+
+def test_tray_full_tunnel_toggle_invokes_vpn_action(tmp_path, monkeypatch):
+    """The toggle's action must route through the router CLI (`vpn off` when
+    tun is on, `vpn on` when it isn't) — the tray never mutates engine
+    state directly."""
+    module = load_tray(tmp_path)
+    app = _tray_app(module, tmp_path, up=True, mode="tun")
+    calls = []
+    monkeypatch.setattr(app.client, "vpn", lambda a: calls.append(a) or (0, ""))
+    app.action_toggle_vpn()
+    assert calls == ["off"]
+
+    app2 = _tray_app(module, tmp_path, up=True, mode="proxy")
+    calls2 = []
+    monkeypatch.setattr(app2.client, "vpn", lambda a: calls2.append(a) or (0, ""))
+    app2.action_toggle_vpn()
+    assert calls2 == ["on"]
+
+
+def test_tray_vpn_off_elevates_via_osascript_on_darwin(tmp_path, monkeypatch):
+    """ROOT CAUSE: the tray runs under launchd with no TTY, so router.py's
+    isatty-gated `_elevate_macos` never fires from it; a plain `vpn off`
+    subprocess would hit the new PermissionError guard and fail with the
+    "run with sudo" hint instead of doing anything useful. The tray must
+    drive the osascript admin dialog itself, with the same SUDO_UID/SUDO_GID
+    hand-back env the CLI injects."""
+    module = load_tray(tmp_path)
+    monkeypatch.setattr(module.sys, "platform", "darwin")
+    monkeypatch.setattr(module.os, "getuid", lambda: 501)
+    monkeypatch.setattr(module.os, "getgid", lambda: 20)
+    monkeypatch.setattr(module.os, "environ", {"PATH": "/usr/bin:/bin"}, raising=False)
+    calls = []
+    monkeypatch.setattr(module.subprocess, "run",
+                        lambda *a, **k: calls.append((a, k)) or type("P", (), {
+                            "returncode": 0, "stdout": "", "stderr": ""})())
+
+    client = module.RouterClient(str(tmp_path))
+    rc, out = client.vpn("off")
+    assert rc == 0
+    (pos, kwargs), = calls
+    argv = pos[0]
+    assert argv[:2] == ["osascript", "-e"]
+    script = argv[2]
+    assert "with administrator privileges" in script
+    assert "SUDO_UID=501" in script
+    assert "SUDO_GID=20" in script
+    assert "PROXY_ROUTER_ELEVATED=1" in script
+    assert "router.py" in script and "vpn off" in script
+    assert kwargs.get("timeout") == module.ELEVATED_COMMAND_TIMEOUT
+
+
+def test_tray_vpn_uses_plain_cli_off_macos(tmp_path, monkeypatch):
+    """Non-macOS has no osascript dialog; the toggle falls back to the plain
+    CLI, whose clear error tells the user to run it with sudo."""
+    module = load_tray(tmp_path)
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    calls = []
+    monkeypatch.setattr(module.subprocess, "run",
+                        lambda *a, **k: calls.append(a) or type("P", (), {
+                            "returncode": 0, "stdout": "", "stderr": ""})())
+
+    client = module.RouterClient(str(tmp_path))
+    rc, out = client.vpn("off")
+    assert rc == 0
+    assert calls and calls[0][0][-2:] == ["vpn", "off"]
+    assert not any(c[0][0] == "osascript" for c in calls)

--- a/tools/proxy-router/tests/test_setup_tui_regressions.py
+++ b/tools/proxy-router/tests/test_setup_tui_regressions.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_setup_tui():
+    name = "setup_tui_under_test"
+    spec = importlib.util.spec_from_file_location(name, ROOT / "setup_tui.py")
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_line_wizard_can_create_custom_preset(tmp_path):
+    """The pipe/line fallback must expose the custom-preset path too.
+
+    The fullscreen TUI already had this flow, but the line wizard only let
+    users apply presets; ``setup> s`` gave no way to create one.
+    """
+    module = load_setup_tui()
+    answers = iter(["new", "banana", "proton", "opencode.ai,roblox.com"])
+    with patch.object(builtins, "input", side_effect=lambda _prompt: next(answers)):
+        rc = module._cmd_preset_prompt(tmp_path)
+
+    assert rc == 0
+    preset = json.loads((tmp_path / "presets" / "banana.json").read_text())
+    assert preset["routes"] == [{
+        "id": "banana",
+        "domains": ["opencode.ai", "roblox.com"],
+        "provider": "proton",
+    }]
+    assert preset["routing"] == {
+        "mode": "vpn-list",
+        "vpn_domains": ["opencode.ai", "roblox.com"],
+    }


### PR DESCRIPTION
## What

Adds `tools/proxy-router`: a selective domain/IP → WireGuard provider router powered by [sing-box](https://sing-box.sagernet.org/), with per-provider failover, egress-aware rotation, full-tunnel (TUN) mode, a macOS menu-bar tray agent, and a setup TUI. Spiritual successor to `tools/opencode-zen-vpn` (retired).

## Highlights

- **Selective routing**: routes map domains/IPs to tunnel providers (e.g. `roblox.com → cloudflare`, `opencode.ai → proton`); everything unmatched goes direct.
- **Root-engine hardening** (this branch's focus): fixes a real-world failure where a regular-user `ensure`/`rotate`/`reload` churn-deleted the pid file of a live root-owned engine (started via `sudo vpn on`):
  - `engine_start` aborts when `engine_stop()` fails instead of spawning a doomed second engine that clobbers the pid file
  - `engine_stop` keeps the pid file on `PermissionError` (root-owned engine) and fails loudly with a sudo hint instead of unlinking it as "garbage"
  - `engine_alive` falls back to a process-table scan when the pid file is unreadable, never declaring a live root engine dead
  - `engine_reload` / `restore_last_good` handle SIGHUP `PermissionError` cleanly instead of crashing
- **Tray "Full tunnel (WARP)" toggle**: checked when TUN mode is active; click to turn off/on. The tray runs under launchd with no TTY, so macOS elevation is driven by the tray itself (osascript admin dialog) with `SUDO_UID`/`SUDO_GID` state-file hand-back.
- **`rulesets/roblox.json`**: Roblox AS22697 announced IPv4/IPv6 CIDRs for selective TUN routing (TUN captures only Roblox).
- **46 passing regression tests** (`python3 -m pytest tests/ -q`), plus tray selftest.

## Notes

- `router.json`, `providers/*.conf`, `state/`, `wgcf-*` are gitignored (live credentials/state never committed).
- `sing-box` 1.12+ is required (bundled in release archives).