### PR TITLE
fix(stage-tamagotchi): stabilize Linux desktop runtime

### DIFF
--- a/.github/scripts/verify-fedora-rpm-lifecycle.sh
+++ b/.github/scripts/verify-fedora-rpm-lifecycle.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rpm_path=${1:?Pass the RPM path as the first argument}
+runtime_root=$(mktemp -d)
+launch_log="$runtime_root/launch.log"
+wrapper_pid=''
+
+stop_airi() {
+  pkill -TERM -f '^/opt/AIRI/airi( |$)' 2>/dev/null || true
+  if [[ -n "$wrapper_pid" ]]; then
+    kill -TERM "$wrapper_pid" 2>/dev/null || true
+  fi
+
+  sleep 2
+  pkill -KILL -f '^/opt/AIRI/airi( |$)' 2>/dev/null || true
+  if [[ -n "$wrapper_pid" ]]; then
+    kill -KILL "$wrapper_pid" 2>/dev/null || true
+    wait "$wrapper_pid" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  stop_airi
+  if rpm -q ai.moeru.airi >/dev/null 2>&1; then
+    dnf remove -y ai.moeru.airi >/dev/null
+  fi
+  rm -rf "$runtime_root"
+}
+
+assert_path_absent() {
+  local path=$1
+  if [[ -e "$path" || -L "$path" ]]; then
+    echo "Unexpected path after RPM removal: $path" >&2
+    return 1
+  fi
+}
+
+trap cleanup EXIT
+
+dnf install -y desktop-file-utils procps-ng xorg-x11-server-Xvfb
+dnf install -y "$rpm_path"
+
+rpm -V ai.moeru.airi
+test "$(readlink -e /usr/bin/airi)" = '/opt/AIRI/airi'
+desktop-file-validate /usr/share/applications/airi.desktop
+
+reinstall_log="$runtime_root/reinstall.log"
+dnf reinstall -y "$rpm_path" 2>&1 | tee "$reinstall_log"
+if grep -Fq 'has not been configured as an alternative' "$reinstall_log"; then
+  echo 'RPM reinstall used the wrong alternatives target.' >&2
+  exit 1
+fi
+
+rpm -V ai.moeru.airi
+test "$(readlink -e /usr/bin/airi)" = '/opt/AIRI/airi'
+
+mkdir -p "$runtime_root/home" "$runtime_root/config" "$runtime_root/cache" "$runtime_root/user-data"
+env \
+  HOME="$runtime_root/home" \
+  XDG_CONFIG_HOME="$runtime_root/config" \
+  XDG_CACHE_HOME="$runtime_root/cache" \
+  xvfb-run -a /opt/AIRI/airi \
+    --no-sandbox \
+    --disable-gpu \
+    --user-data-dir="$runtime_root/user-data" \
+    >"$launch_log" 2>&1 &
+wrapper_pid=$!
+
+sleep 15
+if ! kill -0 "$wrapper_pid" 2>/dev/null && ! pgrep -f '^/opt/AIRI/airi( |$)' >/dev/null; then
+  echo 'AIRI exited before the Fedora launch window ended.' >&2
+  sed -n '1,200p' "$launch_log" >&2
+  exit 1
+fi
+echo 'LAUNCH_STAYED_ACTIVE'
+
+stop_airi
+wrapper_pid=''
+if pgrep -f '^/opt/AIRI/airi( |$)' >/dev/null; then
+  echo 'AIRI processes remained after Fedora launch cleanup.' >&2
+  pgrep -af '^/opt/AIRI/airi( |$)' >&2
+  exit 1
+fi
+
+dnf remove -y ai.moeru.airi
+
+if rpm -q ai.moeru.airi >/dev/null 2>&1; then
+  echo 'The AIRI RPM remained installed after removal.' >&2
+  exit 1
+fi
+
+assert_path_absent /usr/bin/airi
+assert_path_absent /etc/alternatives/airi
+assert_path_absent /usr/share/applications/airi.desktop
+assert_path_absent /etc/apparmor.d/airi
+assert_path_absent /opt/AIRI
+
+trap - EXIT
+rm -rf "$runtime_root"
+echo 'FEDORA_RPM_LIFECYCLE_PASSED'

--- a/.github/workflows/release-tamagotchi.yml
+++ b/.github/workflows/release-tamagotchi.yml
@@ -198,15 +198,20 @@ jobs:
 
       - name: Build (Linux Only) # Linux
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
-        run: pnpm run -F @proj-airi/stage-tamagotchi build && pnpm -F @proj-airi/stage-tamagotchi exec electron-builder build ${{ matrix.builder-args }} --publish=${{ (inputs.build_only || inputs.artifacts_only) && 'never' || 'onTagOrDraft' }}
+        run: |
+          mkdir -p "$TMPDIR"
+          pnpm run -F @proj-airi/stage-tamagotchi build
+          pnpm -F @proj-airi/stage-tamagotchi exec electron-builder build ${{ matrix.builder-args }} --publish=never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=3072
+          TMPDIR: ${{ runner.temp }}/electron-builder
 
       - name: Setup Flatpak (Linux Only)
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
         run: |
           sudo apt update
-          sudo apt install -y flatpak flatpak-builder elfutils
+          sudo apt install -y dbus-x11 elfutils flatpak flatpak-builder libarchive-tools ostree rpm xvfb
           flatpak --version
           flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
@@ -220,6 +225,35 @@ jobs:
           flatpak build-export ./flatpak-repo ./flatpak
           export FLATPAK_OUTPUT_NAME=$(pnpm exec tsx scripts/artifacts-metadata.ts ${{ matrix.target }} --get-output-filename flatpak)
           flatpak build-bundle ./flatpak-repo dist/${FLATPAK_OUTPUT_NAME} ai.moeru.airi
+
+      - name: Verify Linux Packages
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
+        working-directory: ./apps/stage-tamagotchi
+        run: |
+          DEB_OUTPUT_NAME=$(pnpm exec tsx scripts/artifacts-metadata.ts ${{ matrix.target }} --get-output-filename deb)
+          RPM_OUTPUT_NAME=$(pnpm exec tsx scripts/artifacts-metadata.ts ${{ matrix.target }} --get-output-filename rpm)
+          FLATPAK_OUTPUT_NAME=$(pnpm exec tsx scripts/artifacts-metadata.ts ${{ matrix.target }} --get-output-filename flatpak)
+
+          test -f "dist/${DEB_OUTPUT_NAME}"
+          test -f "dist/${RPM_OUTPUT_NAME}"
+          test -f "dist/${FLATPAK_OUTPUT_NAME}"
+
+          pnpm run verify-linux-package \
+            --deb "dist/${DEB_OUTPUT_NAME}" \
+            --rpm "dist/${RPM_OUTPUT_NAME}" \
+            --flatpak "dist/${FLATPAK_OUTPUT_NAME}" \
+            --arch ${{ matrix.arch }}
+
+      - name: Verify RPM Lifecycle on Fedora
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
+        run: |
+          RPM_OUTPUT_NAME=$(cd apps/stage-tamagotchi && pnpm exec tsx scripts/artifacts-metadata.ts ${{ matrix.target }} --get-output-filename rpm)
+          test -f "apps/stage-tamagotchi/dist/${RPM_OUTPUT_NAME}"
+          docker run --rm --privileged \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            fedora:44 \
+            bash /workspace/.github/scripts/verify-fedora-rpm-lifecycle.sh \
+            "/workspace/apps/stage-tamagotchi/dist/${RPM_OUTPUT_NAME}"
 
       # ---------
       # Nightly (schedule) builds only

--- a/apps/stage-tamagotchi/ai.moeru.airi.desktop
+++ b/apps/stage-tamagotchi/ai.moeru.airi.desktop
@@ -7,4 +7,3 @@ Icon=ai.moeru.airi
 StartupWMClass=AIRI
 Comment=AIRI is an AI VTuber/Waifu chatbot supporting Live2D/VRM avatars, featuring human-like interactions and modular stage-based rendering.
 Categories=Utility;
-

--- a/apps/stage-tamagotchi/build/after-remove-linux.tpl
+++ b/apps/stage-tamagotchi/build/after-remove-linux.tpl
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# NOTICE:
+# Electron Builder 26.8.1 removes the launcher path instead of the registered alternatives target.
+# Its removal hook also runs after the new package install during an upgrade.
+# Source: app-builder-lib/templates/linux/after-remove.tpl and the Fedora ARM64 package lifecycle test.
+# Remove this hook when Electron Builder removes the target and preserves upgrade installations correctly.
+if [ ! -e '/opt/${sanitizedProductName}/${executable}' ]; then
+    if type update-alternatives >/dev/null 2>&1; then
+        update-alternatives --remove '${executable}' '/opt/${sanitizedProductName}/${executable}' || true
+    elif [ -L '/usr/bin/${executable}' ] && [ "$(readlink '/usr/bin/${executable}')" = '/opt/${sanitizedProductName}/${executable}' ]; then
+        rm -f '/usr/bin/${executable}'
+    fi
+
+    APPARMOR_PROFILE_DEST='/etc/apparmor.d/${executable}'
+    if [ -f "$APPARMOR_PROFILE_DEST" ]; then
+        if apparmor_status --enabled >/dev/null 2>&1; then
+            if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+                apparmor_parser --remove "$APPARMOR_PROFILE_DEST" || true
+            fi
+        fi
+        rm -f "$APPARMOR_PROFILE_DEST"
+    fi
+
+    # RPM can leave unowned package directories after it removes their files.
+    # Delete only empty directories so that user-created files remain intact.
+    find '/opt/${sanitizedProductName}' -depth -type d -empty -delete 2>/dev/null || true
+fi

--- a/apps/stage-tamagotchi/electron-builder.config.ts
+++ b/apps/stage-tamagotchi/electron-builder.config.ts
@@ -233,6 +233,15 @@ export default {
       'deb',
       'rpm',
     ],
+    files: [
+      // Native packages publish binaries for several operating systems and architectures.
+      // Keep only the Linux payload that matches the current electron-builder matrix target.
+      '!**/onnxruntime-node/bin/napi-v3/!(linux){,/**/*}',
+      '!**/onnxruntime-node/bin/napi-v3/linux/!(${arch}){,/**/*}',
+      '!**/uiohook-napi/prebuilds/!(linux-${arch}){,/**/*}',
+      '!**/electron-click-drag-plugin/build/Release/!(linux-${arch}){,/**/*}',
+      '!**/node_modules/@img/{sharp,sharp-libvips}-!(linux-${arch}){,/**/*}',
+    ],
     // NOTICE: Same channel rule as Windows/macOS. Keep `${arch}` to avoid x64/arm64 feed collisions on Linux.
     publish: {
       provider: 'github',
@@ -246,6 +255,12 @@ export default {
     executableName: 'airi',
     artifactName: '${productName}-${version}-linux-${arch}.${ext}',
     icon: 'build/icons/icon.png',
+  },
+  deb: {
+    afterRemove: 'build/after-remove-linux.tpl',
+  },
+  rpm: {
+    afterRemove: 'build/after-remove-linux.tpl',
   },
   appImage: {
     artifactName: '${productName}-${version}-linux-${arch}.${ext}',

--- a/apps/stage-tamagotchi/electron-builder.config.ts
+++ b/apps/stage-tamagotchi/electron-builder.config.ts
@@ -240,7 +240,8 @@ export default {
       '!**/onnxruntime-node/bin/napi-v3/linux/!(${arch}){,/**/*}',
       '!**/uiohook-napi/prebuilds/!(linux-${arch}){,/**/*}',
       '!**/electron-click-drag-plugin/build/Release/!(linux-${arch}){,/**/*}',
-      '!**/node_modules/@img/{sharp,sharp-libvips}-!(linux-${arch}){,/**/*}',
+      '!**/node_modules/@img/sharp-!(linux-${arch}|libvips-*){,/**/*}',
+      '!**/node_modules/@img/sharp-libvips-!(linux-${arch}){,/**/*}',
     ],
     // NOTICE: Same channel rule as Windows/macOS. Keep `${arch}` to avoid x64/arm64 feed collisions on Linux.
     publish: {

--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -196,6 +196,7 @@
     "get-port-please": "catalog:",
     "h3": "catalog:",
     "less": "catalog:",
+    "minimatch": "catalog:",
     "mkcert": "catalog:",
     "std-env": "catalog:",
     "superjson": "catalog:",

--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -31,6 +31,7 @@
     "merge-latest-mac": "tsx scripts/merge-latest-mac.ts",
     "regenerate-windows-latest": "tsx scripts/regenerate-windows-latest.ts",
     "artifacts-metadata": "tsx scripts/artifacts-metadata.ts",
+    "verify-linux-package": "tsx scripts/verify-linux-package.ts",
     "smoke:desktop-overlay-live-window": "NODE_OPTIONS='--experimental-websocket' tsx scripts/desktop-overlay-live-window-smoke.ts",
     "update-test:generate": "tsx scripts/update-test/generate-manifest.ts",
     "update-test:server": "tsx scripts/update-test/start-server.ts",

--- a/apps/stage-tamagotchi/scripts/linux-packaging.test.ts
+++ b/apps/stage-tamagotchi/scripts/linux-packaging.test.ts
@@ -5,6 +5,7 @@ import type { Configuration } from 'electron-builder'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { minimatch } from 'minimatch'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
@@ -18,6 +19,14 @@ const releaseOptions = {
   release: true,
   autoTag: false,
   tag: ['0.11.3'],
+}
+
+function isIncludedByLinuxFilePatterns(path: string, architecture: 'arm64' | 'x64'): boolean {
+  const exclusions = electronBuilderConfig.linux.files
+    .filter((pattern): pattern is string => typeof pattern === 'string' && pattern.startsWith('!'))
+    .map(pattern => pattern.slice(1).replaceAll('${arch}', architecture))
+
+  return exclusions.every(pattern => !minimatch(path, pattern, { dot: true }))
 }
 
 describe('linux package configuration', () => {
@@ -34,8 +43,41 @@ describe('linux package configuration', () => {
       '!**/onnxruntime-node/bin/napi-v3/linux/!(${arch}){,/**/*}',
       '!**/uiohook-napi/prebuilds/!(linux-${arch}){,/**/*}',
       '!**/electron-click-drag-plugin/build/Release/!(linux-${arch}){,/**/*}',
-      '!**/node_modules/@img/{sharp,sharp-libvips}-!(linux-${arch}){,/**/*}',
+      '!**/node_modules/@img/sharp-!(linux-${arch}|libvips-*){,/**/*}',
+      '!**/node_modules/@img/sharp-libvips-!(linux-${arch}){,/**/*}',
     ])
+  })
+
+  it('keeps the target Sharp and libvips packages while excluding foreign packages', () => {
+    // ROOT CAUSE:
+    //
+    // The combined Sharp brace pattern lets the `sharp-` branch consume the `libvips-` prefix.
+    // Its negative extglob then excludes the target libvips package with every foreign package.
+    // The fix must use non-overlapping exclusions for the two native package families.
+    expect(isIncludedByLinuxFilePatterns(
+      'node_modules/@img/sharp-linux-arm64/lib/sharp-linux-arm64.node',
+      'arm64',
+    )).toBe(true)
+    expect(isIncludedByLinuxFilePatterns(
+      'node_modules/@img/sharp-libvips-linux-arm64/lib/libvips-cpp.so',
+      'arm64',
+    )).toBe(true)
+    expect(isIncludedByLinuxFilePatterns(
+      'node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node',
+      'arm64',
+    )).toBe(false)
+    expect(isIncludedByLinuxFilePatterns(
+      'node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so',
+      'arm64',
+    )).toBe(false)
+    expect(isIncludedByLinuxFilePatterns(
+      'node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node',
+      'x64',
+    )).toBe(true)
+    expect(isIncludedByLinuxFilePatterns(
+      'node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so',
+      'x64',
+    )).toBe(true)
   })
 
   // ROOT CAUSE:
@@ -223,9 +265,9 @@ describe('flatpak package configuration', () => {
         type: 'file',
       }),
       expect.objectContaining({
-        'dest': 'build',
-        'path': 'build/icon-512.png',
-        'type': 'file',
+        dest: 'build',
+        path: 'build/icon-512.png',
+        type: 'file',
       }),
       expect.objectContaining({
         path: 'ai.moeru.airi.metainfo.xml',

--- a/apps/stage-tamagotchi/scripts/linux-packaging.test.ts
+++ b/apps/stage-tamagotchi/scripts/linux-packaging.test.ts
@@ -1,0 +1,246 @@
+/* eslint-disable no-template-curly-in-string */
+
+import type { Configuration } from 'electron-builder'
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+import electronBuilderConfig from '../electron-builder.config'
+
+import { getFilenames } from './utils'
+
+const packageConfig: Configuration = electronBuilderConfig
+
+const releaseOptions = {
+  release: true,
+  autoTag: false,
+  tag: ['0.11.3'],
+}
+
+describe('linux package configuration', () => {
+  it('builds Debian and RPM packages on each Linux architecture', () => {
+    expect(electronBuilderConfig.linux.target).toEqual([
+      'deb',
+      'rpm',
+    ])
+  })
+
+  it('keeps only native dependencies for the Linux target architecture', () => {
+    expect(electronBuilderConfig.linux.files).toEqual([
+      '!**/onnxruntime-node/bin/napi-v3/!(linux){,/**/*}',
+      '!**/onnxruntime-node/bin/napi-v3/linux/!(${arch}){,/**/*}',
+      '!**/uiohook-napi/prebuilds/!(linux-${arch}){,/**/*}',
+      '!**/electron-click-drag-plugin/build/Release/!(linux-${arch}){,/**/*}',
+      '!**/node_modules/@img/{sharp,sharp-libvips}-!(linux-${arch}){,/**/*}',
+    ])
+  })
+
+  // ROOT CAUSE:
+  //
+  // Electron Builder 26.8.1 removes /usr/bin/airi from the alternatives group.
+  // The registered target is /opt/AIRI/airi, so RPM removal leaves two broken links.
+  // An old package also runs its removal hook after a new package is installed.
+  //
+  // Before the fix, reinstall printed "has not been configured as an alternative".
+  // Final removal left /usr/bin/airi and /etc/alternatives/airi on Fedora.
+  //
+  // We fixed this with one package hook that keeps links during an upgrade.
+  // The hook removes the registered target only after the AIRI executable is absent.
+  it('removes the alternatives target only after the final package removal', () => {
+    const afterRemove = 'build/after-remove-linux.tpl'
+
+    expect(packageConfig.deb?.afterRemove).toBe(afterRemove)
+    expect(packageConfig.rpm?.afterRemove).toBe(afterRemove)
+
+    const source = readFileSync(join(import.meta.dirname, '..', afterRemove), 'utf8')
+    expect(source).toContain('if [ ! -e \'/opt/${sanitizedProductName}/${executable}\' ]; then')
+    expect(source).toContain('update-alternatives --remove \'${executable}\' \'/opt/${sanitizedProductName}/${executable}\'')
+    expect(source).not.toContain('update-alternatives --remove \'${executable}\' \'/usr/bin/${executable}\'')
+    expect(source).toContain('apparmor_parser --remove "$APPARMOR_PROFILE_DEST" || true')
+    expect(source).toContain('find \'/opt/${sanitizedProductName}\' -depth -type d -empty -delete')
+  })
+
+  it('generates architecture-aware artifact names for Linux ARM64', async () => {
+    const artifacts = await getFilenames('aarch64-unknown-linux-gnu', releaseOptions)
+
+    expect(artifacts).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        extension: 'deb',
+        outputFilename: 'AIRI-0.11.3-linux-arm64.deb',
+      }),
+      expect.objectContaining({
+        extension: 'rpm',
+        outputFilename: 'AIRI-0.11.3-linux-aarch64.rpm',
+      }),
+      expect.objectContaining({
+        extension: 'flatpak',
+        outputFilename: 'AIRI-0.11.3-linux-arm64.flatpak',
+      }),
+    ]))
+  })
+
+  it('generates architecture-aware artifact names for Linux x64', async () => {
+    const artifacts = await getFilenames('x86_64-unknown-linux-gnu', releaseOptions)
+
+    expect(artifacts).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        extension: 'deb',
+        outputFilename: 'AIRI-0.11.3-linux-amd64.deb',
+      }),
+      expect.objectContaining({
+        extension: 'rpm',
+        outputFilename: 'AIRI-0.11.3-linux-x86_64.rpm',
+      }),
+      expect.objectContaining({
+        extension: 'flatpak',
+        outputFilename: 'AIRI-0.11.3-linux-x64.flatpak',
+      }),
+    ]))
+  })
+})
+
+describe('linux release workflow', () => {
+  const workflowPath = join(import.meta.dirname, '..', '..', '..', '.github', 'workflows', 'release-tamagotchi.yml')
+  const workflowSource = readFileSync(workflowPath, 'utf8')
+  const workflow = parse(workflowSource)
+  const linuxBuildStep = workflow.jobs.build.steps.find((step: { name?: string }) => step.name === 'Build (Linux Only)')
+  const linuxSetupStep = workflow.jobs.build.steps.find((step: { name?: string }) => step.name === 'Setup Flatpak (Linux Only)')
+  const linuxVerificationStep = workflow.jobs.build.steps.find((step: { name?: string }) => step.name === 'Verify Linux Packages')
+  const fedoraLifecycleStep = workflow.jobs.build.steps.find((step: { name?: string }) => step.name === 'Verify RPM Lifecycle on Fedora')
+
+  // ROOT CAUSE:
+  //
+  // A 4 GB ARM64 host exhausted Node's default heap during the renderer build.
+  // Electron Builder then exhausted the tmpfs quota while FPM created the Debian package.
+  //
+  // Before the fix, the Linux step used the default Node heap and the system temporary directory.
+  //
+  // We fixed this by giving Node a bounded 3 GB heap and using the runner's disk-backed temporary directory.
+  it('provides enough heap and disk-backed temporary space for Linux packages', () => {
+    expect(linuxBuildStep.env.NODE_OPTIONS).toBe('--max-old-space-size=3072')
+    expect(linuxBuildStep.env.TMPDIR).toBe('${{ runner.temp }}/electron-builder')
+    expect(linuxBuildStep.run).toContain('mkdir -p "$TMPDIR"')
+  })
+
+  it('installs the RPM and Flatpak inspection tools', () => {
+    expect(linuxSetupStep.run).toContain('rpm')
+    expect(linuxSetupStep.run).toContain('libarchive-tools')
+    expect(linuxSetupStep.run).toContain('ostree')
+  })
+
+  it('verifies every Linux package before upload', () => {
+    expect(linuxVerificationStep.run).toContain('--deb "dist/${DEB_OUTPUT_NAME}"')
+    expect(linuxVerificationStep.run).toContain('--rpm "dist/${RPM_OUTPUT_NAME}"')
+    expect(linuxVerificationStep.run).toContain('--flatpak "dist/${FLATPAK_OUTPUT_NAME}"')
+    expect(linuxVerificationStep.run).toContain('--arch ${{ matrix.arch }}')
+  })
+
+  // ROOT CAUSE:
+  //
+  // Electron Builder uploaded Linux artifacts while it built them.
+  // The package verification steps ran later and could not prevent a broken artifact from publishing.
+  //
+  // Before the fix, the Linux build selected onTagOrDraft for release runs.
+  //
+  // We fixed this by keeping Linux artifacts local. Existing post-verification upload steps publish them.
+  it('does not publish Linux packages before verification succeeds', () => {
+    expect(linuxBuildStep.run).toContain('--publish=never')
+    expect(linuxBuildStep.run).not.toContain('onTagOrDraft')
+  })
+
+  // ROOT CAUSE:
+  //
+  // Package inspection did not run RPM transaction scripts on a Fedora system.
+  // DNF reinstall and removal therefore left broken alternatives links without failing CI.
+  //
+  // Before the fix, the workflow extracted and started the RPM only on Ubuntu.
+  //
+  // We fixed this with a native Fedora container that runs the complete RPM lifecycle.
+  it('runs the RPM install lifecycle on native Fedora userspace', () => {
+    expect(fedoraLifecycleStep.if).toBe('${{ matrix.os == \'ubuntu-latest\' || matrix.os == \'ubuntu-24.04-arm\' }}')
+    expect(fedoraLifecycleStep.run).toContain('fedora:44')
+    expect(fedoraLifecycleStep.run).toContain('--privileged')
+    expect(fedoraLifecycleStep.run).toContain('verify-fedora-rpm-lifecycle.sh')
+
+    const lifecycleSource = readFileSync(join(import.meta.dirname, '..', '..', '..', '.github', 'scripts', 'verify-fedora-rpm-lifecycle.sh'), 'utf8')
+    expect(lifecycleSource).toContain('dnf install -y "$rpm_path"')
+    expect(lifecycleSource).toContain('dnf reinstall -y "$rpm_path"')
+    expect(lifecycleSource).toContain('LAUNCH_STAYED_ACTIVE')
+    expect(lifecycleSource).toContain('dnf remove -y ai.moeru.airi')
+    expect(lifecycleSource).toContain('assert_path_absent /usr/bin/airi')
+    expect(lifecycleSource).toContain('assert_path_absent /etc/alternatives/airi')
+    expect(lifecycleSource).toContain('assert_path_absent /opt/AIRI')
+  })
+})
+
+describe('flatpak package configuration', () => {
+  const manifestPath = join(import.meta.dirname, '..', 'ai.moeru.airi.flatpak.yml')
+  const manifestSource = readFileSync(manifestPath, 'utf8')
+  const manifest = parse(manifestSource)
+  const appModule = manifest.modules[0]
+
+  it('selects the unpacked Electron app for the host architecture', () => {
+    const sources = appModule.sources
+
+    expect(sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        'only-arches': ['x86_64'],
+        'path': 'dist/linux-unpacked',
+      }),
+      expect.objectContaining({
+        'only-arches': ['aarch64'],
+        'path': 'dist/linux-arm64-unpacked',
+      }),
+    ]))
+  })
+
+  it('launches Electron through the Flatpak sandbox wrapper', () => {
+    const launcher = appModule.sources.find((source: { type: string }) => source.type === 'script')
+
+    expect(manifest.command).toBe('airi.sh')
+    expect(launcher['dest-filename']).toBe('airi.sh')
+    expect(launcher.commands).toContain('exec zypak-wrapper /app/lib/airi/airi "$@"')
+    expect(appModule['build-commands']).toContain('install airi.sh /app/bin/airi.sh')
+    expect(appModule['build-commands']).toContain('ln -s /app/bin/airi.sh /app/bin/airi')
+  })
+
+  // ROOT CAUSE:
+  //
+  // The Flatpak copies the Electron application into /app/lib, but it does not
+  // install desktop metadata. Flatpak can export only a command-line symlink.
+  // The installed AIRI application is therefore absent from desktop menus.
+  //
+  // Before the fix, /app/share contains no AIRI desktop entry or application icon.
+  //
+  // We fixed this by installing app-ID-named desktop metadata and its icon.
+  it('exports the desktop entry and application icon', () => {
+    expect(appModule.sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: 'ai.moeru.airi.desktop',
+        type: 'file',
+      }),
+      expect.objectContaining({
+        'dest': 'build',
+        'path': 'build/icon-512.png',
+        'type': 'file',
+      }),
+      expect.objectContaining({
+        path: 'ai.moeru.airi.metainfo.xml',
+        type: 'file',
+      }),
+    ]))
+    expect(appModule['build-commands']).toContain('install -Dm644 ai.moeru.airi.desktop /app/share/applications/ai.moeru.airi.desktop')
+    expect(appModule['build-commands']).toContain('install -Dm644 ai.moeru.airi.metainfo.xml /app/share/metainfo/ai.moeru.airi.metainfo.xml')
+    expect(appModule['build-commands']).toContain('install -Dm644 build/icon-512.png /app/share/icons/hicolor/512x512/apps/ai.moeru.airi.png')
+  })
+
+  it('uses the Flatpak command and application ID in the desktop entry', () => {
+    const desktopEntry = readFileSync(join(import.meta.dirname, '..', 'ai.moeru.airi.desktop'), 'utf8')
+
+    expect(desktopEntry).toContain('\nExec=airi %U\n')
+    expect(desktopEntry).toContain('\nIcon=ai.moeru.airi\n')
+  })
+})

--- a/apps/stage-tamagotchi/scripts/process-group.ts
+++ b/apps/stage-tamagotchi/scripts/process-group.ts
@@ -1,0 +1,127 @@
+import type { Signals } from 'node:process'
+
+import process from 'node:process'
+
+import { spawn } from 'node:child_process'
+
+export interface TimedProcessResult {
+  exitCode: number | null
+  signal: Signals | null
+  timedOut: boolean
+}
+
+function isProcessGroupActive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0)
+    return true
+  }
+  catch (error) {
+    const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
+    if (code === 'ESRCH')
+      return false
+    throw error
+  }
+}
+
+/**
+ * Stops a detached process group and waits until its child processes are gone.
+ *
+ * The function sends the requested signal first. It sends SIGKILL after a one-second grace period.
+ */
+export async function stopProcessGroup(pid: number, signal: Signals): Promise<void> {
+  try {
+    // Electron owns renderer and utility children. One group signal keeps their shutdown order visible.
+    process.kill(-pid, signal)
+  }
+  catch (error) {
+    const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
+    if (code === 'ESRCH')
+      return
+    throw error
+  }
+
+  if (signal !== 'SIGKILL') {
+    await new Promise(resolveDelay => setTimeout(resolveDelay, 1_000))
+    if (isProcessGroupActive(pid))
+      process.kill(-pid, 'SIGKILL')
+  }
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!isProcessGroupActive(pid))
+      return
+    await new Promise(resolveDelay => setTimeout(resolveDelay, 20))
+  }
+
+  throw new Error(`Process group ${pid} remained active after SIGKILL`)
+}
+
+/**
+ * Runs one detached launch process and stops its full process group after the smoke-test window.
+ *
+ * The returned promise waits for forced cleanup when the wrapper exits before its child processes.
+ *
+ * @param command - Executable that owns the detached process group.
+ * @param args - Arguments for the executable.
+ * @param environment - Environment for the executable and its child processes.
+ * @param beforeTimeoutStop - Optional cleanup that must occur before process signals.
+ * @param timeoutMs - Smoke-test window in milliseconds.
+ * @default 15000
+ */
+export async function runTimedProcess(
+  command: string,
+  args: string[],
+  environment: NodeJS.ProcessEnv,
+  beforeTimeoutStop?: () => Promise<void>,
+  timeoutMs = 15_000,
+): Promise<TimedProcessResult> {
+  return await new Promise((resolveProcess, rejectProcess) => {
+    const child = spawn(command, args, {
+      detached: true,
+      env: environment,
+      stdio: 'inherit',
+    })
+
+    let timedOut = false
+    let settled = false
+    let stopPromise: Promise<void> | undefined
+    const resolveOnce = (result: TimedProcessResult) => {
+      if (settled)
+        return
+      settled = true
+      resolveProcess(result)
+    }
+    const rejectOnce = (error: unknown) => {
+      if (settled)
+        return
+      settled = true
+      rejectProcess(error)
+    }
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      stopPromise = (async () => {
+        await beforeTimeoutStop?.()
+        if (child.pid !== undefined)
+          await stopProcessGroup(child.pid, 'SIGTERM')
+      })()
+      stopPromise.catch(rejectOnce)
+    }, timeoutMs)
+
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      rejectOnce(error)
+    })
+    child.once('close', (exitCode, signal) => {
+      clearTimeout(timeout)
+      const result = { exitCode, signal, timedOut }
+      if (!stopPromise) {
+        resolveOnce(result)
+        return
+      }
+
+      stopPromise
+        .then(() => resolveOnce(result))
+        .catch(rejectOnce)
+    })
+  })
+}

--- a/apps/stage-tamagotchi/scripts/process-group.ts
+++ b/apps/stage-tamagotchi/scripts/process-group.ts
@@ -112,8 +112,9 @@ export async function runTimedProcess(
       clearTimeout(timeout)
       const result = { exitCode, signal, timedOut }
       if (!stopPromise) {
-        resolveOnce(result)
-        return
+        stopPromise = child.pid === undefined
+          ? Promise.resolve()
+          : stopProcessGroup(child.pid, 'SIGTERM')
       }
 
       stopPromise

--- a/apps/stage-tamagotchi/scripts/process-group.ts
+++ b/apps/stage-tamagotchi/scripts/process-group.ts
@@ -10,9 +10,9 @@ export interface TimedProcessResult {
   timedOut: boolean
 }
 
-function isProcessGroupActive(pid: number): boolean {
+function signalProcessGroup(pid: number, signal: Signals | 0): boolean {
   try {
-    process.kill(-pid, 0)
+    process.kill(-pid, signal)
     return true
   }
   catch (error) {
@@ -23,27 +23,24 @@ function isProcessGroupActive(pid: number): boolean {
   }
 }
 
+function isProcessGroupActive(pid: number): boolean {
+  return signalProcessGroup(pid, 0)
+}
+
 /**
  * Stops a detached process group and waits until its child processes are gone.
  *
  * The function sends the requested signal first. It sends SIGKILL after a one-second grace period.
  */
 export async function stopProcessGroup(pid: number, signal: Signals): Promise<void> {
-  try {
-    // Electron owns renderer and utility children. One group signal keeps their shutdown order visible.
-    process.kill(-pid, signal)
-  }
-  catch (error) {
-    const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
-    if (code === 'ESRCH')
-      return
-    throw error
-  }
+  // Electron owns renderer and utility children. One group signal keeps their shutdown order visible.
+  if (!signalProcessGroup(pid, signal))
+    return
 
   if (signal !== 'SIGKILL') {
     await new Promise(resolveDelay => setTimeout(resolveDelay, 1_000))
     if (isProcessGroupActive(pid))
-      process.kill(-pid, 'SIGKILL')
+      signalProcessGroup(pid, 'SIGKILL')
   }
 
   for (let attempt = 0; attempt < 100; attempt += 1) {

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
@@ -168,6 +168,17 @@ describe('linux Flatpak package verification', () => {
     expect(() => assertFlatpakPackageContract(validFlatpakPackage, 'arm64')).not.toThrow()
   })
 
+  // https://github.com/moeru-ai/airi/pull/2278#discussion_r3776441935
+  // ROOT CAUSE:
+  //
+  // The package contract checks files/lib/airi/airi, but the launch verifier used
+  // files/bin/airi/airi. The files/bin/airi entry is a launcher symlink, not a directory.
+  //
+  // We fixed this by returning the checked executable path for the launch verifier.
+  it('returns the checked Flatpak executable path', () => {
+    expect(assertFlatpakPackageContract(validFlatpakPackage, 'arm64')).toBe('./files/lib/airi/airi')
+  })
+
   it('accepts the expected x64 Flatpak architecture', () => {
     expect(() => assertFlatpakPackageContract({
       ...validFlatpakPackage,

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
@@ -1,0 +1,442 @@
+import process from 'node:process'
+
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { isWindows } from 'std-env'
+import { describe, expect, it } from 'vitest'
+
+import { runTimedProcess, stopProcessGroup } from './process-group'
+import {
+  assertDebPackageContract,
+  assertDesktopEntryContract,
+  assertExecutableArchitecture,
+  assertFlatpakDesktopEntryContract,
+  assertFlatpakPackageContract,
+  assertRpmPackageContract,
+  isSuccessfulLaunchSmoke,
+} from './verify-linux-package'
+
+const validPackage = {
+  packageName: 'ai.moeru.airi',
+  architecture: 'arm64',
+  entries: [
+    { path: './opt/AIRI/airi', mode: '-rwxr-xr-x' },
+    { path: './usr/share/applications/airi.desktop', mode: '-rw-r--r--' },
+    { path: './usr/share/icons/hicolor/512x512/apps/airi.png', mode: '-rw-r--r--' },
+  ],
+}
+
+const validRpmPackage = {
+  packageName: 'ai.moeru.airi',
+  architecture: 'aarch64',
+  scripts: [
+    'if [ ! -e \'/opt/AIRI/airi\' ]; then',
+    'update-alternatives --remove \'airi\' \'/opt/AIRI/airi\' || true',
+    'find \'/opt/AIRI\' -depth -type d -empty -delete 2>/dev/null || true',
+  ].join('\n'),
+  entries: [
+    { path: '/opt/AIRI/airi', mode: '-rwxr-xr-x' },
+    { path: '/usr/share/applications/airi.desktop', mode: '-rw-r--r--' },
+    { path: '/usr/share/icons/hicolor/512x512/apps/airi.png', mode: '-rw-r--r--' },
+  ],
+}
+
+const validFlatpakPackage = {
+  appId: 'ai.moeru.airi',
+  architecture: 'aarch64',
+  runtime: 'org.freedesktop.Platform/aarch64/24.08',
+  command: 'airi.sh',
+  entries: [
+    { path: './files/lib/airi/airi', mode: '-rwxr-xr-x' },
+    { path: './files/bin/airi.sh', mode: '-rwxr-xr-x' },
+    { path: './export/share/applications/ai.moeru.airi.desktop', mode: '-rw-r--r--' },
+    { path: './export/share/icons/hicolor/512x512/apps/ai.moeru.airi.png', mode: '-rw-r--r--' },
+  ],
+}
+
+function packageWithNativeEntries(architecture: string, paths: string[]) {
+  return {
+    ...validPackage,
+    architecture,
+    entries: [
+      ...validPackage.entries,
+      ...paths.map(path => ({ path, mode: '-rwxr-xr-x' })),
+    ],
+  }
+}
+
+describe('linux DEB package verification', () => {
+  it('accepts the expected ARM64 package contract', () => {
+    expect(() => assertDebPackageContract(validPackage, 'arm64')).not.toThrow()
+  })
+
+  it('accepts the expected x64 Debian architecture', () => {
+    expect(() => assertDebPackageContract({ ...validPackage, architecture: 'amd64' }, 'x64')).not.toThrow()
+  })
+
+  // ROOT CAUSE:
+  //
+  // A successful electron-builder process does not prove that the package matches the runner architecture.
+  // A mislabeled package can reach a release and fail only after a user installs it.
+  //
+  // Before this check, the release workflow uploaded the package without reading its Debian metadata.
+  //
+  // We fixed this by comparing the package architecture with the release-matrix architecture.
+  it('rejects a package for the wrong architecture', () => {
+    expect(() => assertDebPackageContract(validPackage, 'x64')).toThrow('Expected Debian architecture amd64, received arm64')
+  })
+
+  it('rejects a package without the desktop executable', () => {
+    expect(() => assertDebPackageContract({
+      ...validPackage,
+      entries: validPackage.entries.filter(entry => entry.path !== './opt/AIRI/airi'),
+    }, 'arm64')).toThrow('Missing executable: ./opt/AIRI/airi')
+  })
+
+  it('rejects a desktop executable without execute permission', () => {
+    expect(() => assertDebPackageContract({
+      ...validPackage,
+      entries: validPackage.entries.map(entry => entry.path === './opt/AIRI/airi' ? { ...entry, mode: '-rw-r--r--' } : entry),
+    }, 'arm64')).toThrow('Desktop executable is not executable: ./opt/AIRI/airi')
+  })
+
+  it('rejects a package without a desktop entry', () => {
+    expect(() => assertDebPackageContract({
+      ...validPackage,
+      entries: validPackage.entries.filter(entry => entry.path !== './usr/share/applications/airi.desktop'),
+    }, 'arm64')).toThrow('Missing desktop entry')
+  })
+
+  it('rejects a package without an application icon', () => {
+    expect(() => assertDebPackageContract({
+      ...validPackage,
+      entries: validPackage.entries.filter(entry => !entry.path.includes('/icons/')),
+    }, 'arm64')).toThrow('Missing application icon')
+  })
+})
+
+describe('linux RPM package verification', () => {
+  it('accepts the expected ARM64 RPM contract', () => {
+    expect(() => assertRpmPackageContract(validRpmPackage, 'arm64')).not.toThrow()
+  })
+
+  it('accepts the expected x64 RPM architecture', () => {
+    expect(() => assertRpmPackageContract({ ...validRpmPackage, architecture: 'x86_64' }, 'x64')).not.toThrow()
+  })
+
+  it('rejects an RPM for the wrong architecture', () => {
+    expect(() => assertRpmPackageContract(validRpmPackage, 'x64')).toThrow('Expected RPM architecture x86_64, received aarch64')
+  })
+
+  it('rejects an RPM without desktop integration', () => {
+    expect(() => assertRpmPackageContract({
+      ...validRpmPackage,
+      entries: validRpmPackage.entries.filter(entry => !entry.path.endsWith('.desktop')),
+    }, 'arm64')).toThrow('Missing desktop entry')
+  })
+
+  // ROOT CAUSE:
+  //
+  // Electron Builder 26.8.1 passes /usr/bin/airi to update-alternatives --remove.
+  // Fedora registers /opt/AIRI/airi as the alternatives target instead.
+  //
+  // Before the fix, DNF removal succeeded but left two broken launcher links.
+  //
+  // We fixed this by inspecting the final RPM scriptlet and requiring the registered target.
+  it('rejects the Electron Builder removal script that leaves broken alternatives links', () => {
+    expect(() => assertRpmPackageContract({
+      ...validRpmPackage,
+      scripts: 'update-alternatives --remove \'airi\' \'/usr/bin/airi\'',
+    }, 'arm64')).toThrow('RPM removal script must preserve upgrades and remove /opt/AIRI/airi')
+  })
+
+  it('rejects foreign native payloads in an RPM', () => {
+    const foreignPath = '/opt/AIRI/resources/app.asar.unpacked/node_modules/uiohook-napi/prebuilds/linux-x64/uiohook-napi.node'
+
+    expect(() => assertRpmPackageContract({
+      ...validRpmPackage,
+      entries: [...validRpmPackage.entries, { path: foreignPath, mode: '-rwxr-xr-x' }],
+    }, 'arm64')).toThrow(`Foreign native payload for arm64: ${foreignPath}`)
+  })
+})
+
+describe('linux Flatpak package verification', () => {
+  it('accepts the expected ARM64 Flatpak contract', () => {
+    expect(() => assertFlatpakPackageContract(validFlatpakPackage, 'arm64')).not.toThrow()
+  })
+
+  it('accepts the expected x64 Flatpak architecture', () => {
+    expect(() => assertFlatpakPackageContract({
+      ...validFlatpakPackage,
+      architecture: 'x86_64',
+      runtime: 'org.freedesktop.Platform/x86_64/24.08',
+    }, 'x64')).not.toThrow()
+  })
+
+  it('rejects a Flatpak for the wrong architecture', () => {
+    expect(() => assertFlatpakPackageContract(validFlatpakPackage, 'x64')).toThrow('Expected Flatpak architecture x86_64, received aarch64')
+  })
+
+  it('rejects a Flatpak with the wrong runtime', () => {
+    expect(() => assertFlatpakPackageContract({
+      ...validFlatpakPackage,
+      runtime: 'org.freedesktop.Platform/aarch64/23.08',
+    }, 'arm64')).toThrow('Expected Flatpak runtime org.freedesktop.Platform/aarch64/24.08')
+  })
+
+  it('rejects a Flatpak without an exported icon', () => {
+    expect(() => assertFlatpakPackageContract({
+      ...validFlatpakPackage,
+      entries: validFlatpakPackage.entries.filter(entry => !entry.path.includes('/icons/')),
+    }, 'arm64')).toThrow('Missing application icon')
+  })
+
+  it('rejects foreign native payloads in a Flatpak', () => {
+    const foreignPath = './files/lib/airi/resources/app.asar.unpacked/node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node'
+
+    expect(() => assertFlatpakPackageContract({
+      ...validFlatpakPackage,
+      entries: [...validFlatpakPackage.entries, { path: foreignPath, mode: '-rwxr-xr-x' }],
+    }, 'arm64')).toThrow(`Foreign native payload for arm64: ${foreignPath}`)
+  })
+})
+
+describe('linux launch smoke result', () => {
+  it('accepts an app that stays active for the smoke-test window', () => {
+    expect(isSuccessfulLaunchSmoke({ exitCode: null, signal: 'SIGTERM', timedOut: true })).toBe(true)
+  })
+
+  it('rejects an app that exits before the smoke-test window ends', () => {
+    expect(isSuccessfulLaunchSmoke({ exitCode: 0, signal: null, timedOut: false })).toBe(false)
+  })
+
+  // ROOT CAUSE:
+  //
+  // Electron can ignore SIGTERM after Xvfb closes and keep its child processes active.
+  // The verifier sent one signal and returned before the process group stopped.
+  //
+  // Before the fix, a package check left AIRI active on the Fedora runner.
+  //
+  // We fixed this by waiting after SIGTERM and then sending SIGKILL to the same process group.
+  it.skipIf(isWindows)('stops a process group when its parent and child ignore SIGTERM', async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'airi-process-group-'))
+    const processFile = join(runtimeRoot, 'processes.json')
+    const childSource = 'process.on(\'SIGTERM\', () => {}); setInterval(() => {}, 1000)'
+    const parentSource = [
+      'const { spawn } = require(\'node:child_process\')',
+      'const { writeFileSync } = require(\'node:fs\')',
+      `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childSource)}], { stdio: 'ignore' })`,
+      `writeFileSync(${JSON.stringify(processFile)}, JSON.stringify({ parent: process.pid, child: child.pid }))`,
+      'process.on(\'SIGTERM\', () => {})',
+      'setInterval(() => {}, 1000)',
+    ].join(';')
+    const parent = spawn(process.execPath, ['-e', parentSource], {
+      detached: true,
+      stdio: 'ignore',
+    })
+
+    let processIds: { child: number, parent: number } | undefined
+    try {
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        try {
+          processIds = JSON.parse(await readFile(processFile, 'utf8'))
+          break
+        }
+        catch {
+          await new Promise(resolveDelay => setTimeout(resolveDelay, 20))
+        }
+      }
+      expect(processIds).toBeDefined()
+
+      await stopProcessGroup(parent.pid!, 'SIGTERM')
+
+      expect(isProcessActive(processIds!.parent)).toBe(false)
+      expect(isProcessActive(processIds!.child)).toBe(false)
+    }
+    finally {
+      if (parent.pid !== undefined) {
+        try {
+          process.kill(-parent.pid, 'SIGKILL')
+        }
+        catch {
+          // The fixed implementation already stopped the process group.
+        }
+      }
+      await rm(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(isWindows)('waits for process-group cleanup after the wrapper exits', async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'airi-timed-process-'))
+    const processFile = join(runtimeRoot, 'processes.json')
+    const childSource = 'process.on(\'SIGTERM\', () => {}); setInterval(() => {}, 1000)'
+    const wrapperSource = [
+      'const { spawn } = require(\'node:child_process\')',
+      'const { writeFileSync } = require(\'node:fs\')',
+      `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childSource)}], { stdio: 'ignore' })`,
+      `writeFileSync(${JSON.stringify(processFile)}, JSON.stringify({ wrapper: process.pid, child: child.pid }))`,
+      'process.on(\'SIGTERM\', () => process.exit(0))',
+      'setInterval(() => {}, 1000)',
+    ].join(';')
+
+    let processIds: { child: number, wrapper: number } | undefined
+    try {
+      const resultPromise = runTimedProcess(process.execPath, ['-e', wrapperSource], process.env, async () => {
+        // Keep the process group alive until its child PID is observable. A fixed startup delay
+        // races with a loaded CI runner and can signal the wrapper before it creates the fixture.
+        for (let attempt = 0; attempt < 250; attempt += 1) {
+          try {
+            processIds = JSON.parse(await readFile(processFile, 'utf8'))
+            return
+          }
+          catch {
+            await new Promise(resolveDelay => setTimeout(resolveDelay, 20))
+          }
+        }
+        throw new Error('Timed process did not publish its process IDs')
+      }, 100)
+
+      const result = await resultPromise
+
+      expect(processIds).toBeDefined()
+      expect(result.timedOut).toBe(true)
+      expect(isProcessActive(processIds!.wrapper)).toBe(false)
+      expect(isProcessActive(processIds!.child)).toBe(false)
+    }
+    finally {
+      if (processIds !== undefined) {
+        try {
+          process.kill(-processIds.wrapper, 'SIGKILL')
+        }
+        catch {
+          // The fixed implementation already stopped the process group.
+        }
+      }
+      await rm(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+function isProcessActive(processId: number): boolean {
+  try {
+    process.kill(processId, 0)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+describe('linux executable verification', () => {
+  it('accepts an ARM64 ELF executable for an ARM64 package', () => {
+    expect(() => assertExecutableArchitecture('Machine:                           AArch64', 'arm64')).not.toThrow()
+  })
+
+  it('accepts an x64 ELF executable for an x64 package', () => {
+    expect(() => assertExecutableArchitecture('Machine:                           Advanced Micro Devices X86-64', 'x64')).not.toThrow()
+  })
+
+  it('rejects an ELF executable for the wrong architecture', () => {
+    expect(() => assertExecutableArchitecture('Machine:                           Advanced Micro Devices X86-64', 'arm64')).toThrow('Expected an AArch64 executable')
+  })
+})
+
+describe('linux desktop entry verification', () => {
+  it('accepts the AIRI executable and icon names', () => {
+    expect(() => assertDesktopEntryContract('[Desktop Entry]\nExec=/opt/AIRI/airi %U\nIcon=airi\n')).not.toThrow()
+  })
+
+  it('rejects an entry that cannot start AIRI', () => {
+    expect(() => assertDesktopEntryContract('[Desktop Entry]\nExec=missing\nIcon=airi\n')).toThrow('Desktop entry must use Exec=/opt/AIRI/airi')
+  })
+
+  it('rejects an entry without the AIRI icon', () => {
+    expect(() => assertDesktopEntryContract('[Desktop Entry]\nExec=/opt/AIRI/airi\nIcon=missing\n')).toThrow('Desktop entry must use Icon=airi')
+  })
+
+  it('accepts the Flatpak launcher and application icon', () => {
+    expect(() => assertFlatpakDesktopEntryContract('[Desktop Entry]\nExec=airi.sh %U\nIcon=ai.moeru.airi\n')).not.toThrow()
+  })
+
+  it('rejects a Flatpak entry with the direct Electron command', () => {
+    expect(() => assertFlatpakDesktopEntryContract('[Desktop Entry]\nExec=airi %U\nIcon=ai.moeru.airi\n')).toThrow('Flatpak desktop entry must use Exec=airi.sh')
+  })
+})
+
+describe('linux native payload verification', () => {
+  it('accepts ARM64 Linux native binaries in an ARM64 package', () => {
+    expect(() => assertDebPackageContract(packageWithNativeEntries('arm64', [
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/onnxruntime-node/bin/napi-v3/linux/arm64/onnxruntime_binding.node',
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/uiohook-napi/prebuilds/linux-arm64/uiohook-napi.node',
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/electron-click-drag-plugin/build/Release/linux-arm64/drag.node',
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/@img/sharp-linux-arm64/lib/sharp-linux-arm64.node',
+    ]), 'arm64')).not.toThrow()
+  })
+
+  it('accepts neutral parent directories for native payloads', () => {
+    expect(() => assertDebPackageContract({
+      ...validPackage,
+      entries: [
+        ...validPackage.entries,
+        { path: './opt/AIRI/resources/app.asar.unpacked/node_modules/onnxruntime-node/bin/napi-v3/', mode: 'drwxr-xr-x' },
+        { path: './opt/AIRI/resources/app.asar.unpacked/node_modules/onnxruntime-node/bin/napi-v3/linux/', mode: 'drwxr-xr-x' },
+      ],
+    }, 'arm64')).not.toThrow()
+  })
+
+  it('accepts x64 Linux native binaries in an x64 package', () => {
+    expect(() => assertDebPackageContract(packageWithNativeEntries('amd64', [
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/onnxruntime-node/bin/napi-v3/linux/x64/onnxruntime_binding.node',
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/uiohook-napi/prebuilds/linux-x64/uiohook-napi.node',
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/electron-click-drag-plugin/build/Release/linux-x64/drag.node',
+      './opt/AIRI/resources/app.asar.unpacked/node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node',
+    ]), 'x64')).not.toThrow()
+  })
+
+  // ROOT CAUSE:
+  //
+  // The ARM64 Debian package contains native modules for macOS, Windows, and other Linux architectures.
+  // Electron Builder includes all unpacked native-module variants because the file rules do not filter their target directories.
+  // The generated ARM64 package is 568 MB and needs more than 1.7 GB when extracted.
+  //
+  // Before the fix, the package contract accepts every foreign native payload.
+  //
+  // The fix must keep only Linux native binaries that match the package architecture.
+  it('rejects macOS native binaries in a Linux package', () => {
+    const foreignPath = './opt/AIRI/resources/app.asar.unpacked/node_modules/onnxruntime-node/bin/napi-v3/darwin/arm64/libonnxruntime.dylib'
+
+    expect(() => assertDebPackageContract(packageWithNativeEntries('arm64', [foreignPath]), 'arm64'))
+      .toThrow(`Foreign native payload for arm64: ${foreignPath}`)
+  })
+
+  it('rejects Windows native binaries in a Linux package', () => {
+    const foreignPath = './opt/AIRI/resources/app.asar.unpacked/node_modules/electron-click-drag-plugin/build/Release/win32-arm64/drag.node'
+
+    expect(() => assertDebPackageContract(packageWithNativeEntries('arm64', [foreignPath]), 'arm64'))
+      .toThrow(`Foreign native payload for arm64: ${foreignPath}`)
+  })
+
+  it('rejects Linux x64 native binaries in an ARM64 package', () => {
+    const foreignPath = './opt/AIRI/resources/app.asar.unpacked/node_modules/uiohook-napi/prebuilds/linux-x64/uiohook-napi.node'
+
+    expect(() => assertDebPackageContract(packageWithNativeEntries('arm64', [foreignPath]), 'arm64'))
+      .toThrow(`Foreign native payload for arm64: ${foreignPath}`)
+  })
+
+  it('rejects Linux ARM64 native binaries in an x64 package', () => {
+    const foreignPath = './opt/AIRI/resources/app.asar.unpacked/node_modules/@img/sharp-linux-arm64/lib/sharp-linux-arm64.node'
+
+    expect(() => assertDebPackageContract(packageWithNativeEntries('amd64', [foreignPath]), 'x64'))
+      .toThrow(`Foreign native payload for x64: ${foreignPath}`)
+  })
+
+  it('rejects unsupported Linux architectures', () => {
+    const foreignPath = './opt/AIRI/resources/app.asar.unpacked/node_modules/uiohook-napi/prebuilds/linux-loong64/uiohook-napi.node'
+
+    expect(() => assertDebPackageContract(packageWithNativeEntries('arm64', [foreignPath]), 'arm64'))
+      .toThrow(`Foreign native payload for arm64: ${foreignPath}`)
+  })
+})

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { isWindows } from 'std-env'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { runTimedProcess, stopProcessGroup } from './process-group'
 import {
@@ -205,6 +205,11 @@ describe('linux Flatpak package verification', () => {
 })
 
 describe('linux launch smoke result', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
   it('accepts an app that stays active for the smoke-test window', () => {
     expect(isSuccessfulLaunchSmoke({ exitCode: null, signal: 'SIGTERM', timedOut: true })).toBe(true)
   })
@@ -317,6 +322,31 @@ describe('linux launch smoke result', () => {
       }
       await rm(runtimeRoot, { recursive: true, force: true })
     }
+  })
+
+  it.skipIf(isWindows)('accepts a process group that exits before the escalation signal', async () => {
+    // ROOT CAUSE:
+    //
+    // A process group can exit after the active check and before the escalation signal.
+    // The resulting ESRCH means that cleanup is complete, but the verifier reports a failure.
+    // The fix must treat ESRCH from the escalation signal as a successful shutdown.
+    vi.useFakeTimers()
+    const kill = vi.spyOn(process, 'kill')
+    kill
+      .mockImplementationOnce(() => true)
+      .mockImplementationOnce(() => true)
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error('No such process'), { code: 'ESRCH' })
+      })
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error('No such process'), { code: 'ESRCH' })
+      })
+
+    const stopPromise = stopProcessGroup(42, 'SIGTERM')
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expect(stopPromise).resolves.toBeUndefined()
+    expect(kill).toHaveBeenNthCalledWith(3, -42, 'SIGKILL')
   })
 })
 

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
@@ -335,6 +335,46 @@ describe('linux launch smoke result', () => {
     }
   })
 
+  // https://github.com/moeru-ai/airi/pull/2278#discussion_r3776743829
+  it.skipIf(isWindows)('stops child processes when the wrapper exits before the timer', async () => {
+    // ROOT CAUSE:
+    //
+    // The detached wrapper can exit while an Electron child remains in its process group.
+    // The verifier resolved immediately and left the child active during later workflow steps.
+    //
+    // We fixed this by stopping the process group before resolving an early close.
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'airi-early-exit-'))
+    const processFile = join(runtimeRoot, 'processes.json')
+    const childSource = 'process.on(\'SIGTERM\', () => {}); setInterval(() => {}, 1000)'
+    const wrapperSource = [
+      'const { spawn } = require(\'node:child_process\')',
+      'const { writeFileSync } = require(\'node:fs\')',
+      `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childSource)}], { stdio: 'ignore' })`,
+      'child.unref()',
+      `writeFileSync(${JSON.stringify(processFile)}, JSON.stringify({ wrapper: process.pid, child: child.pid }))`,
+    ].join(';')
+
+    let processIds: { child: number, wrapper: number } | undefined
+    try {
+      const result = await runTimedProcess(process.execPath, ['-e', wrapperSource], process.env, undefined, 5_000)
+      processIds = JSON.parse(await readFile(processFile, 'utf8'))
+
+      expect(result.timedOut).toBe(false)
+      expect(isProcessActive(processIds!.child)).toBe(false)
+    }
+    finally {
+      if (processIds !== undefined) {
+        try {
+          process.kill(-processIds.wrapper, 'SIGKILL')
+        }
+        catch {
+          // The fixed implementation already stopped the process group.
+        }
+      }
+      await rm(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+
   it.skipIf(isWindows)('accepts a process group that exits before the escalation signal', async () => {
     // ROOT CAUSE:
     //

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.test.ts
@@ -398,12 +398,19 @@ describe('linux desktop entry verification', () => {
     expect(() => assertDesktopEntryContract('[Desktop Entry]\nExec=/opt/AIRI/airi\nIcon=missing\n')).toThrow('Desktop entry must use Icon=airi')
   })
 
-  it('accepts the Flatpak launcher and application icon', () => {
-    expect(() => assertFlatpakDesktopEntryContract('[Desktop Entry]\nExec=airi.sh %U\nIcon=ai.moeru.airi\n')).not.toThrow()
+  // https://github.com/moeru-ai/airi/pull/2278#discussion_r3776522471
+  // ROOT CAUSE:
+  //
+  // The desktop entry launches /app/bin/airi, which links to the zypak wrapper.
+  // The verifier required airi.sh instead, so it rejected every built Flatpak.
+  //
+  // We fixed this by requiring the launcher name that the desktop entry exports.
+  it('accepts the exported Flatpak launcher and application icon', () => {
+    expect(() => assertFlatpakDesktopEntryContract('[Desktop Entry]\nExec=airi %U\nIcon=ai.moeru.airi\n')).not.toThrow()
   })
 
-  it('rejects a Flatpak entry with the direct Electron command', () => {
-    expect(() => assertFlatpakDesktopEntryContract('[Desktop Entry]\nExec=airi %U\nIcon=ai.moeru.airi\n')).toThrow('Flatpak desktop entry must use Exec=airi.sh')
+  it('rejects a Flatpak entry that bypasses the exported launcher', () => {
+    expect(() => assertFlatpakDesktopEntryContract('[Desktop Entry]\nExec=airi.sh %U\nIcon=ai.moeru.airi\n')).toThrow('Flatpak desktop entry must use Exec=airi')
   })
 })
 

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.ts
@@ -250,8 +250,8 @@ function parseDesktopEntryFields(source: string): Map<string, string> {
 export function assertFlatpakDesktopEntryContract(source: string): void {
   const fields = parseDesktopEntryFields(source)
   const executable = fields.get('Exec')?.split(' ')[0]
-  if (executable !== 'airi.sh')
-    throw new Error('Flatpak desktop entry must use Exec=airi.sh')
+  if (executable !== 'airi')
+    throw new Error('Flatpak desktop entry must use Exec=airi')
   if (fields.get('Icon') !== 'ai.moeru.airi')
     throw new Error('Flatpak desktop entry must use Icon=ai.moeru.airi')
 }

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.ts
@@ -178,8 +178,9 @@ export function assertRpmPackageContract(inspection: RpmPackageInspection, relea
 
 /**
  * Makes sure that a Flatpak exports AIRI's launcher, icon, and matching native payload.
+ * Returns the checked executable entry for later architecture checks.
  */
-export function assertFlatpakPackageContract(inspection: FlatpakPackageInspection, releaseArchitecture: ReleaseArchitecture): void {
+export function assertFlatpakPackageContract(inspection: FlatpakPackageInspection, releaseArchitecture: ReleaseArchitecture): string {
   if (inspection.appId !== 'ai.moeru.airi')
     throw new Error(`Expected Flatpak application ai.moeru.airi, received ${inspection.appId}`)
 
@@ -193,10 +194,11 @@ export function assertFlatpakPackageContract(inspection: FlatpakPackageInspectio
   if (inspection.command !== 'airi.sh')
     throw new Error(`Expected Flatpak command airi.sh, received ${inspection.command}`)
 
+  const executablePath = './files/lib/airi/airi'
   assertDesktopPackageEntries(
     inspection.entries,
     releaseArchitecture,
-    './files/lib/airi/airi',
+    executablePath,
     './export/share/applications/',
     './export/share/icons/',
   )
@@ -204,6 +206,8 @@ export function assertFlatpakPackageContract(inspection: FlatpakPackageInspectio
   const launcher = inspection.entries.find(entry => entry.path === './files/bin/airi.sh')
   if (!launcher || !isRegularFile(launcher) || !isExecutable(launcher))
     throw new Error('Flatpak launcher is missing or is not executable: ./files/bin/airi.sh')
+
+  return executablePath
 }
 
 /**
@@ -654,9 +658,9 @@ export async function verifyFlatpakPackage(packagePath: string, architecture: Re
   let installedAppId: string | undefined
   try {
     const { checkoutPath, inspection } = await inspectFlatpakPackage(resolvedPackagePath, runtimeRoot)
-    assertFlatpakPackageContract(inspection, architecture)
+    const executableEntryPath = assertFlatpakPackageContract(inspection, architecture)
 
-    const executablePath = join(checkoutPath, 'files', 'bin', 'airi', 'airi')
+    const executablePath = join(checkoutPath, executableEntryPath)
     const desktopEntryPath = join(checkoutPath, 'export', 'share', 'applications', 'ai.moeru.airi.desktop')
     const [{ stdout: elfHeader }, desktopEntry] = await Promise.all([
       execFile('readelf', ['--file-header', executablePath], { encoding: 'utf8' }),

--- a/apps/stage-tamagotchi/scripts/verify-linux-package.ts
+++ b/apps/stage-tamagotchi/scripts/verify-linux-package.ts
@@ -1,0 +1,736 @@
+import type { Signals } from 'node:process'
+
+import type { TimedProcessResult } from './process-group'
+
+import process from 'node:process'
+
+import { Buffer } from 'node:buffer'
+import { execFile as execFileCallback, spawn } from 'node:child_process'
+import { lstat, mkdir, mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+import { errorMessageFrom } from '@moeru/std'
+import { cac } from 'cac'
+
+import { runTimedProcess } from './process-group'
+
+const execFile = promisify(execFileCallback)
+
+type ReleaseArchitecture = 'x64' | 'arm64'
+
+interface PackageEntry {
+  path: string
+  mode: string
+}
+
+interface DebPackageInspection {
+  packageName: string
+  architecture: string
+  entries: PackageEntry[]
+}
+
+interface RpmPackageInspection {
+  packageName: string
+  architecture: string
+  scripts: string
+  entries: PackageEntry[]
+}
+
+interface FlatpakPackageInspection {
+  appId: string
+  architecture: string
+  runtime: string
+  command: string
+  entries: PackageEntry[]
+}
+
+type LaunchSmokeResult = TimedProcessResult
+
+function isRegularFile(entry: PackageEntry): boolean {
+  if (entry.mode.startsWith('-'))
+    return true
+
+  const numericMode = Number.parseInt(entry.mode, 8)
+  return Number.isFinite(numericMode) && (numericMode & 0o170000) === 0o100000
+}
+
+function isExecutable(entry: PackageEntry): boolean {
+  if (entry.mode.startsWith('-'))
+    return entry.mode.includes('x')
+
+  const numericMode = Number.parseInt(entry.mode, 8)
+  return Number.isFinite(numericMode) && (numericMode & 0o111) !== 0
+}
+
+function findForeignNativePayload(entries: PackageEntry[], releaseArchitecture: ReleaseArchitecture): string | undefined {
+  const expectedSlashTarget = `linux/${releaseArchitecture}/`
+  const expectedHyphenTarget = `linux-${releaseArchitecture}/`
+
+  return entries.find((entry) => {
+    if (!isRegularFile(entry))
+      return false
+
+    const path = entry.path
+
+    const onnxRoot = '/onnxruntime-node/bin/napi-v3/'
+    const onnxRootIndex = path.indexOf(onnxRoot)
+    if (onnxRootIndex !== -1)
+      return !path.slice(onnxRootIndex + onnxRoot.length).startsWith(expectedSlashTarget)
+
+    const prebuildRoot = '/uiohook-napi/prebuilds/'
+    const prebuildRootIndex = path.indexOf(prebuildRoot)
+    if (prebuildRootIndex !== -1)
+      return !path.slice(prebuildRootIndex + prebuildRoot.length).startsWith(expectedHyphenTarget)
+
+    const dragRoot = '/electron-click-drag-plugin/build/Release/'
+    const dragRootIndex = path.indexOf(dragRoot)
+    if (dragRootIndex !== -1)
+      return !path.slice(dragRootIndex + dragRoot.length).startsWith(expectedHyphenTarget)
+
+    const imagePackageRoot = '/node_modules/@img/'
+    const imagePackageRootIndex = path.indexOf(imagePackageRoot)
+    if (imagePackageRootIndex === -1)
+      return false
+
+    const packageName = path.slice(imagePackageRootIndex + imagePackageRoot.length).split('/')[0]
+    if (!packageName.startsWith('sharp-') && !packageName.startsWith('sharp-libvips-'))
+      return false
+
+    return !packageName.endsWith(`linux-${releaseArchitecture}`)
+  })?.path
+}
+
+function assertDesktopPackageEntries(
+  entries: PackageEntry[],
+  releaseArchitecture: ReleaseArchitecture,
+  executablePath: string,
+  desktopRoot: string,
+  iconRoot: string,
+): void {
+  const executable = entries.find(entry => entry.path === executablePath)
+  if (!executable)
+    throw new Error(`Missing executable: ${executablePath}`)
+  if (!isRegularFile(executable) || !isExecutable(executable))
+    throw new Error(`Desktop executable is not executable: ${executablePath}`)
+
+  if (!entries.some(entry => isRegularFile(entry) && entry.path.startsWith(desktopRoot) && entry.path.endsWith('.desktop')))
+    throw new Error('Missing desktop entry')
+  if (!entries.some(entry => isRegularFile(entry) && entry.path.startsWith(iconRoot) && entry.path.includes('/apps/') && entry.path.endsWith('.png')))
+    throw new Error('Missing application icon')
+
+  const foreignNativePayload = findForeignNativePayload(entries, releaseArchitecture)
+  if (foreignNativePayload)
+    throw new Error(`Foreign native payload for ${releaseArchitecture}: ${foreignNativePayload}`)
+}
+
+/**
+ * Makes sure that a Debian package contains the files and metadata that AIRI needs.
+ *
+ * This check does not start the application. Use the launch smoke after extraction.
+ */
+export function assertDebPackageContract(inspection: DebPackageInspection, releaseArchitecture: ReleaseArchitecture): void {
+  if (inspection.packageName !== 'ai.moeru.airi') {
+    throw new Error(`Expected Debian package ai.moeru.airi, received ${inspection.packageName}`)
+  }
+
+  const expectedArchitecture = releaseArchitecture === 'arm64' ? 'arm64' : 'amd64'
+  if (inspection.architecture !== expectedArchitecture) {
+    throw new Error(`Expected Debian architecture ${expectedArchitecture}, received ${inspection.architecture}`)
+  }
+
+  assertDesktopPackageEntries(
+    inspection.entries,
+    releaseArchitecture,
+    './opt/AIRI/airi',
+    './usr/share/applications/',
+    './usr/share/icons/',
+  )
+}
+
+/**
+ * Makes sure that an RPM contains AIRI's native executable and desktop integration.
+ */
+export function assertRpmPackageContract(inspection: RpmPackageInspection, releaseArchitecture: ReleaseArchitecture): void {
+  if (inspection.packageName !== 'ai.moeru.airi')
+    throw new Error(`Expected RPM package ai.moeru.airi, received ${inspection.packageName}`)
+
+  const expectedArchitecture = releaseArchitecture === 'arm64' ? 'aarch64' : 'x86_64'
+  if (inspection.architecture !== expectedArchitecture)
+    throw new Error(`Expected RPM architecture ${expectedArchitecture}, received ${inspection.architecture}`)
+
+  const executablePath = '/opt/AIRI/airi'
+  const validRemovalScript = inspection.scripts.includes(`if [ ! -e '${executablePath}' ]; then`)
+    && inspection.scripts.includes(`update-alternatives --remove 'airi' '${executablePath}'`)
+    && inspection.scripts.includes('find \'/opt/AIRI\' -depth -type d -empty -delete')
+    && !inspection.scripts.includes('update-alternatives --remove \'airi\' \'/usr/bin/airi\'')
+  if (!validRemovalScript)
+    throw new Error(`RPM removal script must preserve upgrades and remove ${executablePath}`)
+
+  assertDesktopPackageEntries(
+    inspection.entries,
+    releaseArchitecture,
+    executablePath,
+    '/usr/share/applications/',
+    '/usr/share/icons/',
+  )
+}
+
+/**
+ * Makes sure that a Flatpak exports AIRI's launcher, icon, and matching native payload.
+ */
+export function assertFlatpakPackageContract(inspection: FlatpakPackageInspection, releaseArchitecture: ReleaseArchitecture): void {
+  if (inspection.appId !== 'ai.moeru.airi')
+    throw new Error(`Expected Flatpak application ai.moeru.airi, received ${inspection.appId}`)
+
+  const expectedArchitecture = releaseArchitecture === 'arm64' ? 'aarch64' : 'x86_64'
+  if (inspection.architecture !== expectedArchitecture)
+    throw new Error(`Expected Flatpak architecture ${expectedArchitecture}, received ${inspection.architecture}`)
+
+  const expectedRuntime = `org.freedesktop.Platform/${expectedArchitecture}/24.08`
+  if (inspection.runtime !== expectedRuntime)
+    throw new Error(`Expected Flatpak runtime ${expectedRuntime}, received ${inspection.runtime}`)
+  if (inspection.command !== 'airi.sh')
+    throw new Error(`Expected Flatpak command airi.sh, received ${inspection.command}`)
+
+  assertDesktopPackageEntries(
+    inspection.entries,
+    releaseArchitecture,
+    './files/lib/airi/airi',
+    './export/share/applications/',
+    './export/share/icons/',
+  )
+
+  const launcher = inspection.entries.find(entry => entry.path === './files/bin/airi.sh')
+  if (!launcher || !isRegularFile(launcher) || !isExecutable(launcher))
+    throw new Error('Flatpak launcher is missing or is not executable: ./files/bin/airi.sh')
+}
+
+/**
+ * Makes sure that the extracted ELF machine matches the release architecture.
+ */
+export function assertExecutableArchitecture(elfHeader: string, releaseArchitecture: ReleaseArchitecture): void {
+  const expectedMachine = releaseArchitecture === 'arm64' ? 'AArch64' : 'Advanced Micro Devices X86-64'
+  const machineLine = elfHeader.split('\n').find(line => line.trimStart().startsWith('Machine:'))
+  const machine = machineLine?.slice(machineLine.indexOf(':') + 1).trim()
+  if (machine !== expectedMachine)
+    throw new Error(`Expected an ${expectedMachine} executable`)
+}
+
+/**
+ * Makes sure that the Linux desktop entry starts AIRI and selects the AIRI icon.
+ */
+export function assertDesktopEntryContract(source: string): void {
+  const fields = parseDesktopEntryFields(source)
+
+  const executable = fields.get('Exec')?.split(' ')[0]
+  if (executable !== '/opt/AIRI/airi')
+    throw new Error('Desktop entry must use Exec=/opt/AIRI/airi')
+  if (fields.get('Icon') !== 'airi')
+    throw new Error('Desktop entry must use Icon=airi')
+}
+
+function parseDesktopEntryFields(source: string): Map<string, string> {
+  return new Map(source
+    .split('\n')
+    .map((line) => {
+      const separator = line.indexOf('=')
+      return separator === -1 ? [] : [line.slice(0, separator), line.slice(separator + 1)]
+    })
+    .filter((field): field is [string, string] => field.length === 2))
+}
+
+/**
+ * Makes sure that the exported Flatpak desktop entry uses its wrapper and application icon.
+ */
+export function assertFlatpakDesktopEntryContract(source: string): void {
+  const fields = parseDesktopEntryFields(source)
+  const executable = fields.get('Exec')?.split(' ')[0]
+  if (executable !== 'airi.sh')
+    throw new Error('Flatpak desktop entry must use Exec=airi.sh')
+  if (fields.get('Icon') !== 'ai.moeru.airi')
+    throw new Error('Flatpak desktop entry must use Icon=ai.moeru.airi')
+}
+
+/**
+ * Returns true when the application stays active until the smoke-test timer stops it.
+ */
+export function isSuccessfulLaunchSmoke(result: LaunchSmokeResult): boolean {
+  return result.timedOut
+}
+
+function parseDebFields(output: string): Pick<DebPackageInspection, 'architecture' | 'packageName'> {
+  const fields = new Map(output
+    .split('\n')
+    .map(line => line.split(':', 2).map(value => value.trim()))
+    .filter((field): field is [string, string] => field.length === 2 && Boolean(field[0]) && Boolean(field[1])))
+
+  return {
+    packageName: fields.get('Package') ?? '',
+    architecture: fields.get('Architecture') ?? '',
+  }
+}
+
+function parseDebEntries(output: string): PackageEntry[] {
+  return output
+    .split('\n')
+    .map((line) => {
+      const columns = line.trim().split(/\s+/)
+      if (columns.length < 6 || columns[0].length !== 10)
+        return undefined
+
+      return {
+        mode: columns[0],
+        path: columns[5],
+      }
+    })
+    .filter((entry): entry is PackageEntry => entry !== undefined)
+}
+
+async function inspectDebPackage(packagePath: string): Promise<DebPackageInspection> {
+  const [{ stdout: fields }, { stdout: contents }] = await Promise.all([
+    execFile('dpkg-deb', ['--field', packagePath, 'Package', 'Architecture'], { encoding: 'utf8' }),
+    execFile('dpkg-deb', ['--contents', packagePath], { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 }),
+  ])
+
+  return {
+    ...parseDebFields(fields),
+    entries: parseDebEntries(contents),
+  }
+}
+
+function parseRpmEntries(output: string): PackageEntry[] {
+  return output
+    .split('\n')
+    .map((line) => {
+      const columns = line.trim().split(/\s+/)
+      if (columns.length < 5 || !columns[0].startsWith('/'))
+        return undefined
+
+      return {
+        path: columns[0],
+        mode: columns[4],
+      }
+    })
+    .filter((entry): entry is PackageEntry => entry !== undefined)
+}
+
+async function inspectRpmPackage(packagePath: string, runtimeRoot: string): Promise<RpmPackageInspection> {
+  const databasePath = join(runtimeRoot, 'rpm-db')
+  await mkdir(databasePath, { recursive: true })
+
+  const [{ stdout: fields }, { stdout: entries }, { stdout: signature }, { stdout: scripts }] = await Promise.all([
+    execFile('rpm', [
+      '--dbpath',
+      databasePath,
+      '-qp',
+      '--queryformat',
+      'Package: %{NAME}\nArchitecture: %{ARCH}\n',
+      packagePath,
+    ], { encoding: 'utf8' }),
+    execFile('rpm', ['--dbpath', databasePath, '-qpl', '--dump', packagePath], { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 }),
+    execFile('rpm', ['--dbpath', databasePath, '--checksig', packagePath], { encoding: 'utf8' }),
+    execFile('rpm', ['--dbpath', databasePath, '-qp', '--scripts', packagePath], { encoding: 'utf8' }),
+  ])
+
+  if (!signature.includes('digests OK'))
+    throw new Error(`RPM digest verification failed: ${signature.trim()}`)
+
+  const metadata = parseDebFields(fields)
+  return {
+    packageName: metadata.packageName,
+    architecture: metadata.architecture,
+    scripts,
+    entries: parseRpmEntries(entries),
+  }
+}
+
+async function extractRpmPackage(packagePath: string, extractionRoot: string): Promise<void> {
+  await new Promise((resolveExtraction, reject) => {
+    const decoder = spawn('rpm2cpio', [packagePath], { stdio: ['ignore', 'pipe', 'pipe'] })
+    const extractor = spawn('bsdtar', ['--extract', '--file', '-', '--directory', extractionRoot], { stdio: ['pipe', 'ignore', 'pipe'] })
+    decoder.stdout.pipe(extractor.stdin)
+
+    const errors: Buffer[] = []
+    decoder.stderr.on('data', chunk => errors.push(chunk))
+    extractor.stderr.on('data', chunk => errors.push(chunk))
+
+    let decoderComplete = false
+    let decoderExitCode: number | null = null
+    let extractorComplete = false
+    let extractorExitCode: number | null = null
+    const finish = () => {
+      if (!decoderComplete || !extractorComplete)
+        return
+      if (decoderExitCode !== 0 || extractorExitCode !== 0) {
+        reject(new Error(`RPM extraction failed: ${Buffer.concat(errors).toString('utf8').trim()}`))
+        return
+      }
+      resolveExtraction()
+    }
+
+    decoder.once('error', reject)
+    extractor.once('error', reject)
+    decoder.once('close', (exitCode) => {
+      decoderComplete = true
+      decoderExitCode = exitCode
+      finish()
+    })
+    extractor.once('close', (exitCode) => {
+      extractorComplete = true
+      extractorExitCode = exitCode
+      finish()
+    })
+  })
+}
+
+function parseFlatpakMetadata(source: string): Pick<FlatpakPackageInspection, 'appId' | 'command' | 'runtime'> {
+  const fields = new Map<string, string>()
+  let section = ''
+
+  for (const line of source.split('\n')) {
+    const trimmedLine = line.trim()
+    if (trimmedLine.startsWith('[') && trimmedLine.endsWith(']')) {
+      section = trimmedLine.slice(1, -1)
+      continue
+    }
+    if (section !== 'Application')
+      continue
+
+    const separator = trimmedLine.indexOf('=')
+    if (separator !== -1)
+      fields.set(trimmedLine.slice(0, separator), trimmedLine.slice(separator + 1))
+  }
+
+  return {
+    appId: fields.get('name') ?? '',
+    command: fields.get('command') ?? '',
+    runtime: (fields.get('runtime') ?? '').replace(/^runtime\//, ''),
+  }
+}
+
+async function listPackageEntries(rootPath: string, relativePath = ''): Promise<PackageEntry[]> {
+  const entries: PackageEntry[] = []
+  for (const name of await readdir(join(rootPath, relativePath))) {
+    const childRelativePath = join(relativePath, name)
+    const childPath = join(rootPath, childRelativePath)
+    const childStats = await lstat(childPath)
+    entries.push({
+      path: `./${childRelativePath}`,
+      mode: `0${childStats.mode.toString(8)}`,
+    })
+    if (childStats.isDirectory())
+      entries.push(...await listPackageEntries(rootPath, childRelativePath))
+  }
+  return entries
+}
+
+async function inspectFlatpakPackage(packagePath: string, runtimeRoot: string): Promise<{
+  checkoutPath: string
+  inspection: FlatpakPackageInspection
+}> {
+  const repositoryPath = join(runtimeRoot, 'flatpak-repo')
+  const checkoutPath = join(runtimeRoot, 'flatpak-checkout')
+  await execFile('ostree', ['init', `--repo=${repositoryPath}`, '--mode=archive-z2'])
+  await execFile('flatpak', ['build-import-bundle', repositoryPath, packagePath])
+
+  const { stdout: refsOutput } = await execFile('ostree', [`--repo=${repositoryPath}`, 'refs'], { encoding: 'utf8' })
+  const appRefs = refsOutput.split('\n').map(ref => ref.trim()).filter(ref => ref.startsWith('app/'))
+  if (appRefs.length !== 1)
+    throw new Error(`Expected one Flatpak application ref, received ${appRefs.length}`)
+
+  const appRef = appRefs[0]
+  // Flatpak bundle entries can record root ownership. CI checks out as an unprivileged user.
+  await execFile('ostree', [`--repo=${repositoryPath}`, 'checkout', '--user-mode', appRef, checkoutPath])
+  const metadata = parseFlatpakMetadata(await readFile(join(checkoutPath, 'metadata'), 'utf8'))
+
+  return {
+    checkoutPath,
+    inspection: {
+      ...metadata,
+      architecture: appRef.split('/')[2] ?? '',
+      entries: await listPackageEntries(checkoutPath),
+    },
+  }
+}
+
+async function runLaunchSmoke(executablePath: string, runtimeRoot: string): Promise<LaunchSmokeResult> {
+  const homePath = join(runtimeRoot, 'home')
+  const configPath = join(runtimeRoot, 'config')
+  const cachePath = join(runtimeRoot, 'cache')
+  await Promise.all([
+    mkdir(homePath, { recursive: true }),
+    mkdir(configPath, { recursive: true }),
+    mkdir(cachePath, { recursive: true }),
+  ])
+
+  return await runTimedProcess('xvfb-run', [
+    '--auto-servernum',
+    executablePath,
+    '--no-sandbox',
+    '--disable-gpu',
+    `--user-data-dir=${join(runtimeRoot, 'user-data')}`,
+  ], {
+    ...process.env,
+    HOME: homePath,
+    XDG_CACHE_HOME: cachePath,
+    XDG_CONFIG_HOME: configPath,
+  })
+}
+
+async function runFlatpakLaunchSmoke(appId: string): Promise<LaunchSmokeResult> {
+  const existingProcessIds = await findFlatpakAiriProcessIds()
+  const result = await runTimedProcess('dbus-run-session', [
+    '--',
+    'xvfb-run',
+    '--auto-servernum',
+    'flatpak',
+    'run',
+    '--user',
+    appId,
+  ], process.env, async () => {
+    await ignoreMissingFlatpak('flatpak', ['kill', appId])
+    await stopNewFlatpakAiriProcesses(existingProcessIds)
+  })
+  await stopNewFlatpakAiriProcesses(existingProcessIds)
+  return result
+}
+
+async function findFlatpakAiriProcessIds(): Promise<Set<number>> {
+  const processIds = new Set<number>()
+  for (const entry of await readdir('/proc')) {
+    if (!/^\d+$/.test(entry))
+      continue
+
+    try {
+      const commandLine = await readFile(join('/proc', entry, 'cmdline'), 'utf8')
+      if (commandLine.includes('/app/lib/airi/airi'))
+        processIds.add(Number(entry))
+    }
+    catch {
+      // A process can exit between the directory listing and the command-line read.
+    }
+  }
+  return processIds
+}
+
+async function signalProcessIds(processIds: Set<number>, signal: Signals): Promise<void> {
+  for (const processId of processIds) {
+    try {
+      process.kill(processId, signal)
+    }
+    catch (error) {
+      const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
+      if (code !== 'ESRCH')
+        throw error
+    }
+  }
+}
+
+async function stopNewFlatpakAiriProcesses(existingProcessIds: Set<number>): Promise<void> {
+  const newProcessIds = await findFlatpakAiriProcessIds()
+  for (const processId of existingProcessIds)
+    newProcessIds.delete(processId)
+  await signalProcessIds(newProcessIds, 'SIGTERM')
+
+  await new Promise(resolveDelay => setTimeout(resolveDelay, 1_000))
+  const remainingProcessIds = await findFlatpakAiriProcessIds()
+  for (const processId of existingProcessIds)
+    remainingProcessIds.delete(processId)
+  await signalProcessIds(remainingProcessIds, 'SIGKILL')
+}
+
+async function ignoreMissingFlatpak(command: string, args: string[]): Promise<void> {
+  try {
+    await execFile(command, args)
+  }
+  catch (error) {
+    const message = errorMessageFrom(error) ?? ''
+    if (!message.includes('is not running') && !message.includes('is not installed'))
+      throw error
+  }
+}
+
+/**
+ * Inspects and starts an AIRI Debian package on its native Linux runner.
+ *
+ * Call stack:
+ *
+ * verifyLinuxPackage
+ *   -> inspectDebPackage
+ *   -> {@link assertDebPackageContract}
+ *   -> runLaunchSmoke
+ *     -> {@link isSuccessfulLaunchSmoke}
+ */
+export async function verifyLinuxPackage(packagePath: string, architecture: ReleaseArchitecture): Promise<void> {
+  const resolvedPackagePath = resolve(packagePath)
+  const packageStats = await stat(resolvedPackagePath)
+  if (!packageStats.isFile())
+    throw new Error(`Debian package is not a file: ${resolvedPackagePath}`)
+
+  const inspection = await inspectDebPackage(resolvedPackagePath)
+  assertDebPackageContract(inspection, architecture)
+
+  // The AIRI package expands beyond small RAM-backed /tmp mounts. Keep extraction on the artifact filesystem.
+  const extractionRoot = await mkdtemp(join(dirname(resolvedPackagePath), '.airi-linux-package-'))
+  try {
+    await execFile('dpkg-deb', ['--extract', resolvedPackagePath, extractionRoot])
+    const executablePath = join(extractionRoot, 'opt', 'AIRI', 'airi')
+    const desktopEntryPath = join(extractionRoot, 'usr', 'share', 'applications', 'airi.desktop')
+    const [{ stdout: elfHeader }, desktopEntry] = await Promise.all([
+      execFile('readelf', ['--file-header', executablePath], { encoding: 'utf8' }),
+      readFile(desktopEntryPath, 'utf8'),
+    ])
+    assertExecutableArchitecture(elfHeader, architecture)
+    assertDesktopEntryContract(desktopEntry)
+
+    const launchResult = await runLaunchSmoke(executablePath, join(extractionRoot, '.smoke-runtime'))
+    if (!isSuccessfulLaunchSmoke(launchResult)) {
+      throw new Error(`AIRI exited before the launch-smoke window ended (exit code: ${launchResult.exitCode}, signal: ${launchResult.signal ?? 'none'})`)
+    }
+  }
+  finally {
+    await rm(extractionRoot, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Inspects and starts an AIRI RPM package on its native Linux runner.
+ *
+ * Call stack:
+ *
+ * verifyRpmPackage
+ *   -> inspectRpmPackage
+ *   -> {@link assertRpmPackageContract}
+ *   -> runLaunchSmoke
+ */
+export async function verifyRpmPackage(packagePath: string, architecture: ReleaseArchitecture): Promise<void> {
+  const resolvedPackagePath = resolve(packagePath)
+  const packageStats = await stat(resolvedPackagePath)
+  if (!packageStats.isFile())
+    throw new Error(`RPM package is not a file: ${resolvedPackagePath}`)
+
+  const extractionRoot = await mkdtemp(join(dirname(resolvedPackagePath), '.airi-rpm-package-'))
+  try {
+    const inspection = await inspectRpmPackage(resolvedPackagePath, extractionRoot)
+    assertRpmPackageContract(inspection, architecture)
+
+    await extractRpmPackage(resolvedPackagePath, extractionRoot)
+    const executablePath = join(extractionRoot, 'opt', 'AIRI', 'airi')
+    const desktopEntryPath = join(extractionRoot, 'usr', 'share', 'applications', 'airi.desktop')
+    const [{ stdout: elfHeader }, desktopEntry] = await Promise.all([
+      execFile('readelf', ['--file-header', executablePath], { encoding: 'utf8' }),
+      readFile(desktopEntryPath, 'utf8'),
+    ])
+    assertExecutableArchitecture(elfHeader, architecture)
+    assertDesktopEntryContract(desktopEntry)
+
+    const launchResult = await runLaunchSmoke(executablePath, join(extractionRoot, '.smoke-runtime'))
+    if (!isSuccessfulLaunchSmoke(launchResult))
+      throw new Error(`RPM AIRI exited before the launch-smoke window ended (exit code: ${launchResult.exitCode}, signal: ${launchResult.signal ?? 'none'})`)
+  }
+  finally {
+    await rm(extractionRoot, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Inspects and starts an AIRI Flatpak bundle on its native Linux runner.
+ *
+ * Call stack:
+ *
+ * verifyFlatpakPackage
+ *   -> inspectFlatpakPackage
+ *   -> {@link assertFlatpakPackageContract}
+ *   -> runFlatpakLaunchSmoke
+ */
+export async function verifyFlatpakPackage(packagePath: string, architecture: ReleaseArchitecture): Promise<void> {
+  const resolvedPackagePath = resolve(packagePath)
+  const packageStats = await stat(resolvedPackagePath)
+  if (!packageStats.isFile())
+    throw new Error(`Flatpak bundle is not a file: ${resolvedPackagePath}`)
+
+  const runtimeRoot = await mkdtemp(join(dirname(resolvedPackagePath), '.airi-flatpak-package-'))
+  let installedAppId: string | undefined
+  try {
+    const { checkoutPath, inspection } = await inspectFlatpakPackage(resolvedPackagePath, runtimeRoot)
+    assertFlatpakPackageContract(inspection, architecture)
+
+    const executablePath = join(checkoutPath, 'files', 'bin', 'airi', 'airi')
+    const desktopEntryPath = join(checkoutPath, 'export', 'share', 'applications', 'ai.moeru.airi.desktop')
+    const [{ stdout: elfHeader }, desktopEntry] = await Promise.all([
+      execFile('readelf', ['--file-header', executablePath], { encoding: 'utf8' }),
+      readFile(desktopEntryPath, 'utf8'),
+    ])
+    assertExecutableArchitecture(elfHeader, architecture)
+    assertFlatpakDesktopEntryContract(desktopEntry)
+
+    try {
+      await execFile('flatpak', ['info', '--user', inspection.appId])
+      throw new Error(`Flatpak application is already installed: ${inspection.appId}`)
+    }
+    catch (error) {
+      const message = errorMessageFrom(error) ?? ''
+      if (!message.includes('is not installed') && !message.includes('not installed'))
+        throw error
+    }
+
+    await execFile('flatpak', ['install', '--user', '--noninteractive', resolvedPackagePath])
+    installedAppId = inspection.appId
+    const launchResult = await runFlatpakLaunchSmoke(inspection.appId)
+    if (!isSuccessfulLaunchSmoke(launchResult))
+      throw new Error(`Flatpak AIRI exited before the launch-smoke window ended (exit code: ${launchResult.exitCode}, signal: ${launchResult.signal ?? 'none'})`)
+  }
+  finally {
+    if (installedAppId) {
+      await ignoreMissingFlatpak('flatpak', ['kill', installedAppId])
+      await ignoreMissingFlatpak('flatpak', ['uninstall', '--user', '--noninteractive', installedAppId])
+    }
+    await rm(runtimeRoot, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Reads CLI arguments and verifies the DEB, RPM, and Flatpak release artifacts.
+ *
+ * Call stack:
+ *
+ * main
+ *   -> {@link verifyLinuxPackage}
+ *   -> {@link verifyRpmPackage}
+ *   -> {@link verifyFlatpakPackage}
+ */
+async function main(): Promise<void> {
+  const cli = cac('verify-linux-package')
+    .option('--deb <path>', 'Path to the Debian package', { type: [String] })
+    .option('--rpm <path>', 'Path to the RPM package', { type: [String] })
+    .option('--flatpak <path>', 'Path to the Flatpak bundle', { type: [String] })
+    .option('--arch <architecture>', 'Release architecture: x64 or arm64', { type: [String] })
+
+  const args = cli.parse()
+  const debPath = String(args.options.deb?.[0] ?? '').trim()
+  const rpmPath = String(args.options.rpm?.[0] ?? '').trim()
+  const flatpakPath = String(args.options.flatpak?.[0] ?? '').trim()
+  const architecture = String(args.options.arch?.[0] ?? '').trim()
+
+  if (!debPath)
+    throw new Error('--deb is required')
+  if (!rpmPath)
+    throw new Error('--rpm is required')
+  if (!flatpakPath)
+    throw new Error('--flatpak is required')
+  if (architecture !== 'x64' && architecture !== 'arm64')
+    throw new Error('--arch must be x64 or arm64')
+
+  await verifyLinuxPackage(debPath, architecture)
+  await verifyRpmPackage(rpmPath, architecture)
+  await verifyFlatpakPackage(flatpakPath, architecture)
+  console.info(`Linux package verification passed for ${architecture}`)
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(errorMessageFrom(error) ?? 'Linux package verification failed')
+    process.exit(1)
+  })
+}

--- a/apps/stage-tamagotchi/src/main/app/command-line.test.ts
+++ b/apps/stage-tamagotchi/src/main/app/command-line.test.ts
@@ -1,0 +1,74 @@
+import type { CommandLine } from 'electron'
+
+import process from 'node:process'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { configureAppCommandLine } from './command-line'
+
+type ConfigurableCommandLine = Pick<CommandLine, 'appendSwitch' | 'getSwitchValue' | 'hasSwitch' | 'removeSwitch'>
+
+function createCommandLine(initialFeatures: string): {
+  commandLine: ConfigurableCommandLine
+  appendSwitch: ReturnType<typeof vi.fn>
+} {
+  const switches = new Map<string, string>([['enable-features', initialFeatures]])
+  const appendSwitch = vi.fn((name: string, value = '') => {
+    // Chromium stores one current value for each switch key. A later append
+    // replaces the value that getSwitchValue returns to AIRI services.
+    switches.set(name, value)
+  })
+
+  return {
+    appendSwitch,
+    commandLine: {
+      appendSwitch,
+      getSwitchValue: name => switches.get(name) ?? '',
+      hasSwitch: name => switches.has(name),
+      removeSwitch: name => switches.delete(name),
+    },
+  }
+}
+
+describe.runIf(process.platform === 'linux')('configureAppCommandLine on the Linux host', () => {
+  it('preserves user features and writes one combined enable-features switch', () => {
+    // ROOT CAUSE:
+    //
+    // Chromium stores switches by key. AIRI appends `enable-features` once
+    // for each feature, so every append replaces the value from the prior
+    // append. Screen-capture initialization then preserves only that final
+    // value and permanently removes the other Linux startup features.
+    //
+    // Before the fix, X11 keeps only `Vulkan`. Native Wayland keeps only
+    // `WaylandWindowDecorations`.
+    //
+    // The fix must read the existing value and append one deduplicated list.
+    const { appendSwitch, commandLine } = createCommandLine('UserProvidedFeature')
+
+    configureAppCommandLine(commandLine)
+
+    const featureCalls = appendSwitch.mock.calls.filter(([name]) => name === 'enable-features')
+    const enabledFeatures = commandLine.getSwitchValue('enable-features').split(',')
+
+    expect(featureCalls).toHaveLength(1)
+    expect(enabledFeatures).toContain('UserProvidedFeature')
+    expect(enabledFeatures).toContain('SharedArrayBuffer')
+    expect(enabledFeatures).toContain('Vulkan')
+
+    if (process.env.XDG_SESSION_TYPE === 'wayland') {
+      expect(enabledFeatures).toContain('GlobalShortcutsPortal')
+      expect(enabledFeatures).toContain('GlobalShortcutsPortalPreferredTrigger')
+      expect(enabledFeatures).toContain('UseOzonePlatform')
+      expect(enabledFeatures).toContain('WaylandWindowDecorations')
+    }
+  })
+
+  it('adds the standalone WebGPU switch once', () => {
+    const { appendSwitch, commandLine } = createCommandLine('UserProvidedFeature')
+
+    configureAppCommandLine(commandLine)
+
+    expect(appendSwitch).toHaveBeenCalledWith('enable-unsafe-webgpu')
+    expect(appendSwitch.mock.calls.filter(([name]) => name === 'enable-unsafe-webgpu')).toHaveLength(1)
+  })
+})

--- a/apps/stage-tamagotchi/src/main/app/command-line.ts
+++ b/apps/stage-tamagotchi/src/main/app/command-line.ts
@@ -1,0 +1,56 @@
+import type { CommandLine } from 'electron'
+
+import { env } from 'node:process'
+
+import { isLinux } from 'std-env'
+
+type ConfigurableCommandLine = Pick<CommandLine, 'appendSwitch' | 'getSwitchValue' | 'hasSwitch' | 'removeSwitch'>
+
+/**
+ * Adds the Chromium switches that AIRI requires before Electron becomes ready.
+ *
+ * The function reads the real host platform. Tests must not replace the platform
+ * because Chromium selects its backend from the host process at startup.
+ */
+export function configureAppCommandLine(commandLine: ConfigurableCommandLine): void {
+  if (!isLinux)
+    return
+
+  const enabledFeatures = new Set(
+    commandLine
+      .getSwitchValue('enable-features')
+      .split(',')
+      .map(feature => feature.trim())
+      .filter(Boolean),
+  )
+
+  // Thanks to [@blurymind](https://github.com/blurymind),
+  //
+  // When running Electron on Linux, navigator.gpu.requestAdapter() fails.
+  // In order to enable WebGPU and process the shaders fast enough, we need the following
+  // command line switches to be set.
+  //
+  // https://github.com/electron/electron/issues/41763#issuecomment-2051725363
+  // https://github.com/electron/electron/issues/41763#issuecomment-3143338995
+  enabledFeatures.add('SharedArrayBuffer')
+  enabledFeatures.add('Vulkan')
+  commandLine.appendSwitch('enable-unsafe-webgpu')
+
+  // NOTICE: we need UseOzonePlatform, WaylandWindowDecorations for working on Wayland.
+  // Partially related to https://github.com/electron/electron/issues/41551, since X11 is deprecating now,
+  // we can safely remove the feature flags for Electron once they made it default supported.
+  // Fixes: https://github.com/moeru-ai/airi/issues/757
+  // Ref: https://github.com/mmaura/poe2linuxcompanion/blob/90664607a147ea5ccea28df6139bd95fb0ebab0e/electron/main/index.ts#L28-L46
+  if (env.XDG_SESSION_TYPE === 'wayland') {
+    enabledFeatures.add('GlobalShortcutsPortal')
+    enabledFeatures.add('GlobalShortcutsPortalPreferredTrigger')
+    enabledFeatures.add('UseOzonePlatform')
+    enabledFeatures.add('WaylandWindowDecorations')
+  }
+
+  // Chromium keeps one value for each switch. Replace the prior value once
+  // so AIRI preserves user features and does not discard its own features.
+  if (commandLine.hasSwitch('enable-features'))
+    commandLine.removeSwitch('enable-features')
+  commandLine.appendSwitch('enable-features', [...enabledFeatures].join(','))
+}

--- a/apps/stage-tamagotchi/src/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/index.ts
@@ -16,10 +16,10 @@ import { hasSelectedScreenCaptureSource, initScreenCaptureForMain } from '@proj-
 import { app, ipcMain, session } from 'electron'
 import { noop } from 'es-toolkit'
 import { createLoggLogger, injeca, lifecycle } from 'injeca'
-import { isLinux } from 'std-env'
 
 import icon from '../../resources/icon.png?asset'
 
+import { configureAppCommandLine } from './app/command-line'
 import { openDebugger, setupDebugger } from './app/debugger'
 import { nullFileLoggerHandle, setupFileLogger } from './app/file-logger'
 import { installSingleInstanceGuard } from './app/single-instance'
@@ -69,31 +69,7 @@ if (appUserDataPath) {
   app.setPath('userData', appUserDataPath)
 }
 
-// Thanks to [@blurymind](https://github.com/blurymind),
-//
-// When running Electron on Linux, navigator.gpu.requestAdapter() fails.
-// In order to enable WebGPU and process the shaders fast enough, we need the following
-// command line switches to be set.
-//
-// https://github.com/electron/electron/issues/41763#issuecomment-2051725363
-// https://github.com/electron/electron/issues/41763#issuecomment-3143338995
-if (isLinux) {
-  app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer')
-  app.commandLine.appendSwitch('enable-unsafe-webgpu')
-  app.commandLine.appendSwitch('enable-features', 'Vulkan')
-
-  // NOTICE: we need UseOzonePlatform, WaylandWindowDecorations for working on Wayland.
-  // Partially related to https://github.com/electron/electron/issues/41551, since X11 is deprecating now,
-  // we can safely remove the feature flags for Electron once they made it default supported.
-  // Fixes: https://github.com/moeru-ai/airi/issues/757
-  // Ref: https://github.com/mmaura/poe2linuxcompanion/blob/90664607a147ea5ccea28df6139bd95fb0ebab0e/electron/main/index.ts#L28-L46
-  if (env.XDG_SESSION_TYPE === 'wayland') {
-    app.commandLine.appendSwitch('enable-features', 'GlobalShortcutsPortal')
-
-    app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform')
-    app.commandLine.appendSwitch('enable-features', 'WaylandWindowDecorations')
-  }
-}
+configureAppCommandLine(app.commandLine)
 
 app.dock?.setIcon(icon)
 electronApp.setAppUserModelId('ai.moeru.airi')

--- a/apps/stage-tamagotchi/src/main/libs/electron/location.test.ts
+++ b/apps/stage-tamagotchi/src/main/libs/electron/location.test.ts
@@ -1,6 +1,8 @@
+import { EventEmitter } from 'node:events'
+
 import { describe, expect, it, vi } from 'vitest'
 
-import { withHashRoute } from './location'
+import { load, withHashRoute } from './location'
 
 vi.mock(import('@electron-toolkit/utils'), () => {
   return {
@@ -8,6 +10,30 @@ vi.mock(import('@electron-toolkit/utils'), () => {
       dev: true,
     },
   }
+})
+
+describe('load', () => {
+  // https://github.com/moeru-ai/airi/pull/2278#discussion_r3776743822
+  // ROOT CAUSE:
+  //
+  // The load helper removed every did-start-navigation listener after the initial load.
+  // This also removed the window service listener that restores mouse input before reloads.
+  //
+  // We fixed this by preserving listeners that the load helper does not own.
+  it('preserves navigation lifecycle listeners after the initial load', async () => {
+    const webContents = new EventEmitter()
+    const navigationHandler = vi.fn()
+    webContents.on('did-start-navigation', navigationHandler)
+    const window = {
+      loadURL: vi.fn().mockResolvedValue(undefined),
+      webContents,
+    }
+
+    await load(window as never, 'https://example.com')
+    webContents.emit('did-start-navigation')
+
+    expect(navigationHandler).toHaveBeenCalledOnce()
+  })
 })
 
 describe('withHashRoute', () => {

--- a/apps/stage-tamagotchi/src/main/libs/electron/location.ts
+++ b/apps/stage-tamagotchi/src/main/libs/electron/location.ts
@@ -86,9 +86,6 @@ export async function load(window: BrowserWindow, url: string | { url: string, o
 
     throw error
   }
-  finally {
-    window.webContents.removeAllListeners('did-start-navigation')
-  }
 }
 
 /**

--- a/apps/stage-tamagotchi/src/main/services/airi/channel-server/certificate-trust.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/channel-server/certificate-trust.test.ts
@@ -1,0 +1,36 @@
+import process from 'node:process'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { installLinuxCACertificate } from './certificate-trust'
+
+describe.runIf(process.platform === 'linux')('installLinuxCACertificate on the Linux host', () => {
+  it('reports that trust installation failed instead of writing an inactive user certificate', async () => {
+    // ROOT CAUSE:
+    //
+    // A normal Linux process cannot write to `/usr/local/share/ca-certificates`.
+    // AIRI catches that error and writes the CA to
+    // `~/.local/share/ca-certificates`, which `update-ca-certificates` does not
+    // read. The function then returns success without changing the trust store.
+    //
+    // The fix must return an explicit not-installed result. It must leave the
+    // generated CA path available for a supported manual or privileged flow.
+    const systemWriteError = new Error('EACCES: system trust store is read-only')
+    const writeCertificate = vi.fn(() => {
+      throw systemWriteError
+    })
+    const run = vi.fn()
+
+    const result = await installLinuxCACertificate('test-ca', {
+      run,
+      writeCertificate,
+    })
+
+    expect(result).toEqual({
+      status: 'not-installed',
+      error: systemWriteError,
+    })
+    expect(writeCertificate).toHaveBeenCalledTimes(1)
+    expect(run).not.toHaveBeenCalled()
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/channel-server/certificate-trust.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/channel-server/certificate-trust.ts
@@ -1,0 +1,47 @@
+import type { writeFileSync } from 'node:fs'
+
+import type { x } from 'tinyexec'
+
+import { join } from 'node:path'
+
+export interface LinuxCertificateTrustDependencies {
+  /** Runs the distribution certificate command. */
+  run: typeof x
+  /** Writes the certificate to a trust directory. */
+  writeCertificate: typeof writeFileSync
+}
+
+/** Result of an attempt to install the AIRI CA in the Linux system trust store. */
+export type LinuxCertificateTrustResult
+  = | {
+    /** The system trust store contains the AIRI CA. */
+    status: 'installed'
+  }
+  | {
+    /** The system trust store did not accept the AIRI CA. */
+    status: 'not-installed'
+    /** The filesystem or distribution command error that stopped installation. */
+    error: unknown
+  }
+
+/**
+ * Installs the server-channel CA in the Linux system trust store.
+ *
+ * The function does not write to a user certificate directory because
+ * `update-ca-certificates` does not read that directory.
+ */
+export async function installLinuxCACertificate(
+  caCert: string,
+  dependencies: LinuxCertificateTrustDependencies,
+): Promise<LinuxCertificateTrustResult> {
+  const caFileName = 'airi-websocket-ca.crt'
+
+  try {
+    dependencies.writeCertificate(join('/usr', 'local', 'share', 'ca-certificates', caFileName), caCert)
+    await dependencies.run('update-ca-certificates', [], { nodeOptions: { stdio: 'ignore' } })
+    return { status: 'installed' }
+  }
+  catch (error) {
+    return { status: 'not-installed', error }
+  }
+}

--- a/apps/stage-tamagotchi/src/main/services/airi/channel-server/index.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/channel-server/index.ts
@@ -28,6 +28,7 @@ import {
   electronGetServerChannelQrPayload,
 } from '../../../../shared/eventa'
 import { createConfig } from '../../../libs/electron/persistence'
+import { installLinuxCACertificate } from './certificate-trust'
 import { ensureServerChannelConfigDefaults } from './config'
 
 const channelServerConfigSchema = object({
@@ -269,24 +270,12 @@ async function installCACertificate(caCert: string) {
       await x('certutil', ['-addstore', '-f', 'Root', caCertPath], { nodeOptions: { stdio: 'ignore' } })
     }
     else if (platform === 'linux') {
-      const caDir = '/usr/local/share/ca-certificates'
-      const caFileName = 'airi-websocket-ca.crt'
-      try {
-        writeFileSync(join(caDir, caFileName), caCert)
-        await x('update-ca-certificates', [], { nodeOptions: { stdio: 'ignore' } })
-      }
-      catch {
-        const userCaDir = join(env.HOME || '', '.local/share/ca-certificates')
-        try {
-          if (!existsSync(userCaDir)) {
-            await x('mkdir', ['-p', userCaDir], { nodeOptions: { stdio: 'ignore' } })
-          }
-          writeFileSync(join(userCaDir, caFileName), caCert)
-        }
-        catch {
-          // Ignore errors
-        }
-      }
+      const result = await installLinuxCACertificate(caCert, {
+        run: x,
+        writeCertificate: writeFileSync,
+      })
+      if (result.status === 'not-installed')
+        log.withError(result.error).warn(`Failed to install AIRI WebSocket CA certificate from ${caCertPath}`)
     }
   }
   catch (error) {

--- a/apps/stage-tamagotchi/src/main/services/electron/auto-updater.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/auto-updater.test.ts
@@ -11,10 +11,6 @@ const isDevState = vi.hoisted(() => ({
   value: false,
 }))
 
-const stdEnvState = vi.hoisted(() => ({
-  isWindows: false,
-}))
-
 const updaterState = vi.hoisted(() => ({
   instance: createUpdaterMock(),
 }))
@@ -43,12 +39,6 @@ vi.mock('@electron-toolkit/utils', () => ({
     get dev() {
       return isDevState.value
     },
-  },
-}))
-
-vi.mock('std-env', () => ({
-  get isWindows() {
-    return stdEnvState.isWindows
   },
 }))
 
@@ -123,9 +113,9 @@ describe('setupAutoUpdater', () => {
     appMock.getVersion.mockReturnValue('0.9.0-beta.4')
     appMock.getPath.mockImplementation((name: string) => name === 'logs' ? '/tmp/airi/logs' : `/tmp/${name}`)
     isDevState.value = false
-    stdEnvState.isWindows = false
     delete process.env.UPDATE_SERVER_URL
     delete process.env.AIRI_UPDATE_CHANNEL
+    delete process.env.FLATPAK_ID
     mockGitHubReleasesFetch()
   })
 
@@ -193,6 +183,39 @@ describe('setupAutoUpdater', () => {
     expect(updaterState.instance.checkForUpdates).not.toHaveBeenCalled()
     expect(updaterState.instance.downloadUpdate).not.toHaveBeenCalled()
     expect(updaterState.instance.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it.runIf(process.platform === 'linux')('keeps Flatpak outside the GitHub updater flow on the Linux host', async () => {
+    // ROOT CAUSE:
+    //
+    // The Flatpak build copies the DEB/RPM unpacked tree, including its
+    // `package-type` marker. Electron Updater then selects a host package
+    // manager inside the sandbox. AIRI also starts an update check even
+    // though Flatpak owns installation and updates.
+    //
+    // The fix must use Flatpak's runtime identity and keep this service
+    // disabled without a build-time platform replacement.
+    process.env.FLATPAK_ID = 'ai.moeru.airi'
+
+    try {
+      const fetchSpy = mockGitHubReleasesFetch()
+      const { setupAutoUpdater } = await import('./auto-updater')
+      const service = setupAutoUpdater()
+
+      await service.checkForUpdates()
+      await service.downloadUpdate()
+      await service.quitAndInstall()
+
+      expect(service.state.status).toBe('disabled')
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(updaterState.instance.on).not.toHaveBeenCalled()
+      expect(updaterState.instance.checkForUpdates).not.toHaveBeenCalled()
+      expect(updaterState.instance.downloadUpdate).not.toHaveBeenCalled()
+      expect(updaterState.instance.quitAndInstall).not.toHaveBeenCalled()
+    }
+    finally {
+      delete process.env.FLATPAK_ID
+    }
   })
 
   it('supports explicit stable lane selection for future dynamic channel switching', async () => {
@@ -296,17 +319,15 @@ describe('setupAutoUpdater', () => {
     expect(updaterState.instance.allowPrerelease).toBe(false)
   })
 
-  it('uses silent relaunch install on Windows only', async () => {
-    stdEnvState.isWindows = true
+  it('uses the install arguments for the real host platform', async () => {
     const { setupAutoUpdater } = await import('./auto-updater')
     const service = setupAutoUpdater()
 
     await service.quitAndInstall()
-    expect(updaterState.instance.quitAndInstall).toHaveBeenCalledWith(true, true)
 
-    stdEnvState.isWindows = false
-    updaterState.instance.quitAndInstall.mockClear()
-    await service.quitAndInstall()
-    expect(updaterState.instance.quitAndInstall).toHaveBeenCalledWith()
+    if (process.platform === 'win32')
+      expect(updaterState.instance.quitAndInstall).toHaveBeenCalledWith(true, true)
+    else
+      expect(updaterState.instance.quitAndInstall).toHaveBeenCalledWith()
   })
 })

--- a/apps/stage-tamagotchi/src/main/services/electron/auto-updater.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/auto-updater.ts
@@ -306,7 +306,10 @@ function createDisabledAutoUpdater(options: AutoUpdaterOptions): AutoUpdater {
 }
 
 export function setupAutoUpdater(options: AutoUpdaterOptions = {}): AutoUpdater {
-  if (options.enabled === false)
+  // Flatpak owns application installation and updates. Electron Updater must
+  // not select the DEB or RPM updater from files inside the sandbox.
+  const isFlatpak = process.platform === 'linux' && Boolean(process.env.FLATPAK_ID?.trim())
+  if (options.enabled === false || isFlatpak)
     return createDisabledAutoUpdater(options)
 
   const semaphore = new Semaphore(1)

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
@@ -106,7 +106,7 @@ async function setupMocks() {
       listener(e)
   }
 
-  function createDriver(overrides: { platform?: NodeJS.Platform, sessionType?: string } = {}) {
+  function createDriver(overrides: { sessionType?: string } = {}) {
     const broadcastTriggered = vi.fn<(id: string, phase: 'down' | 'up') => void>()
     const logger = {
       warn: vi.fn(),
@@ -115,7 +115,6 @@ async function setupMocks() {
     const driver = createUiohookDriver({
       broadcastTriggered,
       logger: logger as unknown as Parameters<typeof createUiohookDriver>[0]['logger'],
-      platform: overrides.platform ?? 'darwin',
       sessionType: overrides.sessionType,
     })
     return { driver, broadcastTriggered, logger }
@@ -225,7 +224,11 @@ describe('createUiohookDriver', () => {
     const { driver, broadcastTriggered } = m.createDriver()
     driver.tryRegister(exampleBinding('ptt', ['cmd-or-ctrl'], 'KeyK'))
 
-    m.fire('keydown', event({ keycode: 37, metaKey: true }))
+    const hostModifier = process.platform === 'darwin'
+      ? { metaKey: true }
+      : { ctrlKey: true }
+
+    m.fire('keydown', event({ keycode: 37, ...hostModifier }))
     m.fire('keyup', event({ keycode: 37, metaKey: false }))
 
     expect(broadcastTriggered).toHaveBeenCalledWith('ptt', 'down')
@@ -254,28 +257,21 @@ describe('createUiohookDriver', () => {
     expect(broadcastTriggered).not.toHaveBeenCalled()
   })
 
-  it('maps cmd-or-ctrl to metaKey on darwin', async () => {
+  it('maps cmd-or-ctrl from the real host platform', async () => {
     const m = await setupMocks()
-    const { driver, broadcastTriggered } = m.createDriver({ platform: 'darwin' })
+    const { driver, broadcastTriggered } = m.createDriver()
     driver.tryRegister(exampleBinding('ptt', ['cmd-or-ctrl'], 'KeyK'))
 
-    m.fire('keydown', event({ keycode: 37, metaKey: true }))
-    m.fire('keydown', event({ keycode: 37, ctrlKey: true }))
+    const expectedModifier = process.platform === 'darwin'
+      ? { metaKey: true }
+      : { ctrlKey: true }
+    const otherModifier = process.platform === 'darwin'
+      ? { ctrlKey: true }
+      : { metaKey: true }
 
-    expect(broadcastTriggered).toHaveBeenCalledTimes(1)
-    expect(broadcastTriggered).toHaveBeenCalledWith('ptt', 'down')
-  })
+    m.fire('keydown', event({ keycode: 37, ...expectedModifier }))
+    m.fire('keydown', event({ keycode: 37, ...otherModifier }))
 
-  it('maps cmd-or-ctrl to ctrlKey on non-darwin platforms', async () => {
-    const m = await setupMocks()
-    const { driver, broadcastTriggered } = m.createDriver({ platform: 'win32' })
-    driver.tryRegister(exampleBinding('ptt', ['cmd-or-ctrl'], 'KeyK'))
-
-    m.fire('keydown', event({ keycode: 37, ctrlKey: true }))
-    m.fire('keydown', event({ keycode: 37, metaKey: true }))
-
-    // First (ctrl) matches; second (meta) does not — the pressed
-    // state stays cleared and produces no extra broadcast.
     expect(broadcastTriggered).toHaveBeenCalledTimes(1)
     expect(broadcastTriggered).toHaveBeenCalledWith('ptt', 'down')
   })
@@ -290,27 +286,49 @@ describe('createUiohookDriver', () => {
     expect(m.startMock).toHaveBeenCalledTimes(1)
   })
 
-  it('returns Unsupported under a native Wayland session', async () => {
+  it.runIf(process.platform === 'linux')('returns Unsupported under a native Wayland session on Linux', async () => {
     const m = await setupMocks()
-    const { driver } = m.createDriver({ platform: 'linux', sessionType: 'wayland' })
+    const { driver } = m.createDriver({ sessionType: 'wayland' })
 
     const result = driver.tryRegister(exampleBinding('ptt'))
     expect(result).toEqual({ id: 'ptt', ok: false, reason: ShortcutFailureReasons.Unsupported })
     expect(m.startMock).not.toHaveBeenCalled()
   })
 
-  it('permits registration on Linux under X11 / XWayland', async () => {
+  it.runIf(process.platform === 'linux')('permits registration under an X11 session on Linux', async () => {
     const m = await setupMocks()
-    const { driver } = m.createDriver({ platform: 'linux', sessionType: 'x11' })
+    const { driver } = m.createDriver({ sessionType: 'x11' })
 
     expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: true })
     expect(m.startMock).toHaveBeenCalledTimes(1)
   })
 
-  it('returns Denied when macOS Accessibility permission is not granted', async () => {
+  it.runIf(process.platform === 'linux')('permits XWayland when the Linux login session is Wayland', async () => {
+    // ROOT CAUSE:
+    //
+    // XDG_SESSION_TYPE describes the login session. It remains `wayland` when
+    // AIRI selects its X11 backend with `--ozone-platform=x11`. The current
+    // driver treats that login value as the application backend and rejects
+    // a usable XWayland uiohook connection.
+    const originalArgvLength = process.argv.length
+    process.argv.push('--ozone-platform=x11')
+
+    try {
+      const m = await setupMocks()
+      const { driver } = m.createDriver({ sessionType: 'wayland' })
+
+      expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: true })
+      expect(m.startMock).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      process.argv.splice(originalArgvLength)
+    }
+  })
+
+  it.runIf(process.platform === 'darwin')('returns Denied when the host denies macOS Accessibility permission', async () => {
     const m = await setupMocks()
     m.isTrustedAccessibilityClientMock.mockReturnValue(false)
-    const { driver } = m.createDriver({ platform: 'darwin' })
+    const { driver } = m.createDriver()
 
     const result = driver.tryRegister(exampleBinding('ptt'))
     expect(result).toEqual({ id: 'ptt', ok: false, reason: ShortcutFailureReasons.Denied })
@@ -318,9 +336,9 @@ describe('createUiohookDriver', () => {
     expect(m.startMock).not.toHaveBeenCalled()
   })
 
-  it('skips the Accessibility check entirely on non-darwin', async () => {
+  it.runIf(process.platform !== 'darwin')('skips the macOS Accessibility check on the real non-darwin host', async () => {
     const m = await setupMocks()
-    const { driver } = m.createDriver({ platform: 'win32' })
+    const { driver } = m.createDriver()
     driver.tryRegister(exampleBinding('ptt'))
     expect(m.isTrustedAccessibilityClientMock).not.toHaveBeenCalled()
   })

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
@@ -126,8 +126,21 @@ function buildPredicate(acc: ShortcutAccelerator, platform: NodeJS.Platform): { 
   return { predicate, expectedKeycode }
 }
 
-function isNativeWayland(platform: NodeJS.Platform, sessionType: string | undefined): boolean {
-  return platform === 'linux' && sessionType === 'wayland'
+function usesX11OzoneBackend(args: readonly string[]): boolean {
+  return args.some((arg, index) =>
+    arg === '--ozone-platform=x11'
+    || (arg === '--ozone-platform' && args[index + 1] === 'x11'),
+  )
+}
+
+function isNativeWayland(
+  platform: NodeJS.Platform,
+  sessionType: string | undefined,
+  args: readonly string[],
+): boolean {
+  return platform === 'linux'
+    && sessionType === 'wayland'
+    && !usesX11OzoneBackend(args)
 }
 
 function isMacAccessibilityTrusted(platform: NodeJS.Platform, prompt: boolean): boolean {
@@ -145,15 +158,8 @@ export interface UiohookDriverOptions {
   broadcastTriggered: (id: string, phase: 'down' | 'up') => void
   logger: Logger
   /**
-   * Host platform; injected so tests can exercise cross-platform
-   * modifier mapping without stubbing `process`.
-   *
-   * @default process.platform
-   */
-  platform?: NodeJS.Platform
-  /**
    * `XDG_SESSION_TYPE` value used for the Wayland refusal check;
-   * injected for the same reason as `platform`.
+   * injected so compositor-session cases remain explicit.
    *
    * @default process.env.XDG_SESSION_TYPE
    */
@@ -190,9 +196,9 @@ export function createUiohookDriver(options: UiohookDriverOptions): UiohookDrive
   const {
     broadcastTriggered,
     logger,
-    platform = process.platform,
     sessionType = process.env.XDG_SESSION_TYPE,
   } = options
+  const platform = process.platform
   const entries = new Map<string, UiohookEntry>()
   let started = false
   let listenersInstalled = false
@@ -264,7 +270,7 @@ export function createUiohookDriver(options: UiohookDriverOptions): UiohookDrive
     if (entries.has(binding.id))
       return { id: binding.id, ok: false, reason: ShortcutFailureReasons.DuplicateId }
 
-    if (isNativeWayland(platform, sessionType)) {
+    if (isNativeWayland(platform, sessionType, process.argv)) {
       // libuiohook hooks install but never receive events under
       // native Wayland. Refuse rather than register a binding that
       // would silently no-op.

--- a/apps/stage-tamagotchi/src/main/services/electron/system-preferences.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/system-preferences.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockContext {
+  invokeHandlers: Map<string, (payload: unknown) => unknown>
+}
+
+const getMediaAccessStatus = vi.fn()
+const askForMediaAccess = vi.fn()
+
+function createMockContext(): MockContext {
+  return {
+    invokeHandlers: new Map(),
+  }
+}
+
+async function setupService() {
+  vi.doMock('electron', () => ({
+    systemPreferences: {
+      askForMediaAccess,
+      getMediaAccessStatus,
+    },
+  }))
+
+  vi.doMock('@moeru/eventa', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@moeru/eventa')>()
+    return {
+      ...actual,
+      defineInvokeHandler: (
+        context: MockContext,
+        eventa: { sendEvent: { id: string } },
+        handler: (payload: unknown) => unknown,
+      ) => {
+        context.invokeHandlers.set(eventa.sendEvent.id.replace(/-send$/, ''), handler)
+      },
+    }
+  })
+
+  const { createSystemPreferencesService } = await import('./system-preferences')
+  const context = createMockContext()
+  createSystemPreferencesService({
+    context: context as never,
+    window: {} as never,
+  })
+
+  return context.invokeHandlers
+}
+
+describe('system preferences service', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2132
+  it('returns unknown when Linux does not provide getMediaAccessStatus (Issue #2132)', async () => {
+    // ROOT CAUSE:
+    //
+    // Electron does not provide `getMediaAccessStatus` on Linux.
+    // The service calls this platform-specific method without a platform guard.
+    // The fix must return AIRI's normalized unknown status on unsupported platforms.
+    getMediaAccessStatus.mockImplementationOnce(() => {
+      throw new TypeError('systemPreferences.getMediaAccessStatus is not a function')
+    })
+    const handlers = await setupService()
+    const handler = handlers.get('eventa:invoke:electron:system-preferences:get-media-access-status')
+
+    expect(handler).toBeDefined()
+    expect(handler!(['microphone'])).toBe('unknown')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2132
+  it('returns false when Linux cannot show a native media prompt (Issue #2132)', async () => {
+    // ROOT CAUSE:
+    //
+    // Electron provides `askForMediaAccess` only on macOS.
+    // The service calls this method for every platform and rejects the renderer request on Linux.
+    // The fix must report that AIRI cannot open a native prompt on unsupported platforms.
+    askForMediaAccess.mockImplementationOnce(() => {
+      throw new TypeError('systemPreferences.askForMediaAccess is not a function')
+    })
+    const handlers = await setupService()
+    const handler = handlers.get('eventa:invoke:electron:system-preferences:ask-for-media-access')
+
+    expect(handler).toBeDefined()
+    await expect(handler!(['microphone'])).resolves.toBe(false)
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/electron/system-preferences.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/system-preferences.ts
@@ -12,13 +12,39 @@ export function createSystemPreferencesService(params: { context: ReturnType<typ
       return 'not-determined'
     }
 
-    return systemPreferences.getMediaAccessStatus(type[0])
+    try {
+      return systemPreferences.getMediaAccessStatus(type[0])
+    }
+    catch (error) {
+      // NOTICE:
+      // Electron does not provide this API on Linux.
+      // Some Electron builds expose no function, while mocks and older bindings can throw a TypeError.
+      // Source/context: https://github.com/moeru-ai/airi/issues/2132
+      // Removal condition: Electron provides one cross-platform media permission API.
+      if (error instanceof TypeError)
+        return 'unknown'
+
+      throw error
+    }
   })
-  defineInvokeHandler(params.context, electron.systemPreferences.askForMediaAccess, (type) => {
+  defineInvokeHandler(params.context, electron.systemPreferences.askForMediaAccess, async (type) => {
     if (!type) {
-      return Promise.resolve(false)
+      return false
     }
 
-    return systemPreferences.askForMediaAccess(type[0])
+    try {
+      return await systemPreferences.askForMediaAccess(type[0])
+    }
+    catch (error) {
+      // NOTICE:
+      // Electron provides this native prompt only on macOS.
+      // Linux permission requests use the session permission handlers instead.
+      // Source/context: https://github.com/moeru-ai/airi/issues/2132
+      // Removal condition: Electron provides this prompt on Linux and Windows.
+      if (error instanceof TypeError)
+        return false
+
+      throw error
+    }
   })
 }

--- a/apps/stage-tamagotchi/src/main/services/electron/window-interactivity.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/window-interactivity.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockContext {
+  emit: ReturnType<typeof vi.fn>
+  invokeHandlers: Map<string, (payload: unknown, options?: unknown) => unknown>
+}
+
+interface MockEmitter {
+  emit: (event: string, ...args: unknown[]) => void
+  on: ReturnType<typeof vi.fn>
+}
+
+function createEmitter(): MockEmitter {
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const eventHandlers = handlers.get(event) ?? []
+      eventHandlers.push(handler)
+      handlers.set(event, eventHandlers)
+    }),
+    emit(event, ...args) {
+      for (const handler of handlers.get(event) ?? [])
+        handler(...args)
+    },
+  }
+}
+
+function createMockContext(): MockContext {
+  return {
+    emit: vi.fn(),
+    invokeHandlers: new Map(),
+  }
+}
+
+async function setupWindowService(options: { manageWindowInteractivity?: boolean } = {}) {
+  const rendererLoop = {
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+
+  vi.doMock('@moeru/eventa', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@moeru/eventa')>()
+    return {
+      ...actual,
+      defineInvokeHandler: (
+        context: MockContext,
+        eventa: { sendEvent: { id: string } },
+        handler: (payload: unknown, options?: unknown) => unknown,
+      ) => {
+        context.invokeHandlers.set(eventa.sendEvent.id.replace(/-send$/, ''), handler)
+      },
+    }
+  })
+
+  vi.doMock('@proj-airi/electron-eventa', () => ({
+    bounds: { id: 'bounds' },
+    startLoopGetBounds: { sendEvent: { id: 'start-loop-send' } },
+  }))
+
+  vi.doMock('@proj-airi/electron-vueuse/main', () => ({
+    createRendererLoop: () => rendererLoop,
+    safeClose: vi.fn(),
+  }))
+
+  vi.doMock('../../../shared/eventa', () => ({
+    electron: {
+      window: {
+        getBounds: { sendEvent: { id: 'get-bounds-send' } },
+        resize: { sendEvent: { id: 'resize-send' } },
+        setBackgroundMaterial: { sendEvent: { id: 'set-background-material-send' } },
+        setBounds: { sendEvent: { id: 'set-bounds-send' } },
+        setIgnoreMouseEvents: { sendEvent: { id: 'set-ignore-mouse-events-send' } },
+        setVibrancy: { sendEvent: { id: 'set-vibrancy-send' } },
+      },
+    },
+    electronGetWindowLifecycleState: { sendEvent: { id: 'get-lifecycle-send' } },
+    electronWindowClose: { sendEvent: { id: 'close-send' } },
+    electronWindowLifecycleChanged: { id: 'lifecycle-changed' },
+    electronWindowSetAlwaysOnTop: { sendEvent: { id: 'set-always-on-top-send' } },
+  }))
+
+  vi.doMock('../../libs/bootkit/lifecycle', () => ({
+    onAppBeforeQuit: vi.fn(),
+    onAppWindowAllClosed: vi.fn(),
+  }))
+
+  vi.doMock('../../windows/shared/window', () => ({
+    resizeWindowByDelta: vi.fn(),
+  }))
+
+  vi.doMock('std-env', () => ({ isWindows: process.platform === 'win32' }))
+
+  const windowEvents = createEmitter()
+  const webContentsEvents = createEmitter()
+  const setIgnoreMouseEvents = vi.fn()
+  const window = {
+    ...windowEvents,
+    getBounds: vi.fn(() => ({ height: 600, width: 800, x: 0, y: 0 })),
+    isFocused: vi.fn(() => true),
+    isMinimized: vi.fn(() => false),
+    isVisible: vi.fn(() => true),
+    setAlwaysOnTop: vi.fn(),
+    setBackgroundMaterial: vi.fn(),
+    setBounds: vi.fn(),
+    setIgnoreMouseEvents,
+    setVibrancy: vi.fn(),
+    webContents: {
+      ...webContentsEvents,
+      id: 42,
+    },
+  }
+  const context = createMockContext()
+  const { createWindowService } = await import('./window')
+  createWindowService({
+    context: context as never,
+    window: window as never,
+    manageWindowInteractivity: options.manageWindowInteractivity,
+  })
+
+  return {
+    context,
+    setIgnoreMouseEvents,
+    webContents: window.webContents,
+  }
+}
+
+function sameWindowOptions() {
+  return {
+    raw: {
+      ipcMainEvent: {
+        sender: { id: 42 },
+      },
+    },
+  }
+}
+
+describe('window interactivity recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2160
+  it('starts each managed window with mouse input enabled (Issue #2160)', async () => {
+    // ROOT CAUSE:
+    //
+    // The main process does not establish a fail-open input state when it registers a window.
+    // A recreated native window can therefore depend on stale renderer state.
+    // The fix must make the main process set the initial input state.
+    const service = await setupWindowService()
+
+    expect(service.setIgnoreMouseEvents).toHaveBeenCalledWith(false)
+  })
+
+  it('preserves input isolation for a visual-only overlay', async () => {
+    const service = await setupWindowService({ manageWindowInteractivity: false })
+
+    expect(service.setIgnoreMouseEvents).not.toHaveBeenCalled()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2160
+  it('restores mouse input when the renderer process exits (Issue #2160)', async () => {
+    // ROOT CAUSE:
+    //
+    // The renderer owns the native click-through state.
+    // A renderer exit stops the code that can call `setIgnoreMouseEvents(false)`.
+    // The fix must make the main process restore input after a renderer exit.
+    const service = await setupWindowService()
+    const handler = service.context.invokeHandlers.get('set-ignore-mouse-events')
+
+    expect(handler).toBeDefined()
+    handler!([true, { forward: true }], sameWindowOptions())
+    service.webContents.emit('render-process-gone', {}, { reason: 'crashed' })
+
+    expect(service.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false)
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2160
+  it('restores mouse input when the renderer becomes unresponsive (Issue #2160)', async () => {
+    // ROOT CAUSE:
+    //
+    // An unresponsive renderer cannot send the request that restores native mouse input.
+    // The fix must let the main process restore input without renderer cooperation.
+    const service = await setupWindowService()
+    const handler = service.context.invokeHandlers.get('set-ignore-mouse-events')
+
+    expect(handler).toBeDefined()
+    handler!([true, { forward: true }], sameWindowOptions())
+    service.webContents.emit('unresponsive')
+
+    expect(service.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false)
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2160
+  it('restores mouse input before renderer navigation (Issue #2160)', async () => {
+    // ROOT CAUSE:
+    //
+    // Renderer navigation disposes the code that owns the current click-through state.
+    // The fix must restore input before the old renderer lifecycle ends.
+    const service = await setupWindowService()
+    const handler = service.context.invokeHandlers.get('set-ignore-mouse-events')
+
+    expect(handler).toBeDefined()
+    handler!([true, { forward: true }], sameWindowOptions())
+    service.webContents.emit('did-start-navigation', {}, 'file:///app/index.html', false, true)
+
+    expect(service.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false)
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2160
+  it('restores mouse input when a click-through lease expires (Issue #2160)', async () => {
+    // ROOT CAUSE:
+    //
+    // A click-through request has no lifetime and remains active until another renderer request changes it.
+    // The fix must give this transient state a bounded lease that fails open.
+    const service = await setupWindowService()
+    const handler = service.context.invokeHandlers.get('set-ignore-mouse-events')
+
+    expect(handler).toBeDefined()
+    handler!([true, { forward: true }], sameWindowOptions())
+    await vi.advanceTimersByTimeAsync(2001)
+
+    expect(service.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/electron/window.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/window.ts
@@ -18,7 +18,44 @@ import {
 import { onAppBeforeQuit, onAppWindowAllClosed } from '../../libs/bootkit/lifecycle'
 import { resizeWindowByDelta } from '../../windows/shared/window'
 
-export function createWindowService(params: { context: ReturnType<typeof createContext>['context'], window: BrowserWindow }) {
+const mouseInputLeaseDuration = 2000
+
+export function createWindowService(params: {
+  context: ReturnType<typeof createContext>['context']
+  window: BrowserWindow
+  manageWindowInteractivity?: boolean
+}) {
+  const manageWindowInteractivity = params.manageWindowInteractivity ?? true
+  let mouseInputLeaseTimeout: ReturnType<typeof setTimeout> | undefined
+
+  function clearMouseInputLease() {
+    clearTimeout(mouseInputLeaseTimeout)
+    mouseInputLeaseTimeout = undefined
+  }
+
+  function restoreMouseInput() {
+    clearMouseInputLease()
+    params.window.setIgnoreMouseEvents(false)
+  }
+
+  function setIgnoreMouseEvents(ignore: boolean, options: { forward: boolean }) {
+    clearMouseInputLease()
+    params.window.setIgnoreMouseEvents(ignore, options)
+
+    if (!ignore)
+      return
+
+    // NOTICE:
+    // The renderer renews this lease while it needs click-through behavior.
+    // A renderer failure stops renewal, and the main process restores mouse input.
+    // Source/context: https://github.com/moeru-ai/airi/issues/2160
+    // Removal condition: Electron automatically resets click-through state after renderer failure.
+    mouseInputLeaseTimeout = setTimeout(restoreMouseInput, mouseInputLeaseDuration)
+  }
+
+  if (manageWindowInteractivity)
+    restoreMouseInput()
+
   function getWindowLifecycleState(reason: ElectronWindowLifecycleState['reason']): ElectronWindowLifecycleState {
     return {
       focused: params.window.isFocused(),
@@ -54,6 +91,12 @@ export function createWindowService(params: { context: ReturnType<typeof createC
   params.window.on('restore', () => emitWindowLifecycle('restore'))
   params.window.on('focus', () => emitWindowLifecycle('focus'))
   params.window.on('blur', () => emitWindowLifecycle('blur'))
+  if (manageWindowInteractivity) {
+    params.window.on('closed', clearMouseInputLease)
+    params.window.webContents.on('render-process-gone', restoreMouseInput)
+    params.window.webContents.on('unresponsive', restoreMouseInput)
+    params.window.webContents.on('did-start-navigation', restoreMouseInput)
+  }
 
   defineInvokeHandler(params.context, electron.window.getBounds, (_, options) => {
     if (params.window.webContents.id === options?.raw.ipcMainEvent.sender.id) {
@@ -76,7 +119,10 @@ export function createWindowService(params: { context: ReturnType<typeof createC
 
   defineInvokeHandler(params.context, electron.window.setIgnoreMouseEvents, (opts, options) => {
     if (opts && params.window.webContents.id === options?.raw.ipcMainEvent.sender.id) {
-      params.window.setIgnoreMouseEvents(...opts)
+      if (manageWindowInteractivity)
+        setIgnoreMouseEvents(...opts)
+      else
+        params.window.setIgnoreMouseEvents(...opts)
     }
   })
 

--- a/apps/stage-tamagotchi/src/main/windows/caption/index.test.ts
+++ b/apps/stage-tamagotchi/src/main/windows/caption/index.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setupBaseWindowElectronInvokes = vi.hoisted(() => vi.fn(async () => {}))
+
+function createEmitter() {
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const eventHandlers = handlers.get(event) ?? []
+      eventHandlers.push(handler)
+      handlers.set(event, eventHandlers)
+    }),
+  }
+}
+
+async function setupCaptionManager() {
+  const windowEvents = createEmitter()
+  const window = {
+    ...windowEvents,
+    focus: vi.fn(),
+    getBounds: vi.fn(() => ({ x: 120, y: 120, width: 480, height: 180 })),
+    hide: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
+    isVisible: vi.fn(() => true),
+    restore: vi.fn(),
+    setAlwaysOnTop: vi.fn(),
+    setBounds: vi.fn(),
+    setFullScreenable: vi.fn(),
+    setIgnoreMouseEvents: vi.fn(),
+    setPosition: vi.fn(),
+    setVisibleOnAllWorkspaces: vi.fn(),
+    setWindowButtonVisibility: vi.fn(),
+    show: vi.fn(),
+    webContents: {},
+  }
+  const context = { emit: vi.fn() }
+  const config = { isFollowing: true, matrices: {} }
+
+  vi.doMock('electron', () => ({
+    BrowserWindow: class MockBrowserWindow {
+      constructor() {
+        return window
+      }
+    },
+    ipcMain: { setMaxListeners: vi.fn() },
+    screen: {
+      getAllDisplays: vi.fn(() => [{ bounds: { x: 0, y: 0, width: 1920, height: 1080 }, scaleFactor: 1 }]),
+      getDisplayMatching: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } })),
+    },
+  }))
+  vi.doMock('@moeru/eventa', () => ({
+    defineInvokeHandler: vi.fn(() => vi.fn()),
+  }))
+  vi.doMock('@moeru/eventa/adapters/electron/main', () => ({
+    createContext: vi.fn(() => ({ context })),
+  }))
+  vi.doMock('animejs', () => ({
+    animate: vi.fn(() => ({ pause: vi.fn() })),
+    utils: { round: vi.fn(() => (value: number) => value) },
+  }))
+  vi.doMock('es-toolkit', () => ({
+    debounce: vi.fn(() => vi.fn()),
+    throttle: vi.fn((handler: () => void) => handler),
+  }))
+  vi.doMock('../../../shared/eventa', () => ({
+    captionGetIsFollowingWindow: { sendEvent: { id: 'caption-get-is-following-send' } },
+    captionIsFollowingWindowChanged: { id: 'caption-is-following-changed' },
+  }))
+  vi.doMock('../../libs/electron/location', () => ({
+    baseUrl: vi.fn(() => new URL('file:///renderer/')),
+    getElectronMainDirname: vi.fn(() => '/app/main'),
+    load: vi.fn(async () => {}),
+    withHashRoute: vi.fn((url: URL) => url),
+  }))
+  vi.doMock('../../libs/electron/persistence', () => ({
+    createConfig: vi.fn(() => ({
+      get: vi.fn(() => config),
+      setup: vi.fn(),
+      update: vi.fn(),
+    })),
+  }))
+  vi.doMock('../../libs/electron/window-manager', () => ({
+    createReusableWindow: vi.fn((factory: () => Promise<unknown>) => {
+      let createdWindow: Promise<unknown> | undefined
+      return {
+        getWindow: () => {
+          createdWindow ??= factory()
+          return createdWindow
+        },
+      }
+    }),
+  }))
+  vi.doMock('../shared/window', () => ({
+    protectPrivilegedWindowNavigation: vi.fn(),
+    setupBaseWindowElectronInvokes,
+    transparentWindowConfig: vi.fn(() => ({})),
+  }))
+
+  const { setupCaptionWindowManager } = await import('./index')
+  const manager = setupCaptionWindowManager({
+    mainWindow: {
+      getBounds: vi.fn(() => ({ x: 100, y: 100, width: 480, height: 640 })),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+    } as never,
+    serverChannel: {} as never,
+    i18n: {} as never,
+  })
+  await manager.getWindow()
+
+  return { context, window }
+}
+
+describe('caption window interactivity', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('keeps main-process ownership of caption click-through state', async () => {
+    // ROOT CAUSE:
+    //
+    // The caption enables click-through before its initial navigation completes.
+    // Managed navigation recovery then restores mouse input and makes the caption intercept clicks.
+    // The fix must exclude this main-process-owned window from renderer interactivity recovery.
+    const { context, window } = await setupCaptionManager()
+
+    expect(setupBaseWindowElectronInvokes).toHaveBeenCalledWith({
+      context,
+      window,
+      serverChannel: {},
+      i18n: {},
+      manageWindowInteractivity: false,
+    })
+  })
+})

--- a/apps/stage-tamagotchi/src/main/windows/caption/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/caption/index.ts
@@ -308,7 +308,14 @@ export function setupCaptionWindowManager(params: {
     const { context } = createContext(ipcMain, window)
     eventaContext = context
 
-    await setupBaseWindowElectronInvokes({ context, window, serverChannel: params.serverChannel, i18n: params.i18n })
+    await setupBaseWindowElectronInvokes({
+      context,
+      window,
+      serverChannel: params.serverChannel,
+      i18n: params.i18n,
+      // The main process owns caption click-through state. Navigation recovery must not override it.
+      manageWindowInteractivity: false,
+    })
 
     applyIgnoreMouseEvents(window, isFollowing)
 

--- a/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.ts
+++ b/apps/stage-tamagotchi/src/main/windows/desktop-overlay/rpc/index.electron.ts
@@ -45,7 +45,13 @@ export async function setupDesktopOverlayElectronInvokes(params: {
   })
 
   try {
-    await setupBaseWindowElectronInvokes({ context, window: params.window, i18n: params.i18n, serverChannel: params.serverChannel })
+    await setupBaseWindowElectronInvokes({
+      context,
+      window: params.window,
+      i18n: params.i18n,
+      serverChannel: params.serverChannel,
+      manageWindowInteractivity: false,
+    })
     createMcpServersService({ context, manager: params.mcpStdioManager })
     readiness = { state: 'ready' }
   }

--- a/apps/stage-tamagotchi/src/main/windows/shared/window.ts
+++ b/apps/stage-tamagotchi/src/main/windows/shared/window.ts
@@ -136,9 +136,14 @@ export async function setupBaseWindowElectronInvokes(params: {
   window: BrowserWindow
   serverChannel: ServerChannel
   i18n: I18n
+  manageWindowInteractivity?: boolean
 }) {
   createScreenService({ context: params.context, window: params.window })
-  createWindowService({ context: params.context, window: params.window })
+  createWindowService({
+    context: params.context,
+    window: params.window,
+    manageWindowInteractivity: params.manageWindowInteractivity,
+  })
   createAppService({ context: params.context, window: params.window })
   createPowerMonitorService({ context: params.context, window: params.window })
   createSystemPreferencesService({ context: params.context, window: params.window })

--- a/apps/stage-tamagotchi/src/renderer/composables/use-window-interactivity-lease.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/composables/use-window-interactivity-lease.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h } from 'vue'
+
+import { useWindowInteractivityLease } from './use-window-interactivity-lease'
+
+describe('window interactivity lease', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renews click-through state while its Vue owner remains active', async () => {
+    vi.useFakeTimers()
+    const invokeSetIgnoreMouseEvents = vi.fn()
+    let setIgnoreMouseEvents: ((ignore: boolean) => void) | undefined
+    const host = document.createElement('div')
+    const app = createApp({
+      setup() {
+        const interactivity = useWindowInteractivityLease({ invokeSetIgnoreMouseEvents })
+        setIgnoreMouseEvents = interactivity.setIgnoreMouseEvents
+        return () => h('div')
+      },
+    })
+    app.mount(host)
+
+    setIgnoreMouseEvents!(true)
+    await vi.advanceTimersByTimeAsync(1001)
+
+    expect(invokeSetIgnoreMouseEvents).toHaveBeenNthCalledWith(1, [true, { forward: true }])
+    expect(invokeSetIgnoreMouseEvents).toHaveBeenNthCalledWith(2, [true, { forward: true }])
+
+    app.unmount()
+
+    expect(invokeSetIgnoreMouseEvents).toHaveBeenLastCalledWith([false, { forward: true }])
+  })
+
+  it('stops renewal when mouse input is enabled', async () => {
+    vi.useFakeTimers()
+    const invokeSetIgnoreMouseEvents = vi.fn()
+    let setIgnoreMouseEvents: ((ignore: boolean) => void) | undefined
+    const host = document.createElement('div')
+    const app = createApp({
+      setup() {
+        const interactivity = useWindowInteractivityLease({ invokeSetIgnoreMouseEvents })
+        setIgnoreMouseEvents = interactivity.setIgnoreMouseEvents
+        return () => h('div')
+      },
+    })
+    app.mount(host)
+
+    setIgnoreMouseEvents!(true)
+    setIgnoreMouseEvents!(false)
+    invokeSetIgnoreMouseEvents.mockClear()
+    await vi.advanceTimersByTimeAsync(2001)
+
+    expect(invokeSetIgnoreMouseEvents).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+})

--- a/apps/stage-tamagotchi/src/renderer/composables/use-window-interactivity-lease.ts
+++ b/apps/stage-tamagotchi/src/renderer/composables/use-window-interactivity-lease.ts
@@ -1,0 +1,39 @@
+import { useIntervalFn } from '@vueuse/core'
+import { onUnmounted } from 'vue'
+
+const mouseInputLeaseRenewInterval = 1000
+
+/**
+ * Keeps the main-process click-through lease active while the renderer needs it.
+ * The composable restores mouse input when its Vue owner unmounts.
+ */
+export function useWindowInteractivityLease(params: {
+  invokeSetIgnoreMouseEvents: (payload: [boolean, { forward: boolean }]) => unknown
+}): {
+  setIgnoreMouseEvents: (ignore: boolean) => void
+} {
+  let isIgnoringMouseEvents = false
+  const { pause, resume } = useIntervalFn(() => {
+    if (isIgnoringMouseEvents)
+      params.invokeSetIgnoreMouseEvents([true, { forward: true }])
+  }, mouseInputLeaseRenewInterval, { immediate: false })
+
+  function setIgnoreMouseEvents(ignore: boolean) {
+    isIgnoringMouseEvents = ignore
+    params.invokeSetIgnoreMouseEvents([ignore, { forward: true }])
+
+    if (ignore)
+      resume()
+    else
+      pause()
+  }
+
+  onUnmounted(() => {
+    pause()
+    params.invokeSetIgnoreMouseEvents([false, { forward: true }])
+  })
+
+  return {
+    setIgnoreMouseEvents,
+  }
+}

--- a/apps/stage-tamagotchi/src/renderer/pages/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/index.vue
@@ -41,6 +41,7 @@ import StatusIsland from '../components/stage-islands/status-island/index.vue'
 
 import { electronOpenOnboarding } from '../../shared/eventa'
 import { modelSettingsRuntimeSnapshotChannelName } from '../../shared/model-settings-runtime'
+import { useWindowInteractivityLease } from '../composables/use-window-interactivity-lease'
 import { useControlsIslandStore } from '../stores/controls-island'
 import { useStageWindowLifecycleStore } from '../stores/stage-window-lifecycle'
 import { resolveFadeOnHoverInteraction } from '../utils/fade-on-hover'
@@ -60,7 +61,6 @@ const componentStateStage = ref<'pending' | 'loading' | 'mounted'>('pending')
 const stageMounted = computed(() => componentStateStage.value === 'mounted')
 const isLoading = computed(() => !stageMounted.value)
 
-const isIgnoringMouseEvents = ref(false)
 const shouldFadeOnCursorWithin = ref(false)
 
 const onboardingStore = useOnboardingStore()
@@ -140,7 +140,8 @@ const isTransparentForMouseEvents = computed(() => {
 const { isNearAnyBorder: isAroundWindowBorder } = useElectronMouseAroundWindowBorder({ threshold: 10 })
 const isAroundWindowBorderFor250Ms = refDebounced(isAroundWindowBorder, 250)
 
-const setIgnoreMouseEvents = useElectronEventaInvoke(electron.window.setIgnoreMouseEvents)
+const invokeSetIgnoreMouseEvents = useElectronEventaInvoke(electron.window.setIgnoreMouseEvents)
+const { setIgnoreMouseEvents } = useWindowInteractivityLease({ invokeSetIgnoreMouseEvents })
 
 const hearingDialogOpen = computed(() => controlsIslandRef.value?.hearingDialogOpen ?? false)
 
@@ -255,17 +256,15 @@ const modelSettingsRuntimeSnapshot = computed<ModelSettingsRuntimeSnapshot>(() =
  */
 function handleFadeOnHoverInteractionChange() {
   if (stagePaused.value) {
-    isIgnoringMouseEvents.value = false
     shouldFadeOnCursorWithin.value = false
-    setIgnoreMouseEvents([false, { forward: true }])
+    setIgnoreMouseEvents(false)
     return
   }
 
   if (hearingDialogOpen.value) {
     // Hearing dialog/drawer is open; keep window interactive
-    isIgnoringMouseEvents.value = false
     shouldFadeOnCursorWithin.value = false
-    setIgnoreMouseEvents([false, { forward: true }])
+    setIgnoreMouseEvents(false)
     return
   }
 
@@ -274,9 +273,8 @@ function handleFadeOnHoverInteractionChange() {
 
   if (insideControls || nearBorder) {
     // Inside interactive controls or near resize border: do NOT ignore events
-    isIgnoringMouseEvents.value = false
     shouldFadeOnCursorWithin.value = false
-    setIgnoreMouseEvents([false, { forward: true }])
+    setIgnoreMouseEvents(false)
   }
   else {
     const interaction = resolveFadeOnHoverInteraction({
@@ -286,9 +284,8 @@ function handleFadeOnHoverInteractionChange() {
       transparentForPointer: isTransparentForMouseEvents.value,
     })
 
-    isIgnoringMouseEvents.value = interaction.ignoreMouseEvents
     shouldFadeOnCursorWithin.value = interaction.fadeStage
-    setIgnoreMouseEvents([interaction.ignoreMouseEvents, { forward: true }])
+    setIgnoreMouseEvents(interaction.ignoreMouseEvents)
   }
 }
 

--- a/packages/electron-screen-capture/src/main/index.test.ts
+++ b/packages/electron-screen-capture/src/main/index.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockContext {
+  invokeHandlers: Map<string, (payload: never, options?: never) => unknown>
+}
+
+function createEmitter() {
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const eventHandlers = handlers.get(event) ?? []
+      eventHandlers.push(handler)
+      handlers.set(event, eventHandlers)
+    }),
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of handlers.get(event) ?? [])
+        handler(...args)
+    },
+  }
+}
+
+async function setupScreenCapture() {
+  const context: MockContext = { invokeHandlers: new Map() }
+  let displayMediaHandler: unknown = null
+  const setDisplayMediaRequestHandler = vi.fn((handler: unknown) => {
+    displayMediaHandler = handler
+  })
+  const getSources = vi.fn(async () => [])
+  const commandLineSwitches = new Map<string, string>()
+
+  vi.doMock('electron', () => ({
+    app: {
+      commandLine: {
+        appendSwitch: vi.fn((key: string, value: string) => commandLineSwitches.set(key, value)),
+        getSwitchValue: vi.fn((key: string) => commandLineSwitches.get(key) ?? ''),
+        hasSwitch: vi.fn((key: string) => commandLineSwitches.has(key)),
+        removeSwitch: vi.fn((key: string) => commandLineSwitches.delete(key)),
+      },
+    },
+    desktopCapturer: {
+      getSources,
+    },
+    ipcMain: {},
+    session: {
+      defaultSession: {
+        setDisplayMediaRequestHandler,
+      },
+    },
+    shell: {
+      openExternal: vi.fn(),
+    },
+    systemPreferences: {
+      getMediaAccessStatus: vi.fn(),
+    },
+  }))
+
+  vi.doMock('@moeru/eventa/adapters/electron/main', () => ({
+    createContext: () => ({ context }),
+  }))
+
+  vi.doMock('@moeru/eventa', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@moeru/eventa')>()
+    return {
+      ...actual,
+      defineInvokeHandler: (
+        target: MockContext,
+        eventa: { sendEvent: { id: string } },
+        handler: (payload: never, options?: never) => unknown,
+      ) => {
+        target.invokeHandlers.set(eventa.sendEvent.id.replace(/-send$/, ''), handler)
+      },
+    }
+  })
+
+  vi.doMock('@guiiai/logg', () => ({
+    useLogg: () => ({
+      useGlobalConfig: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        withError() {
+          return this
+        },
+        withFields() {
+          return this
+        },
+        withFormat() {
+          return this
+        },
+        withLogLevelString() {
+          return this
+        },
+      }),
+    }),
+  }))
+
+  vi.doMock('nanoid', () => ({ nanoid: () => 'capture-handle' }))
+
+  const screenCapture = await import('./index')
+  screenCapture.initScreenCaptureForMain()
+
+  const windowEvents = createEmitter()
+  const webContentsEvents = createEmitter()
+  const window = {
+    ...windowEvents,
+    getTitle: vi.fn(() => 'AIRI'),
+    id: 7,
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      ...webContentsEvents,
+      id: 42,
+    },
+  }
+  screenCapture.initScreenCaptureForWindow(window as never)
+
+  return {
+    context,
+    getSources,
+    getDisplayMediaHandler: () => displayMediaHandler,
+    screenCapture,
+    setDisplayMediaRequestHandler,
+    window,
+    webContents: window.webContents,
+  }
+}
+
+describe('electron screen capture', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('deduplicates Chromium feature flags', async () => {
+    const { screenCapture } = await setupScreenCapture()
+    const flags = screenCapture.buildFeatureFlags({
+      otherEnabledFeatures: ['Vulkan', 'Vulkan', 'SharedArrayBuffer'],
+    }).split(',')
+
+    expect(flags).toEqual([...new Set(flags)])
+  })
+
+  it('clears a selected source when its renderer process exits', async () => {
+    // ROOT CAUSE:
+    //
+    // The selected source and its mutex belong to the renderer that made the request.
+    // A renderer exit does not reset either resource, so later capture requests can remain blocked.
+    // The fix must release both resources when the owning renderer exits.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+    const resetSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:reset-source')
+
+    expect(setSource).toBeDefined()
+    expect(resetSource).toBeDefined()
+
+    const handle = await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never) as string
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(true)
+    expect(service.getDisplayMediaHandler()).not.toBeNull()
+
+    service.webContents.emit('render-process-gone', {}, { reason: 'crashed' })
+    const sourceSelectedAfterCrash = service.screenCapture.hasSelectedScreenCaptureSource()
+    const handlerAfterCrash = service.getDisplayMediaHandler()
+
+    await resetSource!(handle as never)
+
+    expect(sourceSelectedAfterCrash).toBe(false)
+    expect(handlerAfterCrash).toBeNull()
+  })
+
+  it('clears a selected source when its owner window closes', async () => {
+    // ROOT CAUSE:
+    //
+    // The source mutex outlives its BrowserWindow owner.
+    // The closed window cannot reset the source, so another window can remain blocked until timeout.
+    // The fix must release capture resources when the owner window closes.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+
+    expect(setSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+
+    service.window.emit('closed')
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
+    expect(service.getDisplayMediaHandler()).toBeNull()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2268
+  it('clears capture authorization when the selected Wayland source is unavailable (Issue #2268)', async () => {
+    // ROOT CAUSE:
+    //
+    // A portal or compositor can return a source that is unavailable when Electron starts capture.
+    // The display handler throws but keeps the selection mutex and authorization active.
+    // The fix must clear both resources after this failure.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+
+    expect(setSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+
+    const displayMediaHandler = service.getDisplayMediaHandler() as (
+      request: unknown,
+      callback: (streams: unknown) => void,
+    ) => Promise<void>
+    await expect(displayMediaHandler({}, vi.fn())).rejects.toThrow('Source with id screen:1:0 not found.')
+
+    expect(service.getSources).toHaveBeenCalled()
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
+    expect(service.getDisplayMediaHandler()).toBeNull()
+  })
+
+  it('releases capture authorization after its timeout', async () => {
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+
+    expect(setSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 1000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+    await vi.advanceTimersByTimeAsync(1001)
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
+    expect(service.getDisplayMediaHandler()).toBeNull()
+  })
+})

--- a/packages/electron-screen-capture/src/main/index.ts
+++ b/packages/electron-screen-capture/src/main/index.ts
@@ -54,16 +54,16 @@ export function buildFeatureFlags({
   otherEnabledFeatures?: string[]
   forceCoreAudioTap?: boolean
 }): string {
-  const featureFlags = [...Object.values(DefaultFeatureFlags), ...(otherEnabledFeatures ?? [])]
+  const featureFlags = new Set([...Object.values(DefaultFeatureFlags), ...(otherEnabledFeatures ?? [])])
 
   if (forceCoreAudioTap) {
-    featureFlags.push(CoreAudioTapFeatureFlags.MacCoreAudioTapSystemAudioLoopbackOverride)
+    featureFlags.add(CoreAudioTapFeatureFlags.MacCoreAudioTapSystemAudioLoopbackOverride)
   }
   else {
-    featureFlags.push(ScreenCaptureKitFeatureFlags.MacScreenCaptureKitSystemAudioLoopbackOverride)
+    featureFlags.add(ScreenCaptureKitFeatureFlags.MacScreenCaptureKitSystemAudioLoopbackOverride)
   }
 
-  return featureFlags.join(',')
+  return [...featureFlags].join(',')
 }
 
 let initMainCalled = false
@@ -93,6 +93,7 @@ export interface GetLoopbackAudioMediaStreamOptions {
 
 let setSourceMutex: MutexInterface
 let screenCaptureSourceMutexHandle: string | undefined
+let screenCaptureSourceOwnerWindowId: number | undefined
 let setSourceMutexTimeoutHandle: NodeJS.Timeout | undefined
 
 export function initScreenCaptureForMain(options: InitMainOptions = {}): void {
@@ -142,6 +143,22 @@ function resetScreenCaptureSource() {
   clearTimeout(setSourceMutexTimeoutHandle)
   setSourceMutexTimeoutHandle = undefined
   screenCaptureSourceMutexHandle = undefined
+  screenCaptureSourceOwnerWindowId = undefined
+}
+
+function releaseScreenCaptureSource(params: { handle?: string, ownerWindowId?: number } = {}): boolean {
+  if (!screenCaptureSourceMutexHandle)
+    return false
+
+  if (params.handle && params.handle !== screenCaptureSourceMutexHandle)
+    return false
+
+  if (params.ownerWindowId && params.ownerWindowId !== screenCaptureSourceOwnerWindowId)
+    return false
+
+  resetScreenCaptureSource()
+  setSourceMutex.release()
+  return true
 }
 
 /**
@@ -203,6 +220,12 @@ export function initScreenCaptureForWindow(window: BrowserWindow, options?: Init
   const { context } = createContext(ipcMain, window, { onlySameWindow: true })
   const session = sessionModule.defaultSession
 
+  const releaseWindowCaptureSource = () => {
+    releaseScreenCaptureSource({ ownerWindowId: windowId })
+  }
+  window.on('closed', releaseWindowCaptureSource)
+  window.webContents.on('render-process-gone', releaseWindowCaptureSource)
+
   defineInvokeHandler(context, screenCapture.checkMacOSPermission, async () => checkMacOSScreenCapturePermission())
   defineInvokeHandler(context, screenCapture.requestMacOSPermission, async () => requestMacOSScreenCapturePermission())
 
@@ -233,27 +256,33 @@ export function initScreenCaptureForWindow(window: BrowserWindow, options?: Init
     const handle = nanoid()
     setSourceMutexTimeoutHandle = undefined
     screenCaptureSourceMutexHandle = handle
+    screenCaptureSourceOwnerWindowId = windowId
 
     try {
       session.setDisplayMediaRequestHandler(async (_request, callback) => {
-        const sources = await desktopCapturer.getSources(request.options)
-        const source = sources.find(source => source.id === request.sourceId)
-        if (!source) {
-          throw new Error(`Source with id ${request.sourceId} not found.`)
-        }
+        try {
+          const sources = await desktopCapturer.getSources(request.options)
+          const source = sources.find(source => source.id === request.sourceId)
+          if (!source) {
+            throw new Error(`Source with id ${request.sourceId} not found.`)
+          }
 
-        callback({
-          video: source,
-          audio: options?.loopbackWithMute ? LoopbackAudioTypes.LoopbackWithMute : LoopbackAudioTypes.Loopback,
-        })
+          callback({
+            video: source,
+            audio: options?.loopbackWithMute ? LoopbackAudioTypes.LoopbackWithMute : LoopbackAudioTypes.Loopback,
+          })
+        }
+        catch (error) {
+          releaseScreenCaptureSource({ handle })
+          throw error
+        }
       })
 
       setSourceMutexTimeoutHandle = setTimeout(() => {
         if (screenCaptureSourceMutexHandle !== handle)
           return
 
-        resetScreenCaptureSource()
-        setSourceMutex.release()
+        releaseScreenCaptureSource({ handle })
 
         log
           .withFields({ windowId, windowTitle: tryWindowTitle(window, windowTitle) })
@@ -271,18 +300,14 @@ export function initScreenCaptureForWindow(window: BrowserWindow, options?: Init
         .withError(e)
         .error('screenCaptureSetSourceEx failed for window')
 
-      resetScreenCaptureSource()
-      setSourceMutex.release()
+      releaseScreenCaptureSource({ handle })
       throw e
     }
   })
 
   defineInvokeHandler(context, screenCapture.resetSource, async (mutexHandle) => {
-    if (screenCaptureSourceMutexHandle !== mutexHandle)
+    if (!releaseScreenCaptureSource({ handle: mutexHandle }))
       return
-
-    resetScreenCaptureSource()
-    setSourceMutex.release()
 
     log.withFields({ windowId, windowTitle: tryWindowTitle(window, windowTitle) }).debug('setSourceMutex released by window')
   })

--- a/packages/electron-screen-capture/vitest.config.ts
+++ b/packages/electron-screen-capture/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,9 @@ catalogs:
     mineflayer-tool:
       specifier: ^1.2.0
       version: 1.2.0
+    minimatch:
+      specifier: ^10.2.6
+      version: 10.2.6
     minisearch:
       specifier: ^7.2.0
       version: 7.2.0
@@ -2272,6 +2275,9 @@ importers:
       less:
         specifier: 'catalog:'
         version: 4.6.4
+      minimatch:
+        specifier: 'catalog:'
+        version: 10.2.6
       mkcert:
         specifier: 'catalog:'
         version: 3.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -310,6 +310,7 @@ catalog:
   mineflayer-pathfinder: ^2.4.5
   mineflayer-pvp: ^1.3.2
   mineflayer-tool: ^1.2.0
+  minimatch: ^10.2.6
   minisearch: ^7.2.0
   mkcert: ^3.2.0
   motion-v: ^2.2.1

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'packages/cap-vite',
       'packages/ccc',
       'packages/core-agent',
+      'packages/electron-screen-capture',
       'packages/i18n',
       'packages/better-ws',
       'packages/plugin-sdk',


### PR DESCRIPTION
## Description

This PR makes the AIRI desktop runtime and release packages more stable on Linux.

- Preserve Chromium feature flags and support native Wayland or XWayland shortcut behavior.
- Restore window input after renderer failures and renew click-through state with a bounded lease.
- Release screen-capture ownership after renderer, window, source, or timeout failures.
- Disable Electron Updater inside Flatpak and report unsupported Linux permission requests safely.
- Stop reporting an inactive user CA file as a successful system trust installation.
- Export correct Flatpak desktop metadata and remove foreign native payloads from Linux packages.
- Add DEB, RPM, and Flatpak package inspection and launch tests for x64 and ARM64.
- Add a Fedora RPM install, reinstall, launch, remove, and residue gate before release upload.
- Keep Linux artifacts local until all package checks pass.

## Linked Issues

Closes #2160.
Closes #2132.

Partially addresses #2268 by releasing stale screen-capture ownership after source or portal failures.
Partially addresses #1719.
Related to #1618 through click-through recovery, but does not fix compositor or layer-shell limitations.
Related to #1159, but does not change compositor-specific Always on Top behavior.

## Known Linux limitations

This PR improves AIRI-owned recovery, packaging, and verification. It does not remove all Electron or Linux compositor limitations.

- Native Wayland click-through remains compositor-dependent. Electron does not support the Wayland layer-shell protocol.
- Tiling, window positioning, pinning, and Always on Top behavior can vary between compositors.
- Forced XWayland can produce different multi-window input behavior from native Wayland.
- Screen-capture changes release stale authorization and capture ownership after failures.
- They do not fix KDE Portal or PipeWire permission negotiation, source enumeration, or the `Displays (0)` result from #2268.
- Xvfb launch tests use an X11 server without a complete desktop environment or production window manager.


## Verification

- `pnpm lint` (passes with 7 existing warnings)
- `pnpm typecheck`
- `pnpm exec vitest run apps/stage-tamagotchi/scripts/linux-packaging.test.ts apps/stage-tamagotchi/scripts/verify-linux-package.test.ts apps/stage-tamagotchi/src/main/app/command-line.test.ts apps/stage-tamagotchi/src/main/libs/electron/location.test.ts apps/stage-tamagotchi/src/main/services/airi/channel-server/certificate-trust.test.ts apps/stage-tamagotchi/src/main/services/electron/auto-updater.test.ts apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts apps/stage-tamagotchi/src/main/services/electron/system-preferences.test.ts apps/stage-tamagotchi/src/main/services/electron/window-interactivity.test.ts apps/stage-tamagotchi/src/main/windows/caption/index.test.ts apps/stage-tamagotchi/src/renderer/composables/use-window-interactivity-lease.test.ts packages/electron-screen-capture/src/main/index.test.ts` (122 passed, 8 skipped on macOS)
- `pnpm test:run` unit phase (1,523 passed, 9 skipped)
- `pnpm run test-audio-pipelines-transcribe:run` (1 passed)
- Native Fedora 44 ARM64 RPM lifecycle (passed)
- Ubuntu ARM64 DEB and Flatpak package checks (passed earlier in this branch)

The unrelated `pnpm run test-ui:run` suite has six current BroadcastChannel timeout failures on upstream `main`.

## Visual changes

None. This PR changes runtime recovery and package behavior. It does not change rendered UI pixels.

## Additional Context

The Fedora lifecycle gate uses the official `fedora:44` image on both Linux matrix architectures. Electron Builder cannot publish Linux artifacts before these checks complete.
