### PR TITLE
fix(stage-ui): make streaming transcription requests half-duplex

### DIFF
--- a/packages/stage-ui/src/libs/providers/stream-transcription/index.test.ts
+++ b/packages/stage-ui/src/libs/providers/stream-transcription/index.test.ts
@@ -3,6 +3,38 @@ import { describe, expect, it } from 'vitest'
 import { streamTranscription } from './index'
 
 describe('streamTranscription', () => {
+  it('sets half-duplex transport for the browser audio upload', async () => {
+    // ROOT CAUSE:
+    //
+    // Browser fetch requires `duplex: 'half'` when the request body is a
+    // ReadableStream. The official provider set this in its fetch wrapper,
+    // but that wrapper does not own this adapter's stream transport.
+    //
+    // Report: T-3, Official provider transcription does not work reliably.
+    let requestInit: RequestInit | undefined
+    const audioStream = new ReadableStream<ArrayBuffer>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    const result = streamTranscription({
+      baseURL: 'https://example.invalid/transcription',
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestInit = init
+        return new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close()
+          },
+        }))
+      },
+      inputAudioStream: audioStream,
+    })
+
+    await expect(result.text).resolves.toBe('')
+    expect((requestInit as RequestInit & { duplex?: string }).duplex).toBe('half')
+  })
+
   it('parses split SSE chunks and joins transcription deltas', async () => {
     const encoder = new TextEncoder()
     const responseBody = new ReadableStream<Uint8Array>({

--- a/packages/stage-ui/src/libs/providers/stream-transcription/index.ts
+++ b/packages/stage-ui/src/libs/providers/stream-transcription/index.ts
@@ -123,10 +123,14 @@ export function streamTranscription(options: StreamTranscriptionOptions): AIRISt
         : new URL(typeof options.baseURL === 'string' ? options.baseURL : 'http://localhost')
       const response = await fetcher(requestTarget, {
         body: audioStream,
+        // Browser fetch requires half-duplex mode for a ReadableStream body.
+        // Keep this at the transport boundary so every SSE transcription
+        // provider receives the required request option.
+        duplex: 'half',
         headers: options.headers,
         method: 'POST',
         signal: options.abortSignal,
-      })
+      } as RequestInit & { duplex: 'half' })
 
       if (!response.ok)
         throw new Error(`Streaming transcription request failed with status ${response.status}`)


### PR DESCRIPTION
## Summary

- Set `duplex: 'half'` at the shared streaming transcription transport boundary.
- Add a regression test for browser audio uploads backed by `ReadableStream`.

## Root cause

The adapter sent a `ReadableStream` request body without the required browser fetch duplex option. The previous provider-specific `instanceof ReadableStream` workaround could fail across runtime realms, so the browser rejected the request before it reached the API.

## Verification

- `pnpm exec vitest run --config packages/stage-ui/vitest.config.ts --project node packages/stage-ui/src/libs/providers/stream-transcription/index.test.ts`
- `pnpm exec eslint packages/stage-ui/src/libs/providers/stream-transcription/index.ts packages/stage-ui/src/libs/providers/stream-transcription/index.test.ts`
- `pnpm lint`

The full workspace typecheck and test runs still report pre-existing failures in `testing-audio`, `chat.ts`, and `context-channel.test.ts`.

## Visual changes

No visual changes.