### PR TITLE
test: run Vitest browser projects headlessly

### DIFF
--- a/apps/stage-tamagotchi/vitest.config.ts
+++ b/apps/stage-tamagotchi/vitest.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
           exclude: ['**/node_modules/**', '**/.git/**'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },

--- a/packages/audio-pipelines-transcribe/vitest.config.ts
+++ b/packages/audio-pipelines-transcribe/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig(({ mode }) => ({
           browser: {
             provider: playwright(),
             enabled: true,
+            headless: true,
             // Vitest browser mode requires an explicit browser instance list.
             instances: [
               { browser: 'chromium' },

--- a/packages/stage-ui-mmd/vitest.config.ts
+++ b/packages/stage-ui-mmd/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
           include: ['src/**/*.browser.test.ts'],
           browser: {
             enabled: true,
+            headless: true,
             provider: playwright(),
             instances: [
               { browser: 'chromium' },

--- a/packages/stage-ui/vitest.config.ts
+++ b/packages/stage-ui/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
             exclude: ['**/node_modules/**'],
             browser: {
               enabled: true,
+              headless: true,
               provider: playwright(),
               instances: [
                 { browser: 'chromium' },


### PR DESCRIPTION
## Description

Run all Vitest Browser projects in headless mode. The tests still use Playwright Chromium, but local runs no longer open visible browser windows.

## Linked Issues

None.

## Additional Context

Verification:

- `pnpm run test-stage-tamagotchi:run`
- `pnpm exec vitest run --config packages/audio-pipelines-transcribe/vitest.config.ts --project browser`
- `pnpm exec vitest run --config packages/stage-ui/vitest.config.ts --project browser`
- `pnpm exec vitest run --config packages/stage-ui-mmd/vitest.config.ts --project browser --passWithNoTests`
- `pnpm typecheck`
- `pnpm lint` (passed with seven existing warnings)

This configuration change has no visual effect on the product.