### PR TITLE
docs: fix three groups of dead links

### DIFF
--- a/apps/component-calling/src/plugins/plugin-component-calling-weather/assets/README.md
+++ b/apps/component-calling/src/plugins/plugin-component-calling-weather/assets/README.md
@@ -4,7 +4,7 @@
 
 ## Many other alternatives
 
-- [Weather Icons by Bas](https://basmilius.github.io/weather-icons/index-fill.html)
+- [Weather Icons by Bas](https://basmilius.github.io/weather-icons/)
 - [erikflowers/weather-icons: 215 Weather Themed Icons and CSS](https://github.com/erikflowers/weather-icons)
 - [basmilius/weather-icons: Free to use animated weather icons.](https://github.com/basmilius/weather-icons)
 - [Makin-Things/weather-icons: A set of updated weather icons based of the AmCharts style of icon.](https://github.com/Makin-Things/weather-icons)

--- a/apps/stage-tamagotchi/src/renderer/widgets/weather/assets/README.md
+++ b/apps/stage-tamagotchi/src/renderer/widgets/weather/assets/README.md
@@ -4,7 +4,7 @@
 
 ## Many other alternatives
 
-- [Weather Icons by Bas](https://basmilius.github.io/weather-icons/index-fill.html)
+- [Weather Icons by Bas](https://basmilius.github.io/weather-icons/)
 - [erikflowers/weather-icons: 215 Weather Themed Icons and CSS](https://github.com/erikflowers/weather-icons)
 - [basmilius/weather-icons: Free to use animated weather icons.](https://github.com/basmilius/weather-icons)
 - [Makin-Things/weather-icons: A set of updated weather icons based of the AmCharts style of icon.](https://github.com/Makin-Things/weather-icons)

--- a/docs/content/en/blog/DevLog-2025.04.06/index.md
+++ b/docs/content/en/blog/DevLog-2025.04.06/index.md
@@ -438,7 +438,7 @@ We're excited to see the community starting to contribute to Project AIRI! Some 
 - **Documentation improvements**: Many community members have been helping to improve our documentation
 
 We're grateful for all the support and contributions. If you'd like to contribute, check out our
-[contributing guidelines](https://github.com/moeru-ai/airi/blob/main/CONTRIBUTING.md).
+[contributing guidelines](https://github.com/moeru-ai/airi/blob/main/.github/CONTRIBUTING.md).
 
 ## What's next
 

--- a/docs/content/en/blog/DevLog-2025.05.16/index.md
+++ b/docs/content/en/blog/DevLog-2025.05.16/index.md
@@ -164,7 +164,7 @@ So [@luoling](https://github.com/luoling8192) made another small demo for this t
 #### Birth of xsAI 🤗 Transformers.js
 
 Because the work we have done for VAD, ASR, Chat, and TTS demos, this gave the
-birth of a new side project called [xsAI 🤗 Transformers.js](https://github.com/proj-airi/xsai-transformers)
+birth of a new side project called [xsAI 🤗 Transformers.js](https://github.com/moeru-ai/xsai-transformers)
 , enabling the simplicity to call the WebGPU powered model inference and serving with
 workers while still keeping the API compatible to our prior succeeded project called
 [xsAI](https://github.com/moeru-ai/xsai).

--- a/docs/content/ja/blog/DevLog-2025.05.16/index.md
+++ b/docs/content/ja/blog/DevLog-2025.05.16/index.md
@@ -114,7 +114,7 @@ Project AIRI の DevLog 更新が遅れてしまい申し訳ありません。�
 
 #### xsAI 🤗 Transformers.js の誕生
 
-VAD、ASR、チャット、TTS デモのために行った作業により、[xsAI 🤗 Transformers.js](https://github.com/proj-airi/xsai-transformers) という新しいサイドプロジェクトが生まれました。これは、以前の成功したプロジェクト [xsAI](https://github.com/moeru-ai/xsai) との API 互換性を維持しながら、WebGPU 駆動のモデル推論の呼び出しとワーカーを使用したサービス提供を簡素化します。
+VAD、ASR、チャット、TTS デモのために行った作業により、[xsAI 🤗 Transformers.js](https://github.com/moeru-ai/xsai-transformers) という新しいサイドプロジェクトが生まれました。これは、以前の成功したプロジェクト [xsAI](https://github.com/moeru-ai/xsai) との API 互換性を維持しながら、WebGPU 駆動のモデル推論の呼び出しとワーカーを使用したサービス提供を簡素化します。
 
 これのためのプレイグラウンドも作成しました... [https://xsai-transformers.netlify.app](https://xsai-transformers.netlify.app) で遊んでみてください。
 

--- a/docs/content/ko/blog/DevLog-2025.04.06/index.md
+++ b/docs/content/ko/blog/DevLog-2025.04.06/index.md
@@ -421,7 +421,7 @@ setAccentColor('#ff6b6b')
 - **문서 개선**: 많은 커뮤니티 멤버가 문서 개선을 도와주고 있습니다
 
 모든 지원과 기여에 감사드립니다. 기여하고 싶으시다면
-[기여 가이드라인](https://github.com/moeru-ai/airi/blob/main/CONTRIBUTING.md)을 확인해 주세요.
+[기여 가이드라인](https://github.com/moeru-ai/airi/blob/main/.github/CONTRIBUTING.md)을 확인해 주세요.
 
 ## 다음 계획
 

--- a/docs/content/ko/blog/DevLog-2025.05.16/index.md
+++ b/docs/content/ko/blog/DevLog-2025.05.16/index.md
@@ -146,7 +146,7 @@ macOS, Windows, Linux, Android, iOS 등에서 12개 이상 언어에 걸쳐 18�
 
 #### xsAI 🤗 Transformers.js의 탄생
 
-VAD, ASR, Chat, TTS 데모 작업 덕분에 [xsAI 🤗 Transformers.js](https://github.com/proj-airi/xsai-transformers)
+VAD, ASR, Chat, TTS 데모 작업 덕분에 [xsAI 🤗 Transformers.js](https://github.com/moeru-ai/xsai-transformers)
 라는 새 사이드 프로젝트가 태어났습니다. WebGPU 기반 모델 추론과 워커를 통한 서빙을 간단히 호출할 수 있게 하면서도,
 앞서 성공한 프로젝트 [xsAI](https://github.com/moeru-ai/xsai)와 API 호환성을 유지합니다.
 

--- a/docs/content/zh-Hans/blog/DevLog-2025.05.16/index.md
+++ b/docs/content/zh-Hans/blog/DevLog-2025.05.16/index.md
@@ -114,7 +114,7 @@ import DemoDayHangzhou3 from './assets/demo-day-hangzhou-3.avif'
 
 #### xsAI 🤗 Transformers.js 的诞生
 
-由于我们为 VAD、ASR、聊天和 TTS 演示所做的工作，这催生了一个名为 [xsAI 🤗 Transformers.js](https://github.com/proj-airi/xsai-transformers) 的新副项目，它简化了调用 WebGPU 驱动的模型推理和使用 workers 提供服务，同时仍然保持与我们之前成功的项目 [xsAI](https://github.com/moeru-ai/xsai) 的 API 兼容性。
+由于我们为 VAD、ASR、聊天和 TTS 演示所做的工作，这催生了一个名为 [xsAI 🤗 Transformers.js](https://github.com/moeru-ai/xsai-transformers) 的新副项目，它简化了调用 WebGPU 驱动的模型推理和使用 workers 提供服务，同时仍然保持与我们之前成功的项目 [xsAI](https://github.com/moeru-ai/xsai) 的 API 兼容性。
 
 我们也为此做了一个游乐场...在 [https://xsai-transformers.netlify.app](https://xsai-transformers.netlify.app) 上玩玩吧。
 


### PR DESCRIPTION
Three groups of dead links across 8 files:

1. `proj-airi/xsai-transformers` -> `moeru-ai/xsai-transformers` (repo moved from proj-airi to moeru-ai org; the old URL 404s while the new one is live)
2. `blob/main/CONTRIBUTING.md` -> `blob/main/.github/CONTRIBUTING.md` (file lives under .github/, not at root)
3. `basmilius.github.io/weather-icons/index-fill.html` -> `basmilius.github.io/weather-icons/` (the index-fill page was removed; the root gallery is live)

All replacement URLs verified live (200).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated weather icon attribution links to their current destination.
  * Corrected contribution guide links in the development logs.
  * Updated xsAI Transformers.js project links across English, Japanese, Korean, and Simplified Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->