### PR TITLE
fix(analytics): correct app entry event semantics

### DIFF
--- a/apps/stage-pocket/src/App.vue
+++ b/apps/stage-pocket/src/App.vue
@@ -74,7 +74,7 @@ watch(settings.themeColorsHueDynamic, () => {
 
 // Initialize first-time setup check when app mounts
 onMounted(async () => {
-  initializeAnalytics()
+  initializeAnalytics('primary')
   await displayModelsStore.initialize()
   cardStore.startRuntime(syncedPinia)
   await cardStore.initialize()

--- a/apps/stage-tamagotchi/src/renderer/App.vue
+++ b/apps/stage-tamagotchi/src/renderer/App.vue
@@ -212,7 +212,7 @@ function createFullStageRuntime() {
 
   return {
     async initialize() {
-      initializeAnalytics()
+      initializeAnalytics(windowContext.appEntry)
       await displayModelsStore.initialize()
       cardStore.startRuntime(syncedPinia)
       await cardStore.initialize()

--- a/apps/stage-tamagotchi/src/renderer/window-context.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/window-context.test.ts
@@ -30,6 +30,11 @@ describe('resolveRendererWindowContext', () => {
     })
   })
 
+  it('counts only the main renderer as an app entry', () => {
+    expect(resolveRendererWindowContext('?synced-leader=true').appEntry).toBe('primary')
+    expect(resolveRendererWindowContext('?synced-leader=false').appEntry).toBe('auxiliary')
+  })
+
   it('uses the full Stage runtime unless the query selects the minimal runtime', () => {
     expect(resolveRendererWindowContext('?synced-leader=true').stageRuntime).toBe('full')
     expect(resolveRendererWindowContext('?synced-leader=false').stageRuntime).toBe('full')

--- a/apps/stage-tamagotchi/src/renderer/window-context.ts
+++ b/apps/stage-tamagotchi/src/renderer/window-context.ts
@@ -2,6 +2,8 @@ import type { LeadershipMode } from '@proj-airi/stage-ui/libs/pinia'
 
 /** Describes the synchronization and Stage runtime policy for one renderer. */
 export interface RendererWindowContext {
+  /** Determines whether this renderer represents one user-visible app open. */
+  appEntry: 'primary' | 'auxiliary'
   /** Determines whether this renderer can own synchronized actions. */
   leadership: LeadershipMode
   /** Determines whether this renderer initializes Stage integrations. */
@@ -30,7 +32,7 @@ export function resolveInitialRendererRoutePath(routePath: string, hash = global
  *
  * @example
  * resolveRendererWindowContext('?synced-leader=false&stage-runtime=minimal')
- * // => { leadership: 'follower-only', stageRuntime: 'minimal' }
+ * // => { appEntry: 'auxiliary', leadership: 'follower-only', stageRuntime: 'minimal' }
  */
 export function resolveRendererWindowContext(search = globalThis.location?.search ?? ''): RendererWindowContext {
   const query = new URLSearchParams(search)
@@ -45,6 +47,7 @@ export function resolveRendererWindowContext(search = globalThis.location?.searc
     throw new TypeError(`Invalid stage-runtime query: ${stageRuntime}`)
 
   return {
+    appEntry: syncedLeader === 'true' ? 'primary' : 'auxiliary',
     leadership: syncedLeader === 'true' ? 'leader-only' : 'follower-only',
     stageRuntime: stageRuntime === 'minimal' ? 'minimal' : 'full',
   }

--- a/apps/stage-web/src/App.vue
+++ b/apps/stage-web/src/App.vue
@@ -87,7 +87,7 @@ watch(settings.themeColorsHueDynamic, () => {
 
 // Initialize first-time setup check when app mounts
 onMounted(async () => {
-  initializeAnalytics()
+  initializeAnalytics('primary')
   await displayModelsStore.initialize()
   cardStore.startRuntime(syncedPinia)
   await cardStore.initialize()

--- a/packages/stage-ui/src/composables/use-analytics.ts
+++ b/packages/stage-ui/src/composables/use-analytics.ts
@@ -1070,14 +1070,6 @@ export function useAnalytics() {
     captureAnalyticsEvent('character_updated', properties)
   }
 
-  // ─── App lifecycle ───────────────────────────────────────────────────
-
-  function trackAppLoaded(properties: { platform: 'web' | 'desktop' | 'mobile', version: string, cold_start_ms?: number }) {
-    if (!canCapture())
-      return
-    captureAnalyticsEvent('app_loaded', properties)
-  }
-
   // ─── Feature usage / retention ───────────────────────────────────────
 
   function trackCharacterDeleted(properties: { character_id: string }) {
@@ -1336,8 +1328,6 @@ export function useAnalytics() {
     trackOfficialTtsAutoEnabled,
 
     trackAutonomousGenerateText,
-
-    trackAppLoaded,
 
     trackCardEdited,
     trackSceneBackgroundSet,

--- a/packages/stage-ui/src/libs/analytics/client.test.ts
+++ b/packages/stage-ui/src/libs/analytics/client.test.ts
@@ -24,13 +24,13 @@ describe('analytics client', () => {
     }))
 
     expect(client.ensureInitialized(true)).toBe(true)
-    expect(client.capture('app_loaded', { platform: 'web' })).toBe(true)
+    expect(client.capture('app_opened', { app_surface: 'web' })).toBe(true)
     client.identify('user-1')
     await Promise.resolve()
     install?.(adapter)
 
     await vi.waitFor(() => {
-      expect(adapter.capture).toHaveBeenCalledWith('app_loaded', { platform: 'web' }, undefined)
+      expect(adapter.capture).toHaveBeenCalledWith('app_opened', { app_surface: 'web' }, undefined)
     })
     expect(adapter.identify).toHaveBeenCalledWith('user-1')
   })
@@ -41,7 +41,7 @@ describe('analytics client', () => {
     })
 
     expect(client.ensureInitialized(true)).toBe(true)
-    expect(client.capture('app_loaded', { platform: 'web' })).toBe(true)
+    expect(client.capture('app_opened', { app_surface: 'web' })).toBe(true)
     await vi.waitFor(() => {
       expect(client.capture('first_message_sent', {})).toBe(false)
     })

--- a/packages/stage-ui/src/libs/analytics/events/app/events/lifecycle.ts
+++ b/packages/stage-ui/src/libs/analytics/events/app/events/lifecycle.ts
@@ -1,9 +1,9 @@
 import { defineEvent } from '../../../utils/dsl'
 
-export const appLoadedEvent = defineEvent<{
-  platform: 'web' | 'desktop' | 'mobile'
+export const appOpenedEvent = defineEvent<{
+  app_surface: 'web' | 'electron' | 'mobile'
   version: string
-}>('app_loaded')
+}>('app_opened')
 
 export const analyticsSettingChangedEvent = defineEvent<{
   setting_name: 'analytics_enabled'

--- a/packages/stage-ui/src/libs/analytics/index.ts
+++ b/packages/stage-ui/src/libs/analytics/index.ts
@@ -22,7 +22,7 @@ import {
 } from './client'
 import {
   analyticsSettingChangedEvent,
-  appLoadedEvent,
+  appOpenedEvent,
   characterSwitchedEvent,
   firstMessageSentEvent,
   firstModelSelectedEvent,
@@ -40,6 +40,8 @@ export { defineEvent } from './utils/dsl'
 
 type AnyAnalyticsEvent = AnalyticsEvent<object>
 
+export type AnalyticsAppEntry = 'primary' | 'auxiliary'
+
 /** Minimal analytics boundary that product event modules can depend on. */
 export interface AnalyticsRecorder {
   /** Emits one typed product event when capture is enabled. */
@@ -51,6 +53,14 @@ export interface AnalyticsRecorder {
 function analyticsSurface(): 'web' | 'desktop' | 'mobile' {
   return isStageTamagotchi()
     ? 'desktop'
+    : isStageCapacitor()
+      ? 'mobile'
+      : 'web'
+}
+
+function productAppSurface(): 'web' | 'electron' | 'mobile' {
+  return isStageTamagotchi()
+    ? 'electron'
     : isStageCapacitor()
       ? 'mobile'
       : 'web'
@@ -69,7 +79,7 @@ class Analytics implements AnalyticsRecorder {
   private firstModelSelectedRecorded = false
   private initialized = false
 
-  initialize(): void {
+  initialize(appEntry: AnalyticsAppEntry): void {
     if (this.initialized)
       return
 
@@ -80,10 +90,12 @@ class Analytics implements AnalyticsRecorder {
 
     if (settingsAnalytics.analyticsEnabled && enableAnalytics()) {
       registerAnalyticsBuildInfo(buildInfo)
-      this.emit(appLoadedEvent, {
-        platform: analyticsSurface(),
-        version: buildInfo.version,
-      })
+      if (appEntry === 'primary') {
+        this.emit(appOpenedEvent, {
+          app_surface: productAppSurface(),
+          version: buildInfo.version,
+        })
+      }
     }
 
     if (authStore.isAuthenticated && authStore.user?.id)
@@ -240,8 +252,8 @@ export function disableAnalytics(): void {
 }
 
 /** Starts analytics lifecycle observers after Pinia is available. */
-export function initializeAnalytics(): void {
-  analytics.initialize()
+export function initializeAnalytics(appEntry: AnalyticsAppEntry): void {
+  analytics.initialize(appEntry)
 }
 
 export { configureAnalyticsAdapter, getAnalyticsIdentitySnapshot, isAnalyticsAvailableInBuild }


### PR DESCRIPTION
## Summary

- replace the misleading `app_loaded` event with `app_opened`
- use the canonical `app_surface` values: `web`, `electron`, and `mobile`
- classify Electron renderers as primary or auxiliary so only the main renderer records an app open
- remove the legacy manual `trackAppLoaded` entry point so the old event cannot be emitted accidentally

## Root cause

The analytics singleton was scoped to one JavaScript runtime. Every Electron renderer had its own singleton, which meant auxiliary windows could each emit `app_loaded` even though the application had only been opened once.

The event name also described renderer initialization rather than the user-visible action being measured.

## Impact

Web and Pocket emit one `app_opened` event per primary runtime. Electron auxiliary windows continue initializing analytics observers but no longer count as app opens.

Historical events are unchanged, and clients on older versions will continue sending `app_loaded` until upgraded. Dashboards should migrate from `app_loaded` to `app_opened` for new-version data.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/libs/analytics/client.test.ts` — 2 tests passed
- `pnpm exec vitest run --config vitest.node.config.ts src/renderer/window-context.test.ts` — 6 tests passed
- commit hook lint passed for all 9 changed files
- `git diff --check` passed
- full package typechecks remain blocked by existing unresolved internal-package and baseline errors; filtered diagnostics contain no errors in the changed files