### PR TITLE
fix(analytics): remove model discovery events

### DIFF
--- a/packages/stage-ui/src/composables/use-analytics.test.ts
+++ b/packages/stage-ui/src/composables/use-analytics.test.ts
@@ -572,43 +572,6 @@ describe('useAnalytics conversation product events', () => {
 
   /**
    * @example
-   * analytics.trackModelListLoaded({ provider_id: 'official-provider', provider_mode: 'official', model_count: 3, duration_ms: 25 })
-   * expect(posthog.capture).toHaveBeenCalledWith('model_list_loaded', expect.objectContaining({ provider_id: 'official-provider' }))
-   */
-  it('emits provider model-list health events', () => {
-    const analytics = useAnalytics()
-
-    analytics.trackModelListLoaded({
-      provider_id: 'official-provider',
-      provider_mode: 'official',
-      model_count: 3,
-      duration_ms: 25,
-    })
-    analytics.trackModelListFailed({
-      provider_id: 'openai-compatible',
-      provider_mode: 'custom',
-      error_code: 'provider_error',
-      duration_ms: 40,
-    })
-
-    expect(analyticsMocks.posthogCaptureMock).toHaveBeenNthCalledWith(1, 'model_list_loaded', {
-      app_surface: 'web',
-      provider_id: 'official-provider',
-      provider_mode: 'official',
-      model_count: 3,
-      duration_ms: 25,
-    })
-    expect(analyticsMocks.posthogCaptureMock).toHaveBeenNthCalledWith(2, 'model_list_failed', {
-      app_surface: 'web',
-      provider_id: 'openai-compatible',
-      provider_mode: 'custom',
-      error_code: 'provider_error',
-      duration_ms: 40,
-    })
-  })
-
-  /**
-   * @example
    * analytics.trackProviderConfigFailed({ provider_id: 'openai-compatible', provider_mode: 'custom', step: 'settings_auto_validate', error_code: 'validation_failed', duration_ms: 32 })
    * expect(posthog.capture).toHaveBeenCalledWith('provider_config_failed', expect.objectContaining({ error_code: 'validation_failed' }))
    */

--- a/packages/stage-ui/src/composables/use-analytics.ts
+++ b/packages/stage-ui/src/composables/use-analytics.ts
@@ -528,34 +528,6 @@ export function useAnalytics() {
     })
   }
 
-  function trackModelListLoaded(properties: {
-    provider_id: string
-    provider_mode: ProviderMode
-    model_count: number
-    duration_ms: number
-  }) {
-    if (!canCapture())
-      return
-    captureAnalyticsEvent('model_list_loaded', {
-      ...properties,
-      app_surface: getConversationAnalyticsSurface(),
-    })
-  }
-
-  function trackModelListFailed(properties: {
-    provider_id: string
-    provider_mode: ProviderMode
-    error_code: string
-    duration_ms: number
-  }) {
-    if (!canCapture())
-      return
-    captureAnalyticsEvent('model_list_failed', {
-      ...properties,
-      app_surface: getConversationAnalyticsSurface(),
-    })
-  }
-
   function trackProviderConfigStarted(properties: ProviderConfigBaseProperties) {
     if (!canCapture())
       return
@@ -1286,8 +1258,6 @@ export function useAnalytics() {
     trackChatActivationFailed,
     trackOfficialProviderSelected,
     trackSecondTurnStarted,
-    trackModelListLoaded,
-    trackModelListFailed,
     trackProviderConfigStarted,
     trackProviderConfigSucceeded,
     trackProviderConfigFailed,

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -14,7 +14,7 @@ import type { ProviderMetadata, ProviderValidationPlan } from '../../libs/provid
 import type { ModelInfo, ProviderDefinition, ProviderInstance, VoiceInfo } from '../../libs/providers/types'
 
 import { errorMessageFrom } from '@moeru/std'
-import { isCustomProvidersDisabled, isStageCapacitor, isStageTamagotchi } from '@proj-airi/stage-shared'
+import { isCustomProvidersDisabled } from '@proj-airi/stage-shared'
 import { computedAsync, useIntervalFn } from '@vueuse/core'
 import { listModels } from '@xsai/model'
 import { uniqBy } from 'es-toolkit'
@@ -22,7 +22,6 @@ import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { captureAnalyticsEvent, enableAnalytics, isAnalyticsAvailableInBuild } from '../../libs/analytics'
 import {
   CHAT_COMPLETIONS_VALIDATOR_ID,
   getProviderValidationIntervalMs,
@@ -33,80 +32,7 @@ import {
 } from '../../libs/providers'
 import { selectProviderMetadata, selectProvidersMetadata } from '../../libs/providers/metadata'
 import { useAuthStore } from '../auth'
-import { useSettingsAnalytics } from '../settings/analytics'
 import { useProviderConfigStore } from './config'
-
-/**
- * Classifies provider ids into bounded analytics buckets.
- */
-function analyticsProviderMode(providerId: string): 'official' | 'custom' | 'unknown' {
-  if (!providerId)
-    return 'unknown'
-  return providerId.startsWith('official-provider') || providerId.startsWith('vision-official-provider') ? 'official' : 'custom'
-}
-
-/**
- * Resolves the current app surface without importing the analytics store.
- */
-function analyticsSurface(): 'web' | 'mobile' | 'electron' {
-  if (isStageTamagotchi())
-    return 'electron'
-
-  if (isStageCapacitor())
-    return 'mobile'
-
-  return 'web'
-}
-
-/**
- * Checks analytics settings and initializes PostHog without loading build metadata.
- */
-function canCaptureProviderAnalytics(): boolean {
-  if (!isAnalyticsAvailableInBuild())
-    return false
-
-  const settingsAnalytics = useSettingsAnalytics()
-  if (!settingsAnalytics.analyticsEnabled)
-    return false
-
-  return enableAnalytics()
-}
-
-/**
- * Emits model-list analytics from the provider store without loading build metadata.
- */
-function trackModelListLoaded(properties: {
-  provider_id: string
-  provider_mode: 'official' | 'custom' | 'unknown'
-  model_count: number
-  duration_ms: number
-}) {
-  if (!canCaptureProviderAnalytics())
-    return
-
-  captureAnalyticsEvent('model_list_loaded', {
-    ...properties,
-    app_surface: analyticsSurface(),
-  })
-}
-
-/**
- * Emits model-list failure analytics from the provider store without loading build metadata.
- */
-function trackModelListFailed(properties: {
-  provider_id: string
-  provider_mode: 'official' | 'custom' | 'unknown'
-  error_code: string
-  duration_ms: number
-}) {
-  if (!canCaptureProviderAnalytics())
-    return
-
-  captureAnalyticsEvent('model_list_failed', {
-    ...properties,
-    app_surface: analyticsSurface(),
-  })
-}
 
 export type { ModelInfo, VoiceInfo } from '../../libs/providers/types'
 
@@ -652,7 +578,6 @@ export const useProviderStore = defineStore('provider', () => {
 
   // Function to fetch models for a specific provider
   async function fetchModelsForProvider(providerId: string) {
-    const startedAt = Date.now()
     const definition = findProviderDefinition(providerId)
     if (!definition)
       return []
@@ -698,22 +623,10 @@ export const useProviderStore = defineStore('provider', () => {
             modelError: null,
           },
         }
-        trackModelListLoaded({
-          provider_id: providerId,
-          provider_mode: analyticsProviderMode(providerId),
-          model_count: normalizedModels.length,
-          duration_ms: Date.now() - startedAt,
-        })
         // Synced action results pass through structuredClone. Return the local
         // array because reading the same array from state returns a Vue proxy.
         return normalizedModels
       }
-      trackModelListLoaded({
-        provider_id: providerId,
-        provider_mode: analyticsProviderMode(providerId),
-        model_count: 0,
-        duration_ms: Date.now() - startedAt,
-      })
       return []
     }
     catch (error) {
@@ -729,12 +642,6 @@ export const useProviderStore = defineStore('provider', () => {
           },
         }
       }
-      trackModelListFailed({
-        provider_id: providerId,
-        provider_mode: analyticsProviderMode(providerId),
-        error_code: 'provider_error',
-        duration_ms: Date.now() - startedAt,
-      })
       return []
     }
   }


### PR DESCRIPTION
## Summary

- stop emitting `model_list_loaded` and `model_list_failed` from automatic provider model discovery
- remove the corresponding public analytics helpers
- remove tests that treated provider health activity as product behavior

## Root cause

Provider model discovery runs automatically during initialization and refreshes. It can execute repeatedly for configured providers without a user action, so these events inflate product analytics and do not measure user engagement.

## Impact

Provider model loading behavior and error handling are unchanged. The only behavioral change is that successful and failed background model-list requests no longer produce PostHog product events.

If model discovery reliability needs monitoring, it should be measured through operational logs or service metrics instead of the product analytics event stream.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/composables/use-analytics.test.ts` — 22 tests passed
- targeted ESLint for all 3 changed files passed
- commit hook lint passed for all 3 changed files
- `git diff --check` passed
- verified that `model_list_loaded`, `model_list_failed`, and their tracker names no longer exist under `packages/stage-ui/src`