### PR TITLE
fix(stage-ui): register chat-ingestion consumers only after the transport is ready (#2305)

### DIFF
--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -452,6 +452,29 @@ describe('channel-server store reconnect', () => {
     ])
   })
 
+  it('issue #2313 review: ensureReady resolves false when the connection is disposed while waiting', async () => {
+    const store = useModsServerChannelStore()
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    let result: boolean | undefined
+    const readyPromise = store.ensureReady().then((ready) => {
+      result = ready
+    })
+
+    await Promise.resolve()
+    expect(result).toBeUndefined()
+
+    // The app unmounts between authenticated and ready.
+    store.dispose()
+    await readyPromise
+    expect(result).toBe(false)
+  })
+
   it('does not reconnect while the url scheme is not valid', async () => {
     const store = useModsServerChannelStore()
 

--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -377,6 +377,81 @@ describe('channel-server store reconnect', () => {
     ]))
   })
 
+  it('issue #2305: ensureReady only resolves once the transport reports ready, not at authenticated', async () => {
+    const store = useModsServerChannelStore()
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+
+    // The store is connected from the store's perspective, but the transport
+    // has not reached ready yet: ensureReady must still be pending.
+    let resolved = false
+    const readyPromise = store.ensureReady().then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    client.simulateReconnectReady()
+    await readyPromise
+    expect(resolved).toBe(true)
+  })
+
+  it('issue #2305: flush keeps messages the transport refused instead of dropping them', async () => {
+    const store = useModsServerChannelStore()
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances[0]
+
+    client.simulateAuthenticated()
+    await initializePromise
+    client.simulateReconnectReady()
+
+    store.send({
+      type: 'module:consumer:register',
+      data: { event: 'input:text', mode: 'consumer-group', group: 'chat-ingestion' },
+    } as any)
+
+    expect(store.pendingSendCount).toBe(0)
+
+    // The transport goes back to a non-ready state after a transient error;
+    // a queued message must survive a flush that cannot send it.
+    client.simulateTransientDisconnect()
+    store.send({
+      type: 'module:consumer:register',
+      data: { event: 'input:voice', mode: 'consumer-group', group: 'chat-ingestion' },
+    } as any)
+    expect(store.pendingSendCount).toBe(1)
+
+    // Refuse one send round: the ready-flush must keep the message queued...
+    const originalSend = client.send.bind(client)
+    client.send = () => false
+    client.simulateReconnectReady()
+    expect(store.pendingSendCount).toBe(1)
+    client.send = originalSend
+
+    // ...and the next ready-flush delivers it exactly once.
+    client.simulateReconnectReady()
+    expect(store.pendingSendCount).toBe(0)
+    const registrations = client.sent.filter((event: any) => event?.type === 'module:consumer:register')
+    expect(registrations).toEqual([
+      // First ready-flush: the input:text registration from before the
+      // transient disconnect.
+      expect.objectContaining({
+        data: expect.objectContaining({ event: 'input:text' }),
+      }),
+      // Second ready-flush: the input:voice registration the refused round
+      // kept queued, delivered exactly once.
+      expect.objectContaining({
+        data: expect.objectContaining({ event: 'input:voice' }),
+      }),
+    ])
+  })
+
   it('does not reconnect while the url scheme is not valid', async () => {
     const store = useModsServerChannelStore()
 

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -201,7 +201,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
           connected.value = true
           flush()
           initializeListeners()
-          resolveReadyWaiters()
+          resolveReadyWaiters(true)
 
           if (isReconnect) {
             for (const callback of reconnectedCallbacks) {
@@ -255,21 +255,25 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
   // Callers whose messages must not be silently dropped (the consumer-group
   // registration is the load-bearing one: losing it makes the runtime drop
   // every `input:*` until the next reconnect) await this instead.
-  const readyWaiters = new Set<() => void>()
+  const readyWaiters = new Set<(ready: boolean) => void>()
 
-  function resolveReadyWaiters() {
+  function resolveReadyWaiters(ready: boolean) {
     const waiters = [...readyWaiters]
     readyWaiters.clear()
     for (const waiter of waiters) {
-      waiter()
+      waiter(ready)
     }
   }
 
-  function ensureReady(): Promise<void> {
+  // Resolves true once the transport is ready. Resolves false when the
+  // connection is disposed or enters a terminal failure first, so callers
+  // holding the initialize mutex do not hang across an unmount (#2313
+  // review) and can simply skip the work they were waiting to do.
+  function ensureReady(): Promise<boolean> {
     if (client.value?.isReady) {
-      return Promise.resolve()
+      return Promise.resolve(true)
     }
-    return new Promise<void>((resolve) => {
+    return new Promise<boolean>((resolve) => {
       readyWaiters.add(resolve)
     })
   }
@@ -383,6 +387,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
   function dispose() {
     connectionAttempt += 1
     connectionIdentity = null
+    resolveReadyWaiters(false)
     flush()
     hasEverConnected.value = false
     connected.value = false

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -187,6 +187,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
             // SDK entered terminal state (auth terminal / retries exhausted / autoReconnect disabled).
             connected.value = false
             initializing.value = null
+            resolveReadyWaiters()
             console.warn('WebSocket server connection failed')
           }
         },
@@ -200,6 +201,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
           connected.value = true
           flush()
           initializeListeners()
+          resolveReadyWaiters()
 
           if (isReconnect) {
             for (const callback of reconnectedCallbacks) {
@@ -245,6 +247,31 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     if (!connected.value) {
       return await initialize()
     }
+  }
+
+  // #2305: `module:authenticated` is delivered during the transport's prepare
+  // phase, so `ensureConnected()` resolving there is NOT a guarantee that
+  // `Client.send()` will accept anything — better-ws requires state `ready`.
+  // Callers whose messages must not be silently dropped (the consumer-group
+  // registration is the load-bearing one: losing it makes the runtime drop
+  // every `input:*` until the next reconnect) await this instead.
+  const readyWaiters = new Set<() => void>()
+
+  function resolveReadyWaiters() {
+    const waiters = [...readyWaiters]
+    readyWaiters.clear()
+    for (const waiter of waiters) {
+      waiter()
+    }
+  }
+
+  function ensureReady(): Promise<void> {
+    if (client.value?.isReady) {
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      readyWaiters.add(resolve)
+    })
   }
 
   function clearListeners() {
@@ -312,11 +339,17 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
 
   function flush() {
     if (client.value && connected.value) {
+      // Keep whatever the transport refused (it returns false outside the
+      // `ready` state) so a later flush — e.g. the one `onReady` runs —
+      // retries it instead of the message being dropped (#2305).
+      const unsent: WebSocketEvent[] = []
       for (const update of pendingSend.value) {
-        client.value.send(update)
+        if (!client.value.send(update)) {
+          unsent.push(update)
+        }
       }
 
-      pendingSend.value = []
+      pendingSend.value = unsent
     }
   }
 
@@ -382,6 +415,7 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     websocketAuthToken,
     websocketUrl,
     ensureConnected,
+    ensureReady,
 
     initialize,
     send,

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.contract.browser.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.contract.browser.test.ts
@@ -22,6 +22,7 @@ const resetStreamMock = vi.fn()
 const refreshSessionMock = vi.fn()
 const serverSendMock = vi.fn()
 const ensureConnectedMock = vi.fn().mockResolvedValue(undefined)
+const ensureReadyMock = vi.fn().mockResolvedValue(true)
 const onReconnectedMock = vi.fn(() => () => {})
 const onContextUpdateMock = vi.fn((callback: HookCallback) => registerHook(contextUpdateHooks, callback))
 const onEventMock = vi.fn((eventName: string, callback: HookCallback) => registerServerEventHook(eventName, callback))
@@ -277,6 +278,7 @@ vi.mock('../../providers/provider', () => ({
 vi.mock('./channel-server', () => ({
   useModsServerChannelStore: () => ({
     ensureConnected: ensureConnectedMock,
+    ensureReady: ensureReadyMock,
     onReconnected: onReconnectedMock,
     onContextUpdate: onContextUpdateMock,
     onEvent: onEventMock,
@@ -285,6 +287,27 @@ vi.mock('./channel-server', () => ({
 }))
 
 describe('context bridge contract', () => {
+  it('skips consumer registration when the ready wait reports the connection went away (#2313)', async () => {
+    ensureReadyMock.mockResolvedValue(false)
+    await useContextBridgeStore().initialize()
+    await Promise.resolve()
+
+    const registrations = serverSendMock.mock.calls.filter(
+      call => call[0]?.type === 'module:consumer:register',
+    )
+    expect(registrations).toEqual([])
+  })
+
+  it('registers consumers once the ready wait reports the transport is ready (#2313)', async () => {
+    await useContextBridgeStore().initialize()
+    await Promise.resolve()
+
+    const registrations = serverSendMock.mock.calls.filter(
+      call => call[0]?.type === 'module:consumer:register',
+    )
+    expect(registrations.length).toBe(3)
+  })
+
   beforeEach(async () => {
     setActivePinia(createPinia())
     ;({ useContextBridgeStore } = await import('./context-bridge'))
@@ -298,6 +321,8 @@ describe('context bridge contract', () => {
     serverSendMock.mockReset()
     ensureConnectedMock.mockClear()
     ensureConnectedMock.mockResolvedValue(undefined)
+    ensureReadyMock.mockClear()
+    ensureReadyMock.mockResolvedValue(true)
     onReconnectedMock.mockClear()
     onContextUpdateMock.mockClear()
     onEventMock.mockClear()

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.ts
@@ -447,6 +447,10 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
       }
 
       await serverChannelStore.ensureConnected()
+      // #2305: authenticated lands in the transport's prepare phase; the
+      // registration only sticks once the transport is ready, or the runtime
+      // drops every external input:* until the stage reconnects.
+      await serverChannelStore.ensureReady()
 
       registerConsumers()
       disposeHookFns.value.push(serverChannelStore.onReconnected(() => registerConsumers()))

--- a/packages/stage-ui/src/stores/mods/api/context-bridge.ts
+++ b/packages/stage-ui/src/stores/mods/api/context-bridge.ts
@@ -449,8 +449,12 @@ export const useContextBridgeStore = defineStore('mods:api:context-bridge', () =
       await serverChannelStore.ensureConnected()
       // #2305: authenticated lands in the transport's prepare phase; the
       // registration only sticks once the transport is ready, or the runtime
-      // drops every external input:* until the stage reconnects.
-      await serverChannelStore.ensureReady()
+      // drops every external input:* until the stage reconnects. A `false`
+      // resolution means the connection went away (dispose/terminal failure)
+      // — skip the registration rather than send into a disposed store.
+      if (!await serverChannelStore.ensureReady()) {
+        return
+      }
 
       registerConsumers()
       disposeHookFns.value.push(serverChannelStore.onReconnected(() => registerConsumers()))


### PR DESCRIPTION
Closes #2305.

## The drop, per the issue's diagnosis (which my fix follows)

`module:authenticated` is delivered during the better-ws **prepare phase**. The consumer registration that runs right after `ensureConnected()` therefore sent while the transport was still `preparing`: `Client.send()` returned `false`, nobody checked, and the store marked itself `initialized`. Until the stage's first reconnect, the runtime dropped every external `input:*` with `no consumer registered for event delivery`. The queued path lost the same way: `flush()` cleared `pendingSend` unconditionally, even for messages the transport refused.

## Fix 1 — `ensureReady()`

The store gains `ensureReady()`: resolves once the SDK reports **ready**, or when the connection enters a terminal `failed` state (so callers retry via `ensureConnected()` instead of hanging). The consumer registration in `context-bridge.ts` now awaits it after `ensureConnected()`, so the three `chat-ingestion` registrations always land in a state the transport accepts. The `onReconnected` path already ran from `onReady` and is unchanged. I deliberately did **not** change when `initializing` resolves — five existing tests pin `authenticated ⇒ initialize() resolves` as the first-connect contract; `ensureReady` is the narrower primitive exactly the messages-that-must-not-drop need.

## Fix 2 — lossless `flush()`

`flush()` now keeps messages the transport refused (it returns `false` outside `ready`) instead of dropping them, so a ready-flush that races a not-yet-ready transport retries on the next one. This is the belt for the issue's second loss route.

## Tests

Two additions to the `channel-server` reconnect suite:

1. `ensureReady()` stays pending across `module:authenticated` and resolves exactly on ready;
2. a message queued behind a refusing transport survives the flush that could not send it, and the next ready-flush delivers it exactly once (with the earlier registration already delivered, asserted in order).

Suite: **15/15 green** locally (`vitest run src/stores/mods/api/channel-server.test.ts` from `packages/stage-ui`); eslint clean on all three touched files. The `context-bridge-performance-call` suite fails to resolve `@proj-airi/pipelines-audio` identically with my changes stashed — a local workspace-build artifact, not a regression.