### PR TITLE
fix(plugin-sdk-tamagotchi): allow nullable enum tool parameters

### DIFF
--- a/packages/plugin-sdk-tamagotchi/src/index.test.ts
+++ b/packages/plugin-sdk-tamagotchi/src/index.test.ts
@@ -10,7 +10,7 @@ import type { HostDataRecord } from '@proj-airi/plugin-sdk/plugin-host'
 import type { ToolKitRuntime } from './tools'
 
 import { DisposableStore } from '@proj-airi/plugin-sdk'
-import { object, optional, string } from 'valibot'
+import { object, optional, picklist, string } from 'valibot'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -729,6 +729,38 @@ describe('plugin-sdk-tamagotchi', () => {
 
     expect(parameters.required).toEqual(['mode', 'opening'])
     expect(parameters.properties.opening.type).toEqual(['string', 'null'])
+  })
+
+  // ROOT CAUSE:
+  //
+  // The normalizer added null to an optional enum but kept type: "string".
+  // OpenAI rejected the schema because null does not satisfy the string type.
+  // The fix must allow null in both type and enum.
+  it('serializes optional enum tool fields as nullable enum properties', async () => {
+    const registerTool = vi.fn()
+    const tools = toolKit.createClient(createToolRuntime({
+      extensionId: 'airi-extension-chess',
+      sessionId: 'session-1',
+      moduleId: 'chess',
+      register: registerTool,
+      registerToolsetPrompt: vi.fn(),
+    }))
+
+    await tools.registerTool({
+      id: 'play_chess',
+      title: 'placeholder-title',
+      description: 'placeholder-description',
+      inputSchema: object({
+        airiSide: optional(picklist(['white', 'black'])),
+      }),
+      execute: async () => ({ ok: true }),
+    })
+
+    const parameters = registerTool.mock.calls[0]?.[0].tool.parameters
+
+    expect(parameters.required).toEqual(['airiSide'])
+    expect(parameters.properties.airiSide.type).toEqual(['string', 'null'])
+    expect(parameters.properties.airiSide.enum).toEqual(['white', 'black', null])
   })
 
   /**

--- a/packages/plugin-sdk-tamagotchi/src/tools/index.ts
+++ b/packages/plugin-sdk-tamagotchi/src/tools/index.ts
@@ -171,7 +171,6 @@ function withNullableValue(schema: JsonSchema): JsonSchema {
 
   if (Array.isArray(next.enum)) {
     next.enum = next.enum.includes(null) ? next.enum : [...next.enum, null]
-    return next
   }
 
   if (Array.isArray(next.type)) {
@@ -181,6 +180,11 @@ function withNullableValue(schema: JsonSchema): JsonSchema {
 
   if (typeof next.type === 'string') {
     next.type = next.type === 'null' ? next.type : [next.type, 'null']
+    return next
+  }
+
+  // An enum without a type already accepts every enum value, including null.
+  if (Array.isArray(next.enum)) {
     return next
   }
 


### PR DESCRIPTION
## Summary

- Allow `null` in the JSON Schema type when optional enum tool fields are normalized.
- Add a regression test for optional enum parameters such as `airiSide`.

## Verification

- `pnpm exec vitest run packages/plugin-sdk-tamagotchi/src/index.test.ts` — 16 tests passed.
- `pnpm -F @proj-airi/plugin-sdk-tamagotchi typecheck` — passed.
- `pnpm exec eslint packages/plugin-sdk-tamagotchi/src/tools/index.ts packages/plugin-sdk-tamagotchi/src/index.test.ts` — passed.
- Full typecheck remains blocked by an unrelated error in `packages/core-agent/src/runtime/llm-service.ts:204`.
- Full lint remains blocked by unrelated key-order errors in the existing `pnpm-workspace.yaml` changes.