### PR TITLE
fix(stage-ui): render LaTeX fences as formulas

### DIFF
--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -200,6 +200,7 @@
     "@types/culori": "catalog:",
     "@types/d3": "catalog:",
     "@types/hast": "catalog:",
+    "@types/mdast": "catalog:",
     "@types/splitpanes": "catalog:",
     "@types/unist": "catalog:",
     "@types/ws": "catalog:",

--- a/packages/stage-ui/src/composables/markdown.test.ts
+++ b/packages/stage-ui/src/composables/markdown.test.ts
@@ -30,6 +30,48 @@ describe('useMarkdown', () => {
     expect(html).toContain('<annotation encoding="application/x-tex">\\frac{d}{dx}(e^x)=e^x')
   })
 
+  // https://github.com/moeru-ai/airi/pull/2326#discussion_r3812060520
+  it('preserves a multiline LaTeX environment as one display formula', async () => {
+    // ROOT CAUSE:
+    //
+    // Splitting every physical line separates the begin and end commands from
+    // their environment, so KaTeX receives unmatched fragments.
+    const markdown = [
+      '```latex',
+      String.raw`\begin{aligned}`,
+      String.raw`f(x) &= x^2 \\`,
+      String.raw`f'(x) &= 2x`,
+      String.raw`\end{aligned}`,
+      '```',
+    ].join('\n')
+
+    const html = await useMarkdown().process(markdown)
+
+    expect(html.match(/<math/g) ?? []).toHaveLength(1)
+    expect(html).not.toContain('<merror')
+    expect(html).toContain('\\begin{aligned}')
+    expect(html).toContain('\\end{aligned}')
+  })
+
+  // https://github.com/moeru-ai/airi/pull/2326#discussion_r3812060520
+  it('preserves a fraction split across physical lines as one display formula', () => {
+    const markdown = [
+      '```latex',
+      String.raw`\frac{`,
+      '  a + b',
+      '}{',
+      '  c + d',
+      '}',
+      '```',
+    ].join('\n')
+
+    const html = useMarkdown().processSync(markdown)
+
+    expect(html.match(/<math/g) ?? []).toHaveLength(1)
+    expect(html).not.toContain('<merror')
+    expect(html).toContain('\\frac{\n  a + b\n}{\n  c + d\n}')
+  })
+
   // https://github.com/moeru-ai/airi/discussions/2239
   it('treats a tex fence as display math (Issue #2239)', async () => {
     const markdown = [

--- a/packages/stage-ui/src/composables/markdown.test.ts
+++ b/packages/stage-ui/src/composables/markdown.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { useMarkdown } from './markdown'
+
+describe('useMarkdown', () => {
+  // https://github.com/moeru-ai/airi/discussions/2239
+  it('renders each LaTeX fence line as display math (Issue #2239)', async () => {
+    // ROOT CAUSE:
+    //
+    // LaTeX fences are parsed as source code, so Shiki highlights commands
+    // instead of sending equations to KaTeX. Treating the whole fence as one
+    // math block would also join separate equations on the same line.
+    const markdown = [
+      '```latex',
+      String.raw`\frac{d}{dx}(c)=0`,
+      String.raw`\frac{d}{dx}(x^n)=n x^{n-1}`,
+      String.raw`\frac{d}{dx}(e^x)=e^x`,
+      '```',
+    ].join('\n')
+
+    const { process, processSync } = useMarkdown()
+    const initialHtml = processSync(markdown)
+    const html = await process(markdown)
+
+    expect(initialHtml.match(/<math/g) ?? []).toHaveLength(3)
+    expect(html).not.toContain('class="shiki')
+    expect(html.match(/<math/g) ?? []).toHaveLength(3)
+    expect(html).toContain('<annotation encoding="application/x-tex">\\frac{d}{dx}(c)=0')
+    expect(html).toContain('<annotation encoding="application/x-tex">\\frac{d}{dx}(x^n)=n x^{n-1}')
+    expect(html).toContain('<annotation encoding="application/x-tex">\\frac{d}{dx}(e^x)=e^x')
+  })
+
+  // https://github.com/moeru-ai/airi/discussions/2239
+  it('treats a tex fence as display math (Issue #2239)', async () => {
+    const markdown = [
+      '```tex',
+      String.raw`\int c\,dx = cx + C`,
+      '```',
+    ].join('\n')
+
+    const html = await useMarkdown().process(markdown)
+
+    expect(html).toContain('<math')
+    expect(html).toContain('<annotation encoding="application/x-tex">\\int c\\,dx = cx + C')
+  })
+
+  // https://github.com/moeru-ai/airi/discussions/2239
+  it('keeps two currency amounts as text (Issue #2239)', () => {
+    // ROOT CAUSE:
+    //
+    // remark-math pairs the dollar sign before 5 with the dollar sign before
+    // 10, which turns the words between two prices into an inline equation.
+    const markdown = 'Price is $5 and cost is $10.'
+
+    const html = useMarkdown().processSync(markdown)
+
+    expect(html).toBe('<p>Price is $5 and cost is $10.</p>')
+    expect(html).not.toContain('<math')
+  })
+
+  it('keeps numeric-leading inline math', () => {
+    const html = useMarkdown().processSync('The result is $5 + x$.')
+
+    expect(html).toContain('<math')
+    expect(html).toContain('<annotation encoding="application/x-tex">5 + x</annotation>')
+  })
+
+  it('keeps numeric-leading inline math with trailing whitespace before prose', () => {
+    // ROOT CAUSE:
+    //
+    // A price-only check mistakes a numeric-leading equation for prose when
+    // the equation ends in whitespace and the next text starts with a digit.
+    const html = useMarkdown().processSync('The result is $5 + x $ 7 days later.')
+
+    expect(html).toContain('<math')
+    expect(html).toContain('<annotation encoding="application/x-tex">5 + x </annotation>')
+  })
+
+  it('keeps separate price formulas when both dollar signs close math', () => {
+    const html = useMarkdown().processSync('Values are $5$ and $10$.')
+
+    expect(html.match(/<math/g) ?? []).toHaveLength(2)
+  })
+})

--- a/packages/stage-ui/src/composables/markdown.ts
+++ b/packages/stage-ui/src/composables/markdown.ts
@@ -20,6 +20,37 @@ type MarkdownProcessor = Processor<any, any, any, any, string>
 const processorCache = new Map<string, Promise<MarkdownProcessor>>()
 const langRegex = /```(.{2,})\s/g
 
+function hasBalancedLatexGroups(value: string): boolean {
+  let depth = 0
+
+  for (let index = 0; index < value.length; index++) {
+    if (value[index] === '\\') {
+      index++
+      continue
+    }
+
+    if (value[index] === '{') {
+      depth++
+    }
+    else if (value[index] === '}') {
+      depth--
+      if (depth < 0)
+        return false
+    }
+  }
+
+  return depth === 0
+}
+
+function isIndependentEquationList(equations: string[]): boolean {
+  return equations.length > 1
+    && equations.every(equation => (
+      !/\\(?:begin|end)\s*\{/.test(equation)
+      && /=|\\(?:approx|cong|equiv|geq?|leq?|ne|neq|sim)\b/.test(equation)
+      && hasBalancedLatexGroups(equation)
+    ))
+}
+
 /**
  * Normalizes common chat output before Markdown becomes HTML.
  *
@@ -43,8 +74,12 @@ const remarkChatMath: Plugin<[], Root> = () => (tree, file) => {
       return
 
     // Chat models often put a list of independent equations in one LaTeX
-    // fence. Separate display nodes preserve the vertical list users expect.
-    const mathCodeNodes: RootContent[] = equations.map(value => ({
+    // fence. Only split positively identified equation lists; environments
+    // and expressions continued across physical lines must stay intact.
+    const mathValues = isIndependentEquationList(equations)
+      ? equations
+      : [node.value.trim()]
+    const mathCodeNodes: RootContent[] = mathValues.map(value => ({
       type: 'code',
       lang: 'math',
       meta: null,

--- a/packages/stage-ui/src/composables/markdown.ts
+++ b/packages/stage-ui/src/composables/markdown.ts
@@ -1,6 +1,7 @@
 import type { RehypeShikiOptions } from '@shikijs/rehype'
+import type { Root, RootContent } from 'mdast'
 import type { BundledLanguage } from 'shiki'
-import type { Processor } from 'unified'
+import type { Plugin, Processor } from 'unified'
 
 import rehypeShiki from '@shikijs/rehype'
 import rehypeKatex from 'rehype-katex'
@@ -11,12 +12,71 @@ import RemarkRehype from 'remark-rehype'
 
 import { defaultPerfTracer } from '@proj-airi/stage-shared'
 import { unified } from 'unified'
+import { SKIP, visit } from 'unist-util-visit'
 
 // Define a specific, compatible type for our processor to ensure type safety.
 type MarkdownProcessor = Processor<any, any, any, any, string>
 
 const processorCache = new Map<string, Promise<MarkdownProcessor>>()
 const langRegex = /```(.{2,})\s/g
+
+/**
+ * Normalizes common chat output before Markdown becomes HTML.
+ *
+ * @example
+ * A `latex` fence with two equation lines becomes two display-math nodes,
+ * while `Price is $5 and cost is $10` stays text.
+ */
+const remarkChatMath: Plugin<[], Root> = () => (tree, file) => {
+  const source = String(file)
+
+  visit(tree, 'code', (node, index, parent) => {
+    if (index === undefined || !parent || !['latex', 'tex'].includes(node.lang?.toLowerCase() ?? ''))
+      return
+
+    const equations = node.value
+      .split(/\r?\n/)
+      .map(equation => equation.trim())
+      .filter(Boolean)
+
+    if (equations.length === 0)
+      return
+
+    // Chat models often put a list of independent equations in one LaTeX
+    // fence. Separate display nodes preserve the vertical list users expect.
+    const mathCodeNodes: RootContent[] = equations.map(value => ({
+      type: 'code',
+      lang: 'math',
+      meta: null,
+      value,
+    }))
+
+    parent.children.splice(index, 1, ...mathCodeNodes)
+    return [SKIP, index + mathCodeNodes.length]
+  })
+
+  visit(tree, 'inlineMath', (node, index, parent) => {
+    if (index === undefined || !parent || !/\s$/.test(node.value))
+      return
+
+    const endOffset = node.position?.end.offset
+    // Requiring a multi-letter word separates price prose from single-letter
+    // variables in valid formulas such as `$5 + x $ 7`.
+    const startsWithAmountAndProse = /^\d[\d.,]*\s+\p{L}{2,}(?:\s|$)/u.test(node.value)
+    const followedByAmount = endOffset !== undefined && /^\s*\d/.test(source.slice(endOffset))
+
+    if (!startsWithAmountAndProse || !followedByAmount)
+      return
+
+    // remark-math pairs the dollar signs before two prices. Restore those
+    // delimiters as text without disabling valid single-dollar equations.
+    parent.children[index] = {
+      type: 'text',
+      value: `$${node.value}$`,
+      position: node.position,
+    }
+  })
+}
 
 function extractLangs(markdown: string): BundledLanguage[] {
   const matches = markdown.matchAll(langRegex)
@@ -62,6 +122,7 @@ async function createProcessor(langs: BundledLanguage[]): Promise<MarkdownProces
   return unified()
     .use(RemarkParse)
     .use(remarkMath)
+    .use(remarkChatMath)
     .use(RemarkRehype)
     .use(measuredKatex, { output: 'mathml' })
     .use(rehypeShiki, options)
@@ -84,6 +145,7 @@ export function useMarkdown() {
   const fallbackProcessor = unified()
     .use(RemarkParse)
     .use(remarkMath)
+    .use(remarkChatMath)
     .use(RemarkRehype)
     .use(measuredKatex, { output: 'mathml' })
     .use(RehypeStringify)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ catalogs:
     '@types/markdown-it':
       specifier: ^14.1.2
       version: 14.1.2
+    '@types/mdast':
+      specifier: ^4.0.4
+      version: 4.0.4
     '@types/node':
       specifier: ^24.12.2
       version: 24.12.2
@@ -4607,6 +4610,9 @@ importers:
       '@types/hast':
         specifier: 'catalog:'
         version: 3.0.4
+      '@types/mdast':
+        specifier: 'catalog:'
+        version: 4.0.4
       '@types/splitpanes':
         specifier: 'catalog:'
         version: 2.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -185,6 +185,7 @@ catalog:
   '@types/hast': ^3.0.4
   '@types/ioredis-mock': ^8.2.8
   '@types/markdown-it': ^14.1.2
+  '@types/mdast': ^4.0.4
   '@types/node': ^24.12.2
   '@types/nprogress': ^0.2.3
   '@types/pg': ^8.20.0


### PR DESCRIPTION
## Summary

- render each non-empty line in `latex` and `tex` fences as display math
- keep two currency amounts as text when `remark-math` pairs their dollar signs
- preserve valid single-dollar inline math and add regression coverage for both Markdown pipelines

Discussion: https://github.com/moeru-ai/airi/discussions/2239

## Visual changes

| Before | After |
| --- | --- |
| ![Before: LaTeX is shown as highlighted source and currency text is damaged](https://github.com/user-attachments/assets/90784e6b-6686-41af-a77c-c9b79d16df9b) | ![After: LaTeX is rendered as formulas and currency text is preserved](https://github.com/user-attachments/assets/5235179e-b6c9-4e39-9826-fd2c81da04ad) |
| The LaTeX fence is treated as source code, and the currency sentence loses its dollar signs. | Each equation is rendered separately, and the currency sentence stays intact. |

## Verification

- `pnpm -F @proj-airi/stage-ui exec vitest run --project node src/composables/markdown.test.ts` (6 passed)
- `pnpm -F @proj-airi/stage-ui exec vitest run --project browser` (29 passed)
- `pnpm -F @proj-airi/stage-ui typecheck`
- `pnpm lint` (0 errors; 7 existing warnings in unrelated files)
- `sem diff --staged --no-cosmetics -v --file-exts .ts .tsx` (no broken callers)
- OCR review (4/4 files, 0 findings)

## Existing local blockers

- `pnpm typecheck` reaches `apps/stage-web`, then fails because `vue-router/auto-routes` has no exported member `routes` in `apps/stage-web/src/main.ts`.
- The full `@proj-airi/stage-ui` suite reports 684 passing tests and 10 existing `localStorage.clear()` failures in this local Node environment; the browser project passes in full.
