### PR TITLE
fix(stage-ui): unify module settings panels

### DIFF
--- a/packages/stage-ui/src/components/modules/GamingMinecraft.vue
+++ b/packages/stage-ui/src/components/modules/GamingMinecraft.vue
@@ -54,7 +54,13 @@ onMounted(() => {
 </script>
 
 <template>
-  <div :class="['flex flex-col gap-6']">
+  <div
+    :class="[
+      'h-fit w-full',
+      'flex flex-col gap-4',
+      'rounded-xl bg-neutral-100 p-4 dark:bg-[rgba(0,0,0,0.3)]',
+    ]"
+  >
     <Callout :theme="statusTheme" :label="statusLabel">
       <div :class="['flex flex-col gap-2 text-sm']">
         <div>
@@ -63,8 +69,8 @@ onMounted(() => {
       </div>
     </Callout>
 
-    <div :class="['rounded-2xl border border-neutral-200 bg-neutral-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-900/50']">
-      <div :class="['mb-3 text-sm font-medium text-neutral-900 dark:text-neutral-100']">
+    <div :class="['flex flex-col gap-3']">
+      <div :class="['text-sm font-medium text-neutral-900 dark:text-neutral-100']">
         {{ t('settings.pages.modules.gaming-minecraft.setup.title') }}
       </div>
       <div :class="['flex flex-col gap-2 text-sm text-neutral-600 dark:text-neutral-300']">
@@ -73,8 +79,8 @@ onMounted(() => {
       </div>
     </div>
 
-    <div :class="['rounded-2xl border border-neutral-200 bg-neutral-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-900/50']">
-      <div :class="['mb-3 text-sm font-medium text-neutral-900 dark:text-neutral-100']">
+    <div :class="['flex flex-col gap-3']">
+      <div :class="['text-sm font-medium text-neutral-900 dark:text-neutral-100']">
         {{ t('settings.pages.modules.gaming-minecraft.runtime.title') }}
       </div>
       <div :class="['grid gap-3 text-sm text-neutral-600 dark:text-neutral-300']">
@@ -97,8 +103,8 @@ onMounted(() => {
       </div>
     </div>
 
-    <div :class="['rounded-2xl border border-neutral-200 bg-neutral-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-900/50']">
-      <div :class="['mb-3 text-sm font-medium text-neutral-900 dark:text-neutral-100']">
+    <div :class="['flex flex-col gap-3']">
+      <div :class="['text-sm font-medium text-neutral-900 dark:text-neutral-100']">
         {{ t('settings.pages.modules.gaming-minecraft.debug.title') }}
       </div>
       <div

--- a/packages/stage-ui/src/components/modules/WebSearch.vue
+++ b/packages/stage-ui/src/components/modules/WebSearch.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { FieldCheckbox, FieldInput } from '@proj-airi/ui'
+import { Callout, FieldCheckbox, FieldInput } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 
@@ -13,7 +13,13 @@ const { enabled, apiKey, configured } = storeToRefs(webSearchStore)
 </script>
 
 <template>
-  <div flex="~ col gap-6">
+  <div
+    :class="[
+      'h-fit w-full',
+      'flex flex-col gap-4',
+      'rounded-xl bg-neutral-100 p-4 dark:bg-[rgba(0,0,0,0.3)]',
+    ]"
+  >
     <FieldCheckbox
       v-model="enabled"
       :label="t('settings.pages.modules.web-search.enable')"
@@ -28,8 +34,10 @@ const { enabled, apiKey, configured } = storeToRefs(webSearchStore)
       :placeholder="t('settings.pages.modules.web-search.api-key-placeholder')"
     />
 
-    <div v-if="configured" class="rounded-lg bg-green-100 p-4 text-green-800 dark:bg-green-900 dark:text-green-100">
-      {{ t('settings.pages.modules.web-search.configured') }}
-    </div>
+    <Callout
+      v-if="configured"
+      theme="lime"
+      :label="t('settings.pages.modules.web-search.configured')"
+    />
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Give Web Search and Minecraft one shared settings surface.
- Use the standard rounded neutral panel in light and dark themes.
- Replace the Web Search status block with the shared `Callout` component.

## Verification

- `pnpm typecheck`
- `pnpm lint` (passes with seven existing warnings in unchanged files)
- `pnpm build:tamagotchi`
- Vishot: Web at 1440 × 900
- Vishot: Desktop at 1200 × 900
- Vishot: Pocket at 390 × 844

## Visual changes

Before and after images use the same route, theme, viewport, and fixture state.

### Web

| State | Before | After |
| --- | --- | --- |
| Web Search · Light | ![Web Web Search · Light before](https://github.com/user-attachments/assets/1490f6b3-f868-4b6c-847d-f8dce66d979c) | ![Web Web Search · Light after](https://github.com/user-attachments/assets/d8bb24e6-4b96-4485-b27e-83e0db602b99) |
| Minecraft · Light | ![Web Minecraft · Light before](https://github.com/user-attachments/assets/e2cee922-de8b-43d5-b68b-cf1eb05cf6cd) | ![Web Minecraft · Light after](https://github.com/user-attachments/assets/07db67b8-8646-48f1-8664-ebc486666d32) |
| Web Search · Dark | ![Web Web Search · Dark before](https://github.com/user-attachments/assets/991acbd1-75b8-48b8-898d-3478dffd863a) | ![Web Web Search · Dark after](https://github.com/user-attachments/assets/8645b515-9ec7-410a-bc4f-d394c9e2430b) |
| Minecraft · Dark | ![Web Minecraft · Dark before](https://github.com/user-attachments/assets/6ec68273-6e5b-4ef1-9fb3-8fe01fb9bfe4) | ![Web Minecraft · Dark after](https://github.com/user-attachments/assets/edf27bf1-f23e-4749-8394-9c7bbc066596) |

### Desktop (Electron)

| State | Before | After |
| --- | --- | --- |
| Web Search · Light | ![Desktop (Electron) Web Search · Light before](https://github.com/user-attachments/assets/845d3ef0-0879-4707-ad61-06742040229f) | ![Desktop (Electron) Web Search · Light after](https://github.com/user-attachments/assets/8ee194e9-ccfb-433a-bf12-f1338f859112) |
| Minecraft · Light | ![Desktop (Electron) Minecraft · Light before](https://github.com/user-attachments/assets/667538a2-477a-48c3-8646-65d8ad1e5adc) | ![Desktop (Electron) Minecraft · Light after](https://github.com/user-attachments/assets/2fec3dfa-fb4d-4cf5-9b35-51443d510ecc) |
| Web Search · Dark | ![Desktop (Electron) Web Search · Dark before](https://github.com/user-attachments/assets/26c7c4f1-393a-42f9-99bc-5e2cc7bed9bf) | ![Desktop (Electron) Web Search · Dark after](https://github.com/user-attachments/assets/092a0041-c2b8-4966-9563-639b5e093fc6) |
| Minecraft · Dark | ![Desktop (Electron) Minecraft · Dark before](https://github.com/user-attachments/assets/c6cc7995-5d40-4dd3-ad1d-4d6907ed4337) | ![Desktop (Electron) Minecraft · Dark after](https://github.com/user-attachments/assets/7e8f57a4-f454-4469-9dbf-515792d82ed0) |

### Pocket

| State | Before | After |
| --- | --- | --- |
| Web Search · Light | ![Pocket Web Search · Light before](https://github.com/user-attachments/assets/0f123bfd-626c-4cd6-a184-0384d231a0ab) | ![Pocket Web Search · Light after](https://github.com/user-attachments/assets/cfe2b782-dda5-405b-8ecd-973a69c10dfe) |
| Minecraft · Light | ![Pocket Minecraft · Light before](https://github.com/user-attachments/assets/e425f75a-ec2f-4279-8ce3-db7b785f2718) | ![Pocket Minecraft · Light after](https://github.com/user-attachments/assets/854d44cc-eab6-48c2-b325-6db2a18c9ddd) |
| Web Search · Dark | ![Pocket Web Search · Dark before](https://github.com/user-attachments/assets/48544488-61f0-4a63-8c71-06473a543735) | ![Pocket Web Search · Dark after](https://github.com/user-attachments/assets/32e4bb6e-6d43-4415-aca6-074a73116aca) |
| Minecraft · Dark | ![Pocket Minecraft · Dark before](https://github.com/user-attachments/assets/8fdb6857-49dc-4a65-8eda-1f8ff796a329) | ![Pocket Minecraft · Dark after](https://github.com/user-attachments/assets/c66af6c3-9575-47b6-bc62-840771f21f1c) |

