### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-DUNaQCCxioZ/kN8qNyrg3WqA/KcIn5dLvewxtEprcQE=
+sha256-pgTYXciy712WYkv5NY2mwFsuiCET2+jtQb7r8zBAGjE=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.