### PR TITLE
fix(stage-layouts): clarify active view controls

### DIFF
--- a/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
+++ b/packages/stage-layouts/src/components/Layouts/InteractiveArea/Actions/ViewControls.vue
@@ -2,7 +2,7 @@
 import { defaultControlConfig as threeCtrlConf, supportedControl as threeSupportedControl, useThreeViewControl } from '@proj-airi/stage-ui-three'
 import { defaultControlConfig as l2dCtrlConf, supportedControl as l2dSupportedCtrl, useL2dViewControl } from '@proj-airi/stage-ui/stores/live2d'
 import { useSettingsStageModel } from '@proj-airi/stage-ui/stores/settings/stage-model'
-import { GhostButton } from '@proj-airi/ui'
+import { Button } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 
@@ -32,12 +32,17 @@ function handleViewControlsToggle(targetMode: string) {
   <div w-full flex flex-1 items-center self-end justify-end gap-2>
     <Transition name="fade">
       <div v-if="controlEnabled?.enabled.value" w-full flex justify-between gap-2>
-        <GhostButton
-          v-for="control in controlEnabled.supported" :key="control"
-          :active="controlEnabled.mode.value === control" w-full @click="handleViewControlsToggle(control)"
+        <Button
+          v-for="control in controlEnabled.supported"
+          :key="control"
+          :aria-pressed="controlEnabled.mode.value === control"
+          :color="controlEnabled.mode.value === control ? 'primary' : 'neutral'"
+          variant="secondary"
+          block
+          @click="handleViewControlsToggle(control)"
         >
           {{ (controlEnabled.conf as any)[control].buttonText }}
-        </GhostButton>
+        </Button>
       </div>
     </Transition>
     <button


### PR DESCRIPTION
## Description

- Replace ghost view controls with secondary buttons.
- Use neutral buttons for inactive controls.
- Use a primary button for the active control.
- Expose the active control with `aria-pressed`.

## Linked Issues

None.

## Verification

- `pnpm typecheck`
  - Passed on the exact PR commit.
- `pnpm lint`
  - Finished with 0 errors and 7 existing warnings.
  - The command wrapper did not exit and was interrupted.
- Vishot captured Stage Web at 390 × 844 in dark mode.

## Visual changes

| Before | After |
| --- | --- |
| ![Ghost view controls](https://github.com/user-attachments/assets/5813e2e6-76ae-45ad-a97e-4ccc78b9f9c5) | ![Secondary view controls](https://github.com/user-attachments/assets/7678986c-6e98-4b5c-a0b2-430f76110802) |
| Stage Web mobile view controls | Stage Web mobile view controls |
