### PR TITLE
docs: correct setup and provider guidance

### DIFF
--- a/docs/content/en/docs/contributing/index.md
+++ b/docs/content/en/docs/contributing/index.md
@@ -13,9 +13,9 @@ This section is for contributors who want to change source code, documentation, 
 
 - [Git](https://git-scm.com/downloads)
 - [mise](https://mise.jdx.dev/installing-mise.html), or another version manager that reads `.tool-versions`
-- [Corepack](https://github.com/nodejs/corepack), which is included with recent Node.js releases
+- [Corepack](https://github.com/nodejs/corepack), which is included with the pinned Node.js 24.x release. Install it separately if you use Node.js 25 or later.
 
-The repository pins Node.js in [`.tool-versions`](https://github.com/moeru-ai/airi/blob/main/.tool-versions) (currently 24.13.0). Install that pinned version after cloning instead of relying on the version supplied by a system package manager.
+The repository pins Node.js in [`.tool-versions`](https://github.com/moeru-ai/airi/blob/main/.tool-versions) (currently 24.13.0). Install this version after you clone the repository. Do not use a different system version.
 
 <details>
 <summary>Windows setup</summary>
@@ -62,6 +62,12 @@ The repository pins Node.js in [`.tool-versions`](https://github.com/moeru-ai/ai
 ::: tip
 Skip this section if you have not cloned the repository yet.
 :::
+
+If the `upstream` remote is not configured, add the Project AIRI repository before you fetch changes:
+
+```shell
+git remote add upstream https://github.com/moeru-ai/airi.git
+```
 
 Fetch upstream changes and rebase your local `main` branch:
 
@@ -156,14 +162,6 @@ git push -u origin <your-branch-name>
 ```
 
 Your branch should now be available on GitHub.
-
-::: tip
-If this is your first contribution, add the Project AIRI repository as the `upstream` remote:
-
-```shell
-git remote add upstream https://github.com/moeru-ai/airi.git
-```
-:::
 
 ## Create a pull request
 

--- a/docs/content/en/docs/manual/config/common.md
+++ b/docs/content/en/docs/manual/config/common.md
@@ -22,7 +22,7 @@ Credentials and provider settings are saved in the current device's local settin
 | Field | Meaning | Guidance |
 | --- | --- | --- |
 | API Key | Access token issued by the provider | Paste the complete key without adding quotes or spaces. |
-| Base URL | Root URL of the provider API | Change it only when the provider's documentation requires another URL. Include the complete `https://` or `http://` address. |
+| Base URL | Root URL of the provider API | If the provider's documentation requires another URL, change it. Use `https://` for remote providers. Use `http://` only for trusted local services. A remote HTTP endpoint can expose API keys and request data. |
 | Model | Model ID used for chat, speech, or recognition | Prefer a model from AIRI's list. If the list cannot be loaded and the field accepts custom input, enter the exact ID from the provider's documentation. |
 | Voice | Voice ID used for speech synthesis | Select the model first, then select a voice supported by that model. |
 | Region | Deployment region used by some cloud services | Match the project or resource region shown in the provider console. |

--- a/docs/content/en/docs/manual/config/providers/consciousness/lm-studio.md
+++ b/docs/content/en/docs/manual/config/providers/consciousness/lm-studio.md
@@ -13,12 +13,18 @@ If you want to run the model locally and manage the model files yourself, LM Stu
 
 1. From the [LM Studio Download Page](https://lmstudio.ai/download) install and open LM Studio, then download and load a chat model.
 2. Open **Local Server** and start the local server.
-3. If AIRI cannot access local services, enable CORS in LM Studio's server settings.
+3. If AIRI and LM Studio run on different devices, enable **Serve on Local Network** in LM Studio, or bind the server to a non-loopback address.
+4. If AIRI runs on another device, use the LAN address of the LM Studio device in AIRI.
+5. If a browser blocks the request because of CORS, enable CORS in LM Studio. CORS does not provide network reachability or authentication.
+
+::: warning Network security
+Do not expose the LM Studio server to the public internet. Use it only on a trusted local network.
+:::
 
 ## Configure in AIRI
 
 1. Open **Settings → Providers → Chat → LM Studio**.
-2. Keep the default Base URL: `http://localhost:1234/v1/`.
+2. Keep the default Base URL: `http://localhost:1234/v1/`. For a service on another device, replace `localhost` with its LAN address.
 3. If your LM Studio service requires authentication, fill in the API Key; otherwise, leave it blank.
 
 ## Verify configuration
@@ -28,4 +34,4 @@ If you want to run the model locally and manage the model files yourself, LM Stu
 
 ## Troubleshooting
 
-When unable to connect, first confirm that the Local Server is running and the port is consistent with the Base URL. If AIRI and LM Studio are not on the same device, use a LAN address accessible from the AIRI device and only open the service on a trusted network.
+When AIRI cannot connect, make sure that the Local Server is running and that the port matches the Base URL. If AIRI and LM Studio run on different devices, use a LAN address that the AIRI device can reach.

--- a/docs/content/en/docs/manual/config/providers/transcription/comet-api.md
+++ b/docs/content/en/docs/manual/config/providers/transcription/comet-api.md
@@ -21,16 +21,17 @@ Do not commit the API key, include it in screenshots, or share it with anyone.
 ## Configure in AIRI
 
 1. Open **Settings → Providers → Transcription → Comet API** and fill in the API Key.
-2. Keep the default Base URL: `https://api.cometapi.com/v1/`; modify it only when using a proxy or compatible gateway.
+2. In **Model Name**, enter the exact model ID from the CometAPI model catalog, for example `whisper-1`.
+3. Keep the default Base URL: `https://api.cometapi.com/v1/`. Modify it only when using a proxy or compatible gateway.
 
 ## Verify configuration
 
-1. Select an available transcription model in the provider settings.
+1. Make sure that **Model Name** contains the exact model ID from the CometAPI model catalog.
 2. Use the playground on the same page, allow microphone access, and record a short sample to confirm that text is returned.
 
 ## Enable microphone transcription
 
-Open **Settings → Modules → Hearing**, select **Comet API** and an available model, then choose a microphone and run the Hearing test. Testing the provider page alone does not enable microphone transcription.
+Open **Settings → Modules → Hearing** and select **Comet API**. Make sure that the model matches **Model Name**, then choose a microphone and run the Hearing test. Testing the provider page alone does not enable microphone transcription.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

- Clarify the pinned Node.js and Corepack requirements, and define the `upstream` remote before it is used.
- Require HTTPS for remote providers and document safe LAN setup for LM Studio.
- Align CometAPI transcription instructions with the manual `Model Name` field.

## Linked Issues

Addresses documentation items 1–5 in #2297.

## Additional Context

The Korean pages need a later sync from the corrected English source.

Verification: `corepack pnpm --filter @proj-airi/docs typecheck` and `git diff --check`.
