### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-69tf/xbn9Uay//9Uw+ghhZgIWGvSoWq4/o0+Z5zHt3c=
+sha256-UVJAeNKkrbfyMUthZRTD2XPJ0bvkq2uQfQVLFXFzdNA=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.