### PR TITLE
fix(stage-ui): persist provider validation status

### DIFF
--- a/packages/stage-ui/src/composables/use-provider-validation.ts
+++ b/packages/stage-ui/src/composables/use-provider-validation.ts
@@ -116,6 +116,7 @@ export function useProviderValidation(providerId: string) {
         skipChatPingCheck: true,
       })
       isValid.value = validationResult.valid
+      providerStore.setProviderStatus(providerId, isValid.value ? 'configured' : 'invalid')
 
       if (!isValid.value) {
         finalValidationMessage = validationResult.reason
@@ -131,6 +132,7 @@ export function useProviderValidation(providerId: string) {
     }
     catch (error) {
       isValid.value = false
+      providerStore.setProviderStatus(providerId, 'invalid')
       finalValidationMessage = t('settings.dialogs.onboarding.validationError', {
         error: errorMessageFrom(error) ?? 'Generic error (993b5ad7)',
       })
@@ -206,6 +208,7 @@ export function useProviderValidation(providerId: string) {
     })
     if (!hasAnyCredential) {
       isValid.value = false
+      providerStore.setProviderStatus(providerId, 'unconfigured')
       validationMessage.value = ''
       isValidating.value = 0
       return


### PR DESCRIPTION
## Summary

- Persist the result of automatic provider validation in the provider config store.
- Mark failed validation as invalid and cleared credentials as unconfigured.
- Let validated transcription providers appear in Hearing settings across Electron windows.

## Visual changes

| Before | After |
|---|---|
| ![Hearing settings shows no configured transcription provider](https://github.com/user-attachments/assets/86f38176-4ac4-4eaa-82eb-ceca3be50f4e) | ![Hearing settings shows the validated OpenAI Compatible transcription provider](https://github.com/user-attachments/assets/6d08d3ac-8b00-453a-b1d6-22f9ee2ca6cc) |
| Hearing settings after provider validation | Hearing settings after provider validation |

## Verification

- `pnpm -F @proj-airi/stage-ui exec vitest run src/stores/providers/config.test.ts src/stores/providers/provider.test.ts --project node`
- `pnpm typecheck`
- `pnpm lint` (passes with 7 existing warnings)
- Reproduced in stage-tamagotchi with an isolated profile. Opened Settings from the Controls Island, validated an OpenAI-compatible transcription provider, and checked Hearing in the separate Settings window.
