### PR TITLE
fix(stage-ui): use validator from provider definition for validating

### DIFF
--- a/packages/stage-ui/src/composables/use-provider-validation.ts
+++ b/packages/stage-ui/src/composables/use-provider-validation.ts
@@ -197,16 +197,13 @@ export function useProviderValidation(providerId: string) {
     }
   }
 
-  const AUTH_FIELDS = ['apiKey', 'baseUrl', 'accountId', 'apiToken', 'accessToken'] as const
+  function shouldValidateConfiguration() {
+    const definition = providersStore.getProviderDefinition(providerId)
+    return definition.validationRequiredWhen?.(credentials.value) ?? false
+  }
 
   const debouncedValidateConfiguration = useDebounceFn(() => {
-    const config = credentials.value as Record<string, unknown>
-    // Only check auth credential fields — excludes config-only fields like region, endpoint
-    const hasAnyCredential = AUTH_FIELDS.some((field) => {
-      const v = config[field]
-      return v !== null && v !== undefined && String(v).trim() !== ''
-    })
-    if (!hasAnyCredential) {
+    if (!shouldValidateConfiguration()) {
       isValid.value = false
       providerStore.setProviderStatus(providerId, 'unconfigured')
       validationMessage.value = ''
@@ -218,11 +215,7 @@ export function useProviderValidation(providerId: string) {
 
   onMounted(() => {
     providersStore.initializeProvider(providerId)
-    const config = credentials.value as Record<string, unknown>
-    if (AUTH_FIELDS.some((field) => {
-      const v = config[field]
-      return v !== null && v !== undefined && String(v).trim() !== ''
-    })) {
+    if (shouldValidateConfiguration()) {
       validateConfiguration()
     }
   })

--- a/packages/stage-ui/src/libs/providers/providers/provider-definitions.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/provider-definitions.test.ts
@@ -3,6 +3,7 @@ import type { ComposerTranslation } from 'vue-i18n'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
+import { providerAliyunNlsTranscription } from './aliyun-nls'
 import { providerBrowserWebSpeechApi } from './browser-web-speech-api'
 import { providerElevenLabs } from './elevenlabs'
 import {
@@ -74,6 +75,26 @@ describe('migrated provider definitions', () => {
       streamOutput: false,
       streamInput: false,
     })
+  })
+
+  it('uses all Aliyun NLS credentials to require automatic validation', () => {
+    // ROOT CAUSE:
+    //
+    // The settings composable used a fixed list of common credential fields.
+    // This list did not include the three Aliyun NLS credential fields.
+    // The provider definition now owns the automatic validation condition.
+    expect(providerAliyunNlsTranscription.validationRequiredWhen?.({
+      accessKeyId: 'test-access-key-id',
+      accessKeySecret: 'test-access-key-secret',
+      appKey: '',
+      region: 'cn-shanghai',
+    })).toBe(false)
+    expect(providerAliyunNlsTranscription.validationRequiredWhen?.({
+      accessKeyId: 'test-access-key-id',
+      accessKeySecret: 'test-access-key-secret',
+      appKey: 'test-app-key',
+      region: 'cn-shanghai',
+    })).toBe(true)
   })
 
   it('keeps the local audio base URL validation in the definition', async () => {

--- a/packages/stage-ui/src/libs/providers/types.ts
+++ b/packages/stage-ui/src/libs/providers/types.ts
@@ -198,6 +198,12 @@ export interface ProviderDefinition<TConfig extends any = any> {
   onboardingFields?: (ctx: { t: ComposerTranslation }) => ProviderOnboardingField[]
   createProvider: (config: TConfig) => ProviderInstance
   extraMethods?: ProviderExtraMethods<TConfig>
+  /**
+   * Returns true when the configuration has enough input for automatic validation.
+   * Provider settings keep the status unconfigured while this function returns false.
+   *
+   * @default false
+   */
   validationRequiredWhen?: (config: TConfig) => boolean
   validators?: {
     validateConfig?: Array<(contextOptions: { t: ComposerTranslation }) => ProviderConfigValidator<TConfig>>


### PR DESCRIPTION
## Summary

- let each provider definition decide when automatic configuration validation should start
- validate Aliyun NLS after its Access Key ID, Access Key Secret, and App Key are complete
- keep the Aliyun NLS regression case in the existing provider definition test suite

## Verification

- `pnpm -F @proj-airi/stage-ui exec vitest run src/libs/providers/validators/run.test.ts src/libs/providers/providers/provider-definitions.test.ts --project node`
- `pnpm -F @proj-airi/stage-ui typecheck`
- `pnpm typecheck`
- `pnpm lint` (passes with 7 pre-existing warnings)
- Vishot Electron capture on the merge base and proposed HEAD at a 1200 × 900 viewport

## Visual changes

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/94d62526-f220-4559-8c54-5625e4516d24) | ![](https://github.com/user-attachments/assets/9d821010-59a2-4f48-9d85-b6cb7076ba0d) |
| Aliyun NLS: complete credentials remain unvalidated | Aliyun NLS: complete credentials validate automatically |
