### PR TITLE
fix(stage-ui): provider config lost after onboarding, causing OpenRouter 401s

### DIFF
--- a/packages/stage-ui/src/components/scenarios/dialogs/onboarding/onboarding.vue
+++ b/packages/stage-ui/src/components/scenarios/dialogs/onboarding/onboarding.vue
@@ -42,7 +42,7 @@ const { trackOnboardingCompleted, trackOnboardingStarted, trackOnboardingStepCom
 const providersStore = useProviderStore()
 
 const providerStore = useProviderConfigStore()
-const { configs: providers } = storeToRefs(providerStore)
+const { providers, addedProviders } = storeToRefs(providerStore)
 const { allChatProvidersMetadata } = storeToRefs(providersStore)
 const consciousnessStore = useConsciousnessStore()
 const {
@@ -104,12 +104,29 @@ async function saveProviderConfiguration(data: ProviderConfigData) {
     }
   }
 
-  providers.value[selectedProvider.value.id] = {
-    ...providers.value[selectedProvider.value.id],
-    ...config,
-  }
+  const providerId = selectedProvider.value.id
 
-  activeProvider.value = selectedProvider.value.id
+  // `ensureProvider`/`updateProviderConfig`/`markProviderAdded` are listed
+  // under this store's `synced.actions` (stores/providers/config.ts), which
+  // routes them through pinia-plugin-synced's leader-election RPC — even a
+  // same-window call lands asynchronously, with no promise this function can
+  // await to know it landed. Writing straight to the store's raw `providers`/
+  // `addedProviders` refs is a plain synchronous local mutation (the same
+  // thing those actions do once their round-trip completes), so the config
+  // is guaranteed to be in place before `loadModelsForProvider` reads it
+  // below instead of racing an in-flight sync proposal.
+  providers.value[providerId] = {
+    id: providerId,
+    definitionId: providers.value[providerId]?.definitionId ?? providerId,
+    config: {
+      ...providers.value[providerId]?.config,
+      ...config,
+    },
+    status: 'unconfigured',
+  }
+  addedProviders.value[providerId] = true
+
+  activeProvider.value = providerId
 
   await nextTick()
 

--- a/packages/stage-ui/src/libs/providers/validators/openai-compatible.test.ts
+++ b/packages/stage-ui/src/libs/providers/validators/openai-compatible.test.ts
@@ -128,6 +128,42 @@ describe('createOpenAICompatibleValidators', () => {
     expect(ids).not.toContain('openai-compatible:check-chat-completions')
   })
 
+  it('treats a 400 chat completions response as passing, matching xsai APICallError shape', async () => {
+    // ROOT CAUSE:
+    //
+    // extractStatusCode() only looked for the HTTP status under
+    // `error.cause.status` / `error.cause.statusCode` / `error.cause.response.status`.
+    // @xsai/shared's APICallError (thrown by generateText on a non-ok response)
+    // sets `statusCode` and `response` directly on the error instance instead —
+    // `error.cause` is unrelated (it's the Error `cause` option, unset here).
+    //
+    // Before the fix: extractStatusCode(apiCallError) always returned null, so
+    // the deliberate "a 400 means auth/connectivity are fine, the probe request
+    // was just malformed" heuristic in runChatCheck() never fired, and any
+    // provider returning 400 to the validation ping (e.g. OpenRouter rejecting
+    // `max_tokens: 1` for a model with a higher minimum) failed the whole
+    // chat-completions check even though the provider/key were working.
+    //
+    // Fixed by checking `error.statusCode` / `error.status` / `error.response.status`
+    // directly, before falling back to the `.cause`-nested variants.
+    listModelsMock.mockResolvedValue([{ id: 'some/model' }])
+
+    const response = new Response('{"error":{"message":"bad request"}}', { status: 400 })
+    const apiCallError = Object.assign(new Error('Remote sent 400 response'), {
+      statusCode: response.status,
+      response,
+    })
+    generateTextMock.mockRejectedValue(apiCallError)
+
+    const [, chatValidator] = getProviderValidators({
+      checks: [ProviderValidationCheck.Connectivity, ProviderValidationCheck.ChatCompletions],
+    })
+
+    const result = await chatValidator.validator(config, provider, providerExtra, { t: mockT })
+
+    expect(result.valid).toBe(true)
+  })
+
   it('normalizes the selected model id before chat probing', async () => {
     listModelsMock.mockResolvedValue([
       { id: 'byteplus/seed-2-0-pro-260328' },

--- a/packages/stage-ui/src/libs/providers/validators/openai-compatible.ts
+++ b/packages/stage-ui/src/libs/providers/validators/openai-compatible.ts
@@ -29,6 +29,9 @@ function extractStatusCode(error: unknown): number | null {
     return null
 
   const anyError = error as {
+    status?: unknown
+    statusCode?: unknown
+    response?: { status?: unknown }
     cause?: {
       status?: unknown
       statusCode?: unknown
@@ -37,6 +40,11 @@ function extractStatusCode(error: unknown): number | null {
   }
 
   const candidates = [
+    // xsai's APICallError (see @xsai/shared) sets these directly on the
+    // error instance, not under `.cause` — check them first.
+    anyError.statusCode,
+    anyError.status,
+    anyError.response?.status,
     anyError.cause?.status,
     anyError.cause?.statusCode,
     anyError.cause?.response?.status,


### PR DESCRIPTION
## Summary

Fixes OpenRouter (and other providers) failing to actually work after completing onboarding, even when validation appears to succeed and the API key is correct. Chat requests end up failing with a `401` auth error from the provider.

Two stacked bugs, both in the onboarding path:

1. **`extractStatusCode()` couldn't read xsai's error shape.** It only checked `error.cause.status` / `error.cause.statusCode` / `error.cause.response.status`, but `@xsai/shared`'s `APICallError` (thrown by `generateText` on a non-ok response) sets `statusCode` and `response` directly on the error instance — `error.cause` is unrelated. This meant the deliberate "a 400 on the validation ping means auth/connectivity are fine, the probe request was just malformed" heuristic in the chat-completions validator never fired. Any provider that rejects the lightweight 1-token validation ping with a 400 — for example OpenRouter enforcing a higher `max_tokens` minimum on certain models — failed the whole validation check even though the key and provider were working correctly.

2. **Provider config entered during onboarding was never actually persisted.** `saveProviderConfiguration()` in `onboarding.vue` wrote through `providerConfigStore.configs`, which is a read-only `computed` projection of the store's real `providers` state (`Object.fromEntries(...)` over the source ref). Mutating the object returned by that computed never reaches the underlying `useLocalStorage` ref, so the write was silently discarded. Routing the write through the store's own `ensureProvider`/`updateProviderConfig` actions doesn't fix it either — both are listed under this store's `synced.actions`, which routes them through `pinia-plugin-synced`'s leader-election RPC. Even a same-window call lands asynchronously with no promise the caller can await to know the write landed before reading the value back (confirmed via debug logging: `updateProviderConfig`'s `if (!provider) return` guard fires because the preceding `ensureProvider` call hadn't landed yet).

Net effect: onboarding *looked* successful — validation passed using the in-memory form data — but nothing was actually saved. The app was left with a provider marked active and no persisted credentials, so real chat requests went out with a missing/stale key and OpenRouter returned `401 User not found`.

## Fix

- `packages/stage-ui/src/libs/providers/validators/openai-compatible.ts`: `extractStatusCode()` now checks `error.statusCode` / `error.status` / `error.response?.status` directly, before falling back to the `.cause`-nested variants.
- `packages/stage-ui/src/components/scenarios/dialogs/onboarding/onboarding.vue`: `saveProviderConfiguration()` now writes straight to the store's raw `providers`/`addedProviders` refs — a plain synchronous local mutation, avoiding the async synced-action indirection — so the config is guaranteed to be in place before `loadModelsForProvider` reads it.

## Test plan

- [x] `pnpm -F @proj-airi/stage-ui exec vitest run src/libs/providers/validators/openai-compatible.test.ts` — 7/7 pass, including a new regression test reproducing the real `APICallError` shape.
- [x] `pnpm lint` on the changed files — clean.
- [x] Manually verified end-to-end in a real browser with a live (now-revoked) OpenRouter key:
  - Reproduced the original failure: onboarding validation failed with "Continue Anyway"/"Retry" before the validator fix.
  - After the validator fix, validation passed and reached model selection.
  - Before the persistence fix, `localStorage['settings/providers/configured']` stayed `{}` after completing onboarding with a working key — confirmed via direct inspection.
  - After the persistence fix, the entered API key correctly landed in `localStorage`.
  - Sent a real chat message through the app; the request went out with the correct model/key and got back a `200` with an actual assistant reply.

## Root cause verification

For the validator bug, confirmed `@xsai/shared`'s `APICallError` shape directly from `node_modules`:

```js
class APICallError extends XSAIError {
  constructor(message, options) {
    super(message, "api_call_error", options);
    ...
    this.statusCode = options.response.status;   // <- not under `.cause`
    ...
  }
}
```

For the persistence bug, added temporary debug logging to `saveProviderConfiguration()` and confirmed that immediately after `providersStore.initializeProvider(providerId)`, `providerStore.getProviderConfig(providerId)` still returned `undefined` — proving the synced-action write hadn't landed synchronously, and that `updateProviderConfig`'s existence guard was silently no-opping as a result.
