### PR TITLE
fix(stage-pages): make Web Speech API selectable as a transcription provider

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1459,6 +1459,9 @@ pages:
       browser-web-speech-api:
         description: Browser-native STT (requires Chrome/Edge/Safari)
         title: Web Speech API
+        disable: Disable
+        enable: Enable Web Speech API
+        enabled: Enabled — selectable in the Hearing module
       official:
         title: Official Provider
         description: Official AI provider by AIRI.

--- a/packages/stage-pages/src/pages/settings/providers/transcription/browser-web-speech-api.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/browser-web-speech-api.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { RemovableRef } from '@vueuse/core'
+
 import { errorMessageFromValue } from '@proj-airi/stage-shared'
 import {
   Alert,
@@ -9,6 +11,7 @@ import {
 } from '@proj-airi/stage-ui/components'
 import { selectProviderMetadata } from '@proj-airi/stage-ui/libs'
 import { streamWebSpeechAPITranscription } from '@proj-airi/stage-ui/libs/providers/providers/browser-web-speech-api'
+import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useProviderConfigStore } from '@proj-airi/stage-ui/stores/providers/config'
 import { useProviderStore } from '@proj-airi/stage-ui/stores/providers/provider'
 import { useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
@@ -24,86 +27,89 @@ const { t } = useI18n()
 const router = useRouter()
 
 const providersStore = useProviderStore()
-
 const providerStore = useProviderConfigStore()
-// `ensureProvider`/`markProviderAdded`/`forceProviderConfigured` are listed under
-// this store's `synced.actions`, which routes them through pinia-plugin-synced's
-// leader-election RPC. In a single-tab session that RPC can go unresolved
-// indefinitely (observed: the entry never landed after 10+ seconds), so this page
-// writes straight to the raw `providers`/`addedProviders` refs instead — the same
-// plain synchronous local mutation those actions perform once (if) their
-// round-trip completes.
-const { providers, addedProviders } = storeToRefs(providerStore)
+// `configs` is a per-provider *config* projection of the store's real `providers`
+// state. Once `ensureProviderEntry` below creates the entry, `configs.value[id]`
+// is a live reference to that entry's `config` object, so nested writes here
+// persist through the normal store — see speech-provider-settings.vue for the
+// same pattern.
+const { configs: providers } = storeToRefs(providerStore) as { configs: RemovableRef<Record<string, any>> }
+const hearingStore = useHearingStore()
+const { activeTranscriptionProvider } = storeToRefs(hearingStore)
 
-function ensureProviderEntry() {
-  if (!providers.value[providerId]) {
-    providers.value[providerId] = {
-      id: providerId,
-      definitionId: providerId,
-      config: { language: 'en-US', continuous: true, interimResults: true },
-      status: 'unconfigured',
-    }
+// `providersStore.initializeProvider`/`forceProviderConfigured` call this
+// store's own actions internally without awaiting them, so the effect is lost
+// across pinia-plugin-synced's leader-election RPC boundary — confirmed live:
+// the entry never landed, even awaited, when routed through those wrappers.
+// Calling this store's actions directly instead (each awaited) reliably
+// resolves in a few ms, so route provider changes through the elected leader
+// via the store itself rather than bypassing synchronization.
+async function ensureProviderEntry() {
+  if (!providerStore.getProvider(providerId)) {
+    await providerStore.ensureProvider(providerId, providerId, {
+      language: 'en-US',
+      continuous: true,
+      interimResults: true,
+    })
   }
-  return providers.value[providerId]
 }
-
-ensureProviderEntry()
 
 const providerMetadata = computed(() => selectProviderMetadata(
   providersStore.getProviderDefinition(providerId),
   t,
-  { id: providerId, configured: providers.value[providerId]?.status === 'configured' },
+  { id: providerId, configured: providerStore.getProvider(providerId)?.status === 'configured' },
 ))
 
 // Web Speech API settings (no API key needed, but language and options)
-interface WebSpeechApiSettings {
-  language: string
-  continuous: boolean
-  interimResults: boolean
-}
-
-const settings = computed<WebSpeechApiSettings>(() => {
-  const config = providers.value[providerId]?.config
-  return {
-    language: typeof config?.language === 'string' ? config.language : 'en-US',
-    continuous: typeof config?.continuous === 'boolean' ? config.continuous : true,
-    interimResults: typeof config?.interimResults === 'boolean' ? config.interimResults : true,
-  }
+const settings = computed({
+  get: () => providers.value[providerId] || {},
+  set: (value) => {
+    providers.value[providerId] = value
+  },
 })
 
 const language = computed({
-  get: () => settings.value.language,
-  set: (value: string) => {
-    ensureProviderEntry().config.language = value
+  get: () => settings.value?.language || 'en-US',
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].language = value
   },
 })
 
 const continuous = computed({
-  get: () => settings.value.continuous,
-  set: (value: boolean) => {
-    ensureProviderEntry().config.continuous = value
+  get: () => settings.value?.continuous ?? true,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].continuous = value
   },
 })
 
 const interimResults = computed({
-  get: () => settings.value.interimResults,
-  set: (value: boolean) => {
-    ensureProviderEntry().config.interimResults = value
+  get: () => settings.value?.interimResults ?? true,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].interimResults = value
   },
 })
 
-const isProviderEnabled = computed(() => providers.value[providerId]?.status === 'configured')
+const isProviderEnabled = computed(() => providerStore.getProvider(providerId)?.status === 'configured')
 
-function enableProvider() {
-  const provider = ensureProviderEntry()
-  provider.status = 'configured'
-  addedProviders.value[providerId] = true
+async function enableProvider() {
+  await ensureProviderEntry()
+  await providerStore.setProviderStatus(providerId, 'configured')
+  await providerStore.markProviderAdded(providerId)
 }
 
-function disableProvider() {
-  const provider = providers.value[providerId]
-  if (provider)
-    provider.status = 'unconfigured'
+async function disableProvider() {
+  await providerStore.setProviderStatus(providerId, 'unconfigured')
+  // Disabling while this provider is the active Hearing selection would
+  // otherwise leave it persisted as active — the pipeline only checks for a
+  // non-empty provider id, not whether it's still configured.
+  if (activeTranscriptionProvider.value === providerId)
+    activeTranscriptionProvider.value = ''
 }
 
 // Common language options for Web Speech API
@@ -123,7 +129,11 @@ const languageOptions = [
 ]
 
 function handleResetSettings() {
-  ensureProviderEntry().config = { language: 'en-US', continuous: true, interimResults: true }
+  providers.value[providerId] = {
+    language: 'en-US',
+    continuous: true,
+    interimResults: true,
+  }
 }
 
 // Check if Web Speech API is available
@@ -137,7 +147,7 @@ const { askPermission, stopStream, startStream } = settingsAudioDeviceStore
 const { audioInputOptions, selectedAudioInput, stream } = storeToRefs(settingsAudioDeviceStore)
 
 onMounted(async () => {
-  ensureProviderEntry()
+  await ensureProviderEntry()
   await askPermission()
 })
 
@@ -351,13 +361,13 @@ onUnmounted(() => {
         <Alert v-if="isWebSpeechAPIAvailable && isProviderEnabled" type="success">
           <template #title>
             <div class="w-full flex items-center justify-between">
-              <span>Enabled — selectable in the Hearing module</span>
+              <span>{{ t('settings.pages.providers.provider.browser-web-speech-api.enabled') }}</span>
               <button
                 type="button"
                 class="ml-2 rounded bg-green-100 px-2 py-0.5 text-xs text-green-700 font-medium transition-colors dark:bg-green-800/30 hover:bg-green-200 dark:text-green-300 dark:hover:bg-green-700/40"
                 @click="disableProvider"
               >
-                Disable
+                {{ t('settings.pages.providers.provider.browser-web-speech-api.disable') }}
               </button>
             </div>
           </template>
@@ -367,7 +377,7 @@ onUnmounted(() => {
           class="w-full"
           @click="enableProvider"
         >
-          Enable Web Speech API
+          {{ t('settings.pages.providers.provider.browser-web-speech-api.enable') }}
         </Button>
 
         <ProviderBasicSettings

--- a/packages/stage-pages/src/pages/settings/providers/transcription/browser-web-speech-api.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/browser-web-speech-api.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import type { RemovableRef } from '@vueuse/core'
-
 import { errorMessageFromValue } from '@proj-airi/stage-shared'
 import {
   Alert,
@@ -28,50 +26,85 @@ const router = useRouter()
 const providersStore = useProviderStore()
 
 const providerStore = useProviderConfigStore()
-const { configs: providers } = storeToRefs(providerStore) as { configs: RemovableRef<Record<string, any>> }
+// `ensureProvider`/`markProviderAdded`/`forceProviderConfigured` are listed under
+// this store's `synced.actions`, which routes them through pinia-plugin-synced's
+// leader-election RPC. In a single-tab session that RPC can go unresolved
+// indefinitely (observed: the entry never landed after 10+ seconds), so this page
+// writes straight to the raw `providers`/`addedProviders` refs instead — the same
+// plain synchronous local mutation those actions perform once (if) their
+// round-trip completes.
+const { providers, addedProviders } = storeToRefs(providerStore)
 
-providersStore.initializeProvider(providerId)
+function ensureProviderEntry() {
+  if (!providers.value[providerId]) {
+    providers.value[providerId] = {
+      id: providerId,
+      definitionId: providerId,
+      config: { language: 'en-US', continuous: true, interimResults: true },
+      status: 'unconfigured',
+    }
+  }
+  return providers.value[providerId]
+}
+
+ensureProviderEntry()
 
 const providerMetadata = computed(() => selectProviderMetadata(
   providersStore.getProviderDefinition(providerId),
   t,
-  { id: providerId },
+  { id: providerId, configured: providers.value[providerId]?.status === 'configured' },
 ))
 
 // Web Speech API settings (no API key needed, but language and options)
-const settings = computed({
-  get: () => providers.value[providerId] || {},
-  set: (value) => {
-    providers.value[providerId] = value
-  },
+interface WebSpeechApiSettings {
+  language: string
+  continuous: boolean
+  interimResults: boolean
+}
+
+const settings = computed<WebSpeechApiSettings>(() => {
+  const config = providers.value[providerId]?.config
+  return {
+    language: typeof config?.language === 'string' ? config.language : 'en-US',
+    continuous: typeof config?.continuous === 'boolean' ? config.continuous : true,
+    interimResults: typeof config?.interimResults === 'boolean' ? config.interimResults : true,
+  }
 })
 
 const language = computed({
-  get: () => settings.value?.language || 'en-US',
-  set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
-    providers.value[providerId].language = value
+  get: () => settings.value.language,
+  set: (value: string) => {
+    ensureProviderEntry().config.language = value
   },
 })
 
 const continuous = computed({
-  get: () => settings.value?.continuous ?? true,
-  set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
-    providers.value[providerId].continuous = value
+  get: () => settings.value.continuous,
+  set: (value: boolean) => {
+    ensureProviderEntry().config.continuous = value
   },
 })
 
 const interimResults = computed({
-  get: () => settings.value?.interimResults ?? true,
-  set: (value) => {
-    if (!providers.value[providerId])
-      providers.value[providerId] = {}
-    providers.value[providerId].interimResults = value
+  get: () => settings.value.interimResults,
+  set: (value: boolean) => {
+    ensureProviderEntry().config.interimResults = value
   },
 })
+
+const isProviderEnabled = computed(() => providers.value[providerId]?.status === 'configured')
+
+function enableProvider() {
+  const provider = ensureProviderEntry()
+  provider.status = 'configured'
+  addedProviders.value[providerId] = true
+}
+
+function disableProvider() {
+  const provider = providers.value[providerId]
+  if (provider)
+    provider.status = 'unconfigured'
+}
 
 // Common language options for Web Speech API
 const languageOptions = [
@@ -89,22 +122,8 @@ const languageOptions = [
   { label: 'Russian', value: 'ru-RU' },
 ]
 
-function ensureProviderSettings() {
-  if (!providers.value[providerId]) {
-    providers.value[providerId] = {
-      language: 'en-US',
-      continuous: true,
-      interimResults: true,
-    }
-  }
-}
-
 function handleResetSettings() {
-  providers.value[providerId] = {
-    language: 'en-US',
-    continuous: true,
-    interimResults: true,
-  }
+  ensureProviderEntry().config = { language: 'en-US', continuous: true, interimResults: true }
 }
 
 // Check if Web Speech API is available
@@ -118,7 +137,7 @@ const { askPermission, stopStream, startStream } = settingsAudioDeviceStore
 const { audioInputOptions, selectedAudioInput, stream } = storeToRefs(settingsAudioDeviceStore)
 
 onMounted(async () => {
-  ensureProviderSettings()
+  ensureProviderEntry()
   await askPermission()
 })
 
@@ -328,6 +347,28 @@ onUnmounted(() => {
             Web Speech API is a free, browser-native Speech-to-Text solution that requires no API keys or external services. It uses your browser's built-in speech recognition capabilities.
           </template>
         </Alert>
+
+        <Alert v-if="isWebSpeechAPIAvailable && isProviderEnabled" type="success">
+          <template #title>
+            <div class="w-full flex items-center justify-between">
+              <span>Enabled — selectable in the Hearing module</span>
+              <button
+                type="button"
+                class="ml-2 rounded bg-green-100 px-2 py-0.5 text-xs text-green-700 font-medium transition-colors dark:bg-green-800/30 hover:bg-green-200 dark:text-green-300 dark:hover:bg-green-700/40"
+                @click="disableProvider"
+              >
+                Disable
+              </button>
+            </div>
+          </template>
+        </Alert>
+        <Button
+          v-else-if="isWebSpeechAPIAvailable"
+          class="w-full"
+          @click="enableProvider"
+        >
+          Enable Web Speech API
+        </Button>
 
         <ProviderBasicSettings
           :title="t('settings.pages.providers.common.section.basic.title')"


### PR DESCRIPTION
## Summary

Web Speech API (Browser) could never be selected as a transcription provider in Settings > Hearing, even though its settings/test page implied it was ready to use.

Settings > Hearing filters selectable providers by `status === 'configured'` (`configuredTranscriptionProvidersMetadata` in `stores/providers/provider.ts`). Every other transcription provider page transitions that status via `useProviderValidation`/`providersStore.validateProvider` on successful validation, or via an explicit "Continue Anyway" bypass. `browser-web-speech-api.vue` never did either — it only let you tweak local settings (language/continuous/interim results) and run a local demo test, with no path that ever set `status`. So no matter how the page looked, the provider's status stayed `unconfigured` forever, and it could never appear in the Hearing module's provider list.

On top of that, this page's settings writes went through `storeToRefs(providerStore).configs` — a read-only `computed` projection of the store's real `providers` state, not the state itself. Mutating the object returned by that computed never reaches the underlying `useLocalStorage` ref.

I also confirmed the store's own `ensureProvider`/`markProviderAdded`/`forceProviderConfigured` actions aren't a reliable fix here either: they're listed under this store's `synced.actions`, which routes them through `pinia-plugin-synced`'s leader-election RPC. In a single-tab session I watched that RPC go unresolved indefinitely — the provider entry never landed even after 10+ seconds and user interaction.

## Fix

`packages/stage-pages/src/pages/settings/providers/transcription/browser-web-speech-api.vue`:
- Settings (language/continuous/interimResults) now write directly to the store's raw `providers` ref instead of the read-only `configs` computed.
- Added an explicit **"Enable Web Speech API"** button that sets `status: 'configured'` and marks the provider added — both via a plain synchronous mutation of the raw `providers`/`addedProviders` refs, bypassing the unreliable synced-action RPC layer.
- Added a status alert (with a "Disable" action) so it's clear when the provider is actually active and selectable elsewhere.

## Test plan

- [x] `pnpm lint` on the changed file — clean.
- [x] `vue-tsc --noEmit` on `packages/stage-pages` — no new errors.
- [x] Manually verified end-to-end in a real browser:
  - Before the fix: visited the page, entered settings, ran the test successfully — `localStorage['settings/providers/configured']` stayed `{}` regardless, and the provider never appeared on Settings > Hearing.
  - After the fix: clicking "Enable Web Speech API" immediately persists `status: 'configured'` to `localStorage`, the provider appears as a selectable radio card on Settings > Hearing, and selecting it correctly sets it as the active hearing provider with its model populated.
