### PR TITLE
fix(stage-ui): speech provider config never persisted or became selectable

### DIFF
--- a/packages/stage-ui/src/components/scenarios/providers/speech-provider-settings.vue
+++ b/packages/stage-ui/src/components/scenarios/providers/speech-provider-settings.vue
@@ -2,8 +2,6 @@
 import { useDebounceFn } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
 
 import ProviderSettingsLayout from './provider-settings-layout.vue'
 
@@ -13,11 +11,11 @@ import {
   ProviderBaseUrlInput,
   ProviderBasicSettings,
   ProviderSettingsContainer,
+  ProviderValidationAlerts,
 } from '.'
-import { selectProviderMetadata } from '../../../libs/providers/metadata'
+import { useProviderValidation } from '../../../composables/use-provider-validation'
 import { useSpeechStore } from '../../../stores/modules/speech'
 import { useProviderConfigStore } from '../../../stores/providers/config'
-import { useProviderStore } from '../../../stores/providers/provider'
 
 const props = defineProps<{
   providerId: string
@@ -35,17 +33,31 @@ defineSlots<{
   'advanced-settings': (props: any) => any
   'playground': (props: any) => any
 }>()
-const { t } = useI18n()
-const router = useRouter()
-const providersStore = useProviderStore()
 const providerStore = useProviderConfigStore()
 const speechStore = useSpeechStore()
 const { configs: providers } = storeToRefs(providerStore)
 
-const providerMetadata = computed(() => {
-  const definition = providersStore.getProviderDefinition(props.providerId)
-  return selectProviderMetadata(definition, t, { id: props.providerId })
-})
+// Nothing here previously transitioned this provider's status to
+// `configured`, so it could never appear as selectable on Settings > Speech
+// no matter what credentials were entered — same class of bug fixed for
+// Web Speech API's transcription page. useProviderValidation owns that
+// transition (auto-validation on credential change, plus the "Continue
+// Anyway" override), matching every chat/vision provider page already.
+const {
+  t,
+  router,
+  providerMetadata,
+  isValidating,
+  isValid,
+  validationMessage,
+  handleResetSettings: handleResetCredentials,
+  forceValid,
+  hasManualValidators,
+  isManualTesting,
+  manualTestPassed,
+  manualTestMessage,
+  runManualTest,
+} = useProviderValidation(props.providerId)
 
 // Common provider settings
 const apiKey = computed({
@@ -71,10 +83,9 @@ const baseUrl = computed({
 // Voice settings as reactive objects to allow for different provider settings
 const voiceSettings = ref<Record<string, any>>({})
 
-// Initialize voice settings with defaults or from provider
 function initializeVoiceSettings() {
   if (providers.value[props.providerId]?.voiceSettings) {
-    voiceSettings.value = { ...(providers.value[props.providerId].voiceSettings as Record<string, any> | undefined) }
+    voiceSettings.value = { ...(providers.value[props.providerId].voiceSettings as Record<string, any>) }
   }
   else {
     // Default values that most providers use
@@ -82,35 +93,40 @@ function initializeVoiceSettings() {
       pitch: 0,
       speed: 1.0,
       volume: 0,
-      // Provider-specific defaults can be set in the onMounted lifecycle
       ...props.additionalSettings,
     }
   }
 }
 
-onMounted(() => {
-  providersStore.initializeProvider(props.providerId)
+onMounted(async () => {
+  // useProviderValidation's own onMounted also ensures this entry, but hook
+  // order between composables and this component isn't something to rely
+  // on — ensureProvider is idempotent, so awaiting it here too guarantees
+  // the entry (and any previously saved voiceSettings) exists before reading it.
+  if (!providerStore.getProvider(props.providerId))
+    await providerStore.ensureProvider(props.providerId, props.providerId, {})
 
-  // Initialize refs with current values
-  apiKey.value = providers.value[props.providerId]?.apiKey as string | undefined || ''
-  baseUrl.value = providers.value[props.providerId]?.baseUrl as string | undefined || providerMetadata.value?.defaultConfig.baseUrl as string | undefined || ''
-
-  // Initialize voice settings
   initializeVoiceSettings()
 
-  // Load voices if provider is configured
-  if (providerStore.configuredProviders[props.providerId]) {
-    speechStore.loadVoicesForProvider(props.providerId)
-  }
+  if (providerStore.configuredProviders[props.providerId])
+    await speechStore.loadVoicesForProvider(props.providerId)
 })
 
 const debouncedUpdate = useDebounceFn(() => {
-  providers.value[props.providerId] = {
-    ...providers.value[props.providerId],
+  // `providers` (this store's `configs` projection) only persists nested
+  // mutations of an existing entry — assigning a whole new object to
+  // `providers.value[id]` replaces a property on the projection's own
+  // (read-only, recomputed) container, not the store's real state, so it
+  // silently never saves. voiceSettings has no other write path, so this
+  // was the one thing on this page that never actually persisted.
+  if (!providers.value[props.providerId])
+    providers.value[props.providerId] = {}
+
+  Object.assign(providers.value[props.providerId], {
     apiKey: apiKey.value,
     baseUrl: baseUrl.value || providerMetadata.value?.defaultConfig.baseUrl || '',
     voiceSettings: { ...voiceSettings.value },
-  }
+  })
 }, 1000)
 
 // Watch all settings and update the provider configuration
@@ -120,6 +136,7 @@ watch([apiKey, baseUrl], debouncedUpdate)
 watch(voiceSettings, debouncedUpdate, { deep: true })
 
 function handleResetVoiceSettings() {
+  handleResetCredentials()
   voiceSettings.value = { ...(providerMetadata.value?.defaultConfig.voiceSettings as Record<string, unknown>) }
   debouncedUpdate()
 }
@@ -165,6 +182,19 @@ function handleResetVoiceSettings() {
           <!-- Slot for provider-specific advanced settings -->
           <slot name="advanced-settings" />
         </ProviderAdvancedSettings>
+
+        <ProviderValidationAlerts
+          :is-valid="isValid"
+          :is-validating="isValidating"
+          :validation-message="validationMessage"
+          :has-manual-validators="hasManualValidators"
+          :is-manual-testing="isManualTesting"
+          :manual-test-passed="manualTestPassed"
+          :manual-test-message="manualTestMessage"
+          :on-run-test="runManualTest"
+          :on-force-valid="forceValid"
+          :on-go-to-model-selection="() => router.push('/settings/modules/speech')"
+        />
       </ProviderSettingsContainer>
 
       <!-- Playground section -->

--- a/packages/stage-ui/src/composables/use-provider-validation.ts
+++ b/packages/stage-ui/src/composables/use-provider-validation.ts
@@ -213,8 +213,8 @@ export function useProviderValidation(providerId: string) {
     validateConfiguration()
   }, debounceTime)
 
-  onMounted(() => {
-    providersStore.initializeProvider(providerId)
+  onMounted(async () => {
+    await providersStore.initializeProvider(providerId)
     if (shouldValidateConfiguration()) {
       validateConfiguration()
     }
@@ -243,12 +243,12 @@ export function useProviderValidation(providerId: string) {
     manualTestMessage.value = ''
   }
 
-  function forceValid() {
+  async function forceValid() {
     isValid.value = true
     validationMessage.value = ''
     manualTestPassed.value = true
     manualTestMessage.value = ''
-    providersStore.forceProviderConfigured(providerId)
+    await providersStore.forceProviderConfigured(providerId)
   }
 
   return {

--- a/packages/stage-ui/src/libs/providers/providers/elevenlabs/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/elevenlabs/index.ts
@@ -88,7 +88,7 @@ export const providerElevenLabs = defineProvider<ElevenLabsConfig>({
     }),
   }),
   createProvider(config) {
-    return createUnElevenLabs(config.apiKey.trim(), config.baseUrl?.trim() ?? 'https://unspeech.hyp3r.link/v1/') as SpeechProviderWithExtraOptions<string, UnElevenLabsOptions>
+    return createUnElevenLabs((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? 'https://unspeech.hyp3r.link/v1/') as SpeechProviderWithExtraOptions<string, UnElevenLabsOptions>
   },
 
   validationRequiredWhen: config => Boolean(config.apiKey?.trim() && config.baseUrl?.trim()),
@@ -103,7 +103,7 @@ export const providerElevenLabs = defineProvider<ElevenLabsConfig>({
       deprecated: false,
     })),
     listVoices: async (config) => {
-      const provider = createUnElevenLabs(config.apiKey.trim(), config.baseUrl?.trim() ?? 'https://unspeech.hyp3r.link/v1/') as VoiceProviderWithExtraOptions<UnElevenLabsOptions>
+      const provider = createUnElevenLabs((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? 'https://unspeech.hyp3r.link/v1/') as VoiceProviderWithExtraOptions<UnElevenLabsOptions>
       const voices = await listVoices(toListVoicesOptions(provider))
       if (!Array.isArray(voices))
         return []

--- a/packages/stage-ui/src/libs/providers/providers/google-gemini-audio-speech/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/google-gemini-audio-speech/index.ts
@@ -123,7 +123,7 @@ export const providerGoogleGeminiAudioSpeech = defineProvider<GoogleGeminiSpeech
   iconColor: 'i-lobe-icons:gemini-color',
   createProviderConfig: () => googleGeminiSpeechConfigSchema,
   createProvider(config) {
-    const apiKey = config.apiKey.trim()
+    const apiKey = (config.apiKey ?? '').trim()
     const baseUrl = normalizeBaseUrl(config.baseUrl)
     return {
       speech: (model?: string, options?: Record<string, unknown>) => ({

--- a/packages/stage-ui/src/libs/providers/providers/minimax-speech/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/minimax-speech/index.ts
@@ -20,7 +20,7 @@ export const providerMinimaxSpeech = defineProvider<MinimaxSpeechConfig>({
   iconColor: 'i-lobe-icons:minimax-color',
   createProviderConfig: () => minimaxSpeechConfigSchema,
   createProvider(config) {
-    const apiKey = config.apiKey.trim()
+    const apiKey = (config.apiKey ?? '').trim()
     const baseUrl = (config.baseUrl || 'https://api.minimax.io').replace(/\/$/, '')
 
     return {

--- a/packages/stage-ui/src/libs/providers/providers/openai-audio/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/openai-audio/index.ts
@@ -44,7 +44,7 @@ function normalizeBaseUrl(baseUrl: string | undefined) {
 }
 
 function createAudioProvider(config: AudioConfig) {
-  return createOpenAI(config.apiKey.trim(), normalizeBaseUrl(config.baseUrl))
+  return createOpenAI((config.apiKey ?? '').trim(), normalizeBaseUrl(config.baseUrl))
 }
 
 function createTranscriptionProvider(config: AudioConfig) {

--- a/packages/stage-ui/src/libs/providers/providers/openrouter-audio-speech/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/openrouter-audio-speech/index.ts
@@ -133,7 +133,11 @@ export const providerOpenRouterAudioSpeech = defineProvider<OpenRouterAudioConfi
   icon: 'i-lobe-icons:openrouter',
   createProviderConfig: () => openRouterAudioConfigSchema,
   createProvider(config) {
-    const apiKey = config.apiKey.trim()
+    // `createProvider` also runs for model listing against a freshly-created,
+    // still-credential-less config (e.g. right after ensureProvider, before
+    // the user has entered a key), so apiKey isn't guaranteed to be a string
+    // here despite the schema requiring it once actually configured.
+    const apiKey = (config.apiKey ?? '').trim()
     const baseUrl = normalizeBaseUrl(config.baseUrl)
     return {
       speech: (model?: string) => {

--- a/packages/stage-ui/src/libs/providers/providers/unspeech/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/unspeech/index.ts
@@ -123,7 +123,7 @@ export const providerDeepgramTts = defineProvider<UnspeechConfig>({
   tasks: ['text-to-speech'],
   icon: 'i-simple-icons:deepgram',
   createProviderConfig: ({ t }) => createUnspeechConfigSchema(unspeechConfigSchema, t),
-  createProvider: config => createUnDeepgram(config.apiKey.trim(), config.baseUrl?.trim() ?? ''),
+  createProvider: config => createUnDeepgram((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? ''),
   validationRequiredWhen: config => Boolean(config.apiKey?.trim() && config.baseUrl?.trim()),
   validators: createUnspeechValidators('deepgram-tts'),
   extraMethods: {
@@ -133,7 +133,7 @@ export const providerDeepgramTts = defineProvider<UnspeechConfig>({
       { id: 'aura', name: 'Aura (Legacy)', provider: 'deepgram-tts', description: 'Original Aura model', deprecated: true },
     ],
     listVoices: async (config) => {
-      const provider = createUnDeepgram(config.apiKey.trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnDeepgramOptions>
+      const provider = createUnDeepgram((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnDeepgramOptions>
       const voices = await listVoices(toListVoicesOptions(provider))
       return voices.map(voice => ({
         id: voice.id,
@@ -156,13 +156,13 @@ export const providerMicrosoftSpeech = defineProvider<MicrosoftSpeechConfig>({
   tasks: ['text-to-speech'],
   iconColor: 'i-lobe-icons:microsoft',
   createProviderConfig: ({ t }) => createUnspeechConfigSchema(microsoftSpeechConfigSchema, t),
-  createProvider: config => createUnMicrosoft(config.apiKey.trim(), config.baseUrl?.trim() ?? ''),
+  createProvider: config => createUnMicrosoft((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? ''),
   validationRequiredWhen: config => Boolean(config.apiKey?.trim() && config.baseUrl?.trim()),
   validators: createUnspeechValidators('microsoft-speech'),
   extraMethods: {
     listModels: async () => [{ id: 'v1', name: 'v1', provider: 'microsoft-speech', description: '', deprecated: false }],
     listVoices: async (config) => {
-      const provider = createUnMicrosoft(config.apiKey.trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnMicrosoftOptions>
+      const provider = createUnMicrosoft((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnMicrosoftOptions>
       const voices = await listVoices(toListVoicesOptions(provider, { region: config.region ?? '' }))
       return voices.map(voice => ({
         id: voice.id,
@@ -185,7 +185,7 @@ export const providerAlibabaCloudModelStudio = defineProvider<UnspeechConfig>({
   tasks: ['text-to-speech'],
   iconColor: 'i-lobe-icons:alibabacloud',
   createProviderConfig: ({ t }) => createUnspeechConfigSchema(unspeechConfigSchema, t),
-  createProvider: config => createUnAlibabaCloud(config.apiKey.trim(), config.baseUrl?.trim() ?? ''),
+  createProvider: config => createUnAlibabaCloud((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? ''),
   validationRequiredWhen: config => Boolean(config.apiKey?.trim() && config.baseUrl?.trim()),
   validators: createUnspeechValidators('alibaba-cloud-model-studio'),
   extraMethods: {
@@ -194,7 +194,7 @@ export const providerAlibabaCloudModelStudio = defineProvider<UnspeechConfig>({
       { id: 'cosyvoice-v2', name: 'CosyVoice (New)', provider: 'alibaba-cloud-model-studio', description: '', deprecated: false },
     ],
     listVoices: async (config) => {
-      const provider = createUnAlibabaCloud(config.apiKey.trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnAlibabaCloudOptions>
+      const provider = createUnAlibabaCloud((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnAlibabaCloudOptions>
       const voices = await listVoices(toListVoicesOptions(provider))
       return voices.map(voice => ({
         id: voice.id,
@@ -218,13 +218,13 @@ export const providerVolcengineSpeech = defineProvider<VolcengineSpeechConfig>({
   tasks: ['text-to-speech'],
   iconColor: 'i-lobe-icons:volcengine',
   createProviderConfig: ({ t }) => createUnspeechConfigSchema(volcengineSpeechConfigSchema, t),
-  createProvider: config => createUnVolcengine(config.apiKey.trim(), config.baseUrl?.trim() ?? ''),
+  createProvider: config => createUnVolcengine((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? ''),
   validationRequiredWhen: config => Boolean(config.apiKey?.trim() && config.baseUrl?.trim() && config.app?.appId.trim()),
   validators: createUnspeechValidators<VolcengineSpeechConfig>('volcengine', true),
   extraMethods: {
     listModels: async () => [{ id: 'v1', name: 'v1', provider: 'volcano-engine', description: '', deprecated: false }],
     listVoices: async (config) => {
-      const provider = createUnVolcengine(config.apiKey.trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnVolcengineOptions>
+      const provider = createUnVolcengine((config.apiKey ?? '').trim(), config.baseUrl?.trim() ?? '') as VoiceProviderWithExtraOptions<UnVolcengineOptions>
       const voices = await listVoices(toListVoicesOptions(provider))
       return voices.map(voice => ({
         id: voice.id,

--- a/packages/stage-ui/src/stores/providers/config.ts
+++ b/packages/stage-ui/src/stores/providers/config.ts
@@ -5,7 +5,7 @@ import type { InferenceServiceProvider, ProviderValidationStatus } from '../../l
 import { useMutation, useQuery } from '@pinia/colada'
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { computed, toRaw } from 'vue'
 
 import { client } from '../../composables/api'
 import { getDefinedProvider } from '../../libs/providers'
@@ -107,8 +107,16 @@ export const useProviderConfigStore = defineStore('provider-config', () => {
 
   function ensureProvider(providerId: string, definitionId: string, config: Record<string, unknown> = {}) {
     const current = providers.value[providerId]
-    if (current)
-      return current
+    if (current) {
+      // `ensureProvider` is a synced action: its return value is
+      // structured-cloned back to the caller across the leader/follower
+      // BroadcastChannel. `current`, read live off the reactive `providers`
+      // ref, is a Vue Proxy — cloneable state values must be raw. Callers
+      // are expected to invoke this redundantly (see the idempotency
+      // requirement for synced actions), so this branch is hit routinely,
+      // not just on error paths.
+      return toRaw(current)
+    }
 
     const definition = getDefinedProvider(definitionId)
     if (!definition)
@@ -145,17 +153,20 @@ export const useProviderConfigStore = defineStore('provider-config', () => {
   }
 
   async function fetchProviders() {
+    // `fetchProviders` is a synced action: its return value is
+    // structured-cloned back to the caller across the leader/follower
+    // BroadcastChannel, so it cannot be the live reactive `providers` ref.
     try {
       const state = await providersQuery.refetch(true)
       if (state.data) {
         // The server snapshot has the highest priority for ids that exist remotely.
         mergeProviderSnapshot(state.data)
       }
-      return providers.value
+      return toRaw(providers.value)
     }
     catch {
       // The merged local snapshot is authoritative while the remote endpoint is unavailable.
-      return providers.value
+      return toRaw(providers.value)
     }
   }
 
@@ -198,9 +209,13 @@ export const useProviderConfigStore = defineStore('provider-config', () => {
     if (!provider)
       return
 
+    // `config` may come from a caller reading a reactive source (e.g.
+    // `getProviderConfig`), and a shallow spread doesn't unwrap nested
+    // reactive values within it. `localProvider` becomes this synced
+    // action's return value on the error path, so it must stay fully raw.
     const localProvider = {
-      ...provider,
-      config: { ...config },
+      ...toRaw(provider),
+      config: toRaw({ ...config }),
       status,
     }
     providers.value[providerId] = localProvider

--- a/packages/stage-ui/src/stores/providers/provider.ts
+++ b/packages/stage-ui/src/stores/providers/provider.ts
@@ -160,12 +160,12 @@ export const useProviderStore = defineStore('provider', () => {
     providerAvailabilityOverrides.value = { ...providerAvailabilityOverrides.value, [providerId]: available }
   }
 
-  function markProviderAdded(providerId: string) {
-    providerConfigStore.markProviderAdded(providerId)
+  async function markProviderAdded(providerId: string) {
+    await providerConfigStore.markProviderAdded(providerId)
   }
 
-  function unmarkProviderAdded(providerId: string) {
-    providerConfigStore.unmarkProviderAdded(providerId)
+  async function unmarkProviderAdded(providerId: string) {
+    await providerConfigStore.unmarkProviderAdded(providerId)
   }
 
   function findProviderDefinition(providerId: string) {
@@ -352,13 +352,27 @@ export const useProviderStore = defineStore('provider', () => {
     }
   }
 
-  // Initialize provider configurations
-  function initializeProvider(providerId: string) {
+  // Initialize provider configurations.
+  //
+  // `ensureProvider` is a synced action on the provider-config store — a
+  // separate leader-election Tab instance from this store's own. It must be
+  // awaited: this function is itself a synced action, and if it resolves
+  // before the nested call's RPC round-trip lands, the effect is silently
+  // dropped (confirmed live: calling providerConfigStore.ensureProvider
+  // directly and awaiting it lands in a few ms; calling it unawaited from
+  // inside another synced action never lands, even when the caller awaits
+  // this wrapper). stores/modules/default.ts already awaits this function,
+  // expecting it to complete before proceeding.
+  async function initializeProvider(providerId: string) {
+    // Independent of the config entry below — keep it synchronous so callers
+    // that don't (or, being pre-existing code, can't yet) await this function
+    // still get runtime state available immediately, as before.
+    initializeProviderRuntimeState(providerId)
+
     if (!providerCredentials.value[providerId]) {
       const definitionId = getProviderDefinitionId(providerId)
-      providerConfigStore.ensureProvider(providerId, definitionId, getDefaultProviderConfig(providerId))
+      await providerConfigStore.ensureProvider(providerId, definitionId, getDefaultProviderConfig(providerId))
     }
-    initializeProviderRuntimeState(providerId)
   }
 
   function stopRevalidationLoop(providerId: string) {
@@ -453,7 +467,7 @@ export const useProviderStore = defineStore('provider', () => {
     delete providerRuntimeState.value[providerId]
   }
 
-  function forceProviderConfigured(providerId: string) {
+  async function forceProviderConfigured(providerId: string) {
     if (providerRuntimeState.value[providerId]) {
       // Also cache the current config to prevent re-validation from overwriting
       const config = providerCredentials.value[providerId]
@@ -461,8 +475,10 @@ export const useProviderStore = defineStore('provider', () => {
         providerRuntimeState.value[providerId].validatedCredentialHash = JSON.stringify(config)
       }
     }
-    providerConfigStore.setProviderStatus(providerId, 'configured')
-    markProviderAdded(providerId)
+    // See initializeProvider's comment: these are synced actions on a
+    // different store and must be awaited or their effect is dropped.
+    await providerConfigStore.setProviderStatus(providerId, 'configured')
+    await markProviderAdded(providerId)
   }
 
   function setProviderUnconfigured(providerId: string) {


### PR DESCRIPTION
## Summary

No speech (text-to-speech) provider could ever be selected in Settings > Speech, and any config you entered for one (voice settings especially) could vanish after navigating away. Reported specifically against OpenRouter's speech provider, but the root cause is shared by every provider built on `speech-provider-settings.vue` — ElevenLabs, OpenAI, Google Gemini, Microsoft, Deepgram, Alibaba, Volcengine, MiniMax.

This ended up being three separate, stacked bugs, each only reachable once the one before it was fixed:

**1. Synced actions calling each other without awaiting (`provider.ts`)**

`initializeProvider`/`forceProviderConfigured` call `providerConfigStore`'s synced actions (`ensureProvider`, `setProviderStatus`, `markProviderAdded`) without awaiting them. Each synced store runs its own leader-election `Tab` instance (`pinia-plugin-synced`), so the outer call could resolve before the nested call's RPC round-trip landed — silently dropping the effect, even when the *outer* wrapper itself was awaited by its caller. `stores/modules/default.ts` already `await`s both functions, expecting them to complete, so this was already an implicit contract violation.

Confirmed live via the running Pinia instance: calling `providerConfigStore`'s actions directly and awaiting them lands in a few ms; calling them unawaited from inside another synced action never lands, regardless of whether the outer call is awaited.

**2. Synced actions returning non-cloneable values (`config.ts`)**

Fixing #1 meant these calls actually *complete* now — which surfaced a second, previously-unreachable bug: `ensureProvider`/`fetchProviders`/`updateProviderConfig` could return a live Vue reactive Proxy read straight off the `providers` ref. Synced-action return values get sent back through `postMessage` across the leader/follower `BroadcastChannel`, and a Proxy throws `DataCloneError: could not be cloned` there. This reproduced as an intermittent crash (raced on which of two concurrent `ensureProvider` calls hit the "already exists" branch) — reliably reproducible on a fresh page load before the fix, not reproducible in repeated testing after it. Fixed with `toRaw()` at the return sites, per `AGENTS.md`'s own documented contract ("action results must support structuredClone").

**3. `speech-provider-settings.vue` never validated or persisted correctly**

- Nothing in this component ever transitioned the provider's status to `configured` — no auto-validation, no manual "Continue Anyway" fallback. Settings > Speech only lists providers with `status === 'configured'`, so none could ever appear there no matter what credentials were entered. Fixed by wiring in `useProviderValidation`, the same composable chat/vision provider pages already use.
- `debouncedUpdate` wrote via `providers.value[id] = {...spread, apiKey, baseUrl, voiceSettings}` — a full reassignment through this store's `configs` projection, which only persists *nested* mutations of an existing entry. Assigning a whole new object just replaces a property on the projection's own read-only, recomputed container, not the store's real state — a silent no-op. `apiKey`/`baseUrl` already had separate, correctly-persisting nested-mutation setters, so credentials happened to survive independently, but `voiceSettings` had no other write path and was lost on every reload. Fixed by switching to `Object.assign` onto the existing entry.

**Bonus: unguarded `.trim()` crash surfaced by fixing #1 and #2**

`createProvider(config)` also runs for model/voice listing against a freshly-created, still-credential-less config (right after `ensureProvider`, before the user types a key). `config.apiKey.trim()` crashed on `undefined` in that case — previously masked because the config entry never actually existed when this code ran. Affects OpenRouter, ElevenLabs, Google Gemini, MiniMax, and the unspeech-based Deepgram/Microsoft/Alibaba/Volcengine providers. Guarded with `(config.apiKey ?? '').trim()`, matching the pattern already used elsewhere (e.g. `azure-openai`, `cloudflare-workers-ai`).

## Commits

1. `fix(stage-ui): make synced provider-store actions properly async` — the two `provider.ts`/`config.ts` root-cause fixes.
2. `fix(stage-ui): make speech provider settings actually persist and validate` — the actual user-facing fix.
3. `fix(stage-ui): guard speech providers against a not-yet-configured apiKey` — the surfaced `.trim()` crashes.

## Test plan

- [x] `pnpm lint` on all changed files — clean.
- [x] `vue-tsc --noEmit` on `packages/stage-ui` — no new errors.
- [x] `pnpm -F @proj-airi/stage-ui exec vitest run` — 691/691 tests pass (including tests that previously broke when `initializeProvider` stopped being synchronous, fixed by keeping runtime-state init synchronous and only awaiting the config-store call).
- [x] Manually verified end-to-end against `openrouter-audio-speech` on a clean dev server, repeated across multiple full server restarts and 15+ fresh page loads:
  - Before: the settings page either silently failed to persist anything, or crashed on load with a `DataCloneError`.
  - After: entering an API key transitions the provider to `configured`, it becomes selectable on Settings > Speech, and the full config — including `voiceSettings` — survives navigating away and back.
  - 6/6 clean loads on a fully fresh dev server restart with no crashes (vs. 3/3 reliably crashing before the `config.ts` fix).
