### PR TITLE
feat(stage-ui): add MiniMax voice design support

### DIFF
--- a/packages/stage-ui/src/libs/providers/providers/minimax-speech/index.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/minimax-speech/index.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { providerMinimaxSpeech } from './index'
+
+describe('miniMax voice design', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    ['https://api.minimax.io', 'https://api.minimax.io/v1/voice_design'],
+    ['https://api.minimaxi.com', 'https://api.minimaxi.com/v1/voice_design'],
+  ])('posts the design request to the %s endpoint', async (baseUrl, expectedUrl) => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      voice_id: 'custom-voice-1',
+      base_resp: { status_code: 0 },
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const config = { apiKey: 'test-key', baseUrl }
+    const provider = providerMinimaxSpeech.createProvider(config)
+    const result = await providerMinimaxSpeech.extraMethods?.designVoice?.(
+      config,
+      provider,
+      { prompt: 'A warm, calm narrator', voiceId: 'custom-voice-1' },
+    )
+
+    expect(result).toEqual({ voiceId: 'custom-voice-1' })
+    expect(fetchMock).toHaveBeenCalledWith(expectedUrl, expect.objectContaining({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer test-key',
+      },
+      body: JSON.stringify({ prompt: 'A warm, calm narrator', voice_id: 'custom-voice-1' }),
+    }))
+  })
+
+  it('rejects unsuccessful responses and missing voice ids', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      base_resp: { status_code: 1004, status_msg: 'invalid prompt' },
+    }), { status: 400, statusText: 'Bad Request' })))
+
+    const config = { apiKey: 'test-key', baseUrl: 'https://api.minimax.io' }
+    const provider = providerMinimaxSpeech.createProvider(config)
+    await expect(providerMinimaxSpeech.extraMethods?.designVoice?.(
+      config,
+      provider,
+      { prompt: 'prompt', voiceId: 'voice' },
+    )).rejects.toThrow('MiniMax voice design request failed')
+  })
+
+  it('advertises voice design in model metadata', async () => {
+    const models = await providerMinimaxSpeech.extraMethods?.listModels?.(
+      { apiKey: 'test-key', baseUrl: 'https://api.minimax.io' },
+      providerMinimaxSpeech.createProvider({ apiKey: 'test-key', baseUrl: 'https://api.minimax.io' }),
+    )
+
+    expect(models?.find(model => model.id === 'voice-design')).toMatchObject({
+      capabilities: ['voice-design'],
+    })
+  })
+})

--- a/packages/stage-ui/src/libs/providers/providers/minimax-speech/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/minimax-speech/index.ts
@@ -1,3 +1,5 @@
+import type { ProviderInstance, VoiceDesignInput, VoiceDesignResult } from '../../types'
+
 import { z } from 'zod'
 
 import { defineProvider } from '../registry'
@@ -9,30 +11,82 @@ const minimaxSpeechConfigSchema = z.object({
 
 type MinimaxSpeechConfig = z.input<typeof minimaxSpeechConfigSchema>
 
+interface MiniMaxVoiceDesignResponse {
+  voice_id?: unknown
+  base_resp?: {
+    status_code?: unknown
+    status_msg?: unknown
+  }
+}
+
+function normalizeApiBase(baseUrl: string | undefined) {
+  const normalized = (baseUrl || 'https://api.minimax.io').replace(/\/+$/, '')
+  return normalized.endsWith('/v1') ? normalized : `${normalized}/v1`
+}
+
+async function designMinimaxVoice(
+  config: MinimaxSpeechConfig,
+  _provider: ProviderInstance,
+  input: VoiceDesignInput,
+): Promise<VoiceDesignResult> {
+  const apiKey = config.apiKey?.trim() ?? ''
+  if (!apiKey)
+    throw new Error('MiniMax voice design requires an API key.')
+
+  const prompt = input.prompt.trim()
+  const voiceId = (input.voiceId ?? input.voice_id ?? '').trim()
+  if (!prompt)
+    throw new Error('MiniMax voice design requires a prompt.')
+  if (!voiceId)
+    throw new Error('MiniMax voice design requires a voice id.')
+
+  const response = await fetch(`${normalizeApiBase(config.baseUrl)}/voice_design`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ prompt, voice_id: voiceId }),
+  })
+
+  const payload = await response.json().catch(() => ({})) as MiniMaxVoiceDesignResponse
+  const statusCode = payload.base_resp?.status_code
+  if (!response.ok || (typeof statusCode === 'number' && statusCode !== 0)) {
+    const statusMessage = typeof payload.base_resp?.status_msg === 'string' ? `: ${payload.base_resp.status_msg}` : ''
+    throw new Error(`MiniMax voice design request failed: ${response.status} ${response.statusText}${statusMessage}`)
+  }
+
+  const createdVoiceId = typeof payload.voice_id === 'string' ? payload.voice_id.trim() : ''
+  if (!createdVoiceId)
+    throw new Error('MiniMax voice design response missing voice_id.')
+
+  return { voiceId: createdVoiceId }
+}
+
 export const providerMinimaxSpeech = defineProvider<MinimaxSpeechConfig>({
   id: 'minimax-speech',
   name: 'MiniMax Speech',
   nameLocalize: ({ t }) => t('settings.pages.providers.provider.minimax-speech.title'),
   description: 'minimax.io',
   descriptionLocalize: ({ t }) => t('settings.pages.providers.provider.minimax-speech.description'),
-  tasks: ['text-to-speech'],
+  tasks: ['text-to-speech', 'voice-design'],
   icon: 'i-lobe-icons:minimax',
   iconColor: 'i-lobe-icons:minimax-color',
   createProviderConfig: () => minimaxSpeechConfigSchema,
   createProvider(config) {
-    const apiKey = config.apiKey.trim()
-    const baseUrl = (config.baseUrl || 'https://api.minimax.io').replace(/\/$/, '')
+    const apiKey = config.apiKey?.trim() ?? ''
+    const apiBase = normalizeApiBase(config.baseUrl)
 
     return {
       speech: () => ({
-        baseURL: `${baseUrl}/v1/`,
+        baseURL: `${apiBase}/`,
         model: 'speech-2.8-hd',
         fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
           if (!init?.body || typeof init.body !== 'string')
             throw new Error('Invalid request body')
 
           const body = JSON.parse(init.body) as { input?: string, voice?: string, model?: string }
-          const response = await fetch(`${baseUrl}/v1/t2a_v2`, {
+          const response = await fetch(`${apiBase}/t2a_v2`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -133,9 +187,11 @@ export const providerMinimaxSpeech = defineProvider<MinimaxSpeechConfig>({
   },
   extraMethods: {
     listModels: async () => [
-      { id: 'speech-2.8-hd', name: 'Speech 2.8 HD', provider: 'minimax-speech', description: 'High-definition TTS model with natural prosody', deprecated: false },
-      { id: 'speech-2.8-turbo', name: 'Speech 2.8 Turbo', provider: 'minimax-speech', description: 'Fast TTS model for low-latency scenarios', deprecated: false },
+      { id: 'speech-2.8-hd', name: 'Speech 2.8 HD', provider: 'minimax-speech', description: 'High-definition TTS model with natural prosody', deprecated: false, capabilities: ['text-to-speech'] },
+      { id: 'speech-2.8-turbo', name: 'Speech 2.8 Turbo', provider: 'minimax-speech', description: 'Fast TTS model for low-latency scenarios', deprecated: false, capabilities: ['text-to-speech'] },
+      { id: 'voice-design', name: 'MiniMax Voice Design', provider: 'minimax-speech', description: 'Design a voice from a natural-language description', deprecated: false, capabilities: ['voice-design'] },
     ],
+    designVoice: designMinimaxVoice,
     listVoices: async () => [
       { id: 'English_Graceful_Lady', name: 'Graceful Lady', provider: 'minimax-speech', gender: 'female', languages: [{ code: 'en', title: 'English' }] },
       { id: 'English_Insightful_Speaker', name: 'Insightful Speaker', provider: 'minimax-speech', gender: 'male', languages: [{ code: 'en', title: 'English' }] },

--- a/packages/stage-ui/src/libs/providers/types.ts
+++ b/packages/stage-ui/src/libs/providers/types.ts
@@ -68,6 +68,14 @@ export interface ProviderExtraMethods<TConfig> {
    * narrow the result. Providers with a single catalogue ignore it.
    */
   listVoices?: (config: TConfig, provider: ProviderInstance, model?: string) => Promise<VoiceInfo[]>
+  /**
+   * Creates a provider-managed voice from a natural-language description.
+   *
+   * Voice-design providers return the id that can subsequently be selected in
+   * the regular speech request. The provider owns the wire format and response
+   * validation; callers only provide the prompt and requested voice id.
+   */
+  designVoice?: (config: TConfig, provider: ProviderInstance, input: VoiceDesignInput) => Promise<VoiceDesignResult>
   loadModel?: (config: TConfig, provider: ProviderInstance, hooks?: { onProgress?: (progress: ProgressInfo) => Promise<void> | void }) => Promise<void>
 }
 
@@ -143,6 +151,18 @@ export interface VoiceInfo {
     code: string
     title: string
   }[]
+}
+
+export interface VoiceDesignInput {
+  prompt: string
+  /** Preferred camelCase form used by AIRI callers. */
+  voiceId?: string
+  /** Wire-compatible alias for callers that mirror MiniMax's JSON field. */
+  voice_id?: string
+}
+
+export interface VoiceDesignResult {
+  voiceId: string
 }
 
 // eslint-disable-next-line ts/no-unnecessary-type-constraint


### PR DESCRIPTION
Reason: Add MiniMax voice design support with regional voice-design requests and metadata.

Implemented MiniMax voice design requests for both global and China base URLs using `POST /v1/voice_design`, including prompt and voice ID validation, authorization, response parsing, and error handling. Added the provider extension contract and voice-design model capability metadata.

Checks:
- `pnpm exec eslint packages/stage-ui/src/libs/providers/providers/minimax-speech/index.ts packages/stage-ui/src/libs/providers/providers/minimax-speech/index.test.ts packages/stage-ui/src/libs/providers/types.ts`
- `pnpm -F @proj-airi/stage-ui exec vitest run src/libs/providers/providers/minimax-speech/index.test.ts`
