### PR TITLE
ci: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/release-pocket-android.yml
+++ b/.github/workflows/release-pocket-android.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '21'


### PR DESCRIPTION
## Description

Upgrade actions/setup-java from v4 to v6 in the active Pocket Android release workflow. This adopts the current Node.js 24 action runtime without changing the configured Java distribution or version.

## Linked Issues

None.

## Additional Context

Validated with `git diff --check` and confirmed no pre-v6 actions/setup-java references remain in active workflows.