### PR TITLE
fix(stage-ui): use compatible chat validation token limit

### DIFF
--- a/packages/stage-ui/src/libs/providers/validators/openai-compatible.test.ts
+++ b/packages/stage-ui/src/libs/providers/validators/openai-compatible.test.ts
@@ -145,4 +145,30 @@ describe('createOpenAICompatibleValidators', () => {
       model: 'seed-2-0-pro-260328',
     }))
   })
+
+  it('uses a provider-compatible output limit for chat probing', async () => {
+    listModelsMock.mockResolvedValue([
+      { id: 'meta-llama/test-model' },
+    ])
+
+    const [chatValidator] = await getProviderValidators({
+      checks: [ProviderValidationCheck.ChatCompletions],
+    })
+
+    const result = await chatValidator.validator(config, provider, providerExtra, { t: mockT })
+
+    // ROOT CAUSE:
+    //
+    // The chat probe requested one output token. Some providers reject requests
+    // with fewer than 16 output tokens.
+    //
+    // max_tokens: 1
+    //
+    // The probe now uses the minimum that these providers accept.
+    // max_tokens: 16
+    expect(result.valid).toBe(true)
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      max_tokens: 16,
+    }))
+  })
 })

--- a/packages/stage-ui/src/libs/providers/validators/openai-compatible.ts
+++ b/packages/stage-ui/src/libs/providers/validators/openai-compatible.ts
@@ -140,7 +140,12 @@ export function createOpenAICompatibleValidators<TConfig extends { apiKey?: stri
         headers: additionalHeaders,
         model: normalizedModel,
         messages: message.messages(message.user('ping')),
-        max_tokens: 1,
+        // NOTICE:
+        // Some OpenAI-compatible providers reject output limits below 16.
+        // OpenRouter documents this minimum for some upstream providers.
+        // Source/context: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request
+        // Removal condition: All supported providers accept lower limits, or the probe learns each model's minimum.
+        max_tokens: 16,
       })
 
       return { connectivityOk: true, chatOk: true }


### PR DESCRIPTION
## Summary

- Raise the chat validation output limit from 1 to 16 tokens.
- Support upstream providers that reject lower output limits.
- Add a regression test for the validation request.

## Verification

- `pnpm -F @proj-airi/stage-ui exec vitest run src/libs/providers/validators/openai-compatible.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Visual changes

None. This change only updates the provider validation request.