### PR TITLE
fix(ui-server-auth): exclude stage inference assets

### DIFF
--- a/apps/ui-server-auth/package.json
+++ b/apps/ui-server-auth/package.json
@@ -20,7 +20,6 @@
     "@date-fns/utc": "catalog:",
     "@fontsource-variable/nunito": "catalog:",
     "@formkit/auto-animate": "catalog:",
-    "@huggingface/transformers": "catalog:",
     "@moeru/eventa": "catalog:",
     "@moeru/std": "catalog:",
     "@proj-airi/font-chillroundm": "workspace:^",

--- a/apps/ui-server-auth/src/App.vue
+++ b/apps/ui-server-auth/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ToasterRoot } from '@proj-airi/stage-ui/components'
-import { useSettingsGeneral, useSettingsTheme } from '@proj-airi/stage-ui/stores/settings'
+import { ToasterRoot } from '@proj-airi/stage-ui/components/scenarios/toasters'
+import { useSettingsGeneral } from '@proj-airi/stage-ui/stores/settings/general'
+import { useSettingsTheme } from '@proj-airi/stage-ui/stores/settings/theme'
 import { storeToRefs } from 'pinia'
 import { watch } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/apps/ui-server-auth/src/modules/analytics.ts
+++ b/apps/ui-server-auth/src/modules/analytics.ts
@@ -14,7 +14,7 @@
  * policy linked on the sign-in page.
  */
 
-import type { OauthCallbackFailureStage } from '@proj-airi/stage-ui/composables'
+import type { OauthCallbackFailureStage } from '@proj-airi/stage-ui/composables/use-analytics'
 
 /** Login/signup credential kinds shown on the sign-in page. */
 export type AuthMethod = 'email' | 'github' | 'google' | 'steam'

--- a/apps/ui-server-auth/src/pages/profile.vue
+++ b/apps/ui-server-auth/src/pages/profile.vue
@@ -2,7 +2,7 @@
 import type { ProfileUser } from '../modules/profile'
 
 import { defaultSignInProviders } from '@proj-airi/stage-ui/components/auth'
-import { useLinkedAccounts } from '@proj-airi/stage-ui/composables'
+import { useLinkedAccounts } from '@proj-airi/stage-ui/composables/use-linked-accounts'
 import { SERVER_URL } from '@proj-airi/stage-ui/libs/server'
 import { Avatar, Button, FieldInput } from '@proj-airi/ui'
 import { computed, onMounted, reactive, shallowRef } from 'vue'

--- a/apps/ui-server-auth/vite.config.ts
+++ b/apps/ui-server-auth/vite.config.ts
@@ -113,8 +113,16 @@ export default defineConfig({
     // https://github.com/JohnCampionJr/vite-plugin-vue-layouts
     Layouts({
       layoutsDirs: [
-        resolve(import.meta.dirname, 'src', 'layouts'),
         resolve(import.meta.dirname, '..', '..', 'packages', 'stage-layouts', 'src', 'layouts'),
+      ],
+      // Auth routes use only the plain layout. Loading other shared layouts
+      // pulls the stage renderer, model assets, and local inference runtime
+      // into the auth deployment.
+      exclude: [
+        '**/default.vue',
+        '**/home.vue',
+        '**/settings.vue',
+        '**/stage.vue',
       ],
     }),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2765,9 +2765,6 @@ importers:
       '@formkit/auto-animate':
         specifier: 'catalog:'
         version: 0.10.0(vue@3.5.41(typescript@6.0.3))
-      '@huggingface/transformers':
-        specifier: 'catalog:'
-        version: 3.8.1
       '@moeru/eventa':
         specifier: 'catalog:'
         version: 1.0.0(electron@43.4.1(supports-color@10.2.2))(h3@2.0.1-rc.29(crossws@0.4.12(srvx@0.12.7)))(hono@4.13.3)


### PR DESCRIPTION
## Description

- Restrict the auth layout scan to the `plain` layout that all auth routes use.
- Use specific Stage UI entry points to prevent imports of unrelated stage modules.
- Remove the unused `@huggingface/transformers` dependency from the auth workspace.

The broad layout scan loaded the settings layout. That import chain loaded voice input, `onnxruntime-web`, and its ORT WASM file.

The production output now contains no ORT or ONNX files. Its total size decreased from about 174 MB to 16 MB.

## Linked Issues

- Failed GitHub Actions job: https://github.com/moeru-ai/airi/actions/runs/32970191671/job/98181844778

## Verification

- `pnpm --filter @proj-airi/ui-server-auth build`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check origin/main...HEAD`
- `find apps/ui-server-auth/dist -type f \( -iname "*ort*" -o -iname "*onnx*" \) -print`

The largest output file is 6,515,060 bytes. The Cloudflare Pages limit is 25 MiB per file.

## Visual changes

None. This change only affects application imports and build output.

## Additional Context

A configuration-only unit test cannot prove the final import graph. The production build provides the regression check for this change.