### PR TITLE
fix(stage-ui-live2d): avoid proxying renderer instances

### DIFF
--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Canvas.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Canvas.vue
@@ -3,7 +3,7 @@ import { Application } from '@pixi/app'
 import { extensions } from '@pixi/extensions'
 import { Ticker, TickerPlugin } from '@pixi/ticker'
 import { Live2DModel } from 'pixi-live2d-display/cubism4'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 
 const props = withDefaults(defineProps<{
   width: number
@@ -23,7 +23,7 @@ const componentState = defineModel<'pending' | 'loading' | 'mounted'>('state', {
 
 const containerRef = ref<HTMLDivElement>()
 const isPixiCanvasReady = ref(false)
-const pixiApp = ref<Application>()
+const pixiApp = shallowRef<Application>()
 const pixiAppCanvas = ref<HTMLCanvasElement>()
 
 function resolveMaxFps(limit?: number) {

--- a/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
+++ b/packages/stage-ui-live2d/src/components/scenes/live2d/Model.vue
@@ -93,7 +93,7 @@ const offset = computed(() => ({
 const pixiApp = toRef(() => props.app)
 const paused = toRef(() => props.paused)
 const focusAt = toRef(() => props.focusAt)
-const model = ref<Live2DModel<PixiLive2DInternalModel>>()
+const model = shallowRef<Live2DModel<PixiLive2DInternalModel>>()
 const initialModelWidth = ref<number>(0)
 const initialModelHeight = ref<number>(0)
 const mouthOpenSize = computed(() => Math.max(0, Math.min(100, props.mouthOpenSize)))
@@ -176,7 +176,7 @@ const live2dExpressionEnabled = toRef(() => props.live2dExpressionEnabled)
 const live2dShadowEnabled = toRef(() => props.live2dShadowEnabled)
 
 // --- Expression controller
-const internalModelRef = ref<PixiLive2DInternalModel>()
+const internalModelRef = shallowRef<PixiLive2DInternalModel>()
 const expressionController = useExpressionController({
   internalModel: internalModelRef,
   modelId: props.modelId,


### PR DESCRIPTION
## Summary

- Keep Pixi `Application` instances outside Vue deep reactivity.
- Keep Live2D model and internal Cubism model instances outside Vue deep reactivity.
- Reduce render-loop allocations that caused long garbage-collection pauses.

## Verification

- `pnpm -F @proj-airi/stage-ui-live2d exec vitest run` (37 tests passed)
- `pnpm -F @proj-airi/stage-ui-live2d typecheck`
- `pnpm typecheck`
- `pnpm lint`
- Electron AR-HMM stress test: 300 seconds, 132 seeds, and 8,886 visible motion updates. No Stage rAF gap exceeded 50 ms.
- Heap allocation sampling: about 104.4 MB/s before the fix and 22.1 MB/s after the fix.

## Visual changes

None. This change only updates Vue reactivity boundaries for renderer objects.
