### PR TITLE
fix(stage-layouts): preserve mobile Safari input focus

### DIFF
--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -273,10 +273,23 @@ function handleInputBubbleLongPress() {
   inputBubble.value!.style.transform = 'translate3d(0, 0, 0) scale(.98)'
 }
 
+function handleInputBubblePointerDown(event: PointerEvent) {
+  suppressNextInputBubbleClick = false
+
+  const messageInput = inputBubble.value!.querySelector<HTMLTextAreaElement>('textarea')!
+
+  // NOTICE:
+  // The focused textarea must suppress native text selection before a dock drag starts.
+  // A blurred textarea must keep native activation so Safari can cancel an active keyboard dismissal.
+  // See the closing-focus regression in adaptive-input.test.ts.
+  // Remove this branch when Safari exposes a keyboard lifecycle that can cancel an active dismissal.
+  if (document.activeElement === messageInput)
+    event.preventDefault()
+}
+
 onLongPress(inputBubble, handleInputBubbleLongPress, {
   delay: 500,
   distanceThreshold: 10,
-  modifiers: { prevent: true },
   onMouseUp: (_duration, _distance, longPressed) => longPressed && finishInputBubbleDrag(),
 })
 
@@ -535,7 +548,7 @@ onUnmounted(() => {
               : 'max-w-[70%] w-full focus-within:max-w-full',
           ]"
           @click="handleInputBubbleClick"
-          @pointerdown="suppressNextInputBubbleClick = false"
+          @pointerdown="handleInputBubblePointerDown"
         >
           <BasicTextarea
             v-model="messageInput"
@@ -549,7 +562,7 @@ onUnmounted(() => {
               'transition-colors duration-250 ease-in-out hover:text-neutral-600 dark:hover:text-neutral-200',
               'placeholder:text-[14px] placeholder:vertical-middle placeholder:leading-6 placeholder:text-neutral-400',
               'placeholder:transition-all placeholder:duration-250 placeholder:ease-in-out placeholder:hover:text-neutral-500 dark:placeholder:text-neutral-500 dark:placeholder:hover:text-neutral-400',
-              'pointer-events-none group-focus-within:pointer-events-auto',
+              inputBubbleDocked ? 'pointer-events-none' : 'pointer-events-auto',
               themeColorsHueDynamic ? 'transition-colors-none placeholder:transition-colors-none' : undefined,
             ]"
             default-height="1lh"


### PR DESCRIPTION
## Summary

- Let the undocked textarea receive native pointer events.
- Prevent text selection only when the textarea is already focused.
- Keep the dock drag gesture without replacing Safari's native input activation.

## Root cause

PR #2363 made the blurred textarea ignore pointer events. Its wrapper also canceled every pointer down.

The next tap reached a `div`, then focused the textarea from the later `click` handler. This bypassed `AdaptiveInput`'s Safari closing-keyboard path.

Safari could finish the old keyboard dismissal after the programmatic focus. The textarea then remained focused without an open keyboard.

## Verification

- `pnpm exec vitest run src/browser/adaptive-input.test.ts --root packages/stage-layouts --environment jsdom`
- `pnpm typecheck`
- `pnpm lint` (passes with 11 existing warnings)
- iOS 26.5 Simulator, iPhone 17 Pro: AUV focus, outside tap, and refocus sequence
- Appium native source: the software keyboard remains present after refocus

## Visual changes

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/f7a6ce12-6e0f-418f-8608-207795e33df2) | ![](https://github.com/user-attachments/assets/f071bb27-ba52-41c0-a040-844e0ade3e64) |
| Stage Pocket / idle composer (390x844) | Stage Pocket / idle composer (390x844) |

The pointer-event fix does not change the idle layout.

## Native verification

[iOS Simulator focus-dismiss-refocus recording](https://github.com/user-attachments/assets/0b0dce39-a9d0-4a1d-8e6e-18ad9172c6be)
