### PR TITLE
fix(stage-pocket): add iOS microphone usage description

### DIFF
--- a/apps/stage-pocket/ios/App/App/Info.plist
+++ b/apps/stage-pocket/ios/App/App/Info.plist
@@ -39,6 +39,8 @@
 	<string>AIRI needs access to your local network to connect to your Tamagotchi host.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>AIRI uses the camera to scan Tamagotchi connection QR codes.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>AIRI uses the microphone for voice interaction.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
## Description

Add `NSMicrophoneUsageDescription` to the iOS app's `Info.plist` with this purpose string:

> AIRI uses the microphone for voice interaction.

The device reports in #2388 show that microphone access terminates both tested builds with `EXC_CRASH (SIGABRT)` in the `TCC` namespace. Both reports identify the missing usage description.

This change adds the required permission metadata. Debug and Release both use this plist. All existing plist values remain unchanged.

## Linked Issues

Fixes #2388

## Verification

- `plutil -lint apps/stage-pocket/ios/App/App/Info.plist` — passed.
- `plutil -extract NSMicrophoneUsageDescription raw -o - apps/stage-pocket/ios/App/App/Info.plist` — failed before the change and returned the purpose string after it.
- Parsed the base and changed plists with Python `plistlib` — only the microphone description differs.
- `git diff --cached --check` — passed before commit.
- `sem diff --staged --no-cosmetics -v` and JSON review — completed. A plist comparison confirmed that XML element-matching noise did not represent other changes.
- `sem impact --entity-id 'apps/stage-pocket/ios/App/App/Info.plist::element::plist' --json --dependents` — no indexed dependents.
- `npm_config_registry=https://registry.npmjs.org pnpm lint` — passed with warnings in unchanged files.
- The normal `nano-staged` commit hook passed.

## Additional Context

Full type checking did not pass: `pnpm typecheck` reported missing `@proj-airi/better-ws` declarations and related errors in unchanged `server-sdk` code. The repository has no `type-check` script.

CR review was unavailable because its login expired. The manual and sem reviews completed.

## Device verification

User-assisted tests ran on an iPhone 16 Plus with iOS 26.6.1 (23G83).

- **Before:** the existing 0.12.0 (21) app crashed at 16:46:24 UTC+08:00 on 2026-08-28. The new `.ips` report again identifies the missing `NSMicrophoneUsageDescription`.
- **Permission prompt:** the diagnostic app showed the native microphone dialog with the exact purpose string from this PR. The system recorded `AUTHREQ_PROMPTING` at 16:50:44.
- **Permission denied:** at 16:52:07, TCC recorded the user decision. WebKit returned `PermissionDenied`. The same app process remained alive and the microphone panel stayed visible.
- **Repeat tap:** the user reported no crash after another tap. A device process snapshot showed the same app process alive. The microphone panel remained visible in a new native screenshot.
- **Permission granted and capture:** not verified. The final log archive contained no new grant result or capture request. Its recorded authorization state still said `Denied`. This repeat tap does not establish successful microphone capture or transcription.
- **Cleanup:** the diagnostic app stopped at 16:59:29. A later device process snapshot showed that its process was absent.

The diagnostic package uses the existing 0.12.0 (21) IPA with this plist change and a separate app identity (`AIRI Mic Test`). All 1,170 non-signing resources remain unchanged. This verifies the permission metadata fix on a real device, but it is not a full source rebuild of the PR. The two existing AIRI installations and their data remain unchanged.

## Visual changes

| Before | After |
| --- | --- |
| Permission dialog absent: the app terminated with a TCC privacy violation. See #2388. | ![Native microphone permission dialog](https://github.com/user-attachments/assets/b8e38a9d-7f00-4d6f-83e0-cdada968d1a0) |
| iOS microphone permission | iOS microphone permission |
| Denial path unavailable because the app terminated before the permission dialog. | ![App remains open after permission denial](https://github.com/user-attachments/assets/f9768855-44b7-45cc-8b75-81142f32bf7c) |
| Microphone permission denied | Microphone permission denied |
| The original app terminated before this state could be reached. | ![App remains open after a repeat microphone tap](https://github.com/user-attachments/assets/84f2a80d-081b-42a8-b9df-1dcc2b0d9002) |
| Repeat microphone tap | Repeat microphone tap; capture not verified |
