### PR TITLE
fix(server-runtime): disable socket port reuse

### DIFF
--- a/packages/server-runtime/src/server/index.ts
+++ b/packages/server-runtime/src/server/index.ts
@@ -4,7 +4,6 @@ import type { AppOptions } from '..'
 
 import { isIP } from 'node:net'
 import { networkInterfaces } from 'node:os'
-import { platform } from 'node:process'
 
 import { useLogg } from '@guiiai/logg'
 import { merge } from '@moeru/std'
@@ -166,7 +165,7 @@ export function createServer(opts?: ServerOptions): Server {
         port,
         hostname,
         tls: options?.tlsConfig || undefined,
-        reusePort: platform !== 'win32',
+        reusePort: false,
         silent: true,
         manual: true,
         gracefulShutdown: {


### PR DESCRIPTION
## Summary

- Disable `reusePort` for the server runtime on every platform.
- Prevent `ENOTSUP` when srvx forwards the option to Node on macOS.
- Keep one listener as the owner of the server runtime port.

## Verification

- `pnpm exec vitest run packages/server-runtime/src/server.test.ts`
- `pnpm -F @proj-airi/server-runtime typecheck`
- `pnpm exec eslint packages/server-runtime/src/server/index.ts`
- `pnpm typecheck`
- `pnpm lint`
- Confirmed that Electron listens on `127.0.0.1:6121` and serves an HTTP response.