### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-BoAKo9uvxB4hjEgZkoFzTzh6GjoM5L5YhZTR958pRDI=
+sha256-sFURilvmkwGUxuZlZisa/HbC8RkXukvwuaMnNWPIXt8=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.