### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-sFURilvmkwGUxuZlZisa/HbC8RkXukvwuaMnNWPIXt8=
+sha256-eIk/5wAE+oZHjH9UIz+pFoPvvbt7mMsilBMfYG96J7c=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.