### PR TITLE
fix(settings): unblock navigation from settings index

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/pages/settings/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/index.vue
@@ -1,27 +1,11 @@
 <script setup lang="ts">
 import { IconItem } from '@proj-airi/stage-ui/components'
-import { useSettings } from '@proj-airi/stage-ui/stores/settings'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-const resolveAnimation = ref<() => void>()
 const { t } = useI18n()
-const settingsStore = useSettings()
-
-const removeBeforeEach = router.beforeEach(async (_, __, next) => {
-  if (!settingsStore.usePageSpecificTransitions || settingsStore.disableTransitions) {
-    next()
-    return
-  }
-
-  await new Promise<void>((resolve) => {
-    resolveAnimation.value = resolve
-  })
-  removeBeforeEach()
-  next()
-})
 
 const settings = computed(() => {
   return router

--- a/apps/stage-web/src/pages/settings-navigation.browser.test.ts
+++ b/apps/stage-web/src/pages/settings-navigation.browser.test.ts
@@ -1,0 +1,69 @@
+import SharedSettingsIndex from '@proj-airi/stage-pages/pages/settings/index.vue'
+
+import { createPinia } from 'pinia'
+import { afterEach, describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import { createI18n } from 'vue-i18n'
+import { createMemoryHistory, createRouter, RouterView } from 'vue-router'
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+async function renderSettingsIndex() {
+  localStorage.setItem('settings/disable-transitions', 'false')
+  localStorage.setItem('settings/use-page-specific-transitions', 'true')
+
+  const pinia = createPinia()
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/settings', component: SharedSettingsIndex },
+      { path: '/target', component: { template: '<div>Target page</div>' } },
+    ],
+  })
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: {} },
+    missingWarn: false,
+    fallbackWarn: false,
+  })
+
+  await router.push('/settings')
+  await router.isReady()
+
+  const screen = await render(RouterView, {
+    global: {
+      plugins: [pinia, i18n, router],
+      directives: { motion: {} },
+      stubs: {
+        IconItem: true,
+        RippleGrid: true,
+      },
+    },
+  })
+
+  return { router, screen }
+}
+
+describe('settings index navigation', () => {
+  it('does not block navigation when page-specific transitions are enabled', async () => {
+    // ROOT CAUSE:
+    //
+    // The settings index registered a route guard that waited for a callback
+    // with no caller. Every later navigation remained pending.
+    const { router, screen } = await renderSettingsIndex()
+
+    const result = await Promise.race([
+      router.push('/target').then(() => 'completed'),
+      new Promise<string>(resolve => setTimeout(resolve, 250, 'blocked')),
+    ])
+
+    expect(result).toBe('completed')
+    expect(router.currentRoute.value.path).toBe('/target')
+    await expect.element(screen.getByText('Target page')).toBeVisible()
+
+    screen.unmount()
+  })
+})

--- a/apps/stage-web/vite.config.ts
+++ b/apps/stage-web/vite.config.ts
@@ -235,7 +235,7 @@ export default defineConfig({
     }),
 
     // https://github.com/webfansplz/vite-plugin-vue-devtools
-    VueDevTools(),
+    ...(env.NODE_ENV === 'test' ? [] : [VueDevTools()]),
 
     DownloadLive2DSDK(),
     Download('https://dist.ayaka.moe/live2d-models/hiyori_free_zh.zip', 'hiyori_free_zh.zip', 'live2d/models', { parentDir: stageUIAssetsRoot, cacheDir: sharedCacheDir }),

--- a/packages/stage-pages/src/pages/settings/index.vue
+++ b/packages/stage-pages/src/pages/settings/index.vue
@@ -1,30 +1,13 @@
 <script setup lang="ts">
 import { IconItem, RippleGrid } from '@proj-airi/stage-ui/components'
 import { useRippleGridState } from '@proj-airi/stage-ui/composables/use-ripple-grid-state'
-import { useSettings } from '@proj-airi/stage-ui/stores/settings'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-const resolveAnimation = ref<() => void>()
 const { t } = useI18n()
 const { lastClickedIndex, setLastClickedIndex } = useRippleGridState()
-
-const settingsStore = useSettings()
-
-const removeBeforeEach = router.beforeEach(async (_, __, next) => {
-  if (!settingsStore.usePageSpecificTransitions || settingsStore.disableTransitions) {
-    next()
-    return
-  }
-
-  await new Promise<void>((resolve) => {
-    resolveAnimation.value = resolve
-  })
-  removeBeforeEach()
-  next()
-})
 
 const settings = computed(() => {
   return router
@@ -81,4 +64,5 @@ meta:
   titleKey: settings.title
   stageTransition:
     name: slide
+    pageSpecificAvailable: true
 </route>


### PR DESCRIPTION
## Summary

- Remove settings-index route guards that waited for a callback with no caller.
- Let the shared settings page use the existing page-specific transition flow.
- Add a browser regression test for navigation with page-specific transitions enabled.

## Verification

- `pnpm -F @proj-airi/stage-web exec vitest run --config vitest.config.ts src/pages/settings-navigation.browser.test.ts --project browser`
- `pnpm typecheck`
- `pnpm lint` (passes with existing repository warnings)
- `pnpm -F @proj-airi/stage-tamagotchi build`

## Visual changes

The same action opens **System** from the settings index. Before this change, the URL changed but the settings index remained visible. After this change, navigation completes.

| Surface | Before | After |
| --- | --- | --- |
| Web | ![Web settings index remains visible](https://github.com/user-attachments/assets/122e5e1c-71ba-4ab4-af3a-3c6ef7e6b0d3) | ![Web System settings page opens](https://github.com/user-attachments/assets/547957ea-b3ef-4cb8-a711-7c952384d5a9) |
| Electron | ![Electron settings index remains visible](https://github.com/user-attachments/assets/fdf8fc75-af22-474a-8de2-f208cd42a4e7) | ![Electron System settings page opens](https://github.com/user-attachments/assets/34c05748-d2ff-4524-976e-6aa9e30a7f6a) |
