### PR TITLE
fix(stage-tamagotchi): hide inactive title bar info icon

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/Window/TitleBar.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/Window/TitleBar.vue
@@ -40,6 +40,12 @@ const { platform } = useAppRuntime()
       >
         <slot name="actions" />
       </div>
+      <!--
+        NOTICE:
+        The planned collapse feature was not implemented. Keep this icon hidden until the feature exists.
+        https://github.com/moeru-ai/airi/issues/1835#issuecomment-4487178613
+      -->
+      <!--
       <div
         bg="hover:neutral-200 hover:dark:neutral-800"
         transition="all duration-200 ease-in-out"
@@ -47,6 +53,7 @@ const { platform } = useAppRuntime()
       >
         <div i-solar:info-circle-bold text="neutral-400 dark:neutral-500" whitespace-nowrap />
       </div>
+      -->
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->
### AS-IS

<img width="602" height="309" alt="스크린샷 2026-08-29 오후 10 00 10" src="https://github.com/user-attachments/assets/d8756b51-242f-4eba-b9e1-9645c594abc2" />


### TO-BE

<img width="603" height="300" alt="스크린샷 2026-08-29 오후 10 00 27" src="https://github.com/user-attachments/assets/35942d09-8f4e-454c-8583-4ef5be990824" />



Hide info icon performs no function

## Linked Issues
close #1835

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I commented this out because the intention is to display specific information later, depending on the [issue comments](https://github.com/moeru-ai/airi/issues/1835#issuecomment-4487178613).
Removing the comments can also be an option.
