### PR TITLE
fix(better-ws): publish the package so server-sdk installs

### DIFF
--- a/packages/better-ws/package.json
+++ b/packages/better-ws/package.json
@@ -2,7 +2,6 @@
   "name": "@proj-airi/better-ws",
   "type": "module",
   "version": "0.12.0-beta.5",
-  "private": true,
   "description": "Transport-agnostic reliable WebSocket runtime primitives",
   "author": {
     "name": "Moeru AI Project AIRI Team",


### PR DESCRIPTION
Closes #2359.

`@proj-airi/server-sdk` cannot be installed from npm by external projects:

```
[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/@proj-airi%2Fbetter-ws: Not Found - 404
```

**Root cause:** `packages/better-ws/package.json` has `"private": true`, so the release workflow's `pnpm publish -r --access public` skips it. But `server-sdk` (published) declares `@proj-airi/better-ws` as a runtime **dependency**, so the published SDK references a package that never made it to the registry.

`better-ws` is otherwise fully configured for publishing (`files`, `exports`, `dist` build), and its published siblings `@proj-airi/server-sdk` and `@proj-airi/server-shared` are **not** `private`. Removing the flag lets it publish alongside them, so the next release fixes external installs. No changeset is needed (releases use `pnpm publish -r` directly).