### PR TITLE
fix(stage-ui): use MiMo v2.5 ASR for transcription

### DIFF
--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -1444,6 +1444,20 @@ pages:
       mimo:
         description: api.xiaomimimo.com
         title: Xiaomi MiMo
+        transcription:
+          language:
+            label: ASR language
+            description: MiMo uses automatic language detection unless you choose Chinese or English.
+            options:
+              auto: Auto-detect
+              zh: Chinese
+              en: English
+          validation:
+            local-complete: Local configuration is complete
+            local-complete-description: >-
+              API key and Base URL are present. This local check does not prove
+              Xiaomi MiMo ASR runtime availability; use the transcription test
+              below for an actual request.
       mistral:
         description: mistral.ai
         title: Mistral

--- a/packages/stage-pages/src/pages/settings/providers/transcription/mimo-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/mimo-audio-transcription.vue
@@ -64,11 +64,22 @@ const language = computed<MimoAsrLanguage>({
   },
 })
 
-const languageOptions = [
-  { value: 'auto', label: 'Auto-detect' },
-  { value: 'zh', label: 'Chinese' },
-  { value: 'en', label: 'English' },
-]
+const {
+  t,
+  router,
+  providerMetadata,
+  isValidating,
+  isValid,
+  validationMessage,
+  handleResetSettings,
+  forceValid,
+} = useProviderValidation(providerId)
+
+const languageOptions = computed(() => [
+  { value: 'auto', label: t('settings.pages.providers.provider.mimo.transcription.language.options.auto') },
+  { value: 'zh', label: t('settings.pages.providers.provider.mimo.transcription.language.options.zh') },
+  { value: 'en', label: t('settings.pages.providers.provider.mimo.transcription.language.options.en') },
+])
 
 const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 
@@ -98,17 +109,6 @@ async function handleGenerateTranscription(file: File) {
     'json',
   )
 }
-
-const {
-  t,
-  router,
-  providerMetadata,
-  isValidating,
-  isValid,
-  validationMessage,
-  handleResetSettings,
-  forceValid,
-} = useProviderValidation(providerId)
 </script>
 
 <template>
@@ -137,8 +137,8 @@ const {
         />
         <FieldCombobox
           v-model="language"
-          label="ASR language"
-          description="MiMo uses automatic language detection unless you choose Chinese or English."
+          :label="t('settings.pages.providers.provider.mimo.transcription.language.label')"
+          :description="t('settings.pages.providers.provider.mimo.transcription.language.description')"
           :options="languageOptions"
         />
       </ProviderBasicSettings>
@@ -171,10 +171,10 @@ const {
       </Alert>
       <Alert v-if="isValid && isValidating === 0" type="success">
         <template #title>
-          Local configuration is complete
+          {{ t('settings.pages.providers.provider.mimo.transcription.validation.local-complete') }}
         </template>
         <template #content>
-          API key and Base URL are present. This local check does not prove Xiaomi MiMo ASR runtime availability; use the transcription test below for an actual request.
+          {{ t('settings.pages.providers.provider.mimo.transcription.validation.local-complete-description') }}
         </template>
       </Alert>
     </ProviderSettingsContainer>

--- a/packages/stage-pages/src/pages/settings/providers/transcription/mimo-audio-transcription.vue
+++ b/packages/stage-pages/src/pages/settings/providers/transcription/mimo-audio-transcription.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { MimoAsrLanguage } from '@proj-airi/stage-ui/libs/providers/providers/mimo-audio'
 import type { RemovableRef } from '@vueuse/core'
 import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
 
@@ -13,6 +14,7 @@ import {
   TranscriptionPlayground,
 } from '@proj-airi/stage-ui/components'
 import { useProviderValidation } from '@proj-airi/stage-ui/composables/use-provider-validation'
+import { MIMO_ASR_LANGUAGES, MIMO_ASR_MODEL } from '@proj-airi/stage-ui/libs/providers/providers/mimo-audio'
 import { useHearingStore } from '@proj-airi/stage-ui/stores/modules/hearing'
 import { useProviderConfigStore } from '@proj-airi/stage-ui/stores/providers/config'
 import { useProviderStore } from '@proj-airi/stage-ui/stores/providers/provider'
@@ -45,13 +47,28 @@ const baseUrl = computed({
 })
 
 const model = computed({
-  get: () => providers.value[providerId]?.model || 'mimo-v2-omni',
+  get: () => MIMO_ASR_MODEL,
+  set: (_value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].model = MIMO_ASR_MODEL
+  },
+})
+
+const language = computed<MimoAsrLanguage>({
+  get: () => providers.value[providerId]?.language || 'auto',
   set: (value) => {
     if (!providers.value[providerId])
       providers.value[providerId] = {}
-    providers.value[providerId].model = value
+    providers.value[providerId].language = MIMO_ASR_LANGUAGES.includes(value) ? value : 'auto'
   },
 })
+
+const languageOptions = [
+  { value: 'auto', label: 'Auto-detect' },
+  { value: 'zh', label: 'Chinese' },
+  { value: 'en', label: 'English' },
+]
 
 const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 
@@ -60,6 +77,10 @@ const providerModels = computed(() => providersStore.getModelsForProvider(provid
 const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
 
 onMounted(async () => {
+  providersStore.initializeProvider(providerId)
+  model.value = MIMO_ASR_MODEL
+  if (!MIMO_ASR_LANGUAGES.includes(language.value))
+    language.value = 'auto'
   await providersStore.loadModelsForConfiguredProviders()
   await providersStore.fetchModelsForProvider(providerId)
 })
@@ -114,6 +135,12 @@ const {
           :disabled="isLoadingModels || providerModels.length === 0"
           placeholder="Select a model..."
         />
+        <FieldCombobox
+          v-model="language"
+          label="ASR language"
+          description="MiMo uses automatic language detection unless you choose Chinese or English."
+          :options="languageOptions"
+        />
       </ProviderBasicSettings>
 
       <ProviderAdvancedSettings :title="t('settings.pages.providers.common.section.advanced.title')">
@@ -144,7 +171,10 @@ const {
       </Alert>
       <Alert v-if="isValid && isValidating === 0" type="success">
         <template #title>
-          {{ t('settings.dialogs.onboarding.validationSuccess') }}
+          Local configuration is complete
+        </template>
+        <template #content>
+          API key and Base URL are present. This local check does not prove Xiaomi MiMo ASR runtime availability; use the transcription test below for an actual request.
         </template>
       </Alert>
     </ProviderSettingsContainer>

--- a/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.test.ts
@@ -34,8 +34,8 @@ function createProvider(config: Record<string, unknown> = {}) {
   }
 }
 
-async function callProvider(file = createWavFile(), config: Record<string, unknown> = {}, model = 'mimo-v2.5') {
-  const request = createProvider(config).transcription(model)
+async function callProvider(file = createWavFile(), config: Record<string, unknown> = {}, model = 'mimo-v2.5', options?: { language?: string }) {
+  const request = createProvider(config).transcription(model, options)
   const form = new FormData()
   form.set('file', file)
   return await request.fetch('https://unused.invalid/v1/audio/transcriptions', { method: 'POST', body: form })
@@ -108,6 +108,18 @@ describe('xiaomi MiMo ASR transcription provider', () => {
       await callProvider(createWavFile(), { language })
       expect(lastPayload(fetchMock).asr_options).toEqual({ language })
     }
+  })
+
+  it('prefers the current request language over cached provider configuration', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: 'ok' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await callProvider(createWavFile(), { language: 'auto' }, 'mimo-v2.5', { language: 'zh' })
+
+    expect(lastPayload(fetchMock).asr_options).toEqual({ language: 'zh' })
   })
 
   it('preserves the actual WAV bytes in a matching data URL and format field', async () => {

--- a/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.test.ts
+++ b/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.test.ts
@@ -1,0 +1,219 @@
+import type { ComposerTranslation } from 'vue-i18n'
+
+import { toWavFromPCM16 } from '@proj-airi/audio/encoding'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import {
+  MIMO_ASR_MODEL,
+  parseMimoAsrResponse,
+  providerMimoAudioTranscription,
+} from './index'
+
+const translate = ((key: string) => key) as unknown as ComposerTranslation
+
+function createWavFile() {
+  const pcm = new Uint8Array([0, 0, 0x40, 0, 0x80, 0, 0xC0, 0])
+  return new File([toWavFromPCM16(pcm, 16_000)], 'recording.wav', { type: 'audio/wav' })
+}
+
+function createMp3File() {
+  return new File([new Uint8Array([0xFF, 0xFB, 0x90, 0x64])], 'recording.mp3', { type: 'audio/mpeg' })
+}
+
+function createProvider(config: Record<string, unknown> = {}) {
+  return providerMimoAudioTranscription.createProvider({
+    apiKey: 'test-key',
+    baseUrl: 'https://api.xiaomimimo.com/v1/',
+    ...config,
+  } as never) as {
+    transcription: (model: string, options?: { language?: string }) => {
+      model: string
+      fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    }
+  }
+}
+
+async function callProvider(file = createWavFile(), config: Record<string, unknown> = {}, model = 'mimo-v2.5') {
+  const request = createProvider(config).transcription(model)
+  const form = new FormData()
+  form.set('file', file)
+  return await request.fetch('https://unused.invalid/v1/audio/transcriptions', { method: 'POST', body: form })
+}
+
+function lastPayload(fetchMock: ReturnType<typeof vi.fn>) {
+  const calls = fetchMock.mock.calls as unknown as Array<[RequestInfo | URL, RequestInit]>
+  const call = calls.at(-1)!
+  return JSON.parse(String(call[1].body)) as Record<string, any>
+}
+
+describe('xiaomi MiMo ASR transcription provider', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the dedicated ASR model by default and removes generic models from the catalog', async () => {
+    const schema = await providerMimoAudioTranscription.createProviderConfig({ t: translate })
+    const defaults = z.parse(schema, { apiKey: 'test-key' }) as {
+      apiKey: string
+      baseUrl?: string
+      model?: typeof MIMO_ASR_MODEL
+      language?: 'auto' | 'zh' | 'en'
+    }
+    const provider = await providerMimoAudioTranscription.createProvider(defaults)
+    const models = await providerMimoAudioTranscription.extraMethods?.listModels?.(defaults, provider)
+
+    expect(defaults).toMatchObject({ model: MIMO_ASR_MODEL, language: 'auto' })
+    expect(createProvider().transcription('mimo-v2.5').model).toBe(MIMO_ASR_MODEL)
+    expect(models?.map(model => model.id)).toEqual([MIMO_ASR_MODEL])
+    expect(models?.some(model => model.id === 'mimo-v2.5')).toBe(false)
+    expect(models?.some(model => model.id === 'mimo-v2-omni')).toBe(false)
+  })
+
+  it('sends one official input_audio part to the MiMo chat completions endpoint', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: '这是测试' } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await callProvider()
+    const payload = lastPayload(fetchMock)
+    const inputAudio = payload.messages[0].content[0].input_audio
+    const calls = fetchMock.mock.calls as unknown as Array<[RequestInfo | URL, RequestInit]>
+
+    expect(String(calls[0][0])).toBe('https://api.xiaomimimo.com/v1/chat/completions')
+    expect(payload.model).toBe(MIMO_ASR_MODEL)
+    expect(payload.asr_options).toEqual({ language: 'auto' })
+    expect(payload.messages).toHaveLength(1)
+    expect(payload.messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'input_audio', input_audio: inputAudio }],
+    })
+    expect(payload.messages[0].content).toHaveLength(1)
+    expect(JSON.stringify(payload)).not.toContain('Transcribe the audio content.')
+    expect(inputAudio.format).toBe('wav')
+    expect(inputAudio.data).toMatch(/^data:audio\/wav;base64,/)
+    expect(await response.json()).toEqual({ text: '这是测试' })
+  })
+
+  it('maps the supported Chinese and English language options', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: 'ok' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    for (const language of ['zh', 'en']) {
+      await callProvider(createWavFile(), { language })
+      expect(lastPayload(fetchMock).asr_options).toEqual({ language })
+    }
+  })
+
+  it('preserves the actual WAV bytes in a matching data URL and format field', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: 'ok' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const file = createWavFile()
+
+    await callProvider(file)
+
+    const inputAudio = lastPayload(fetchMock).messages[0].content[0].input_audio
+    const encoded = inputAudio.data.split(',')[1]
+    const binary = atob(encoded)
+    const decoded = Uint8Array.from(binary, character => character.charCodeAt(0))
+    expect(inputAudio.format).toBe('wav')
+    expect(decoded).toEqual(new Uint8Array(await file.arrayBuffer()))
+  })
+
+  it('preserves supported MP3 bytes in a matching data URL and format field', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: 'ok' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const file = createMp3File()
+
+    await callProvider(file)
+
+    const inputAudio = lastPayload(fetchMock).messages[0].content[0].input_audio
+    const encoded = inputAudio.data.split(',')[1]
+    const binary = atob(encoded)
+    const decoded = Uint8Array.from(binary, character => character.charCodeAt(0))
+    expect(inputAudio.format).toBe('mp3')
+    expect(inputAudio.data).toMatch(/^data:audio\/mpeg;base64,/)
+    expect(decoded).toEqual(new Uint8Array(await file.arrayBuffer()))
+  })
+
+  it('converts an unsupported recorder container to a real WAV before sending', async () => {
+    class FakeAudioContext {
+      async decodeAudioData() {
+        return {
+          length: 2,
+          numberOfChannels: 1,
+          sampleRate: 16_000,
+          getChannelData: () => new Float32Array([0.5, -0.5]),
+        }
+      }
+
+      async close() {}
+    }
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: 'converted' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('AudioContext', FakeAudioContext)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await callProvider(new File([new Uint8Array([0x1A, 0x45, 0xDF, 0xA3])], 'recording.webm', { type: 'audio/webm' }))
+
+    const inputAudio = lastPayload(fetchMock).messages[0].content[0].input_audio
+    const binary = atob(inputAudio.data.split(',')[1])
+    const bytes = Uint8Array.from(binary, character => character.charCodeAt(0))
+    expect(inputAudio.format).toBe('wav')
+    expect(inputAudio.data).toMatch(/^data:audio\/wav;base64,/)
+    expect(String.fromCharCode(...bytes.slice(0, 4))).toBe('RIFF')
+    expect(String.fromCharCode(...bytes.slice(8, 12))).toBe('WAVE')
+  })
+
+  it('accepts an empty ASR transcript as an empty result', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: '   ' } }],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect((await callProvider()).json()).resolves.toEqual({ text: '' })
+  })
+
+  it('rejects HTTP errors, malformed ASR responses, and generic assistant output', async () => {
+    const fetchMock = vi.fn(async () => new Response('upstream error', { status: 401, statusText: 'Unauthorized' }))
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(callProvider()).rejects.toThrow('MiMo ASR request failed: 401 Unauthorized')
+
+    fetchMock.mockImplementationOnce(async () => new Response('not json', { status: 200 }))
+    await expect(callProvider()).rejects.toThrow('not valid JSON')
+
+    fetchMock.mockImplementationOnce(async () => new Response(JSON.stringify({
+      model: MIMO_ASR_MODEL,
+      choices: [{ message: { content: { text: 'not a string' } } }],
+    }), { status: 200 }))
+    await expect(callProvider()).rejects.toThrow('missing a string transcript')
+
+    fetchMock.mockImplementationOnce(async () => new Response(JSON.stringify({
+      model: 'mimo-v2.5',
+      choices: [{ message: { content: 'I am unable to process or transcribe audio content.' } }],
+    }), { status: 200 }))
+    await expect(callProvider()).rejects.toThrow('dedicated mimo-v2.5-asr model')
+  })
+
+  it('requires the dedicated response model even when content looks like a transcript', () => {
+    expect(() => parseMimoAsrResponse({
+      model: 'mimo-v2.5',
+      choices: [{ message: { content: 'hello' } }],
+    })).toThrow('dedicated mimo-v2.5-asr model')
+  })
+})

--- a/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.ts
@@ -1,10 +1,20 @@
+import { errorMessageFrom } from '@moeru/std'
+import { encodeBase64 } from '@moeru/std/base64'
+import { toWav } from '@proj-airi/audio/encoding'
 import { z } from 'zod'
 
 import { defineProvider } from '../registry'
 
+export const MIMO_ASR_MODEL = 'mimo-v2.5-asr'
+export const MIMO_ASR_LANGUAGES = ['auto', 'zh', 'en'] as const
+export type MimoAsrLanguage = typeof MIMO_ASR_LANGUAGES[number]
+
+const MIMO_DEFAULT_BASE_URL = 'https://api.xiaomimimo.com/v1/'
+const MIMO_MAX_AUDIO_BASE64_LENGTH = 10 * 1024 * 1024
+
 const mimoSpeechConfigSchema = z.object({
   apiKey: z.string(),
-  baseUrl: z.string().default('https://api.xiaomimimo.com/v1/'),
+  baseUrl: z.string().default(MIMO_DEFAULT_BASE_URL),
   model: z.string().default('mimo-v2.5-tts'),
   voice: z.string().default('mimo_default'),
   format: z.string().default('wav'),
@@ -14,8 +24,9 @@ const mimoSpeechConfigSchema = z.object({
 
 const mimoTranscriptionConfigSchema = z.object({
   apiKey: z.string(),
-  baseUrl: z.string().default('https://api.xiaomimimo.com/v1/'),
-  model: z.string().default('mimo-v2-omni'),
+  baseUrl: z.string().default(MIMO_DEFAULT_BASE_URL),
+  model: z.literal(MIMO_ASR_MODEL).default(MIMO_ASR_MODEL),
+  language: z.enum(MIMO_ASR_LANGUAGES).default('auto'),
 })
 
 type MimoSpeechConfig = z.input<typeof mimoSpeechConfigSchema>
@@ -23,7 +34,7 @@ type MimoTranscriptionConfig = z.input<typeof mimoTranscriptionConfigSchema>
 type MimoConfig = MimoSpeechConfig | MimoTranscriptionConfig
 
 function normalizeBaseUrl(baseUrl: string | undefined) {
-  return `${(baseUrl || 'https://api.xiaomimimo.com/v1/').replace(/\/+$/, '')}/`
+  return `${(baseUrl || MIMO_DEFAULT_BASE_URL).replace(/\/+$/, '')}/`
 }
 
 function createMimoValidators<TConfig extends MimoConfig>(id: string) {
@@ -137,34 +148,119 @@ function createMimoSpeechProvider(config: MimoSpeechConfig) {
   }
 }
 
-function audioFormatFromDataUri(dataUri: string) {
-  const mimeType = dataUri.split(';')[0]?.split(':')[1] || 'audio/wav'
-  const format = mimeType.split('/')[1] || 'wav'
-  if (format === 'webm' || format === 'mp4')
-    return format
-  if (format === 'mpeg' || format === 'mp3')
-    return 'mp3'
-  return 'wav'
+function hasFourCc(bytes: Uint8Array, offset: number, value: string) {
+  if (bytes.byteLength < offset + value.length)
+    return false
+  return value.split('').every((character, index) => bytes[offset + index] === character.charCodeAt(0))
 }
 
-function readBlobAsDataUri(file: Blob) {
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(String(reader.result))
-    reader.onerror = () => reject(new Error('Failed to read audio file'))
-    reader.readAsDataURL(file)
-  })
+function isWavAudio(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer)
+  return bytes.byteLength >= 44 && hasFourCc(bytes, 0, 'RIFF') && hasFourCc(bytes, 8, 'WAVE')
+}
+
+function isLikelyMp3Audio(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer)
+  if (bytes.byteLength < 2)
+    return false
+  if (hasFourCc(bytes, 0, 'ID3'))
+    return true
+  return bytes[0] === 0xFF && (bytes[1] & 0xE0) === 0xE0
+}
+
+function createMimoAudioData(buffer: ArrayBuffer, format: 'wav' | 'mp3') {
+  const mimeType = format === 'wav' ? 'audio/wav' : 'audio/mpeg'
+  const base64 = encodeBase64(buffer)
+  if (base64.length > MIMO_MAX_AUDIO_BASE64_LENGTH)
+    throw new Error('MiMo ASR audio exceeds the 10 MB Base64 limit.')
+
+  return {
+    data: `data:${mimeType};base64,${base64}`,
+    format,
+  }
+}
+
+function getAudioContextConstructor() {
+  return globalThis.AudioContext
+    ?? (globalThis as typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+}
+
+async function convertToMimoWav(buffer: ArrayBuffer) {
+  const AudioContextConstructor = getAudioContextConstructor()
+  if (!AudioContextConstructor)
+    throw new Error('MiMo ASR accepts only WAV or MP3 audio, and this runtime cannot decode the recorder format.')
+
+  const audioContext = new AudioContextConstructor()
+  try {
+    const decoded = await audioContext.decodeAudioData(buffer.slice(0))
+    const monoSamples = new Float32Array(decoded.length)
+    for (let channel = 0; channel < decoded.numberOfChannels; channel++) {
+      const channelSamples = decoded.getChannelData(channel)
+      for (let index = 0; index < decoded.length; index++)
+        monoSamples[index] += channelSamples[index] / decoded.numberOfChannels
+    }
+
+    return createMimoAudioData(toWav(monoSamples.buffer, decoded.sampleRate), 'wav')
+  }
+  catch (error) {
+    const reason = errorMessageFrom(error) ?? 'unknown decode error'
+    throw new Error(`Unable to convert recorder audio to a MiMo-compatible WAV file: ${reason}`)
+  }
+  finally {
+    await audioContext.close().catch(() => {})
+  }
+}
+
+async function prepareMimoAsrAudio(file: Blob) {
+  const buffer = await file.arrayBuffer()
+
+  // Validate the container bytes before trusting the Blob MIME type. This prevents
+  // sending WebM/MP4 bytes with a relabelled WAV/MP3 MIME type.
+  if (isWavAudio(buffer))
+    return createMimoAudioData(buffer, 'wav')
+  if (isLikelyMp3Audio(buffer))
+    return createMimoAudioData(buffer, 'mp3')
+
+  return await convertToMimoWav(buffer)
+}
+
+function normalizeMimoAsrLanguage(value: unknown): MimoAsrLanguage {
+  return typeof value === 'string' && (MIMO_ASR_LANGUAGES as readonly string[]).includes(value)
+    ? value as MimoAsrLanguage
+    : 'auto'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function parseMimoAsrResponse(value: unknown) {
+  if (!isRecord(value) || value.model !== MIMO_ASR_MODEL)
+    throw new Error('MiMo ASR response did not identify the dedicated mimo-v2.5-asr model.')
+
+  const choices = value.choices
+  const firstChoice = Array.isArray(choices) ? choices[0] : undefined
+  const message = isRecord(firstChoice) ? firstChoice.message : undefined
+  const content = isRecord(message) ? message.content : undefined
+  if (typeof content !== 'string')
+    throw new Error('MiMo ASR response is missing a string transcript.')
+
+  return content.trim()
+}
+
+export interface MimoTranscriptionOptions {
+  language?: string
 }
 
 function createMimoTranscriptionProvider(config: MimoTranscriptionConfig) {
   const apiKey = config.apiKey?.trim() ?? ''
   const baseUrl = normalizeBaseUrl(config.baseUrl)
-  const defaultModel = config.model || 'mimo-v2-omni'
+  const configuredLanguage = config.language
 
   return {
-    transcription: (model: string) => ({
+    transcription: (_model: string, extraOptions?: MimoTranscriptionOptions) => ({
       baseURL: baseUrl,
-      model: model || defaultModel,
+      model: MIMO_ASR_MODEL,
       headers: {},
       fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
         if (!(init?.body instanceof FormData))
@@ -174,30 +270,37 @@ function createMimoTranscriptionProvider(config: MimoTranscriptionConfig) {
         if (!(file instanceof Blob))
           throw new Error('No audio file provided for transcription.')
 
-        const modelName = String(init.body.get('model') || defaultModel)
-        const dataUri = await readBlobAsDataUri(file)
-        const base64Data = dataUri.split(',')[1]
-        const response = await fetch(new URL('chat/completions', baseUrl), {
+        const audio = await prepareMimoAsrAudio(file)
+        const response = await globalThis.fetch(new URL('chat/completions', baseUrl), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'api-key': apiKey },
           body: JSON.stringify({
-            model: modelName,
+            model: MIMO_ASR_MODEL,
             messages: [{
               role: 'user',
               content: [
-                { type: 'text', text: 'Transcribe the audio content.' },
-                { type: 'input_audio', input_audio: { data: base64Data, format: audioFormatFromDataUri(dataUri) } },
+                { type: 'input_audio', input_audio: audio },
               ],
             }],
+            asr_options: {
+              language: normalizeMimoAsrLanguage(configuredLanguage ?? extraOptions?.language),
+            },
           }),
         })
         if (!response.ok) {
-          const errorBody = await response.text().catch(() => '')
-          throw new Error(`MiMo transcription failed: ${response.status} ${response.statusText}${errorBody ? ` — ${errorBody}` : ''}`)
+          throw new Error(`MiMo ASR request failed: ${response.status} ${response.statusText}`)
         }
 
-        const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> }
-        return new Response(JSON.stringify({ text: data.choices?.[0]?.message?.content || '' }), {
+        let data: unknown
+        try {
+          data = await response.json()
+        }
+        catch {
+          throw new Error('MiMo ASR response was not valid JSON.')
+        }
+
+        const text = parseMimoAsrResponse(data)
+        return new Response(JSON.stringify({ text }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })
@@ -255,8 +358,7 @@ export const providerMimoAudioTranscription = defineProvider<MimoTranscriptionCo
   validators: createMimoValidators<MimoTranscriptionConfig>('mimo-audio-transcription'),
   extraMethods: {
     listModels: async () => [
-      { id: 'mimo-v2-omni', name: 'MiMo V2 Omni', provider: 'mimo-audio-transcription', description: 'Omni-modal model with native audio understanding and speech-to-text', contextLength: 256000, deprecated: false },
-      { id: 'mimo-v2.5', name: 'MiMo V2.5', provider: 'mimo-audio-transcription', description: 'Latest omni-modal model with audio understanding, 1M context', contextLength: 1_000_000, deprecated: false },
+      { id: MIMO_ASR_MODEL, name: 'MiMo v2.5 ASR', provider: 'mimo-audio-transcription', description: 'Dedicated Xiaomi MiMo Speech Recognition model', contextLength: 8_000, deprecated: false },
     ],
   },
 })

--- a/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.ts
+++ b/packages/stage-ui/src/libs/providers/providers/mimo-audio/index.ts
@@ -283,7 +283,7 @@ function createMimoTranscriptionProvider(config: MimoTranscriptionConfig) {
               ],
             }],
             asr_options: {
-              language: normalizeMimoAsrLanguage(configuredLanguage ?? extraOptions?.language),
+              language: normalizeMimoAsrLanguage(extraOptions?.language ?? configuredLanguage),
             },
           }),
         })

--- a/packages/stage-ui/src/stores/modules/hearing.ts
+++ b/packages/stage-ui/src/stores/modules/hearing.ts
@@ -1202,7 +1202,12 @@ export const useHearingSpeechInputPipeline = defineStore('modules:hearing:speech
 
       const providerConfig = providerStore.getProviderConfig(providerId)
       const model = resolveActiveTranscriptionModel(activeTranscriptionModel.value, providerConfig)
-      const providerOptions = resolveTranscriptionProviderOptions(providerConfig)
+      // MiMo ASR has its own language contract and defaults to auto-detect. Do
+      // not infer a language from the browser locale when the provider config
+      // has not explicitly selected zh/en.
+      const providerOptions = providerId === 'mimo-audio-transcription'
+        ? resolveTranscriptionProviderOptions(providerConfig, '')
+        : resolveTranscriptionProviderOptions(providerConfig)
       console.info('[Hearing Pipeline] Transcribing recording', {
         providerId,
         language: providerOptions.language,


### PR DESCRIPTION
## Description

The Xiaomi MiMo transcription provider used general multimodal models for speech recognition.

A text prompt asked `mimo-v2.5` to transcribe audio. The model could return an assistant refusal, a model self-introduction, or an ambient-audio description. AIRI then accepted that assistant content as a voice transcript.

This change uses Xiaomi's dedicated `mimo-v2.5-asr` Speech Recognition contract. It:

- uses `mimo-v2.5-asr` as the only transcription model;
- sends one `input_audio` part to `/v1/chat/completions`;
- removes the generic transcription prompt;
- supports `auto`, `zh`, and `en` language options, with `auto` as the default;
- preserves valid WAV and MP3 input;
- converts unsupported recorder containers to a real WAV file before upload;
- validates the response model and transcript type before returning text;
- keeps empty transcripts separate from malformed or failed responses;
- labels provider validation as local configuration completeness, not runtime proof.

## Linked Issues

None.

## Additional Context

Exact PR head automated validation:

- MiMo focused Vitest regression suite: 10 tests passed;
- `@proj-airi/stage-ui` typecheck passed;
- `@proj-airi/stage-pages` typecheck passed;
- repository lint passed with existing warnings outside this patch;
- `build:packages` passed;
- `git diff --check` passed.

A source-equivalent repair was additionally validated against the real Xiaomi MiMo API with live microphone input before upstreaming. The exact PR head was not microphone-tested in this contribution task.

Review focus:

- the request shape and dedicated response model check;
- the WAV/MP3 container check and unsupported-format conversion;
- the boundary between local configuration validation and runtime transcription.

Xiaomi Speech Recognition documentation: https://mimo.mi.com/docs/en-US/api/audio/Speech-Recognition