### PR TITLE
fix(stage-tamagotchi): keep expanded controls island reachable on small windows

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -4,7 +4,7 @@ import { useElectronEventaContext, useElectronEventaInvoke, useElectronMouseInEl
 import { IS_DEV } from '@proj-airi/stage-shared'
 import { useSettings, useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
 import { useTheme } from '@proj-airi/ui'
-import { refDebounced, useIntervalFn } from '@vueuse/core'
+import { refDebounced, useIntervalFn, useWindowSize } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -40,6 +40,12 @@ const emit = defineEmits<Emits>()
 const { isDark, toggleDark } = useTheme()
 const { t } = useI18n()
 const { dock, isLeft, isTop, motionPhase } = useControlsIslandPlacement()
+const { height: windowHeight } = useWindowSize()
+
+// Below this window height, `auto` icon sizing switches to the smaller icons so
+// the controls column (and the expanded drawer next to it) still fit; above it,
+// the larger, more legible icons are used.
+const AUTO_LARGE_MIN_HEIGHT = 420
 
 const settingsAudioDeviceStore = useSettingsAudioDevice()
 const settingsStore = useSettings()
@@ -128,9 +134,9 @@ const adjustStyleClasses = computed(() => {
       break
     case 'auto':
     default:
-      // Fixed to large for better visibility in the new layout,
-      // can be changed to windowHeight based check if absolutely needed.
-      isLarge = true
+      // Use the more legible large icons when there's vertical room, and shrink
+      // to the smaller ones on short windows so the controls stay reachable.
+      isLarge = windowHeight.value >= AUTO_LARGE_MIN_HEIGHT
       break
   }
 

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -226,6 +226,10 @@ function resetMainWindowPosition() {
           :class="[
             'flex flex-col gap-1 rounded-2xl border border-neutral-200 p-2 dark:border-neutral-800',
             'bg-neutral-100/80 shadow-2xl shadow-black/20 backdrop-blur-xl dark:bg-neutral-900/80',
+            // Keep the drawer reachable on small windows: cap its height to the
+            // viewport (leaving room for the main controls docked next to it)
+            // and scroll internally instead of clipping controls out of reach.
+            'max-h-[calc(100dvh_-_5rem)] overflow-y-auto overscroll-contain',
             panelPositionClasses,
           ]"
         >

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -210,7 +210,9 @@ function resetMainWindowPosition() {
   >
     <div
       :class="[
-        'flex gap-1',
+        // Bound the island to the viewport so the drawer can size from the
+        // remaining flex space next to the (fixed-height) main controls.
+        'flex gap-1 max-h-[calc(100dvh_-_1rem)]',
         islandLayoutClasses,
       ]"
     >
@@ -226,10 +228,10 @@ function resetMainWindowPosition() {
           :class="[
             'flex flex-col gap-1 rounded-2xl border border-neutral-200 p-2 dark:border-neutral-800',
             'bg-neutral-100/80 shadow-2xl shadow-black/20 backdrop-blur-xl dark:bg-neutral-900/80',
-            // Keep the drawer reachable on small windows: cap its height to the
-            // viewport (leaving room for the main controls docked next to it)
-            // and scroll internally instead of clipping controls out of reach.
-            'max-h-[calc(100dvh_-_5rem)] overflow-y-auto overscroll-contain',
+            // Keep the drawer reachable on small windows: let it shrink within
+            // the island's bounded height and scroll internally instead of
+            // clipping controls out of reach.
+            'min-h-0 overflow-y-auto overscroll-contain',
             panelPositionClasses,
           ]"
         >
@@ -359,7 +361,7 @@ function resetMainWindowPosition() {
       </Transition>
 
       <!-- Main Controls -->
-      <div :class="mainControlsLayoutClasses">
+      <div :class="['shrink-0', mainControlsLayoutClasses]">
         <ControlButtonTooltip side="inward">
           <ControlButton
             v-track-button="{


### PR DESCRIPTION
Fixes #2400.

On a small window, expanding the controls island grows the drawer (auth button + the grid of actions) with no height bound, so it overflows the window and its controls get clipped out of reach — and since nothing scrolls, there's no way to reach them (the reporter's "no way to make any further adjustments").

**Fix:** cap the expanded drawer to the viewport height and let it scroll internally, so every control stays reachable at any window size and dock corner:

```
max-h-[calc(100dvh - 5rem)] overflow-y-auto overscroll-contain
```

I bound the **drawer** rather than the whole island on purpose, so the expand toggle and the main controls docked next to it stay fixed and visible; only the drawer scrolls.

**Heads-up / where I'd love your call:**
- I couldn't reproduce visually end-to-end locally (needs the desktop app on a small window), so this is my best guess — happy to adjust.
- The `5rem` reserve (room for the main controls next to the drawer) is an estimate; easy to tune.
- If you'd rather solve it by **shrinking the icons** on small windows instead of scrolling, the plumbing already exists (`controlsIslandIconSize` auto/small/large, currently forced to `large`) — I can switch `auto` to size by window height instead. Let me know which UX you prefer.