### PR TITLE
feat(stage-ui): support separate display text and TTS pronunciation via ruby annotations

### DIFF
--- a/packages/stage-ui/src/components/scenes/Stage.vue
+++ b/packages/stage-ui/src/components/scenes/Stage.vue
@@ -39,6 +39,7 @@ import { live2dMotionMagicProfiles, useLive2DMotionMagic, useLive2DMotionMagicSe
 import { getDefaultStreamingModel, getDefinedProvider } from '../../libs/providers/providers'
 import { OFFICIAL_SPEECH_PROVIDER_ID, OFFICIAL_SPEECH_STREAMING_PROVIDER_ID } from '../../libs/providers/providers/official'
 import { bindSpeakingStateToPlaybackManager } from '../../libs/speech/playback-speaking-state'
+import { createRubyProjector } from '../../libs/speech/ruby-annotation'
 import { createStageTtsSession } from '../../libs/speech/tts-session'
 import { getSpeechBusContext, speechOutputGetPlaybackState } from '../../services/speech/bus'
 import { useLlmStreamingControlStore } from '../../stores/ai/chat-llm/streaming-control'
@@ -716,6 +717,14 @@ function setupAnalyser() {
 // decision point. See `packages/stage-ui/src/libs/speech/tts-session.ts`.
 let currentSession: StageTtsSession | null = null
 
+// Projects ruby-annotated assistant tokens (`｜base《reading》`) into speech
+// text (reading substituted for the base) before they reach TTS, so the model
+// can control pronunciation without the markup being spoken. Streaming-safe and
+// reset per message so a partial annotation never leaks across turns.
+// ponytail: speech side only; rendering the `displayText` in chat is the #2255
+// follow-up (it lives in the message renderer, not this TTS side-channel).
+let rubyProjector = createRubyProjector()
+
 function stopSpeechOutput(reason: string) {
   currentSession?.cancel(reason)
   currentSession = null
@@ -845,6 +854,7 @@ watch(speechMuted, (muted) => {
 chatHookCleanups.push(onBeforeMessageComposed(async (_message, context) => {
   playbackManager.stopAll('new-message')
   resetAssistantSpeechSurface('new-message')
+  rubyProjector = createRubyProjector()
 
   currentSession?.cancel('new-message')
   currentSession = null
@@ -862,7 +872,11 @@ chatHookCleanups.push(onBeforeSend(async () => {
 }))
 
 chatHookCleanups.push(onTokenLiteral(async (literal) => {
-  currentSession?.appendText(literal)
+  // Withhold text buffered inside an unclosed annotation; it surfaces once the
+  // reading closes (or on flush at stream end), so TTS never speaks the markup.
+  const { speechText } = rubyProjector.push(literal)
+  if (speechText)
+    currentSession?.appendText(speechText)
 }))
 
 chatHookCleanups.push(onTokenSpecial(async (special, context) => {
@@ -877,6 +891,10 @@ chatHookCleanups.push(onTokenSpecial(async (special, context) => {
 }))
 
 chatHookCleanups.push(onStreamEnd(async () => {
+  // Emit any text left inside an unterminated annotation so nothing is dropped.
+  const { speechText } = rubyProjector.flush()
+  if (speechText)
+    currentSession?.appendText(speechText)
   currentSession?.finishInput()
 }))
 

--- a/packages/stage-ui/src/libs/speech/ruby-annotation.test.ts
+++ b/packages/stage-ui/src/libs/speech/ruby-annotation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { createRubyProjector, projectRuby } from './ruby-annotation'
+
+describe('projectRuby', () => {
+  it('splits explicit-base ruby into display (base) and speech (reading)', () => {
+    expect(projectRuby('｜約束《やくそく》は')).toEqual({
+      displayText: '約束は',
+      speechText: 'やくそくは',
+    })
+  })
+
+  it('passes through text without annotations unchanged', () => {
+    const s = 'Hello, world! 普通のテキストです。'
+    expect(projectRuby(s)).toEqual({ displayText: s, speechText: s })
+  })
+
+  it('handles multiple annotations in one string', () => {
+    expect(projectRuby('｜今日《きょう》は｜晴《は》れ')).toEqual({
+      displayText: '今日は晴れ',
+      speechText: 'きょうははれ',
+    })
+  })
+
+  it('treats a lone 《…》 without a base mark as literal text', () => {
+    const s = '彼は《強い》と言った'
+    expect(projectRuby(s)).toEqual({ displayText: s, speechText: s })
+  })
+
+  it('emits an unterminated annotation verbatim (no text loss)', () => {
+    expect(projectRuby('｜約束《やくそく')).toEqual({
+      displayText: '｜約束《やくそく',
+      speechText: '｜約束《やくそく',
+    })
+    expect(projectRuby('｜約束')).toEqual({
+      displayText: '｜約束',
+      speechText: '｜約束',
+    })
+  })
+
+  it('handles empty input', () => {
+    expect(projectRuby('')).toEqual({ displayText: '', speechText: '' })
+  })
+})
+
+describe('createRubyProjector — streaming boundary safety', () => {
+  const input = '｜約束《やくそく》は｜晴《は》れ、tail'
+  const whole = projectRuby(input)
+
+  it('produces identical output for every possible chunk split point', () => {
+    for (let i = 1; i < input.length; i++) {
+      const p = createRubyProjector()
+      const a = p.push(input.slice(0, i))
+      const b = p.push(input.slice(i))
+      const c = p.flush()
+      expect({
+        displayText: a.displayText + b.displayText + c.displayText,
+        speechText: a.speechText + b.speechText + c.speechText,
+      }).toEqual(whole)
+    }
+  })
+
+  it('survives one-character-at-a-time streaming', () => {
+    const p = createRubyProjector()
+    let displayText = ''
+    let speechText = ''
+    for (const ch of input) {
+      const r = p.push(ch)
+      displayText += r.displayText
+      speechText += r.speechText
+    }
+    const f = p.flush()
+    expect({
+      displayText: displayText + f.displayText,
+      speechText: speechText + f.speechText,
+    }).toEqual(whole)
+  })
+
+  it('withholds a partial annotation until it completes', () => {
+    const p = createRubyProjector()
+    // The annotation is still open — nothing should surface yet.
+    expect(p.push('｜約束《やく')).toEqual({ displayText: '', speechText: '' })
+    // Closing chunk commits base to display and reading to speech.
+    expect(p.push('そく》です')).toEqual({
+      displayText: '約束です',
+      speechText: 'やくそくです',
+    })
+  })
+})

--- a/packages/stage-ui/src/libs/speech/ruby-annotation.ts
+++ b/packages/stage-ui/src/libs/speech/ruby-annotation.ts
@@ -1,0 +1,138 @@
+/**
+ * Streaming-safe projection of ruby-annotated assistant text into separate
+ * display and speech strings.
+ *
+ * Ruby syntax (Aozora/pixiv-style, explicit-base form):
+ *
+ *     ｜<base>《<reading>》
+ *
+ * e.g. `｜約束《やくそく》は` → display `約束は`, speech `やくそくは`.
+ *
+ * `displayText` preserves the base (e.g. kanji) for the chat surface;
+ * `speechText` substitutes the reading so TTS pronounces it correctly. The
+ * annotation markers themselves are never displayed nor pronounced.
+ *
+ * The projector is stateful so a single annotation may be split across
+ * arbitrary streaming chunk boundaries (e.g. `｜約` + `束《やく` + `そく》は`):
+ * partial annotations are buffered and only committed once the closing `》`
+ * arrives. `flush()` emits any unterminated buffer verbatim — graceful
+ * degradation, so malformed markup is shown literally rather than dropped.
+ *
+ * Text without annotations passes through unchanged (`displayText` ===
+ * `speechText`), so this is a no-op for the common non-annotated case.
+ */
+
+/** ｜ U+FF5C fullwidth vertical line — marks the start of the base run. */
+const RUBY_BASE_MARK = '｜'
+/** 《 U+300A — opens the reading. */
+const RUBY_OPEN = '《'
+/** 》 U+300B — closes the reading. */
+const RUBY_CLOSE = '》'
+
+export interface RubyProjection {
+  /** Text to render in the chat surface (base preserved, markers stripped). */
+  displayText: string
+  /** Text to feed the TTS pipeline (reading substituted, markers stripped). */
+  speechText: string
+}
+
+type State = 'normal' | 'base' | 'reading'
+
+export interface RubyProjector {
+  /**
+   * Feed the next streaming chunk. Returns only the portion that can be
+   * committed now — text outside annotations, plus any annotation whose
+   * closing `》` arrived in this chunk. A partial annotation is withheld
+   * (empty delta) until it completes in a later chunk.
+   */
+  push: (chunk: string) => RubyProjection
+  /**
+   * Emit any unterminated annotation buffer verbatim and reset. Call once the
+   * stream ends so no buffered text is lost.
+   */
+  flush: () => RubyProjection
+}
+
+export function createRubyProjector(): RubyProjector {
+  let state: State = 'normal'
+  let base = ''
+  let reading = ''
+
+  function push(chunk: string): RubyProjection {
+    let display = ''
+    let speech = ''
+
+    for (const ch of chunk) {
+      switch (state) {
+        case 'normal':
+          if (ch === RUBY_BASE_MARK) {
+            state = 'base'
+            base = ''
+          }
+          else {
+            display += ch
+            speech += ch
+          }
+          break
+
+        case 'base':
+          if (ch === RUBY_OPEN) {
+            state = 'reading'
+            reading = ''
+          }
+          else if (ch === RUBY_BASE_MARK) {
+            // A new base mark while still buffering the previous one: the
+            // previous run was malformed. Emit it literally and restart.
+            display += RUBY_BASE_MARK + base
+            speech += RUBY_BASE_MARK + base
+            base = ''
+          }
+          else {
+            base += ch
+          }
+          break
+
+        case 'reading':
+          if (ch === RUBY_CLOSE) {
+            display += base
+            speech += reading
+            base = ''
+            reading = ''
+            state = 'normal'
+          }
+          else {
+            reading += ch
+          }
+          break
+      }
+    }
+
+    return { displayText: display, speechText: speech }
+  }
+
+  function flush(): RubyProjection {
+    let leftover = ''
+    if (state === 'base')
+      leftover = RUBY_BASE_MARK + base
+    else if (state === 'reading')
+      leftover = RUBY_BASE_MARK + base + RUBY_OPEN + reading
+
+    state = 'normal'
+    base = ''
+    reading = ''
+    return { displayText: leftover, speechText: leftover }
+  }
+
+  return { push, flush }
+}
+
+/** Convenience: project a complete (non-streaming) string in one call. */
+export function projectRuby(text: string): RubyProjection {
+  const projector = createRubyProjector()
+  const body = projector.push(text)
+  const tail = projector.flush()
+  return {
+    displayText: body.displayText + tail.displayText,
+    speechText: body.speechText + tail.speechText,
+  }
+}


### PR DESCRIPTION
### Problem

For languages like Japanese, the text you want to **show** and the text you want to **pronounce** differ: the chat should keep the kanji (`約束`), but TTS needs the reading (`やくそく`) to speak it correctly. Today the assistant's raw output feeds both the chat and TTS verbatim, so there's no way to control pronunciation without corrupting the display (and vice-versa).

Closes the design gap described in #2255. As the reporter suggested, a general `displayText` / `speechText` projection at the *core agent-to-speech boundary* is more reusable than doing it per TTS provider — that's the approach here.

### Approach

A small, self-contained streaming projector (`libs/speech/ruby-annotation.ts`) parses Aozora/pixiv-style ruby markup and splits one token stream into two:

```
｜約束《やくそく》は   →   displayText: 約束は     speechText: やくそくは
```

- **`displayText`** keeps the base (markers stripped) for the chat surface.
- **`speechText`** substitutes the reading for TTS.
- The markers themselves are never displayed nor spoken.
- Text without annotations passes through unchanged (`displayText === speechText`) — a no-op for the common case.

**Streaming-safe by construction.** The projector is stateful, so an annotation may be split across *arbitrary* chunk boundaries (`｜約` + `束《やく` + `そく》は`): partial annotations are buffered and only committed once the closing `》` arrives. `flush()` emits any unterminated buffer verbatim, so no text is ever dropped even on malformed input.

### Wiring (speech side)

`Stage.vue` projects assistant tokens at the `onTokenLiteral` boundary before they reach TTS, with the projector reset per message so a partial annotation can't leak across turns, and flushed at `onStreamEnd`. This side-channel is TTS-only, so **the chat display is untouched** (no regression) — it keeps rendering the raw stream today.

Rendering the `displayText` in the chat message (stripping the markup from what the user sees) is a natural **follow-up** in the message renderer; I kept it out of this PR so the boundary change stays minimal and reviewable. Happy to do it here too if you'd prefer.

### Tests

`ruby-annotation.test.ts` (9 cases, `vitest`), including the hard part — an exhaustive sweep asserting the output is identical for **every possible chunk split point**, plus one-character-at-a-time streaming, multiple annotations, malformed/unterminated input, and "a partial annotation is withheld until it completes".

```
Test Files  1 passed (1)
     Tests  9 passed (9)
```

### Notes for reviewers

The issue is labelled `needs-more-info`, so I've kept the **syntax** (`｜base《reading》`) and **placement** as an explicit proposal — both are easy to change: the syntax is three constants in one file, and the projection is a pure function you can drop anywhere along the boundary. Let me know if you'd like a different notation, a different location, or the display-side rendering folded in.

Addresses #2255