### PR TITLE
fix(stage-ui): deliver sends issued during the transport prepare phase

### DIFF
--- a/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.test.ts
@@ -8,6 +8,10 @@ const serverSdkMocks = vi.hoisted(() => {
 
     readonly listeners = new Map<string, Set<(event: any) => void | Promise<void>>>()
     readonly sent: any[] = []
+    // Mirrors better-ws: the real transport only accepts sends in state `ready`.
+    // Defaults to true so existing tests are unaffected; set false to model the
+    // prepare phase where Client.send() returns false.
+    ready = true
 
     constructor(public readonly options: Record<string, any>) {
       MockClient.instances.push(this)
@@ -45,6 +49,8 @@ const serverSdkMocks = vi.hoisted(() => {
     }
 
     send(event: any) {
+      if (!this.ready)
+        return false
       this.sent.push(event)
       return true
     }
@@ -373,6 +379,56 @@ describe('channel-server store reconnect', () => {
       expect.objectContaining({
         type: 'spark:notify',
         data: { message: 'reconnect-authenticated-queued' },
+      }),
+    ]))
+  })
+
+  // ROOT CAUSE:
+  //
+  // On a fresh connect, `module:authenticated` marks the store connected while
+  // the better-ws transport is still in its prepare phase, so `Client.send()`
+  // returns false. Both `send()` and `flush()` ignored that result — `send()`
+  // dropped the message and `flush()` cleared the queue unconditionally — so
+  // the stage's consumer registration (sent in exactly this window) never
+  // reached the server, and external `input:text` was dropped until the first
+  // reconnect. Regressed silently when the SDK moved onto better-ws (#1989).
+  //
+  // Before the fix this test fails: the send issued during `preparing` is
+  // dropped, so `pendingSendCount` is 0 instead of 1. The fix keeps unsent
+  // messages queued so the `onReady` flush delivers them.
+  //
+  // Regression coverage for https://github.com/moeru-ai/airi/issues/2305
+  it('issue #2305: queues sends issued while the transport is preparing and delivers them on ready', async () => {
+    const store = useModsServerChannelStore()
+
+    const initializePromise = store.initialize({ token: 'secret' })
+    const client = serverSdkMocks.MockClient.instances.at(-1)!
+
+    // Authenticated but not yet `ready` — the prepare phase, where send() fails.
+    client.ready = false
+    client.simulateAuthenticated()
+    await initializePromise
+
+    store.send({
+      type: 'spark:notify',
+      data: { message: 'sent-while-preparing' },
+    } as any)
+
+    // Held, not dropped.
+    expect(store.pendingSendCount).toBe(1)
+    expect(client.sent).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ data: { message: 'sent-while-preparing' } }),
+    ]))
+
+    // Transport reaches ready → the onReady flush delivers the queued send.
+    client.ready = true
+    client.simulateReconnectReady()
+
+    expect(store.pendingSendCount).toBe(0)
+    expect(client.sent).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'spark:notify',
+        data: { message: 'sent-while-preparing' },
       }),
     ]))
   })

--- a/packages/stage-ui/src/stores/mods/api/channel-server.ts
+++ b/packages/stage-ui/src/stores/mods/api/channel-server.ts
@@ -302,21 +302,29 @@ export const useModsServerChannelStore = defineStore('mods:channels:proj-airi:se
     if (!client.value && !initializing.value)
       void initialize()
 
-    if (client.value && connected.value) {
-      client.value.send(data as WebSocketEvent)
-    }
-    else {
-      pendingSend.value.push(data as WebSocketEvent)
-    }
+    // `Client.send()` returns false when the transport is not yet `ready` —
+    // e.g. still in the better-ws prepare phase, which is the case right after
+    // `module:authenticated` even though `connected` is already true. Keep any
+    // such message queued so the `onReady` flush delivers it, instead of
+    // dropping it silently (which lost the stage's consumer registration on a
+    // fresh load until the first reconnect).
+    if (client.value && connected.value && client.value.send(data as WebSocketEvent))
+      return
+
+    pendingSend.value.push(data as WebSocketEvent)
   }
 
   function flush() {
-    if (client.value && connected.value) {
-      for (const update of pendingSend.value) {
-        client.value.send(update)
-      }
+    if (!client.value || !connected.value)
+      return
 
-      pendingSend.value = []
+    const pending = pendingSend.value
+    pendingSend.value = []
+    for (const update of pending) {
+      // Re-queue anything the transport still refuses (not `ready` yet) so a
+      // later flush can deliver it, rather than clearing it unconditionally.
+      if (!client.value.send(update))
+        pendingSend.value.push(update)
     }
   }
 


### PR DESCRIPTION
### Problem

Fixes #2305. On a **freshly loaded** stage, the consumer registration for `input:text` / `input:text:voice` / `input:voice` (the `chat-ingestion` consumer group) never reaches the server. Every `input:text` from an external module (Discord, Twitter, any SDK producer) is then dropped by the runtime with *"no consumer registered for event delivery"* — the character never answers, the console is clean, and the store still reports itself healthy. It heals itself only on the first reconnect.

Full forensic diagnosis is in the issue; thanks to the reporter for it.

### Root cause

`module:authenticated` sets `connected = true` and flushes **while the better-ws transport is still in its prepare phase**. In that window `Client.send()` returns `false` (it only accepts sends in state `ready`), but neither send path honored the result:

```ts
function send(data) {
  // ...
  if (client.value && connected.value) {
    client.value.send(data)   // ← returns false during `preparing`, ignored → dropped
  } else {
    pendingSend.value.push(data)
  }
}

function flush() {
  if (client.value && connected.value) {
    for (const update of pendingSend.value)
      client.value.send(update)   // ← also ignored
    pendingSend.value = []          // ← queue cleared unconditionally
  }
}
```

The stage's registration is sent exactly in this window, so it is dropped, and the queue is cleared before the real `onReady` flush runs.

This regressed silently when the SDK moved onto **better-ws** (#1989), which introduced the `open → preparing → ready` state machine and performs authenticate/announce inside the prepare phase. Before that, `send()` only required an `OPEN` socket, and at `module:authenticated` the socket is open — so the registration went through.

### Fix

Honor the boolean: keep a message queued when `Client.send()` reports it was not sent, and re-queue from `flush()` anything the transport still refuses. The `onReady` flush (which runs in state `ready`) then delivers it. This fixes the root cause for **every** early send, not just consumer registration.

### Why it slipped through the tests

The existing mock client's `send()` always returned `true`, so the prepare-phase drop was never exercised. The mock now models the not-ready state (defaulting to `true`, so the 13 existing cases are unaffected), and a regression test sends during `preparing` and asserts it is queued and then delivered on ready:

```
Test Files  1 passed (1)
     Tests  14 passed (14)
```

The new test **fails without the source fix** (`pendingSendCount` is `0` — the message is dropped).

Fixes #2305