### PR TITLE
test(i18n): cover supported locale normalization

### DIFF
--- a/packages/i18n/src/index.test.ts
+++ b/packages/i18n/src/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { all, resolveSupportedLocale } from './index'
+
+const supportedLocales = Object.keys(all)
+
+describe('resolveSupportedLocale', () => {
+  it.each([
+    ['zh-TW', 'zh-Hant'],
+    ['zh-HK', 'zh-Hant'],
+    ['zh-Hant', 'zh-Hant'],
+    ['zh-CN', 'zh-Hans'],
+    ['zh-Hans', 'zh-Hans'],
+    ['en-US', 'en'],
+    ['en-GB', 'en'],
+    ['es-MX', 'es'],
+    ['fr-FR', 'fr'],
+    ['ja-JP', 'ja'],
+    ['ko-KR', 'ko'],
+    ['ru-RU', 'ru'],
+    ['vi-VN', 'vi'],
+  ])('maps %s to the supported locale %s', (locale, expected) => {
+    expect(resolveSupportedLocale(locale, supportedLocales)).toBe(expected)
+  })
+
+  it('falls back to English for an unsupported locale', () => {
+    expect(resolveSupportedLocale('de-DE', supportedLocales)).toBe('en')
+  })
+
+  it('uses the fallback when the locale is absent', () => {
+    expect(resolveSupportedLocale(undefined, supportedLocales, 'zh-Hant')).toBe('zh-Hant')
+  })
+})

--- a/packages/i18n/vitest.config.ts
+++ b/packages/i18n/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['glossary/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'glossary/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Summary

- add focused tests for `resolveSupportedLocale`
- include `src/**/*.test.ts` in the `@proj-airi/i18n` Vitest project

## Why

The shared locale resolver maps regional locales such as `zh-TW` and `zh-HK` to the supported `zh-Hant` locale, but the package had no regression coverage for that behavior. This test-only change protects the locale normalization used by the desktop bootstrap and other callers.

## Verification

- `git diff main...HEAD --check`
- static review against `packages/i18n/src/index.ts` and its supported locale map

The targeted Vitest command was attempted but could not start because this filtered clone has no installed dependencies and pnpm's registry requests repeatedly returned `ECONNRESET`.
