### PR TITLE
chore(stage-ui): remove leftover TTS debug logging

### DIFF
--- a/packages/stage-ui/src/utils/tts.ts
+++ b/packages/stage-ui/src/utils/tts.ts
@@ -221,9 +221,6 @@ export async function* chunkTTSInput(
     current = next
   }
 
-  // TODO: remove later
-  // eslint-disable-next-line no-console
-  console.debug('while loop ends, chunk/buffer:', chunk, buffer)
   if (chunk.length > 0 || buffer.length > 0) {
     const text = (chunk + buffer).trim()
     yield {


### PR DESCRIPTION
## Summary

- remove the leftover `console.debug` from the Stage UI TTS chunker flush path
- remove the temporary TODO and lint suppression that existed only for that log

## Why

The log runs on every normal TTS chunker flush and exposes chunk/buffer contents in application logs. The corresponding `packages/pipelines-audio` implementation is already clean on current `main`; this PR is intentionally limited to the remaining Stage UI copy.

## Verification

- `git diff --check`
- reviewed the current main implementation and confirmed the patch is exactly three removed debug-only lines

The focused Stage UI test suite was not run in this filtered clone because dependencies are not installed.
