### PR TITLE
test: include pipelines audio in root vitest projects

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'packages/ccc',
       'packages/core-agent',
       'packages/i18n',
+      'packages/pipelines-audio',
       'packages/input-gamepad',
       'packages/input-gamepad-vueuse',
       'packages/input-playstation-dualsense-5',


### PR DESCRIPTION
## Summary

- add `packages/pipelines-audio` to the root Vitest project list

## Why

`packages/pipelines-audio` has a package-local Vitest config and seven test files, but the root `vitest.config.ts` did not include it. As a result, the normal root test entry did not execute this package's tests. The other packages mentioned in the original backlog candidate are already included or no longer exist on current `main`, so this PR is limited to the remaining gap.

## Verification

- `git diff --check`
- package manifest resolution via `pnpm --filter @proj-airi/pipelines-audio list --depth=-1`
- static comparison with `packages/pipelines-audio/vitest.config.ts` and its current test files

The full root Vitest run was not started because dependencies are not installed in this filtered clone.
