### PR TITLE
feat(api): add Steam MicroTxn payment channel

### DIFF
--- a/.github/workflows/release-tamagotchi-steam.yml
+++ b/.github/workflows/release-tamagotchi-steam.yml
@@ -36,7 +36,6 @@ jobs:
     env:
       VITE_DISTRIBUTION: steam
       VITE_DISABLE_CUSTOM_PROVIDERS: 'true'
-      VITE_DISABLE_FLUX_PURCHASE: 'true'
       VITE_ENABLE_POSTHOG: 'false'
     strategy:
       fail-fast: false

--- a/packages/i18n/src/locales/en/settings.yaml
+++ b/packages/i18n/src/locales/en/settings.yaml
@@ -963,6 +963,13 @@ pages:
       success: Payment successful! Your Flux has been topped up.
       canceled: Payment was canceled.
       error: Something went wrong. Please try again later.
+      steamAccountNotLinked: Link a Steam account in Account settings. Then try again.
+      steamPending: Finish the purchase in Steam. Flux updates when you return.
+      payWith: Pay with
+      paymentStripe: Stripe
+      paymentSteam: Steam Wallet
+      steamLinkHint: After you link a Steam account, you can pay with Steam Wallet.
+      steamLinkHintAction: Link Steam account
     audit:
       title: Transaction History
       time: Time

--- a/packages/i18n/src/locales/zh-Hans/settings.yaml
+++ b/packages/i18n/src/locales/zh-Hans/settings.yaml
@@ -926,6 +926,13 @@ pages:
       success: 谢谢你！你的 Flux 通量已经更新好啦～
       canceled: 支付被取消
       error: 哎呀，出错了，请稍后再试
+      steamAccountNotLinked: 请先在账号设置里绑定 Steam 账号，然后再试一次。
+      steamPending: 请在 Steam 完成购买。返回后 Flux 会更新。
+      payWith: 付款方式
+      paymentStripe: Stripe
+      paymentSteam: Steam 钱包
+      steamLinkHint: 绑定后可以用 Steam 钱包支付。
+      steamLinkHintAction: 去绑定
     audit:
       title: 使用记录
       time: 时间

--- a/packages/stage-pages/src/pages/settings/flux.vue
+++ b/packages/stage-pages/src/pages/settings/flux.vue
@@ -1,16 +1,20 @@
 <script setup lang="ts">
 import type { FluxBalanceBucket } from '@proj-airi/stage-ui/composables/use-analytics'
 
-import { isFluxPurchaseDisabled, isStageTamagotchi } from '@proj-airi/stage-shared'
+import { errorMessageFrom } from '@moeru/std'
+import { isFluxPurchaseDisabled, isStageTamagotchi, isSteamDistribution } from '@proj-airi/stage-shared'
 import { client } from '@proj-airi/stage-ui/composables/api'
 import { useAnalytics } from '@proj-airi/stage-ui/composables/use-analytics'
+import { useFluxSteamCheckout } from '@proj-airi/stage-ui/composables/use-flux-steam-checkout'
 import { useAuthStore } from '@proj-airi/stage-ui/stores/auth'
-import { Button, SelectTab } from '@proj-airi/ui'
+import { Button, Callout, SelectTab } from '@proj-airi/ui'
 import { useEventListener } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
+
+type CheckoutMethod = 'stripe' | 'steam'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -27,6 +31,7 @@ const {
 } = useAnalytics()
 
 const fluxPurchaseDisabled = isFluxPurchaseDisabled()
+const steamDistribution = isSteamDistribution()
 
 // On desktop, checkout happens in the external system browser (see handleBuy), so
 // the app never receives the success_url redirect that web/mobile use to refresh.
@@ -243,15 +248,21 @@ const groupedRows = computed<GroupedRow[]>(() => {
   return rows
 })
 
-async function fetchPackages() {
+async function fetchPackages(method: CheckoutMethod) {
+  packages.value = []
   try {
-    const res = await client.api.v1.stripe.packages.$get()
-    if (res.ok) {
-      const data = await res.json() as FluxPackage[]
-      packages.value = data
-      if (data.length > 0)
-        selectedCurrency.value = data[0].defaultCurrency
+    const res = method === 'steam'
+      ? await client.api.v1.steam.packages.$get()
+      : await client.api.v1.stripe.packages.$get()
+    if (!res.ok) {
+      if (!checkoutReturnMessageActive.value)
+        message.value = { type: 'error', text: t('settings.pages.flux.packagesError') }
+      return
     }
+    const data = await res.json() as FluxPackage[]
+    packages.value = data
+    if (data.length > 0)
+      selectedCurrency.value = data[0].defaultCurrency
   }
   catch {
     if (!checkoutReturnMessageActive.value)
@@ -267,9 +278,42 @@ function showCheckoutReturnMessage(type: 'success' | 'error', text: string) {
   message.value = { type, text }
 }
 
+const {
+  steamLinked,
+  returningFromSteam,
+  startCheckout: startSteamCheckout,
+} = useFluxSteamCheckout({
+  onBanner: showCheckoutReturnMessage,
+  onPaid: () => Promise.allSettled([authStore.updateCredits(), fetchAuditHistory()]),
+})
+
+const selectedMethod = ref<CheckoutMethod>(
+  (returningFromSteam || steamDistribution || sessionStorage.getItem('airi.fluxCheckoutMethod') === 'steam') ? 'steam' : 'stripe',
+)
+const steamUnlinked = computed(() => selectedMethod.value === 'steam' && !steamLinked.value)
+
+const checkoutMethodOptions = computed(() => [
+  {
+    label: t('settings.pages.flux.checkout.paymentStripe'),
+    value: 'stripe' as const,
+    icon: 'i-simple-icons-stripe',
+  },
+  {
+    label: t('settings.pages.flux.checkout.paymentSteam'),
+    value: 'steam' as const,
+    icon: 'i-simple-icons-steam',
+  },
+])
+
+watch(selectedMethod, (method) => {
+  sessionStorage.setItem('airi.fluxCheckoutMethod', method)
+  if (!fluxPurchaseDisabled)
+    void fetchPackages(method)
+}, { immediate: true })
+
 onMounted(async () => {
   const creditsRefresh = authStore.updateCredits()
-  void Promise.allSettled([fetchStats(), fetchAuditHistory(), ...(fluxPurchaseDisabled ? [] : [fetchPackages()])])
+  void Promise.allSettled([fetchStats(), fetchAuditHistory()])
 
   if (route.query.success === 'true') {
     showCheckoutReturnMessage('success', t('settings.pages.flux.checkout.success'))
@@ -322,6 +366,19 @@ async function handleBuy(packKey: string) {
     entry_surface: 'settings_flux',
   })
   try {
+    if (selectedMethod.value === 'steam') {
+      const url = await startSteamCheckout(packKey)
+      trackCheckoutStarted(packKey, {
+        currency: selectedCurrency.value,
+        entry_surface: 'settings_flux',
+      })
+      if (isStageTamagotchi())
+        window.open(url, '_blank')
+      else
+        window.location.href = url
+      return
+    }
+
     const res = await client.api.v1.stripe.checkout.$post({ json: { packKey, currency: selectedCurrency.value } })
     if (!res.ok) {
       const data = await res.json() as { error?: string, message?: string }
@@ -347,8 +404,8 @@ async function handleBuy(packKey: string) {
         window.location.href = data.url
     }
   }
-  catch {
-    message.value = { type: 'error', text: t('settings.pages.flux.checkout.error') }
+  catch (error) {
+    message.value = { type: 'error', text: errorMessageFrom(error) ?? t('settings.pages.flux.checkout.error') }
   }
   finally {
     loadingPackKey.value = null
@@ -391,8 +448,22 @@ async function handleBuy(packKey: string) {
     </div>
 
     <div v-if="!fluxPurchaseDisabled" flex="~ col gap-4">
+      <fieldset
+        v-if="!steamDistribution"
+        min-w-0 space-y-3
+      >
+        <legend p-0 text-sm font-medium>
+          {{ t('settings.pages.flux.checkout.payWith') }}
+        </legend>
+        <SelectTab
+          v-model="selectedMethod"
+          :options="checkoutMethodOptions"
+          w-full
+        />
+      </fieldset>
+
       <!-- Currency selector -->
-      <div v-if="currencyOptions.length > 1" flex="~ justify-start sm:justify-end">
+      <div v-if="!steamUnlinked && currencyOptions.length > 1" flex="~ justify-start sm:justify-end">
         <SelectTab
           v-model="selectedCurrency"
           :options="currencyOptions"
@@ -400,7 +471,31 @@ async function handleBuy(packKey: string) {
         />
       </div>
 
-      <div grid="~ cols-1 sm:cols-3 gap-4">
+      <Callout
+        v-if="steamUnlinked"
+        theme="primary"
+      >
+        <template #label>
+          {{ t('settings.pages.flux.checkout.paymentSteam') }}
+        </template>
+        <div flex="~ col gap-3">
+          <p>{{ t('settings.pages.flux.checkout.steamLinkHint') }}</p>
+          <RouterLink
+            to="/settings/account"
+            :class="[
+              'w-fit rounded-lg bg-primary-500 px-4 py-2 text-white',
+              'transition-colors active:scale-95 hover:bg-primary-600',
+            ]"
+          >
+            {{ t('settings.pages.flux.checkout.steamLinkHintAction') }}
+          </RouterLink>
+        </div>
+      </Callout>
+
+      <div
+        v-else
+        grid="~ cols-1 sm:cols-3 gap-4"
+      >
         <button
           v-for="(pkg, index) in packages" :key="pkg.packKey"
           :disabled="loadingPackKey !== null"

--- a/packages/stage-shared/src/env-vars.ts
+++ b/packages/stage-shared/src/env-vars.ts
@@ -13,6 +13,10 @@ export function isFluxPurchaseDisabled(): boolean {
   return isEnvTruthy(import.meta.env.VITE_DISABLE_FLUX_PURCHASE)
 }
 
+export function isSteamDistribution(): boolean {
+  return import.meta.env.VITE_DISTRIBUTION === 'steam'
+}
+
 export function isCustomProvidersDisabled(): boolean {
   return isEnvTruthy(import.meta.env.VITE_DISABLE_CUSTOM_PROVIDERS)
 }

--- a/packages/stage-ui/src/composables/use-flux-steam-checkout.ts
+++ b/packages/stage-ui/src/composables/use-flux-steam-checkout.ts
@@ -1,0 +1,130 @@
+import { isFluxPurchaseDisabled, isStageTamagotchi } from '@proj-airi/stage-shared'
+import { useEventListener } from '@vueuse/core'
+import { onMounted, shallowRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+
+import { authClient } from '../libs/auth-client'
+import { client } from './api'
+
+const PENDING_KEY = 'airi.steamPendingOrderId'
+
+/**
+ * Steam Wallet InitTxn / FinalizeTxn for Flux. Stripe stays on the page.
+ */
+export function useFluxSteamCheckout(options: {
+  onBanner: (type: 'success' | 'error', text: string) => void
+  onPaid: () => Promise<unknown>
+}) {
+  const { t } = useI18n()
+  const route = useRoute()
+  const router = useRouter()
+  const steamLinked = shallowRef(false)
+  const returningFromSteam = queryString(route.query.steam_order) != null
+  const enabled = !isFluxPurchaseDisabled()
+  let finalizeInFlight: Promise<void> | undefined
+
+  if (enabled && isStageTamagotchi()) {
+    useEventListener(window, 'focus', async () => {
+      const orderId = sessionStorage.getItem(PENDING_KEY)
+      if (orderId)
+        await finalize(orderId, true)
+    })
+  }
+
+  onMounted(() => {
+    if (!enabled)
+      return
+    void discoverLink()
+    const orderId = queryString(route.query.steam_order)
+    if (!orderId)
+      return
+    sessionStorage.setItem(PENDING_KEY, orderId)
+    void finalize(orderId, false)
+    void router.replace({ query: {} })
+  })
+
+  async function startCheckout(packKey: string): Promise<string> {
+    const res = await client.api.v1.steam.checkout.$post({ json: { packKey } })
+    const data = await res.json() as { orderId?: string, url?: string, error?: string, message?: string }
+    if (!res.ok)
+      throw new Error(steamErrorText(data, t('settings.pages.flux.checkout.error')))
+    if (data.orderId)
+      sessionStorage.setItem(PENDING_KEY, data.orderId)
+    if (!data.url)
+      throw new Error(t('settings.pages.flux.checkout.error'))
+    return data.url
+  }
+
+  async function discoverLink() {
+    try {
+      const { data } = await authClient.listAccounts()
+      steamLinked.value = data?.some(account => account.providerId === 'steam') ?? false
+    }
+    catch {
+      steamLinked.value = false
+    }
+  }
+
+  async function finalize(orderId: string, quietIfPending: boolean) {
+    if (finalizeInFlight) {
+      await finalizeInFlight
+      return
+    }
+
+    finalizeInFlight = (async () => {
+      try {
+        const res = await client.api.v1.steam.finalize.$post({ json: { orderId } })
+        const data = await res.json() as { error?: string, message?: string, status?: string }
+
+        if (res.status === 409 && data.error === 'STEAM_TXN_NOT_APPROVED') {
+          if (!quietIfPending)
+            options.onBanner('error', t('settings.pages.flux.checkout.steamPending'))
+          return
+        }
+
+        // Steam has no webhook. Keep the order id unless FinalizeTxn returns paid or canceled.
+        if (!res.ok) {
+          options.onBanner('error', steamErrorText(data, t('settings.pages.flux.checkout.error')))
+          return
+        }
+
+        sessionStorage.removeItem(PENDING_KEY)
+        if (data.status === 'canceled') {
+          options.onBanner('error', t('settings.pages.flux.checkout.canceled'))
+          return
+        }
+
+        options.onBanner('success', t('settings.pages.flux.checkout.success'))
+        await options.onPaid()
+      }
+      catch {
+        options.onBanner('error', t('settings.pages.flux.checkout.error'))
+      }
+    })()
+
+    try {
+      await finalizeInFlight
+    }
+    finally {
+      finalizeInFlight = undefined
+    }
+  }
+
+  function steamErrorText(data: { error?: string, message?: string } | undefined, fallback: string): string {
+    if (data?.error === 'STEAM_ACCOUNT_NOT_LINKED')
+      return t('settings.pages.flux.checkout.steamAccountNotLinked')
+    return data?.message || fallback
+  }
+
+  return {
+    steamLinked,
+    returningFromSteam,
+    startCheckout,
+  }
+}
+
+function queryString(value: unknown): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined
+}

--- a/server/apps/api/README.md
+++ b/server/apps/api/README.md
@@ -16,10 +16,10 @@ auth/OIDC routes.
 
 `src/services/domain/payment` owns pack grant and `payment_order` rows.
 CORE exposes `openPending`, `bindProcessorOrder`, `abandon`, `settle`,
-and `deleteAllForUser`. Checkout and package list live in the Stripe
-adapter on `/api/v1/stripe/*`. CORE never sees a raw processor event.
-The adapter maps the processor result onto a `ClaimReceipt`, then calls
-`settle`.
+and `deleteAllForUser`. Checkout and package list live in each adapter:
+Stripe on `/api/v1/stripe/*`, Steam on `/api/v1/steam/*`. CORE never sees
+a raw processor event. The adapter maps the processor result onto a
+`ClaimReceipt`, then calls `settle`.
 
 ## Run locally
 

--- a/server/apps/api/src/app.test.ts
+++ b/server/apps/api/src/app.test.ts
@@ -21,6 +21,7 @@ function createTestDeps() {
     fluxService: {} as never,
     fluxTransactionService: {} as never,
     paymentService: {} as never,
+    steamClient: null,
     stripe: null,
     billingService: {} as never,
     ttsMeter: {} as never,

--- a/server/apps/api/src/app.ts
+++ b/server/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import type { Database } from './libs/db'
 import type { Env } from './libs/env'
 import type { OtelInstance } from './otel'
 import type { StreamingTtsVoiceType } from './routes/audio-speech-ws/session'
+import type { SteamMicroTxnClient } from './routes/steam/client'
 import type { ConfigKVService } from './services/adapters/config-kv'
 import type { BillingService } from './services/domain/billing/billing-service'
 import type { FluxMeter } from './services/domain/billing/flux-meter'
@@ -56,6 +57,8 @@ import { createFluxRoutes } from './routes/flux'
 import { createInternalAuthRoutes } from './routes/internal-auth'
 import { createV1Routes } from './routes/openai/v1'
 import { createProviderRoutes } from './routes/providers'
+import { createSteamRoutes } from './routes/steam'
+import { createSteamMicroTxnClient } from './routes/steam/client'
 import { createStripeRoutes } from './routes/stripe'
 import { createVoicePackRoutes } from './routes/voice-packs'
 import { createConfigKVService } from './services/adapters/config-kv'
@@ -88,6 +91,7 @@ interface AppDeps {
   fluxService: FluxService
   fluxTransactionService: FluxTransactionService
   paymentService: PaymentService
+  steamClient: SteamMicroTxnClient | null
   stripe: Stripe | null
   billingService: BillingService
   ttsMeter: FluxMeter
@@ -411,6 +415,18 @@ export async function buildApp(deps: AppDeps) {
     ))
 
     /**
+     * Steam MicroTxn routes (web InitTxn checkout and FinalizeTxn settle).
+     */
+    .route('/api/v1/steam', createSteamRoutes(
+      deps.paymentService,
+      deps.db,
+      deps.steamClient,
+      deps.configKV,
+      deps.env,
+      deps.otel?.rateLimit ?? null,
+    ))
+
+    /**
      * Catch-all 404 in JSON. Replaces hono's default `text/html` "404 Not
      * Found" so unmatched routes (typos, stale email links, scanners) get a
      * structured response and a hint at where to go for the real product UI.
@@ -587,6 +603,20 @@ export async function createApp() {
     },
   })
 
+  const steamClient = injeca.provide('services:steamClient', {
+    dependsOn: { env: parsedEnv },
+    build: ({ dependsOn }) => {
+      if (!dependsOn.env.STEAM_PUBLISHER_KEY || dependsOn.env.STEAM_APP_ID == null)
+        return null
+      const sandboxRaw = dependsOn.env.STEAM_MICROTXN_SANDBOX
+      return createSteamMicroTxnClient({
+        publisherKey: dependsOn.env.STEAM_PUBLISHER_KEY,
+        appId: dependsOn.env.STEAM_APP_ID,
+        sandbox: sandboxRaw === 'true' || sandboxRaw === '1',
+      })
+    },
+  })
+
   const fluxTransactionService = injeca.provide('services:fluxTransaction', {
     dependsOn: { db },
     build: ({ dependsOn }) => createFluxTransactionService(dependsOn.db),
@@ -706,6 +736,7 @@ export async function createApp() {
     voicePackService,
     productEventService,
     paymentService,
+    steamClient,
     stripe,
     billingService,
     ttsMeter,
@@ -732,6 +763,7 @@ export async function createApp() {
     fluxService: resolved.fluxService,
     fluxTransactionService: resolved.fluxTransactionService,
     paymentService: resolved.paymentService,
+    steamClient: resolved.steamClient,
     stripe: resolved.stripe,
     voicePackService: resolved.voicePackService,
     billingService: resolved.billingService,

--- a/server/apps/api/src/libs/env.ts
+++ b/server/apps/api/src/libs/env.ts
@@ -5,7 +5,7 @@ import { env, exit } from 'node:process'
 
 import { useLogger } from '@guiiai/logg'
 import { injeca } from 'injeca'
-import { array, check, integer, maxValue, minValue, nonEmpty, object, optional, parse, pipe, string, transform, url } from 'valibot'
+import { array, check, integer, maxValue, minValue, nonEmpty, object, optional, parse, picklist, pipe, string, transform, url } from 'valibot'
 
 const AdditionalTrustedOriginsSchema = pipe(
   string(),
@@ -115,6 +115,19 @@ const EnvSchema = object({
   STRIPE_SECRET_KEY: optional(string()),
 
   STRIPE_WEBHOOK_SECRET: optional(string()),
+  // Steam MicroTxn (ISteamMicroTxn). When STEAM_PUBLISHER_KEY or STEAM_APP_ID
+  // is unset, steam routes stay mounted. Checkout and finalize return 503
+  // STEAM_MICROTXN_DISABLED.
+  STEAM_PUBLISHER_KEY: optional(string()),
+  STEAM_APP_ID: optional(pipe(
+    string(),
+    nonEmpty('STEAM_APP_ID must not be empty when set'),
+    transform(input => Number(input)),
+    integer('STEAM_APP_ID must be an integer'),
+    minValue(1, 'STEAM_APP_ID must be at least 1'),
+  )),
+  // When true, call ISteamMicroTxnSandbox instead of production.
+  STEAM_MICROTXN_SANDBOX: optional(picklist(['true', 'false', '1', '0']), 'false'),
   // Testing-only bearer token bypass. Keep unset in production. When set,
   // Authorization: Bearer $TEST_AUTH_TOKEN resolves to the virtual user below
   // through resolveRequestAuth without creating an Auth session row.
@@ -122,11 +135,11 @@ const EnvSchema = object({
   TEST_AUTH_USER_EMAIL: optional(pipe(string(), nonEmpty('TEST_AUTH_USER_EMAIL must not be empty when set')), 'test@example.com'),
   TEST_AUTH_USER_ID: optional(pipe(string(), nonEmpty('TEST_AUTH_USER_ID must not be empty when set')), 'test-user'),
   TEST_AUTH_USER_NAME: optional(pipe(string(), nonEmpty('TEST_AUTH_USER_NAME must not be empty when set')), 'Test User'),
-  // Canonical user-facing web app origin. Used as the Stripe redirect base
-  // (success_url / cancel_url / portal return_url) when a request has no trusted
-  // browser origin — notably the Electron desktop renderer, which loads from
-  // file:// and sends no usable web origin. Web/mobile requests keep returning to
-  // their own origin; only origin-less clients fall back to this.
+  // Canonical user-facing web app origin. Used as the Stripe and Steam redirect
+  // base when a request has no trusted browser origin — notably the Electron
+  // desktop renderer, which loads from file:// and sends no usable web origin.
+  // Web/mobile requests keep returning to their own origin; only origin-less
+  // clients fall back to this.
   WEB_APP_URL: optional(string(), 'https://airi.moeru.ai'),
 })
 

--- a/server/apps/api/src/routes/steam/client.ts
+++ b/server/apps/api/src/routes/steam/client.ts
@@ -1,0 +1,238 @@
+import type { InferOutput } from 'valibot'
+
+import { errorMessageFrom } from '@moeru/std'
+import { ofetch } from 'ofetch'
+import { looseObject, minLength, number, object, optional, picklist, pipe, safeParse, string, union } from 'valibot'
+
+import { ApiError, createInternalError, createServiceUnavailableError } from '../../utils/error'
+
+const PARTNER_BASE = 'https://partner.steam-api.com'
+
+type SteamMicroTxnInterface = 'ISteamMicroTxn' | 'ISteamMicroTxnSandbox'
+
+/** Steam: user has not authorized the transaction yet. */
+const STEAM_ERROR_NOT_APPROVED = 5
+/** Steam: FinalizeTxn already captured this order. */
+const STEAM_ERROR_ALREADY_COMMITTED = 6
+/** Steam: user denied the transaction. */
+const STEAM_ERROR_DENIED = 10
+
+export const STEAM_TXN_NOT_APPROVED = 'STEAM_TXN_NOT_APPROVED'
+export const STEAM_TXN_DENIED = 'STEAM_TXN_DENIED'
+export const STEAM_TXN_ALREADY_COMMITTED = 'STEAM_TXN_ALREADY_COMMITTED'
+
+const SteamApiErrorSchema = object({
+  errorcode: optional(union([number(), string()])),
+  errordesc: optional(string()),
+})
+
+const SteamEnvelopeSchema = object({
+  response: object({
+    result: picklist(['OK', 'Failure']),
+    params: optional(looseObject({})),
+    error: optional(SteamApiErrorSchema),
+  }),
+})
+
+const InitTxnParamsSchema = object({
+  steamurl: pipe(string(), minLength(1)),
+})
+
+const FinalizeTxnParamsSchema = object({
+  transid: pipe(string(), minLength(1)),
+})
+
+const QueryTxnParamsSchema = object({
+  status: optional(string()),
+  transid: optional(string()),
+})
+
+type SteamApiError = InferOutput<typeof SteamApiErrorSchema>
+
+export interface SteamMicroTxnClientOptions {
+  publisherKey: string
+  appId: number
+  /**
+   * When true, call `ISteamMicroTxnSandbox` instead of production.
+   * @default false
+   */
+  sandbox?: boolean
+  /**
+   * @default 15_000
+   */
+  timeoutMs?: number
+}
+
+export interface SteamInitTxnResult {
+  steamUrl: string
+}
+
+export interface SteamFinalizeTxnResult {
+  transId?: string
+}
+
+/**
+ * Steamworks `ISteamMicroTxn` client. Channel operations call this.
+ * Payment CORE never sees the partner HTTP envelope.
+ */
+export interface SteamMicroTxnClient {
+  initTxn: (txn: {
+    orderId: string
+    steamId: string
+    itemId: number
+    amount: number
+    currency: string
+    description: string
+    ipAddress: string
+  }) => Promise<SteamInitTxnResult>
+  finalizeTxn: (txn: { orderId: string }) => Promise<SteamFinalizeTxnResult>
+}
+
+/**
+ * Creates a typed `ofetch` client for Steamworks `ISteamMicroTxn`.
+ */
+export function createSteamMicroTxnClient({
+  publisherKey,
+  appId,
+  sandbox = false,
+  timeoutMs = 15_000,
+}: SteamMicroTxnClientOptions): SteamMicroTxnClient {
+  const iface: SteamMicroTxnInterface = sandbox ? 'ISteamMicroTxnSandbox' : 'ISteamMicroTxn'
+  const key = publisherKey
+  const appid = appId
+
+  async function request(
+    method: string,
+    version: string,
+    httpMethod: 'GET' | 'POST',
+    fields: Record<string, string | number>,
+  ) {
+    const url = `${PARTNER_BASE}/${iface}/${method}/${version}/`
+    let raw: unknown
+    try {
+      raw = httpMethod === 'GET'
+        ? await ofetch(url, {
+            method: 'GET',
+            query: { key, appid, ...fields },
+            timeout: timeoutMs,
+          })
+        : await ofetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+              key,
+              appid: String(appid),
+              ...Object.fromEntries(Object.entries(fields).map(([name, value]) => [name, String(value)])),
+            }).toString(),
+            timeout: timeoutMs,
+          })
+    }
+    catch (error) {
+      throw createServiceUnavailableError(
+        `Steam MicroTxn ${method} failed: ${errorMessageFrom(error) ?? 'network error'}`,
+        'STEAM_MICROTXN_UNAVAILABLE',
+      )
+    }
+
+    const envelope = safeParse(SteamEnvelopeSchema, raw)
+    if (!envelope.success) {
+      throw createInternalError(
+        `Steam MicroTxn ${method} returned an invalid response`,
+        { errorCode: 'STEAM_MICROTXN_FAILURE' },
+      )
+    }
+
+    const { result, params, error } = envelope.output.response
+    if (result === 'Failure')
+      throw createSteamFailure(method, error)
+
+    return params
+  }
+
+  async function queryTxn(orderId: string) {
+    const parsed = safeParse(QueryTxnParamsSchema, await request('QueryTxn', 'v3', 'GET', { orderid: orderId }))
+    return parsed.success ? parsed.output : {}
+  }
+
+  return {
+    async initTxn({ orderId, steamId, itemId, amount, currency, description, ipAddress }) {
+      const parsed = safeParse(InitTxnParamsSchema, await request('InitTxn', 'v3', 'POST', {
+        'orderid': orderId,
+        'steamid': steamId,
+        'itemcount': 1,
+        'language': 'en',
+        'currency': currency.toUpperCase(),
+        'usersession': 'web',
+        'ipaddress': ipAddress,
+        'itemid[0]': itemId,
+        'qty[0]': 1,
+        'amount[0]': amount,
+        'description[0]': description,
+      }))
+      if (!parsed.success) {
+        throw createServiceUnavailableError(
+          'Steam InitTxn did not return a checkout URL',
+          'STEAM_CHECKOUT_URL_MISSING',
+        )
+      }
+      return { steamUrl: parsed.output.steamurl }
+    },
+
+    async finalizeTxn({ orderId }) {
+      try {
+        const parsed = safeParse(FinalizeTxnParamsSchema, await request('FinalizeTxn', 'v2', 'POST', {
+          orderid: orderId,
+        }))
+        if (!parsed.success) {
+          throw createServiceUnavailableError(
+            'Steam FinalizeTxn did not return a transaction id',
+            'STEAM_TRANSID_MISSING',
+          )
+        }
+        return { transId: parsed.output.transid }
+      }
+      catch (error) {
+        if (!(error instanceof ApiError) || error.errorCode !== STEAM_TXN_ALREADY_COMMITTED)
+          throw error
+
+        const queried = await queryTxn(orderId)
+        if (queried.status === 'Succeeded' || queried.status === 'Approved')
+          return { transId: queried.transid }
+
+        throw error
+      }
+    },
+  }
+}
+
+function createSteamFailure(method: string, error?: SteamApiError): ApiError {
+  const code = Number(error?.errorcode)
+  const description = error?.errordesc ?? 'Steam MicroTxn failure'
+
+  switch (code) {
+    case STEAM_ERROR_NOT_APPROVED:
+      return new ApiError(409, STEAM_TXN_NOT_APPROVED, 'Steam transaction is not approved yet', {
+        steamErrorCode: code,
+        steamErrorDesc: description,
+      })
+    case STEAM_ERROR_DENIED:
+      return new ApiError(400, STEAM_TXN_DENIED, 'Steam transaction was denied', {
+        steamErrorCode: code,
+        steamErrorDesc: description,
+      })
+    case STEAM_ERROR_ALREADY_COMMITTED:
+      return new ApiError(409, STEAM_TXN_ALREADY_COMMITTED, 'Steam transaction is already committed', {
+        steamErrorCode: code,
+        steamErrorDesc: description,
+      })
+    default:
+      return createInternalError(
+        `Steam MicroTxn ${method} returned Failure: ${description}`,
+        {
+          errorCode: 'STEAM_MICROTXN_FAILURE',
+          steamErrorCode: Number.isNaN(code) ? error?.errorcode : code,
+          steamErrorDesc: description,
+        },
+      )
+  }
+}

--- a/server/apps/api/src/routes/steam/index.ts
+++ b/server/apps/api/src/routes/steam/index.ts
@@ -1,0 +1,65 @@
+import type { Database } from '../../libs/db'
+import type { Env } from '../../libs/env'
+import type { RateLimitMetrics } from '../../otel'
+import type { ConfigDefinitions, ConfigKVService } from '../../services/adapters/config-kv'
+import type { PaymentService } from '../../services/domain/payment'
+import type { HonoEnv } from '../../types/hono'
+import type { SteamMicroTxnClient } from './client'
+
+import { Hono } from 'hono'
+
+import { authGuard } from '../../middlewares/auth'
+import { rateLimiter } from '../../middlewares/rate-limit'
+import { formatPrice } from '../../utils/format-price'
+import { createCheckoutOperation } from './operations/checkout'
+import { createFinalizeOperation } from './operations/finalize'
+
+/**
+ * Creates Steam HTTP routes for Flux purchase.
+ *
+ * Paths stay on `/api/v1/steam`. Checkout opens the order through CORE,
+ * then calls InitTxn. Finalize maps FinalizeTxn onto CORE `settle`.
+ */
+export function createSteamRoutes(
+  payment: PaymentService,
+  db: Database,
+  client: SteamMicroTxnClient | null,
+  configKV: ConfigKVService,
+  env: Pick<Env, 'WEB_APP_URL' | 'ADDITIONAL_TRUSTED_ORIGINS'>,
+  rateLimitMetrics: RateLimitMetrics | null = null,
+) {
+  const checkout = createCheckoutOperation(payment, db, client, configKV, env)
+  const finalize = createFinalizeOperation(payment, db, client)
+
+  return new Hono<HonoEnv>()
+    .get('/packages', async (c) => {
+      const packs = await configKV.getOptional('FLUX_PACKS') ?? []
+      return c.json(listSteamPackages(packs))
+    })
+    .post('/checkout', authGuard, rateLimiter({ max: 10, windowSec: 60, metrics: rateLimitMetrics, routeLabel: 'steam.checkout' }), async (c) => {
+      const body = await c.req.json()
+      return c.json(await checkout(c.get('user')!, body, c.req.raw))
+    })
+    .post('/finalize', authGuard, rateLimiter({ max: 10, windowSec: 60, metrics: rateLimitMetrics, routeLabel: 'steam.finalize' }), async (c) => {
+      const body = await c.req.json()
+      return c.json(await finalize(c.get('user')!, body))
+    })
+}
+
+function listSteamPackages(packs: ConfigDefinitions['FLUX_PACKS']) {
+  const items = []
+  for (const pack of packs) {
+    const steam = pack.processors?.steam
+    if (!steam)
+      continue
+
+    items.push({
+      packKey: pack.key,
+      label: pack.name,
+      defaultCurrency: steam.currency,
+      currencies: { [steam.currency]: formatPrice(steam.amount, steam.currency) },
+      recommended: pack.recommended,
+    })
+  }
+  return items
+}

--- a/server/apps/api/src/routes/steam/linked-steam-id.ts
+++ b/server/apps/api/src/routes/steam/linked-steam-id.ts
@@ -1,0 +1,17 @@
+import type { Database } from '../../libs/db'
+
+import { account } from '@proj-airi/auth-shared'
+import { and, eq } from 'drizzle-orm'
+
+export async function findLinkedSteamId(db: Database, userId: string): Promise<string | undefined> {
+  const [row] = await db
+    .select({ accountId: account.accountId })
+    .from(account)
+    .where(and(
+      eq(account.userId, userId),
+      eq(account.providerId, 'steam'),
+    ))
+    .limit(1)
+
+  return row?.accountId
+}

--- a/server/apps/api/src/routes/steam/operations/checkout.ts
+++ b/server/apps/api/src/routes/steam/operations/checkout.ts
@@ -1,0 +1,106 @@
+import type { Database } from '../../../libs/db'
+import type { Env } from '../../../libs/env'
+import type { ConfigKVService } from '../../../services/adapters/config-kv'
+import type { PaymentService } from '../../../services/domain/payment'
+import type { SteamMicroTxnClient } from '../client'
+
+import { randomInt } from 'node:crypto'
+
+import { minLength, object, pipe, safeParse, string } from 'valibot'
+
+import { createBadRequestError, createServiceUnavailableError } from '../../../utils/error'
+import { resolveCheckoutRedirectBase } from '../../../utils/origin'
+import { findLinkedSteamId } from '../linked-steam-id'
+
+const CheckoutBodySchema = object({
+  packKey: pipe(string(), minLength(1)),
+})
+
+/**
+ * Opens a pending order through Payment CORE, then calls Steam InitTxn.
+ *
+ * `{ packKey }` resolves a Flux pack with `processors.steam`. Returns the Steam
+ * checkout URL so the caller can open it in a browser.
+ */
+export function createCheckoutOperation(
+  payment: PaymentService,
+  db: Database,
+  client: SteamMicroTxnClient | null,
+  configKV: ConfigKVService,
+  env: Pick<Env, 'WEB_APP_URL' | 'ADDITIONAL_TRUSTED_ORIGINS'>,
+) {
+  return async (
+    user: { id: string },
+    body: unknown,
+    request: Request,
+  ): Promise<{ orderId: string, url: string }> => {
+    if (!client)
+      throw createServiceUnavailableError('Steam MicroTxn is not configured', 'STEAM_MICROTXN_DISABLED')
+
+    const parsed = safeParse(CheckoutBodySchema, body)
+    if (!parsed.success)
+      throw createBadRequestError('Invalid checkout request', 'INVALID_REQUEST', parsed.issues)
+
+    const { packKey } = parsed.output
+    const packs = await configKV.getOptional('FLUX_PACKS') ?? []
+    const pack = packs.find(item => item.key === packKey)
+    if (!pack)
+      throw createBadRequestError('Invalid pack', 'INVALID_PACKAGE', { packKey })
+
+    const steamPack = pack.processors?.steam
+    if (!steamPack)
+      throw createServiceUnavailableError('Steam pack mapping is missing', 'STEAM_PACK_NOT_MAPPED', { packKey })
+
+    const steamId = await findLinkedSteamId(db, user.id)
+    if (!steamId)
+      throw createBadRequestError('Steam account is not linked', 'STEAM_ACCOUNT_NOT_LINKED')
+
+    // InitTxn needs the payer IP; Caddy/Railway put it in these headers.
+    const ipAddress = request.headers.get('x-real-ip')?.trim()
+      || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    if (!ipAddress)
+      throw createBadRequestError('Client IP is required', 'STEAM_CLIENT_IP_REQUIRED')
+    // Steam InitTxn `orderid` is a uint64. `payment_order.id` is a nanoid.
+    // `randomInt` range must be less than 2^48.
+    const orderId = String(randomInt(1, 2 ** 48))
+
+    const order = await payment.openPending({
+      userId: user.id,
+      processor: 'steam',
+      packKey: pack.key,
+      fluxAmount: pack.fluxAmount,
+      currency: steamPack.currency,
+    })
+
+    const redirectBase = resolveCheckoutRedirectBase(request, env.ADDITIONAL_TRUSTED_ORIGINS, env.WEB_APP_URL)
+    const returnUrl = `${redirectBase}/settings/flux?steam_order=${orderId}`
+
+    let steamUrl: string
+    try {
+      const created = await client.initTxn({
+        orderId,
+        steamId,
+        itemId: steamPack.itemId,
+        amount: steamPack.amount,
+        currency: steamPack.currency,
+        description: pack.name,
+        ipAddress,
+      })
+      steamUrl = created.steamUrl
+    }
+    catch (error) {
+      await payment.abandon(order.id)
+      throw error
+    }
+
+    await payment.bindProcessorOrder(order.id, {
+      processorOrderId: orderId,
+      amount: steamPack.amount,
+      currency: steamPack.currency,
+    })
+
+    const checkoutUrl = new URL(steamUrl)
+    checkoutUrl.searchParams.set('returnurl', returnUrl)
+    return { orderId, url: checkoutUrl.toString() }
+  }
+}

--- a/server/apps/api/src/routes/steam/operations/finalize.ts
+++ b/server/apps/api/src/routes/steam/operations/finalize.ts
@@ -1,0 +1,122 @@
+import type { Database } from '../../../libs/db'
+import type { ClaimReceipt, PaymentService } from '../../../services/domain/payment'
+import type { SteamMicroTxnClient } from '../client'
+
+import { and, eq } from 'drizzle-orm'
+import { minLength, object, pipe, safeParse, string } from 'valibot'
+
+import { ApiError, createBadRequestError, createNotFoundError, createServiceUnavailableError } from '../../../utils/error'
+import { STEAM_TXN_DENIED } from '../client'
+import { findLinkedSteamId } from '../linked-steam-id'
+
+import * as schema from '../../../schemas/payment'
+
+const FinalizeBodySchema = object({
+  orderId: pipe(string(), minLength(1)),
+})
+
+/**
+ * Calls Steam FinalizeTxn for the caller's pending order, then CORE `settle`.
+ */
+export function createFinalizeOperation(
+  payment: PaymentService,
+  db: Database,
+  client: SteamMicroTxnClient | null,
+) {
+  return async (
+    user: { id: string },
+    body: unknown,
+  ) => {
+    if (!client)
+      throw createServiceUnavailableError('Steam MicroTxn is not configured', 'STEAM_MICROTXN_DISABLED')
+
+    const parsed = safeParse(FinalizeBodySchema, body)
+    if (!parsed.success)
+      throw createBadRequestError('Invalid finalize request', 'INVALID_REQUEST', parsed.issues)
+
+    const { orderId } = parsed.output
+    const [order] = await db
+      .select()
+      .from(schema.paymentOrder)
+      .where(and(
+        eq(schema.paymentOrder.processor, 'steam'),
+        eq(schema.paymentOrder.processorOrderId, orderId),
+        eq(schema.paymentOrder.userId, user.id),
+      ))
+      .limit(1)
+
+    if (!order)
+      throw createNotFoundError('Payment order not found')
+
+    if (order.status === 'paid')
+      return { status: 'paid' as const }
+
+    if (order.status !== 'pending')
+      throw createBadRequestError('Payment order is not pending', 'ORDER_NOT_PENDING', { status: order.status })
+
+    const steamId = await findLinkedSteamId(db, user.id)
+    const { id: paymentOrderId, amount, currency } = order
+
+    try {
+      const { transId } = await client.finalizeTxn({ orderId })
+      await payment.settle(steamClaimReceipt({
+        paymentOrderId,
+        orderId,
+        status: 'paid',
+        amount,
+        currency,
+        steamId,
+        transId,
+      }))
+      return { status: 'paid' as const }
+    }
+    catch (error) {
+      if (error instanceof ApiError && error.errorCode === STEAM_TXN_DENIED) {
+        await payment.settle(steamClaimReceipt({
+          paymentOrderId,
+          orderId,
+          status: 'canceled',
+          amount,
+          currency,
+          steamId,
+        }))
+        return { status: 'canceled' as const }
+      }
+      throw error
+    }
+  }
+}
+
+function steamClaimReceipt({
+  paymentOrderId,
+  orderId,
+  status,
+  amount,
+  currency,
+  steamId,
+  transId,
+}: {
+  paymentOrderId: string
+  orderId: string
+  status: ClaimReceipt['status']
+  amount?: number | null
+  currency?: string | null
+  steamId?: string
+  transId?: string
+}): ClaimReceipt {
+  return {
+    kind: 'claim',
+    processor: 'steam',
+    paymentOrderId,
+    processorOrderId: orderId,
+    status,
+    amount: amount ?? undefined,
+    currency: currency ?? undefined,
+    customerId: steamId,
+    extras: {
+      orderId,
+      transId,
+      steamId,
+    },
+  }
+}

--- a/server/apps/api/src/routes/steam/route.test.ts
+++ b/server/apps/api/src/routes/steam/route.test.ts
@@ -1,0 +1,312 @@
+import type { Database } from '../../libs/db'
+import type { ConfigKVService } from '../../services/adapters/config-kv'
+import type { PaymentService } from '../../services/domain/payment'
+import type { HonoEnv } from '../../types/hono'
+import type { SteamMicroTxnClient } from './client'
+
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { mockDB } from '../../libs/mock-db'
+import { createTestRedis } from '../../libs/tests/redis'
+import { createBillingService } from '../../services/domain/billing/billing-service'
+import { createPaymentService } from '../../services/domain/payment'
+import { ApiError } from '../../utils/error'
+import { STEAM_TXN_NOT_APPROVED } from './client'
+import { createSteamRoutes } from './index'
+
+import * as schema from '../../schemas'
+
+const testUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+}
+
+const linkedSteamId = '76561198000000001'
+
+const starterPack = {
+  key: 'starter',
+  name: '500 Flux',
+  fluxAmount: 500,
+  recommended: false,
+  processors: {
+    stripe: { priceId: 'price_starter' },
+    steam: { itemId: 1001, amount: 499, currency: 'usd' },
+  },
+}
+
+const stripeOnlyPack = {
+  key: 'stripe-only',
+  name: 'Stripe only',
+  fluxAmount: 100,
+  recommended: false,
+  processors: { stripe: { priceId: 'price_other' } },
+}
+
+function createMockPayment(): PaymentService {
+  return {
+    openPending: vi.fn(async () => ({ id: 'po_mock' })),
+    bindProcessorOrder: vi.fn(async () => {}),
+    abandon: vi.fn(async () => {}),
+    settle: vi.fn(async () => ({ applied: true, userId: 'user-1', fluxAmount: 500, balanceAfter: 500 })),
+    deleteAllForUser: vi.fn(),
+  }
+}
+
+function createLivePayment(db: Database) {
+  const redis = createTestRedis()
+  const billing = createBillingService(db, redis, createMockConfigKV())
+  return createPaymentService(db, billing)
+}
+
+function createMockClient(): SteamMicroTxnClient {
+  return {
+    initTxn: vi.fn(async () => ({ steamUrl: 'https://store.steampowered.com/checkout/approvetxn/1' })),
+    finalizeTxn: vi.fn(async () => ({ transId: 't1' })),
+  }
+}
+
+function createMockConfigKV(): ConfigKVService {
+  return {
+    getOptional: vi.fn(async (key: string) => {
+      if (key === 'FLUX_PACKS')
+        return [starterPack, stripeOnlyPack]
+      return null
+    }),
+    getOrThrow: vi.fn(),
+    get: vi.fn(),
+    refresh: vi.fn(),
+    invalidateCache: vi.fn(),
+  } as ConfigKVService
+}
+
+const testEnv = {
+  WEB_APP_URL: 'https://airi.moeru.ai',
+  ADDITIONAL_TRUSTED_ORIGINS: [],
+}
+
+function createTestApp(
+  payment: PaymentService,
+  client: SteamMicroTxnClient | null,
+  db: Database,
+) {
+  const routes = createSteamRoutes(payment, db, client, createMockConfigKV(), testEnv, null)
+  const app = new Hono<HonoEnv>()
+
+  app.onError((err, c) => {
+    if (err instanceof ApiError) {
+      return c.json({
+        error: err.errorCode,
+        message: err.message,
+        details: err.details,
+      }, err.statusCode)
+    }
+    return c.json({ error: 'Internal Server Error', message: err.message }, 500)
+  })
+
+  app.use('*', async (c, next) => {
+    const user = (c.env as { user?: typeof testUser })?.user
+    if (user)
+      c.set('user', user as HonoEnv['Variables']['user'])
+    await next()
+  })
+
+  app.route('/api/v1/steam', routes)
+  return app
+}
+
+function authedJson(app: ReturnType<typeof createTestApp>, path: string, body: unknown) {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.10',
+      },
+      body: JSON.stringify(body),
+    }),
+    { user: testUser } as never,
+  )
+}
+
+describe('steam routes', () => {
+  let db: Database
+  let payment: PaymentService
+  let client: SteamMicroTxnClient
+
+  beforeAll(async () => {
+    db = await mockDB(schema)
+    await db.insert(schema.user).values({
+      id: testUser.id,
+      name: testUser.name,
+      email: testUser.email,
+    })
+    await db.insert(schema.account).values({
+      id: 'acc-steam-1',
+      accountId: linkedSteamId,
+      providerId: 'steam',
+      userId: testUser.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    await db.insert(schema.user).values({
+      id: 'user-unlinked',
+      name: 'Unlinked',
+      email: 'unlinked@example.com',
+    })
+  })
+
+  beforeEach(async () => {
+    payment = createMockPayment()
+    client = createMockClient()
+    await db.delete(schema.paymentOrder).where(eq(schema.paymentOrder.userId, testUser.id))
+  })
+
+  it('returns 503 when checkout runs without a Steam client', async () => {
+    const app = createTestApp(payment, null, db)
+    const res = await authedJson(app, '/api/v1/steam/checkout', { packKey: 'starter' })
+    expect(res.status).toBe(503)
+    expect(await res.json()).toMatchObject({ error: 'STEAM_MICROTXN_DISABLED' })
+  })
+
+  it('lists only packs that have a Steam mapping', async () => {
+    const app = createTestApp(payment, client, db)
+    const res = await app.request('/api/v1/steam/packages')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{
+      packKey: 'starter',
+      label: '500 Flux',
+      defaultCurrency: 'usd',
+      currencies: { usd: '$4.99' },
+      recommended: false,
+    }])
+  })
+
+  it('returns 400 when checkout has no linked Steam account', async () => {
+    const app = createTestApp(payment, client, db)
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/steam/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ packKey: 'starter' }),
+      }),
+      { user: { id: 'user-unlinked', name: 'Unlinked', email: 'unlinked@example.com' } } as never,
+    )
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ error: 'STEAM_ACCOUNT_NOT_LINKED' })
+    expect(client.initTxn).not.toHaveBeenCalled()
+  })
+
+  it('inserts a pending order then calls InitTxn', async () => {
+    const app = createTestApp(createLivePayment(db), client, db)
+    const res = await authedJson(app, '/api/v1/steam/checkout', { packKey: 'starter' })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { orderId: string, url: string }
+    expect(body.orderId).toMatch(/^\d+$/)
+    expect(body.url).toContain('https://store.steampowered.com/checkout/approvetxn/1')
+    expect(new URL(body.url).searchParams.get('returnurl')).toBe(
+      `https://airi.moeru.ai/settings/flux?steam_order=${body.orderId}`,
+    )
+
+    const [order] = await db.select().from(schema.paymentOrder).where(eq(schema.paymentOrder.userId, testUser.id))
+    expect(order?.status).toBe('pending')
+    expect(order?.processor).toBe('steam')
+    expect(order?.processorOrderId).toBe(body.orderId)
+    expect(order?.packKey).toBe('starter')
+    expect(order?.fluxAmount).toBe(500)
+    expect(order?.amount).toBe(499)
+    expect(order?.currency).toBe('usd')
+
+    expect(client.initTxn).toHaveBeenCalledWith({
+      orderId: body.orderId,
+      steamId: linkedSteamId,
+      itemId: 1001,
+      amount: 499,
+      currency: 'usd',
+      description: '500 Flux',
+      ipAddress: '203.0.113.10',
+    })
+  })
+
+  it('abandons the pending order when InitTxn fails', async () => {
+    vi.mocked(client.initTxn).mockRejectedValueOnce(new Error('steam down'))
+    const app = createTestApp(createLivePayment(db), client, db)
+
+    const res = await authedJson(app, '/api/v1/steam/checkout', { packKey: 'starter' })
+    expect(res.status).toBe(500)
+
+    const [order] = await db.select().from(schema.paymentOrder).where(eq(schema.paymentOrder.userId, testUser.id))
+    expect(order?.status).toBe('canceled')
+    expect(order?.processorOrderId).toBeNull()
+  })
+
+  it('settles a paid claim after FinalizeTxn succeeds', async () => {
+    const [order] = await db.insert(schema.paymentOrder).values({
+      userId: testUser.id,
+      processor: 'steam',
+      processorOrderId: '9001',
+      status: 'pending',
+      packKey: 'starter',
+      fluxAmount: 500,
+      amount: 499,
+      currency: 'usd',
+    }).returning()
+
+    const app = createTestApp(payment, client, db)
+    const res = await authedJson(app, '/api/v1/steam/finalize', { orderId: '9001' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ status: 'paid' })
+    expect(client.finalizeTxn).toHaveBeenCalledWith({ orderId: '9001' })
+    expect(payment.settle).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'claim',
+      processor: 'steam',
+      paymentOrderId: order!.id,
+      processorOrderId: '9001',
+      status: 'paid',
+      customerId: linkedSteamId,
+    }))
+  })
+
+  it('returns 409 when Steam says the transaction is not approved yet', async () => {
+    await db.insert(schema.paymentOrder).values({
+      userId: testUser.id,
+      processor: 'steam',
+      processorOrderId: '9002',
+      status: 'pending',
+      packKey: 'starter',
+      fluxAmount: 500,
+    })
+    vi.mocked(client.finalizeTxn).mockRejectedValueOnce(
+      new ApiError(409, STEAM_TXN_NOT_APPROVED, 'Steam transaction is not approved yet'),
+    )
+
+    const app = createTestApp(payment, client, db)
+    const res = await authedJson(app, '/api/v1/steam/finalize', { orderId: '9002' })
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({ error: STEAM_TXN_NOT_APPROVED })
+    expect(payment.settle).not.toHaveBeenCalled()
+
+    const [order] = await db.select().from(schema.paymentOrder).where(eq(schema.paymentOrder.processorOrderId, '9002'))
+    expect(order?.status).toBe('pending')
+  })
+
+  it('does not call FinalizeTxn again for a paid order', async () => {
+    await db.insert(schema.paymentOrder).values({
+      userId: testUser.id,
+      processor: 'steam',
+      processorOrderId: '9003',
+      status: 'paid',
+      packKey: 'starter',
+      fluxAmount: 500,
+    })
+
+    const app = createTestApp(payment, client, db)
+    const res = await authedJson(app, '/api/v1/steam/finalize', { orderId: '9003' })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ status: 'paid' })
+    expect(client.finalizeTxn).not.toHaveBeenCalled()
+    expect(payment.settle).not.toHaveBeenCalled()
+  })
+})

--- a/server/apps/api/src/services/adapters/config-kv/definitions.ts
+++ b/server/apps/api/src/services/adapters/config-kv/definitions.ts
@@ -247,8 +247,9 @@ export const configEntrySchemas = {
   // Debt-ledger TTL: residual TTS chars below 1 Flux are forgiven on expiry.
   // 24h gives users a long-enough window for accumulated dust to settle naturally.
   TTS_DEBT_TTL_SECONDS: optional(number(), 86400),
-  // One-time Flux packs. Display prices are preformatted strings keyed by
-  // currency. Processor ids map each pack onto Stripe.
+  // One-time Flux packs. Adapters format display prices at list time.
+  // `processors.stripe.priceId` maps onto a Stripe Price.
+  // `processors.steam` holds the MicroTxn item id, amount, and currency.
   FLUX_PACKS: optional(array(object({
     key: pipe(string(), nonEmpty('FLUX_PACKS[].key must not be empty')),
     name: pipe(string(), nonEmpty('FLUX_PACKS[].name must not be empty')),
@@ -257,6 +258,11 @@ export const configEntrySchemas = {
     processors: optional(object({
       stripe: optional(object({
         priceId: pipe(string(), nonEmpty('FLUX_PACKS[].processors.stripe.priceId must not be empty')),
+      })),
+      steam: optional(object({
+        itemId: pipe(number(), minValue(1, 'FLUX_PACKS[].processors.steam.itemId must be >= 1')),
+        amount: pipe(number(), minValue(1, 'FLUX_PACKS[].processors.steam.amount must be >= 1')),
+        currency: pipe(string(), nonEmpty('FLUX_PACKS[].processors.steam.currency must not be empty')),
       })),
     }), {}),
   })), []),

--- a/server/apps/api/src/services/domain/payment/index.ts
+++ b/server/apps/api/src/services/domain/payment/index.ts
@@ -30,13 +30,13 @@ const logger = useLogger('payment')
  *
  * Call stack:
  *
- * Stripe `POST /checkout`
+ * Stripe `POST /checkout` / Steam `POST /checkout`
  * -> {@link createPaymentService} `openPending`
- * -> Stripe adapter creates the Checkout Session
+ * -> adapter creates the processor checkout
  * -> {@link createPaymentService} `bindProcessorOrder`
  *
- * Stripe `POST /webhook` (after signature verify)
- * -> Stripe adapter maps session to {@link ClaimReceipt}
+ * Stripe `POST /webhook` / Steam `POST /finalize` (after processor confirm)
+ * -> adapter maps the processor result to {@link ClaimReceipt}
  * -> {@link createPaymentService} `settle`
  * -> {@link BillingService.creditFlux}
  */

--- a/server/apps/api/src/utils/origin.ts
+++ b/server/apps/api/src/utils/origin.ts
@@ -86,12 +86,12 @@ export function resolveTrustedRequestOrigin(
 }
 
 /**
- * Resolves the base URL for Stripe redirect targets (`success_url` / `cancel_url` / portal `return_url`).
+ * Resolves the base URL for Stripe and Steam redirect targets.
  *
  * Prefers the request's trusted browser origin so web and mobile users return to the surface they
  * started from. Falls back to the configured web app URL when the request carries no trusted origin —
  * notably the Electron desktop renderer, which loads from `file://` and sends no usable web origin,
- * so Stripe (which only accepts http/https redirect URLs) can still land users on a real page.
+ * so Stripe and Steam (which only accept http/https redirect URLs) can still land users on a real page.
  *
  * Expects:
  * - Same trust inputs as {@link resolveTrustedRequestOrigin}.


### PR DESCRIPTION
## Why

Stripe checkout already goes through Payment CORE. This PR adds Steam MicroTxn as a second channel on the same `openPending` / `bindProviderOrder` / `abandon` / `settle` path.

Stacked on [#2335](https://github.com/moeru-ai/airi/pull/2335).

## Changes

- Add `/api/v1/steam/packages`, `/checkout`, and `/finalize`.
- Checkout opens a pending `payment_order`, calls InitTxn, then binds the Steam order id. InitTxn failure calls `abandon`.
- Finalize calls FinalizeTxn, maps the result onto a `ClaimReceipt`, and calls `settle`.
- Flux settings can start Steam checkout when a Steam account is linked.

## Test plan

- [x] `pnpm exec vitest run server/apps/api/src/routes/steam/route.test.ts`
- [x] `pnpm -F @proj-airi/api-server typecheck`

## Visual changes

iPhone 15 (393×852).

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/15d1509e-30c8-43eb-8bd6-c44377b5ae6d) | ![](https://github.com/user-attachments/assets/c688757a-34e8-46e5-ab0e-9eef5343b2c9) |
| Settings / Flux | Settings / Flux, Steam Wallet linked |
| | ![](https://github.com/user-attachments/assets/8de70cd4-f05b-4f94-85bf-a4fbe10f3710) |
| | Settings / Flux, Steam Wallet, account not linked |