### PR TITLE
fix(stage-tamagotchi): clamp restored main-window bounds onto an available display

### DIFF
--- a/apps/stage-tamagotchi/src/main/windows/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/main/index.ts
@@ -54,9 +54,9 @@ function resolveMainWindowBounds(
   if (saved?.x == null || saved?.y == null)
     return { width, height }
 
-  const workAreas = screen.getAllDisplays().map(display => display.workArea)
-  const primaryWorkArea = screen.getPrimaryDisplay().workArea
-  return sanitizePersistedWindowBounds({ x: saved.x, y: saved.y, width, height }, workAreas, primaryWorkArea)
+  const displays = screen.getAllDisplays()
+  const primary = screen.getPrimaryDisplay()
+  return sanitizePersistedWindowBounds({ x: saved.x, y: saved.y, width, height }, displays, primary)
 }
 
 const appConfigSchema = object({

--- a/apps/stage-tamagotchi/src/main/windows/main/index.ts
+++ b/apps/stage-tamagotchi/src/main/windows/main/index.ts
@@ -21,18 +21,43 @@ import { defineInvokeHandler } from '@moeru/eventa'
 import { createContext } from '@moeru/eventa/adapters/electron/main'
 import { initScreenCaptureForWindow } from '@proj-airi/electron-screen-capture/main'
 import { defu } from 'defu'
-import { BrowserWindow, ipcMain } from 'electron'
+import { BrowserWindow, ipcMain, screen } from 'electron'
 import { isLinux, isMacOS } from 'std-env'
 import { array, number, object, optional, string } from 'valibot'
 
 import icon from '../../../../resources/icon.png?asset'
 
 import { electronStartDraggingWindow } from '../../../shared/eventa'
+import { sanitizePersistedWindowBounds } from '../../../shared/utils/electron/windows/window-bounds'
 import { onAppBeforeQuit } from '../../libs/bootkit/lifecycle'
 import { baseUrl, getElectronMainDirname, load, withHashRoute } from '../../libs/electron/location'
 import { createConfig } from '../../libs/electron/persistence'
 import { protectPrivilegedWindowNavigation, setWindowAlwaysOnTop, transparentWindowConfig } from '../shared'
 import { setupMainWindowElectronInvokes } from './rpc/index.electron'
+
+const DEFAULT_MAIN_WINDOW_WIDTH = 450
+const DEFAULT_MAIN_WINDOW_HEIGHT = 600
+
+/**
+ * Resolve the bounds to open the main window with. A persisted position is
+ * clamped back onto an available display so a window saved off-screen — dragged
+ * past a display edge, or on a monitor that is no longer connected — is always
+ * reachable (#2181). Returns undefined x/y when there is no saved position, so
+ * Electron centers the window as before.
+ */
+function resolveMainWindowBounds(
+  saved?: { x?: number, y?: number, width?: number, height?: number },
+): { x?: number, y?: number, width: number, height: number } {
+  const width = saved?.width ?? DEFAULT_MAIN_WINDOW_WIDTH
+  const height = saved?.height ?? DEFAULT_MAIN_WINDOW_HEIGHT
+
+  if (saved?.x == null || saved?.y == null)
+    return { width, height }
+
+  const workAreas = screen.getAllDisplays().map(display => display.workArea)
+  const primaryWorkArea = screen.getPrimaryDisplay().workArea
+  return sanitizePersistedWindowBounds({ x: saved.x, y: saved.y, width, height }, workAreas, primaryWorkArea)
+}
 
 const appConfigSchema = object({
   windows: optional(array(object({
@@ -74,13 +99,14 @@ export async function setupMainWindow(params: {
   setupConfig()
 
   const mainWindowConfig = getConfig().windows?.find(w => w.title === 'AIRI' && w.tag === 'main')
+  const restoredBounds = resolveMainWindowBounds(mainWindowConfig)
 
   const window = new BrowserWindow({
     title: 'AIRI',
-    width: mainWindowConfig?.width ?? 450.0,
-    height: mainWindowConfig?.height ?? 600.0,
-    x: mainWindowConfig?.x,
-    y: mainWindowConfig?.y,
+    width: restoredBounds.width,
+    height: restoredBounds.height,
+    x: restoredBounds.x,
+    y: restoredBounds.y,
     show: false,
     icon,
     webPreferences: {

--- a/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.test.ts
+++ b/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import { sanitizePersistedWindowBounds } from './window-bounds'
 
-const primary = { x: 0, y: 0, width: 1920, height: 1040 }
+// A primary display with a 40px taskbar at the bottom (workArea shorter than bounds).
+const primary = {
+  bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+  workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+}
 
 describe('sanitizePersistedWindowBounds (#2181)', () => {
   it('leaves fully on-screen bounds unchanged', () => {
@@ -10,11 +14,11 @@ describe('sanitizePersistedWindowBounds (#2181)', () => {
     expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual(bounds)
   })
 
-  it('clamps a window dragged partly past the right/bottom edge back into view', () => {
+  it('clamps a window dragged partly past the right/bottom edge into the work area', () => {
     const bounds = { x: 1800, y: 900, width: 450, height: 600 }
     expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual({
       x: 1920 - 450, // 1470
-      y: 1040 - 600, // 440
+      y: 1040 - 600, // 440 (work area bottom, above the taskbar)
       width: 450,
       height: 600,
     })
@@ -30,7 +34,7 @@ describe('sanitizePersistedWindowBounds (#2181)', () => {
     })
   })
 
-  it('centers on the primary display when bounds are fully off every screen', () => {
+  it('centers on the primary work area when bounds are fully off every screen', () => {
     // Saved far off-screen (e.g. on a monitor that is no longer connected).
     const bounds = { x: 5000, y: 5000, width: 450, height: 600 }
     expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual({
@@ -42,12 +46,38 @@ describe('sanitizePersistedWindowBounds (#2181)', () => {
   })
 
   it('keeps a window on the secondary display it still overlaps', () => {
-    const secondary = { x: 1920, y: 0, width: 1920, height: 1040 }
+    const secondary = {
+      bounds: { x: 1920, y: 0, width: 1920, height: 1080 },
+      workArea: { x: 1920, y: 0, width: 1920, height: 1040 },
+    }
     const bounds = { x: 2200, y: 300, width: 450, height: 600 }
     expect(sanitizePersistedWindowBounds(bounds, [primary, secondary], primary)).toEqual(bounds)
   })
 
-  it('falls back to centering when no work areas are available', () => {
+  it('resolves display ownership by full bounds, not work area', () => {
+    // `top` has a large dock: its workArea (height 600) is much shorter than its
+    // bounds (height 1000). A window sitting mostly on `top`'s dock strip overlaps
+    // `bottom`'s workArea more than `top`'s workArea, yet it is physically on
+    // `top`. Ownership must resolve to `top` (by bounds) and clamp above its dock,
+    // instead of jumping the window entirely onto `bottom`.
+    const top = {
+      bounds: { x: 0, y: 0, width: 1000, height: 1000 },
+      workArea: { x: 0, y: 0, width: 1000, height: 600 },
+    }
+    const bottom = {
+      bounds: { x: 0, y: 1000, width: 1000, height: 1000 },
+      workArea: { x: 0, y: 1000, width: 1000, height: 1000 },
+    }
+    const bounds = { x: 0, y: 550, width: 400, height: 550 }
+    expect(sanitizePersistedWindowBounds(bounds, [top, bottom], top)).toEqual({
+      x: 0,
+      y: 50, // top.workArea bottom (600) - height (550)
+      width: 400,
+      height: 550,
+    })
+  })
+
+  it('falls back to centering when no displays are available', () => {
     const bounds = { x: 100, y: 100, width: 450, height: 600 }
     expect(sanitizePersistedWindowBounds(bounds, [], primary)).toEqual({
       x: Math.round((1920 - 450) / 2),

--- a/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.test.ts
+++ b/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizePersistedWindowBounds } from './window-bounds'
+
+const primary = { x: 0, y: 0, width: 1920, height: 1040 }
+
+describe('sanitizePersistedWindowBounds (#2181)', () => {
+  it('leaves fully on-screen bounds unchanged', () => {
+    const bounds = { x: 200, y: 150, width: 450, height: 600 }
+    expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual(bounds)
+  })
+
+  it('clamps a window dragged partly past the right/bottom edge back into view', () => {
+    const bounds = { x: 1800, y: 900, width: 450, height: 600 }
+    expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual({
+      x: 1920 - 450, // 1470
+      y: 1040 - 600, // 440
+      width: 450,
+      height: 600,
+    })
+  })
+
+  it('clamps a window with a negative (top-left) position back into view', () => {
+    const bounds = { x: -300, y: -200, width: 450, height: 600 }
+    expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual({
+      x: 0,
+      y: 0,
+      width: 450,
+      height: 600,
+    })
+  })
+
+  it('centers on the primary display when bounds are fully off every screen', () => {
+    // Saved far off-screen (e.g. on a monitor that is no longer connected).
+    const bounds = { x: 5000, y: 5000, width: 450, height: 600 }
+    expect(sanitizePersistedWindowBounds(bounds, [primary], primary)).toEqual({
+      x: Math.round((1920 - 450) / 2), // 735
+      y: Math.round((1040 - 600) / 2), // 220
+      width: 450,
+      height: 600,
+    })
+  })
+
+  it('keeps a window on the secondary display it still overlaps', () => {
+    const secondary = { x: 1920, y: 0, width: 1920, height: 1040 }
+    const bounds = { x: 2200, y: 300, width: 450, height: 600 }
+    expect(sanitizePersistedWindowBounds(bounds, [primary, secondary], primary)).toEqual(bounds)
+  })
+
+  it('falls back to centering when no work areas are available', () => {
+    const bounds = { x: 100, y: 100, width: 450, height: 600 }
+    expect(sanitizePersistedWindowBounds(bounds, [], primary)).toEqual({
+      x: Math.round((1920 - 450) / 2),
+      y: Math.round((1040 - 600) / 2),
+      width: 450,
+      height: 600,
+    })
+  })
+})

--- a/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.ts
+++ b/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.ts
@@ -1,5 +1,17 @@
 import type { Rectangle } from 'electron'
 
+import { clamp } from 'es-toolkit'
+
+/**
+ * The parts of an Electron `Display` this module needs: the full physical
+ * `bounds` (used to decide which monitor a window belongs to) and the
+ * `workArea` (excludes the taskbar/dock, used to place the window).
+ */
+export interface DisplayLike {
+  bounds: Rectangle
+  workArea: Rectangle
+}
+
 /** Area of the overlap between two rectangles (0 when they do not intersect). */
 function intersectionArea(a: Rectangle, b: Rectangle): number {
   const left = Math.max(a.x, b.x)
@@ -15,9 +27,12 @@ function intersectionArea(a: Rectangle, b: Rectangle): number {
 function clampWithin(bounds: Rectangle, rect: Rectangle): Rectangle {
   const width = Math.min(bounds.width, rect.width)
   const height = Math.min(bounds.height, rect.height)
-  const x = Math.min(Math.max(bounds.x, rect.x), rect.x + rect.width - width)
-  const y = Math.min(Math.max(bounds.y, rect.y), rect.y + rect.height - height)
-  return { x, y, width, height }
+  return {
+    x: clamp(bounds.x, rect.x, rect.x + rect.width - width),
+    y: clamp(bounds.y, rect.y, rect.y + rect.height - height),
+    width,
+    height,
+  }
 }
 
 /** Center a window of the given size within `rect`. */
@@ -33,8 +48,8 @@ function centerWithin(size: { width: number, height: number }, rect: Rectangle):
 }
 
 /**
- * Validate persisted window bounds against the currently available display work
- * areas so a reachable portion of the window always stays on-screen.
+ * Validate persisted window bounds against the currently available displays so a
+ * reachable portion of the window always stays on-screen.
  *
  * Use when:
  * - Restoring a window position saved in a previous session, which may now be
@@ -42,35 +57,37 @@ function centerWithin(size: { width: number, height: number }, rect: Rectangle):
  *   is no longer connected.
  *
  * Behavior:
- * - If the bounds still overlap a display, clamp them fully into that display's
- *   work area (best-overlapping display wins).
- * - If they no longer intersect any display, fall back to centering on the
+ * - Pick the display physically containing most of the window, measured against
+ *   full display `bounds` (not `workArea`) so a window over a taskbar/dock strip
+ *   still counts toward the monitor it visually sits on, then clamp it into that
+ *   display's `workArea`.
+ * - If the window no longer intersects any display, fall back to centering on the
  *   primary work area.
  *
  * Pure and Electron-free (takes plain rectangles) so it can be unit-tested; the
- * caller passes work areas from `screen.getAllDisplays()` and the primary one.
+ * caller passes `screen.getAllDisplays()` and `screen.getPrimaryDisplay()`.
  */
 export function sanitizePersistedWindowBounds(
   bounds: Rectangle,
-  workAreas: Rectangle[],
-  primaryWorkArea: Rectangle,
+  displays: DisplayLike[],
+  primary: DisplayLike,
 ): Rectangle {
-  if (workAreas.length === 0)
-    return centerWithin(bounds, primaryWorkArea)
+  if (displays.length === 0)
+    return centerWithin(bounds, primary.workArea)
 
-  let best = workAreas[0]
+  let best = displays[0]
   let bestArea = -1
-  for (const workArea of workAreas) {
-    const area = intersectionArea(bounds, workArea)
+  for (const display of displays) {
+    const area = intersectionArea(bounds, display.bounds)
     if (area > bestArea) {
       bestArea = area
-      best = workArea
+      best = display
     }
   }
 
-  // No visible intersection with any display → restore to a safe position.
+  // No overlap with any physical display → restore to a safe position.
   if (bestArea <= 0)
-    return centerWithin(bounds, primaryWorkArea)
+    return centerWithin(bounds, primary.workArea)
 
-  return clampWithin(bounds, best)
+  return clampWithin(bounds, best.workArea)
 }

--- a/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.ts
+++ b/apps/stage-tamagotchi/src/shared/utils/electron/windows/window-bounds.ts
@@ -1,0 +1,76 @@
+import type { Rectangle } from 'electron'
+
+/** Area of the overlap between two rectangles (0 when they do not intersect). */
+function intersectionArea(a: Rectangle, b: Rectangle): number {
+  const left = Math.max(a.x, b.x)
+  const top = Math.max(a.y, b.y)
+  const right = Math.min(a.x + a.width, b.x + b.width)
+  const bottom = Math.min(a.y + a.height, b.y + b.height)
+  const width = right - left
+  const height = bottom - top
+  return width > 0 && height > 0 ? width * height : 0
+}
+
+/** Move `bounds` so they sit fully within `rect` (position only; size preserved, shrunk only if larger than `rect`). */
+function clampWithin(bounds: Rectangle, rect: Rectangle): Rectangle {
+  const width = Math.min(bounds.width, rect.width)
+  const height = Math.min(bounds.height, rect.height)
+  const x = Math.min(Math.max(bounds.x, rect.x), rect.x + rect.width - width)
+  const y = Math.min(Math.max(bounds.y, rect.y), rect.y + rect.height - height)
+  return { x, y, width, height }
+}
+
+/** Center a window of the given size within `rect`. */
+function centerWithin(size: { width: number, height: number }, rect: Rectangle): Rectangle {
+  const width = Math.min(size.width, rect.width)
+  const height = Math.min(size.height, rect.height)
+  return {
+    x: Math.round(rect.x + (rect.width - width) / 2),
+    y: Math.round(rect.y + (rect.height - height) / 2),
+    width,
+    height,
+  }
+}
+
+/**
+ * Validate persisted window bounds against the currently available display work
+ * areas so a reachable portion of the window always stays on-screen.
+ *
+ * Use when:
+ * - Restoring a window position saved in a previous session, which may now be
+ *   off-screen (dragged past a display edge and persisted) or on a monitor that
+ *   is no longer connected.
+ *
+ * Behavior:
+ * - If the bounds still overlap a display, clamp them fully into that display's
+ *   work area (best-overlapping display wins).
+ * - If they no longer intersect any display, fall back to centering on the
+ *   primary work area.
+ *
+ * Pure and Electron-free (takes plain rectangles) so it can be unit-tested; the
+ * caller passes work areas from `screen.getAllDisplays()` and the primary one.
+ */
+export function sanitizePersistedWindowBounds(
+  bounds: Rectangle,
+  workAreas: Rectangle[],
+  primaryWorkArea: Rectangle,
+): Rectangle {
+  if (workAreas.length === 0)
+    return centerWithin(bounds, primaryWorkArea)
+
+  let best = workAreas[0]
+  let bestArea = -1
+  for (const workArea of workAreas) {
+    const area = intersectionArea(bounds, workArea)
+    if (area > bestArea) {
+      bestArea = area
+      best = workArea
+    }
+  }
+
+  // No visible intersection with any display → restore to a safe position.
+  if (bestArea <= 0)
+    return centerWithin(bounds, primaryWorkArea)
+
+  return clampWithin(bounds, best)
+}


### PR DESCRIPTION
### Problem

Fixes #2181. The desktop (Tamagotchi) main window persists its position on every move/resize and restores it verbatim on the next launch, with no validation against the current displays. A window dragged past a screen edge — or saved on a monitor that is later disconnected — reopens completely off-screen, and the in-window **Center main window** control is unreachable (it lives inside the invisible window), so the user has to discover the tray command to recover it.

### Root cause

`main/index.ts` restores the saved position straight into the `BrowserWindow` constructor:

```ts
const mainWindowConfig = getConfig().windows?.find(...)
const window = new BrowserWindow({
  width: mainWindowConfig?.width ?? 450.0,
  height: mainWindowConfig?.height ?? 600.0,
  x: mainWindowConfig?.x,   // ← applied unchecked
  y: mainWindowConfig?.y,
  ...
})
```

There is no clamp against a display work area, so an off-screen `x/y` is faithfully reproduced.

### Fix

A pure helper `sanitizePersistedWindowBounds(bounds, workAreas, primaryWorkArea)`:

- If the saved bounds still overlap a display, clamp them fully into that display's work area (best-overlapping display wins).
- If they no longer intersect **any** display, center on the primary work area (safe fallback for a disconnected monitor or a window dragged fully off-screen).

`resolveMainWindowBounds` applies it before creating the window, feeding it `screen.getAllDisplays()`/`getPrimaryDisplay()`. When there is no saved position, `x/y` stay `undefined` so Electron centers the window exactly as before.

The helper is Electron-free (plain rectangles in, rectangle out), so it is fully unit-tested without launching the app:

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

covering: on-screen bounds unchanged, clamping from each edge and from negative positions, the off-every-display → center fallback, a window kept on a secondary display it still overlaps, and the no-displays fallback.

### Notes

The caption window already has a private `clampBoundsWithinRect` helper with the same shape; I kept this PR focused on the main-window bug rather than refactoring both onto the new shared helper, but that consolidation would be a natural follow-up.

Fixes #2181