### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-qw7tvvOmVv40NTgU8EeF5MkoSu+G2u1aeq68Bmfm5H4=
+sha256-IWT04ExJHS5tAmDMgeDK4ZPpDyf7hJRq/LmbO/gXKfI=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.