### PR TITLE
fix(electron-screen-capture): scope source release to its owning handle and window

### DIFF
--- a/packages/electron-screen-capture/src/main/index.test.ts
+++ b/packages/electron-screen-capture/src/main/index.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockContext {
+  invokeHandlers: Map<string, (payload: never, options?: never) => unknown>
+}
+
+function createEmitter() {
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const eventHandlers = handlers.get(event) ?? []
+      eventHandlers.push(handler)
+      handlers.set(event, eventHandlers)
+    }),
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of handlers.get(event) ?? [])
+        handler(...args)
+    },
+  }
+}
+
+async function setupScreenCapture() {
+  const context: MockContext = { invokeHandlers: new Map() }
+  let displayMediaHandler: unknown = null
+  const setDisplayMediaRequestHandler = vi.fn((handler: unknown) => {
+    displayMediaHandler = handler
+  })
+  const getSources = vi.fn(async () => [])
+  const commandLineSwitches = new Map<string, string>()
+
+  vi.doMock('electron', () => ({
+    app: {
+      commandLine: {
+        appendSwitch: vi.fn((key: string, value: string) => commandLineSwitches.set(key, value)),
+        getSwitchValue: vi.fn((key: string) => commandLineSwitches.get(key) ?? ''),
+        hasSwitch: vi.fn((key: string) => commandLineSwitches.has(key)),
+        removeSwitch: vi.fn((key: string) => commandLineSwitches.delete(key)),
+      },
+    },
+    desktopCapturer: {
+      getSources,
+    },
+    ipcMain: {},
+    session: {
+      defaultSession: {
+        setDisplayMediaRequestHandler,
+      },
+    },
+    shell: {
+      openExternal: vi.fn(),
+    },
+    systemPreferences: {
+      getMediaAccessStatus: vi.fn(),
+    },
+  }))
+
+  vi.doMock('@moeru/eventa/adapters/electron/main', () => ({
+    createContext: () => ({ context }),
+  }))
+
+  vi.doMock('@moeru/eventa', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@moeru/eventa')>()
+    return {
+      ...actual,
+      defineInvokeHandler: (
+        target: MockContext,
+        eventa: { sendEvent: { id: string } },
+        handler: (payload: never, options?: never) => unknown,
+      ) => {
+        target.invokeHandlers.set(eventa.sendEvent.id.replace(/-send$/, ''), handler)
+      },
+    }
+  })
+
+  vi.doMock('@guiiai/logg', () => ({
+    useLogg: () => ({
+      useGlobalConfig: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        withError() {
+          return this
+        },
+        withFields() {
+          return this
+        },
+        withFormat() {
+          return this
+        },
+        withLogLevelString() {
+          return this
+        },
+      }),
+    }),
+  }))
+
+  vi.doMock('nanoid', () => ({ nanoid: () => 'capture-handle' }))
+
+  const screenCapture = await import('./index')
+  screenCapture.initScreenCaptureForMain()
+
+  const windowEvents = createEmitter()
+  const webContentsEvents = createEmitter()
+  const window = {
+    ...windowEvents,
+    getTitle: vi.fn(() => 'AIRI'),
+    id: 7,
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      ...webContentsEvents,
+      id: 42,
+    },
+  }
+  screenCapture.initScreenCaptureForWindow(window as never)
+
+  return {
+    context,
+    getSources,
+    getDisplayMediaHandler: () => displayMediaHandler,
+    screenCapture,
+    setDisplayMediaRequestHandler,
+    window,
+    webContents: window.webContents,
+  }
+}
+
+describe('electron screen capture', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('deduplicates Chromium feature flags', async () => {
+    const { screenCapture } = await setupScreenCapture()
+    const flags = screenCapture.buildFeatureFlags({
+      otherEnabledFeatures: ['Vulkan', 'Vulkan', 'SharedArrayBuffer'],
+    }).split(',')
+
+    expect(flags).toEqual([...new Set(flags)])
+  })
+
+  it('clears a selected source when its renderer process exits', async () => {
+    // ROOT CAUSE:
+    //
+    // The selected source and its mutex belong to the renderer that made the request.
+    // A renderer exit does not reset either resource, so later capture requests can remain blocked.
+    // The fix must release both resources when the owning renderer exits.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+    const resetSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:reset-source')
+
+    expect(setSource).toBeDefined()
+    expect(resetSource).toBeDefined()
+
+    const handle = await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never) as string
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(true)
+    expect(service.getDisplayMediaHandler()).not.toBeNull()
+
+    service.webContents.emit('render-process-gone', {}, { reason: 'crashed' })
+    const sourceSelectedAfterCrash = service.screenCapture.hasSelectedScreenCaptureSource()
+    const handlerAfterCrash = service.getDisplayMediaHandler()
+
+    await resetSource!(handle as never)
+
+    expect(sourceSelectedAfterCrash).toBe(false)
+    expect(handlerAfterCrash).toBeNull()
+  })
+
+  it('clears a selected source when its owner window closes', async () => {
+    // ROOT CAUSE:
+    //
+    // The source mutex outlives its BrowserWindow owner.
+    // The closed window cannot reset the source, so another window can remain blocked until timeout.
+    // The fix must release capture resources when the owner window closes.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+
+    expect(setSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+
+    service.window.emit('closed')
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
+    expect(service.getDisplayMediaHandler()).toBeNull()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2268
+  it('clears capture authorization when the selected Wayland source is unavailable (Issue #2268)', async () => {
+    // ROOT CAUSE:
+    //
+    // A portal or compositor can return a source that is unavailable when Electron starts capture.
+    // The display handler throws but keeps the selection mutex and authorization active.
+    // The fix must clear both resources after this failure.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+
+    expect(setSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+
+    const displayMediaHandler = service.getDisplayMediaHandler() as (
+      request: unknown,
+      callback: (streams: unknown) => void,
+    ) => Promise<void>
+    await expect(displayMediaHandler({}, vi.fn())).rejects.toThrow('Source with id screen:1:0 not found.')
+
+    expect(service.getSources).toHaveBeenCalled()
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
+    expect(service.getDisplayMediaHandler()).toBeNull()
+  })
+
+  it('releases capture authorization after its timeout', async () => {
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+
+    expect(setSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 1000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+    await vi.advanceTimersByTimeAsync(1001)
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
+    expect(service.getDisplayMediaHandler()).toBeNull()
+  })
+})

--- a/packages/electron-screen-capture/src/main/index.test.ts
+++ b/packages/electron-screen-capture/src/main/index.test.ts
@@ -248,4 +248,38 @@ describe('electron screen capture', () => {
     expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(false)
     expect(service.getDisplayMediaHandler()).toBeNull()
   })
+
+  it('rejects an empty-string handle instead of releasing an unrelated source', async () => {
+    // ROOT CAUSE:
+    //
+    // The release guard used `params.handle && params.handle !== screenCaptureSourceMutexHandle`.
+    // A truthy check treats an empty-string handle as "no handle supplied" and skips the
+    // ownership comparison entirely, so any renderer calling resetSource('') released a
+    // source it did not select, racing whichever window actually owns it.
+    //
+    // Before the fix, resetSource('') always returned true and cleared the source.
+    // We fixed this by comparing with `!== undefined` instead of truthiness, so an empty
+    // string is still compared against the current mutex handle and rejected on mismatch.
+    const service = await setupScreenCapture()
+    const setSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:set-source')
+    const resetSource = service.context.invokeHandlers.get('eventa:invoke:electron:screen-capture:reset-source')
+
+    expect(setSource).toBeDefined()
+    expect(resetSource).toBeDefined()
+
+    await setSource!({
+      options: { types: ['screen'] },
+      sourceId: 'screen:1:0',
+      timeout: 5000,
+    } as never, {
+      raw: { ipcMainEvent: { sender: { id: 42 } } },
+    } as never)
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(true)
+
+    await resetSource!('' as never)
+
+    expect(service.screenCapture.hasSelectedScreenCaptureSource()).toBe(true)
+    expect(service.getDisplayMediaHandler()).not.toBeNull()
+  })
 })

--- a/packages/electron-screen-capture/src/main/index.ts
+++ b/packages/electron-screen-capture/src/main/index.ts
@@ -54,16 +54,16 @@ export function buildFeatureFlags({
   otherEnabledFeatures?: string[]
   forceCoreAudioTap?: boolean
 }): string {
-  const featureFlags = [...Object.values(DefaultFeatureFlags), ...(otherEnabledFeatures ?? [])]
+  const featureFlags = new Set([...Object.values(DefaultFeatureFlags), ...(otherEnabledFeatures ?? [])])
 
   if (forceCoreAudioTap) {
-    featureFlags.push(CoreAudioTapFeatureFlags.MacCoreAudioTapSystemAudioLoopbackOverride)
+    featureFlags.add(CoreAudioTapFeatureFlags.MacCoreAudioTapSystemAudioLoopbackOverride)
   }
   else {
-    featureFlags.push(ScreenCaptureKitFeatureFlags.MacScreenCaptureKitSystemAudioLoopbackOverride)
+    featureFlags.add(ScreenCaptureKitFeatureFlags.MacScreenCaptureKitSystemAudioLoopbackOverride)
   }
 
-  return featureFlags.join(',')
+  return [...featureFlags].join(',')
 }
 
 let initMainCalled = false
@@ -93,6 +93,7 @@ export interface GetLoopbackAudioMediaStreamOptions {
 
 let setSourceMutex: MutexInterface
 let screenCaptureSourceMutexHandle: string | undefined
+let screenCaptureSourceOwnerWindowId: number | undefined
 let setSourceMutexTimeoutHandle: NodeJS.Timeout | undefined
 
 export function initScreenCaptureForMain(options: InitMainOptions = {}): void {
@@ -142,6 +143,22 @@ function resetScreenCaptureSource() {
   clearTimeout(setSourceMutexTimeoutHandle)
   setSourceMutexTimeoutHandle = undefined
   screenCaptureSourceMutexHandle = undefined
+  screenCaptureSourceOwnerWindowId = undefined
+}
+
+function releaseScreenCaptureSource(params: { handle?: string, ownerWindowId?: number } = {}): boolean {
+  if (!screenCaptureSourceMutexHandle)
+    return false
+
+  if (params.handle && params.handle !== screenCaptureSourceMutexHandle)
+    return false
+
+  if (params.ownerWindowId && params.ownerWindowId !== screenCaptureSourceOwnerWindowId)
+    return false
+
+  resetScreenCaptureSource()
+  setSourceMutex.release()
+  return true
 }
 
 /**
@@ -203,6 +220,12 @@ export function initScreenCaptureForWindow(window: BrowserWindow, options?: Init
   const { context } = createContext(ipcMain, window, { onlySameWindow: true })
   const session = sessionModule.defaultSession
 
+  const releaseWindowCaptureSource = () => {
+    releaseScreenCaptureSource({ ownerWindowId: windowId })
+  }
+  window.on('closed', releaseWindowCaptureSource)
+  window.webContents.on('render-process-gone', releaseWindowCaptureSource)
+
   defineInvokeHandler(context, screenCapture.checkMacOSPermission, async () => checkMacOSScreenCapturePermission())
   defineInvokeHandler(context, screenCapture.requestMacOSPermission, async () => requestMacOSScreenCapturePermission())
 
@@ -233,27 +256,33 @@ export function initScreenCaptureForWindow(window: BrowserWindow, options?: Init
     const handle = nanoid()
     setSourceMutexTimeoutHandle = undefined
     screenCaptureSourceMutexHandle = handle
+    screenCaptureSourceOwnerWindowId = windowId
 
     try {
       session.setDisplayMediaRequestHandler(async (_request, callback) => {
-        const sources = await desktopCapturer.getSources(request.options)
-        const source = sources.find(source => source.id === request.sourceId)
-        if (!source) {
-          throw new Error(`Source with id ${request.sourceId} not found.`)
-        }
+        try {
+          const sources = await desktopCapturer.getSources(request.options)
+          const source = sources.find(source => source.id === request.sourceId)
+          if (!source) {
+            throw new Error(`Source with id ${request.sourceId} not found.`)
+          }
 
-        callback({
-          video: source,
-          audio: options?.loopbackWithMute ? LoopbackAudioTypes.LoopbackWithMute : LoopbackAudioTypes.Loopback,
-        })
+          callback({
+            video: source,
+            audio: options?.loopbackWithMute ? LoopbackAudioTypes.LoopbackWithMute : LoopbackAudioTypes.Loopback,
+          })
+        }
+        catch (error) {
+          releaseScreenCaptureSource({ handle })
+          throw error
+        }
       })
 
       setSourceMutexTimeoutHandle = setTimeout(() => {
         if (screenCaptureSourceMutexHandle !== handle)
           return
 
-        resetScreenCaptureSource()
-        setSourceMutex.release()
+        releaseScreenCaptureSource({ handle })
 
         log
           .withFields({ windowId, windowTitle: tryWindowTitle(window, windowTitle) })
@@ -271,18 +300,14 @@ export function initScreenCaptureForWindow(window: BrowserWindow, options?: Init
         .withError(e)
         .error('screenCaptureSetSourceEx failed for window')
 
-      resetScreenCaptureSource()
-      setSourceMutex.release()
+      releaseScreenCaptureSource({ handle })
       throw e
     }
   })
 
   defineInvokeHandler(context, screenCapture.resetSource, async (mutexHandle) => {
-    if (screenCaptureSourceMutexHandle !== mutexHandle)
+    if (!releaseScreenCaptureSource({ handle: mutexHandle }))
       return
-
-    resetScreenCaptureSource()
-    setSourceMutex.release()
 
     log.withFields({ windowId, windowTitle: tryWindowTitle(window, windowTitle) }).debug('setSourceMutex released by window')
   })

--- a/packages/electron-screen-capture/src/main/index.ts
+++ b/packages/electron-screen-capture/src/main/index.ts
@@ -150,10 +150,16 @@ function releaseScreenCaptureSource(params: { handle?: string, ownerWindowId?: n
   if (!screenCaptureSourceMutexHandle)
     return false
 
-  if (params.handle && params.handle !== screenCaptureSourceMutexHandle)
+  // NOTICE:
+  // Compare with `!== undefined`, not truthiness. A caller can legitimately
+  // pass an empty-string handle (e.g. a renderer that lost its stored mutex
+  // handle) or a window id of 0; a truthiness check would then skip the
+  // ownership comparison entirely and let that caller release a source it
+  // does not own.
+  if (params.handle !== undefined && params.handle !== screenCaptureSourceMutexHandle)
     return false
 
-  if (params.ownerWindowId && params.ownerWindowId !== screenCaptureSourceOwnerWindowId)
+  if (params.ownerWindowId !== undefined && params.ownerWindowId !== screenCaptureSourceOwnerWindowId)
     return false
 
   resetScreenCaptureSource()

--- a/packages/electron-screen-capture/vitest.config.ts
+++ b/packages/electron-screen-capture/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'packages/cap-vite',
       'packages/ccc',
       'packages/core-agent',
+      'packages/electron-screen-capture',
       'packages/i18n',
       'packages/input-gamepad',
       'packages/input-gamepad-vueuse',


### PR DESCRIPTION
## Summary

Split off #2278 per maintainer feedback ("Too big, split."). Not Linux-specific, but was part of the original branch's diff — flagging as its own PR for the maintainer's call on whether it belongs in the "Linux stability" line of work.

- `releaseScreenCaptureSource` now requires the caller's mutex handle and window id to match the current holder before releasing the shared screen-capture source.
- Prevents a stale or unrelated caller from clearing a screen-capture source another window still owns.

## Test plan

- [x] `pnpm -F @proj-airi/electron-screen-capture typecheck`
- [x] `pnpm -F @proj-airi/electron-screen-capture exec vitest run` (5 passed)
- [x] `pnpm exec eslint` on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)