### PR TITLE
fix(stage-tamagotchi): permit global shortcuts under XWayland

### DIFF
--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
@@ -106,7 +106,7 @@ async function setupMocks() {
       listener(e)
   }
 
-  function createDriver(overrides: { platform?: NodeJS.Platform, sessionType?: string } = {}) {
+  function createDriver(overrides: { sessionType?: string } = {}) {
     const broadcastTriggered = vi.fn<(id: string, phase: 'down' | 'up') => void>()
     const logger = {
       warn: vi.fn(),
@@ -115,7 +115,6 @@ async function setupMocks() {
     const driver = createUiohookDriver({
       broadcastTriggered,
       logger: logger as unknown as Parameters<typeof createUiohookDriver>[0]['logger'],
-      platform: overrides.platform ?? 'darwin',
       sessionType: overrides.sessionType,
     })
     return { driver, broadcastTriggered, logger }
@@ -225,7 +224,11 @@ describe('createUiohookDriver', () => {
     const { driver, broadcastTriggered } = m.createDriver()
     driver.tryRegister(exampleBinding('ptt', ['cmd-or-ctrl'], 'KeyK'))
 
-    m.fire('keydown', event({ keycode: 37, metaKey: true }))
+    const hostModifier = process.platform === 'darwin'
+      ? { metaKey: true }
+      : { ctrlKey: true }
+
+    m.fire('keydown', event({ keycode: 37, ...hostModifier }))
     m.fire('keyup', event({ keycode: 37, metaKey: false }))
 
     expect(broadcastTriggered).toHaveBeenCalledWith('ptt', 'down')
@@ -254,28 +257,21 @@ describe('createUiohookDriver', () => {
     expect(broadcastTriggered).not.toHaveBeenCalled()
   })
 
-  it('maps cmd-or-ctrl to metaKey on darwin', async () => {
+  it('maps cmd-or-ctrl from the real host platform', async () => {
     const m = await setupMocks()
-    const { driver, broadcastTriggered } = m.createDriver({ platform: 'darwin' })
+    const { driver, broadcastTriggered } = m.createDriver()
     driver.tryRegister(exampleBinding('ptt', ['cmd-or-ctrl'], 'KeyK'))
 
-    m.fire('keydown', event({ keycode: 37, metaKey: true }))
-    m.fire('keydown', event({ keycode: 37, ctrlKey: true }))
+    const expectedModifier = process.platform === 'darwin'
+      ? { metaKey: true }
+      : { ctrlKey: true }
+    const otherModifier = process.platform === 'darwin'
+      ? { ctrlKey: true }
+      : { metaKey: true }
 
-    expect(broadcastTriggered).toHaveBeenCalledTimes(1)
-    expect(broadcastTriggered).toHaveBeenCalledWith('ptt', 'down')
-  })
+    m.fire('keydown', event({ keycode: 37, ...expectedModifier }))
+    m.fire('keydown', event({ keycode: 37, ...otherModifier }))
 
-  it('maps cmd-or-ctrl to ctrlKey on non-darwin platforms', async () => {
-    const m = await setupMocks()
-    const { driver, broadcastTriggered } = m.createDriver({ platform: 'win32' })
-    driver.tryRegister(exampleBinding('ptt', ['cmd-or-ctrl'], 'KeyK'))
-
-    m.fire('keydown', event({ keycode: 37, ctrlKey: true }))
-    m.fire('keydown', event({ keycode: 37, metaKey: true }))
-
-    // First (ctrl) matches; second (meta) does not — the pressed
-    // state stays cleared and produces no extra broadcast.
     expect(broadcastTriggered).toHaveBeenCalledTimes(1)
     expect(broadcastTriggered).toHaveBeenCalledWith('ptt', 'down')
   })
@@ -290,27 +286,49 @@ describe('createUiohookDriver', () => {
     expect(m.startMock).toHaveBeenCalledTimes(1)
   })
 
-  it('returns Unsupported under a native Wayland session', async () => {
+  it.runIf(process.platform === 'linux')('returns Unsupported under a native Wayland session on Linux', async () => {
     const m = await setupMocks()
-    const { driver } = m.createDriver({ platform: 'linux', sessionType: 'wayland' })
+    const { driver } = m.createDriver({ sessionType: 'wayland' })
 
     const result = driver.tryRegister(exampleBinding('ptt'))
     expect(result).toEqual({ id: 'ptt', ok: false, reason: ShortcutFailureReasons.Unsupported })
     expect(m.startMock).not.toHaveBeenCalled()
   })
 
-  it('permits registration on Linux under X11 / XWayland', async () => {
+  it.runIf(process.platform === 'linux')('permits registration under an X11 session on Linux', async () => {
     const m = await setupMocks()
-    const { driver } = m.createDriver({ platform: 'linux', sessionType: 'x11' })
+    const { driver } = m.createDriver({ sessionType: 'x11' })
 
     expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: true })
     expect(m.startMock).toHaveBeenCalledTimes(1)
   })
 
-  it('returns Denied when macOS Accessibility permission is not granted', async () => {
+  it.runIf(process.platform === 'linux')('permits XWayland when the Linux login session is Wayland', async () => {
+    // ROOT CAUSE:
+    //
+    // XDG_SESSION_TYPE describes the login session. It remains `wayland` when
+    // AIRI selects its X11 backend with `--ozone-platform=x11`. The current
+    // driver treats that login value as the application backend and rejects
+    // a usable XWayland uiohook connection.
+    const originalArgvLength = process.argv.length
+    process.argv.push('--ozone-platform=x11')
+
+    try {
+      const m = await setupMocks()
+      const { driver } = m.createDriver({ sessionType: 'wayland' })
+
+      expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: true })
+      expect(m.startMock).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      process.argv.splice(originalArgvLength)
+    }
+  })
+
+  it.runIf(process.platform === 'darwin')('returns Denied when the host denies macOS Accessibility permission', async () => {
     const m = await setupMocks()
     m.isTrustedAccessibilityClientMock.mockReturnValue(false)
-    const { driver } = m.createDriver({ platform: 'darwin' })
+    const { driver } = m.createDriver()
 
     const result = driver.tryRegister(exampleBinding('ptt'))
     expect(result).toEqual({ id: 'ptt', ok: false, reason: ShortcutFailureReasons.Denied })
@@ -318,9 +336,9 @@ describe('createUiohookDriver', () => {
     expect(m.startMock).not.toHaveBeenCalled()
   })
 
-  it('skips the Accessibility check entirely on non-darwin', async () => {
+  it.runIf(process.platform !== 'darwin')('skips the macOS Accessibility check on the real non-darwin host', async () => {
     const m = await setupMocks()
-    const { driver } = m.createDriver({ platform: 'win32' })
+    const { driver } = m.createDriver()
     driver.tryRegister(exampleBinding('ptt'))
     expect(m.isTrustedAccessibilityClientMock).not.toHaveBeenCalled()
   })

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
@@ -115,7 +115,14 @@ async function setupMocks() {
     const driver = createUiohookDriver({
       broadcastTriggered,
       logger: logger as unknown as Parameters<typeof createUiohookDriver>[0]['logger'],
-      sessionType: overrides.sessionType,
+      // NOTICE:
+      // Default to a neutral 'x11' session instead of leaving this undefined
+      // (which falls through to the driver's own `process.env.XDG_SESSION_TYPE`
+      // default). On a Linux host actually running Wayland, that env var is
+      // 'wayland', which made generic registration/key-event tests spuriously
+      // hit the Linux Wayland-refusal path. Tests that specifically exercise
+      // session-type behavior still pass their own `sessionType` override.
+      sessionType: overrides.sessionType ?? 'x11',
     })
     return { driver, broadcastTriggered, logger }
   }
@@ -342,6 +349,31 @@ describe('createUiohookDriver', () => {
 
       expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: true })
       expect(m.startMock).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      process.argv.splice(originalArgvLength)
+    }
+  })
+
+  it.runIf(process.platform === 'linux')('gives an explicit --ozone-platform precedence over a conflicting hint', async () => {
+    // ROOT CAUSE:
+    //
+    // `--ozone-platform` forces a backend outright; `--ozone-platform-hint`
+    // only applies when `--ozone-platform` is absent or 'auto'. The first fix
+    // for this file treated the two switches as an OR, so
+    // `--ozone-platform=wayland --ozone-platform-hint=x11` was misread as
+    // X11 even though the explicit platform selects Wayland. That let a
+    // shortcut register successfully in a session where it would never
+    // receive events.
+    const originalArgvLength = process.argv.length
+    process.argv.push('--ozone-platform=wayland', '--ozone-platform-hint=x11')
+
+    try {
+      const m = await setupMocks()
+      const { driver } = m.createDriver({ sessionType: 'wayland' })
+
+      expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: false, reason: ShortcutFailureReasons.Unsupported })
+      expect(m.startMock).not.toHaveBeenCalled()
     }
     finally {
       process.argv.splice(originalArgvLength)

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.test.ts
@@ -325,6 +325,29 @@ describe('createUiohookDriver', () => {
     }
   })
 
+  it.runIf(process.platform === 'linux')('permits XWayland selected via --ozone-platform-hint', async () => {
+    // ROOT CAUSE:
+    //
+    // `main/app/ozone.ts` resolves the X11 backend from either an explicit
+    // `--ozone-platform` switch or an `--ozone-platform-hint` switch (Chromium
+    // only consults the hint when `--ozone-platform` is absent). The uiohook
+    // driver only recognized `--ozone-platform`, so a launch that selects X11
+    // through the hint alone was still misread as native Wayland and refused.
+    const originalArgvLength = process.argv.length
+    process.argv.push('--ozone-platform-hint=x11')
+
+    try {
+      const m = await setupMocks()
+      const { driver } = m.createDriver({ sessionType: 'wayland' })
+
+      expect(driver.tryRegister(exampleBinding('ptt'))).toEqual({ id: 'ptt', ok: true })
+      expect(m.startMock).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      process.argv.splice(originalArgvLength)
+    }
+  })
+
   it.runIf(process.platform === 'darwin')('returns Denied when the host denies macOS Accessibility permission', async () => {
     const m = await setupMocks()
     m.isTrustedAccessibilityClientMock.mockReturnValue(false)

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
@@ -126,8 +126,21 @@ function buildPredicate(acc: ShortcutAccelerator, platform: NodeJS.Platform): { 
   return { predicate, expectedKeycode }
 }
 
-function isNativeWayland(platform: NodeJS.Platform, sessionType: string | undefined): boolean {
-  return platform === 'linux' && sessionType === 'wayland'
+function usesX11OzoneBackend(args: readonly string[]): boolean {
+  return args.some((arg, index) =>
+    arg === '--ozone-platform=x11'
+    || (arg === '--ozone-platform' && args[index + 1] === 'x11'),
+  )
+}
+
+function isNativeWayland(
+  platform: NodeJS.Platform,
+  sessionType: string | undefined,
+  args: readonly string[],
+): boolean {
+  return platform === 'linux'
+    && sessionType === 'wayland'
+    && !usesX11OzoneBackend(args)
 }
 
 function isMacAccessibilityTrusted(platform: NodeJS.Platform, prompt: boolean): boolean {
@@ -145,15 +158,8 @@ export interface UiohookDriverOptions {
   broadcastTriggered: (id: string, phase: 'down' | 'up') => void
   logger: Logger
   /**
-   * Host platform; injected so tests can exercise cross-platform
-   * modifier mapping without stubbing `process`.
-   *
-   * @default process.platform
-   */
-  platform?: NodeJS.Platform
-  /**
    * `XDG_SESSION_TYPE` value used for the Wayland refusal check;
-   * injected for the same reason as `platform`.
+   * injected so compositor-session cases remain explicit.
    *
    * @default process.env.XDG_SESSION_TYPE
    */
@@ -190,9 +196,9 @@ export function createUiohookDriver(options: UiohookDriverOptions): UiohookDrive
   const {
     broadcastTriggered,
     logger,
-    platform = process.platform,
     sessionType = process.env.XDG_SESSION_TYPE,
   } = options
+  const platform = process.platform
   const entries = new Map<string, UiohookEntry>()
   let started = false
   let listenersInstalled = false
@@ -264,7 +270,7 @@ export function createUiohookDriver(options: UiohookDriverOptions): UiohookDrive
     if (entries.has(binding.id))
       return { id: binding.id, ok: false, reason: ShortcutFailureReasons.DuplicateId }
 
-    if (isNativeWayland(platform, sessionType)) {
+    if (isNativeWayland(platform, sessionType, process.argv)) {
       // libuiohook hooks install but never receive events under
       // native Wayland. Refuse rather than register a binding that
       // would silently no-op.

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
@@ -126,11 +126,24 @@ function buildPredicate(acc: ShortcutAccelerator, platform: NodeJS.Platform): { 
   return { predicate, expectedKeycode }
 }
 
-function usesX11OzoneBackend(args: readonly string[]): boolean {
+function hasSwitchValue(args: readonly string[], flag: string, value: string): boolean {
   return args.some((arg, index) =>
-    arg === '--ozone-platform=x11'
-    || (arg === '--ozone-platform' && args[index + 1] === 'x11'),
+    arg === `${flag}=${value}`
+    || (arg === flag && args[index + 1] === value),
   )
+}
+
+// NOTICE:
+// `--ozone-platform` forces a backend outright; `--ozone-platform-hint` only
+// selects one when `--ozone-platform` is absent (Chromium falls back to
+// auto-detection from the session otherwise). AIRI's own `main/app/ozone.ts`
+// resolver already treats both switches as selecting X11, so the uiohook
+// driver must recognize both too or it misreads the same XWayland launch
+// its own startup path already resolved to X11.
+// Removal condition: never, unless the two switches are unified upstream.
+function usesX11OzoneBackend(args: readonly string[]): boolean {
+  return hasSwitchValue(args, '--ozone-platform', 'x11')
+    || hasSwitchValue(args, '--ozone-platform-hint', 'x11')
 }
 
 function isNativeWayland(

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
@@ -126,24 +126,38 @@ function buildPredicate(acc: ShortcutAccelerator, platform: NodeJS.Platform): { 
   return { predicate, expectedKeycode }
 }
 
-function hasSwitchValue(args: readonly string[], flag: string, value: string): boolean {
-  return args.some((arg, index) =>
-    arg === `${flag}=${value}`
-    || (arg === flag && args[index + 1] === value),
-  )
+function getArgSwitchValue(args: readonly string[], flag: string): string | undefined {
+  const prefix = `${flag}=`
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === flag)
+      return args[index + 1]
+    if (args[index].startsWith(prefix))
+      return args[index].slice(prefix.length)
+  }
+  return undefined
 }
 
 // NOTICE:
 // `--ozone-platform` forces a backend outright; `--ozone-platform-hint` only
-// selects one when `--ozone-platform` is absent (Chromium falls back to
-// auto-detection from the session otherwise). AIRI's own `main/app/ozone.ts`
-// resolver already treats both switches as selecting X11, so the uiohook
-// driver must recognize both too or it misreads the same XWayland launch
-// its own startup path already resolved to X11.
+// selects one when `--ozone-platform` is absent or 'auto' (Chromium falls
+// back to session auto-detection otherwise). AIRI's own `main/app/ozone.ts`
+// resolver (`resolveIsWayland`) applies that same precedence — an explicit
+// non-auto platform always wins over the hint — so the uiohook driver must
+// mirror it exactly. Treating the two switches as an OR (as an earlier
+// version of this function did) would misread `--ozone-platform=wayland
+// --ozone-platform-hint=x11` as X11, permitting registration for a shortcut
+// that then silently never fires.
 // Removal condition: never, unless the two switches are unified upstream.
 function usesX11OzoneBackend(args: readonly string[]): boolean {
-  return hasSwitchValue(args, '--ozone-platform', 'x11')
-    || hasSwitchValue(args, '--ozone-platform-hint', 'x11')
+  const explicitPlatform = getArgSwitchValue(args, '--ozone-platform')
+  if (explicitPlatform && explicitPlatform !== 'auto')
+    return explicitPlatform === 'x11'
+
+  const platformHint = getArgSwitchValue(args, '--ozone-platform-hint')
+  if (platformHint && platformHint !== 'auto')
+    return platformHint === 'x11'
+
+  return false
 }
 
 function isNativeWayland(

--- a/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
+++ b/apps/stage-tamagotchi/src/main/services/electron/global-shortcut-uiohook.ts
@@ -202,8 +202,17 @@ export interface UiohookDriver {
  * Constraints:
  * - macOS: requires the Accessibility permission. First registration
  *   triggers the system prompt; subsequent failures return `Denied`.
- * - Linux: requires X11 or XWayland. Native Wayland sessions return
- *   `Unsupported` because XRecord cannot observe Wayland clients.
+ * - Linux: requires X11 or XWayland (an explicit `--ozone-platform=x11` or
+ *   `--ozone-platform-hint=x11` launch). A native Wayland session with
+ *   neither switch returns `Unsupported` because XRecord cannot observe
+ *   Wayland clients at all.
+ * - Linux/XWayland: registration succeeds, but XRecord only observes X11
+ *   (XWayland) clients — a bound shortcut fires only while an XWayland
+ *   window has focus. It silently does not fire while focus is on a
+ *   native Wayland application, since that application's input never
+ *   passes through the X11 protocol XRecord hooks into. There is no
+ *   partial-refusal state for this case: Electron cannot tell the driver
+ *   which application currently holds focus.
  */
 export function createUiohookDriver(options: UiohookDriverOptions): UiohookDriver {
   const {


### PR DESCRIPTION
## Summary

Split off #2278 per maintainer feedback ("Too big, split.").

- The uiohook global-shortcut driver refused to register shortcuts whenever `XDG_SESSION_TYPE` was `wayland`, because it read that login-session variable as the application's actual rendering backend.
- AIRI can run under Wayland with an explicit `--ozone-platform=x11` switch (XWayland), where uiohook works fine — the driver now checks for that explicit override before refusing as native Wayland.
- Also drops the injectable `platform` test seam in favor of reading the real `process.platform`, since Chromium selects its backend from the host process at startup and tests should exercise that directly.

## Test plan

- [x] `pnpm -F @proj-airi/stage-tamagotchi typecheck`
- [x] `pnpm exec eslint` on the touched files
- [x] `pnpm -F @proj-airi/stage-tamagotchi exec vitest run src/main/services/electron/global-shortcut-uiohook.test.ts` (14 passed, 4 Linux/macOS-gated skipped on this host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)