### PR TITLE
fix(core-agent): prevent plain-text tool call leaks

### DIFF
--- a/packages/core-agent/README.md
+++ b/packages/core-agent/README.md
@@ -1,0 +1,40 @@
+# Core Agent
+
+Shared agent runtime for AIRI. This package provides chat orchestration, context
+and session contracts, response parsing, and LLM streaming.
+
+## When to use it
+
+Use the public exports for agent behavior shared by multiple applications.
+Keep Vue stores, UI state, and application-specific tools in their owning packages.
+
+## LLM streaming
+
+Import `streamFrom` and `StreamFromOptions` from `@proj-airi/core-agent`.
+Pass the model, chat provider, messages, and optional tools and callbacks.
+Await the returned promise to handle completion or failure.
+
+The runtime checks text and reasoning for serialized calls to registered tools.
+It buffers JSON candidates until the step ends. Valid ordinary objects retain
+their nested examples. Native tool activity does not disable this check.
+
+Each channel has a parse-work budget for each step. The budget permits candidate
+lengths to total at most eight times the channel length, measured in UTF-16 code units.
+Valid objects need one pass. The budget adds no size or depth limit to valid objects.
+
+If malformed candidates exhaust the budget, the response rejects with
+`Model output exceeded the JSON inspection work limit.`
+The runtime discards unchecked buffered output and skips message, finish, and usage callbacks.
+Earlier streamed output and native tool side effects cannot be rolled back.
+Deeply malformed output can fail this check even without a tool call.
+This error does not establish tool incompatibility. The Stage UI store does not
+retry it or change the tool compatibility cache.
+
+## Development
+
+Build the public exports before tests in consuming packages:
+
+```shell
+pnpm -F @proj-airi/core-agent build
+pnpm -F @proj-airi/core-agent exec vitest run
+```

--- a/packages/core-agent/src/index.ts
+++ b/packages/core-agent/src/index.ts
@@ -28,6 +28,7 @@ export { createContextRegistry } from './runtime/context-registry'
 export { useLlmmarkerParser } from './runtime/llm-marker-parser'
 export {
   isContentArrayRelatedError,
+  isPlainTextToolCallError,
   isToolRelatedError,
   modelKey,
   sanitizeMessages,

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -80,6 +80,16 @@ describe('streamFrom tool errors', () => {
     expect(onMessages).toHaveBeenCalledWith(finalMessages)
   })
 
+  // ROOT CAUSE:
+  //
+  // A request could require a tool while the request-level capability gate
+  // explicitly removed every tool from the provider payload.
+  //
+  // Before the fix, streamFrom silently removed the required tool choice and
+  // still called the provider without any way to satisfy the request.
+  //
+  // We fixed this by rejecting required choices with no resolved tools before
+  // the provider is called.
   it('rejects a required tool choice before the provider when tools are explicitly disabled', async () => {
     await expect(streamFrom({
       model: 'model-a',
@@ -299,6 +309,16 @@ describe('streamFrom tool errors', () => {
     expect(events).toContainEqual({ type: 'finish' })
   })
 
+  // ROOT CAUSE:
+  //
+  // Some providers serialize an offered tool call as assistant text instead
+  // of emitting the native tool-call protocol events.
+  //
+  // Before the fix, both the raw JSON and its preceding reasoning reached the
+  // UI as ordinary model output.
+  //
+  // We fixed this by buffering each candidate step and rejecting a complete
+  // JSON call that names one of the tools offered in that step.
   // https://github.com/moeru-ai/airi/issues/2161
   it('rejects reasoning and a known plain-text tool call before emitting them for Issue #2161', async () => {
     let resolveSteps: ((steps: unknown[]) => void) | undefined
@@ -360,12 +380,92 @@ describe('streamFrom tool errors', () => {
     expect(events).not.toContainEqual({ type: 'finish' })
   })
 
+  // ROOT CAUSE:
+  //
+  // Reasoning deltas were buffered but excluded from the text inspected by
+  // the plain-text tool-call guard.
+  //
+  // Before the fix, a complete tool JSON emitted only through reasoning was
+  // flushed when the step ended or ordinary assistant text started.
+  //
+  // We fixed this by tracking text and reasoning candidates separately and
+  // rejecting a complete registered-tool call found in either channel.
+  // https://github.com/moeru-ai/airi/issues/2161
+  it('rejects a known plain-text tool call emitted only through reasoning for Issue #2161', async () => {
+    const rawToolCall = JSON.stringify({
+      name: 'builtIn_emitSparkCommand',
+      parameters: { destinations: [] },
+    })
+    const sparkTool = {
+      type: 'function',
+      function: {
+        name: 'builtIn_emitSparkCommand',
+        description: 'Send a command to a connected game module.',
+        parameters: { type: 'object', properties: {} },
+      },
+      execute: vi.fn(async () => 'ok'),
+    } satisfies Tool
+
+    const expectRejectedReasoningCall = async (trailingEvents: unknown[]) => {
+      let resolveSteps: ((steps: unknown[]) => void) | undefined
+      const events: unknown[] = []
+
+      streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => Promise<void> }) => {
+        const steps = new Promise<unknown[]>((resolve) => {
+          resolveSteps = resolve
+        })
+
+        queueMicrotask(async () => {
+          await options.onEvent({ type: 'step.start' })
+          await options.onEvent({ type: 'reasoning.delta', delta: rawToolCall })
+          for (const event of trailingEvents)
+            await options.onEvent(event)
+          await options.onEvent({ type: 'step.done', usage: {} })
+          resolveSteps?.([])
+        })
+
+        return createMockStreamResult(steps)
+      })
+
+      const error = await streamFrom({
+        model: 'model-a',
+        chatProvider: provider,
+        messages: [{ role: 'user', content: 'Can you play games?' }] as Message[],
+        options: {
+          tools: [sparkTool],
+          onStreamEvent: (event) => {
+            events.push(event)
+          },
+        },
+      }).then(
+        () => undefined,
+        error => error,
+      )
+
+      expect(error).toBeInstanceOf(Error)
+      expect(String(error)).toContain('tool call "builtIn_emitSparkCommand" as plain text')
+      expect(isPlainTextToolCallError(error)).toBe(true)
+      expect(events).not.toContainEqual({ type: 'reasoning-delta', text: rawToolCall })
+      expect(events).not.toContainEqual({ type: 'finish' })
+    }
+
+    await expectRejectedReasoningCall([])
+    await expectRejectedReasoningCall([
+      { type: 'text.delta', delta: 'I cannot play that game.' },
+    ])
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+  })
+
   it('preserves a JSON answer that does not name an available tool', async () => {
     let resolveSteps: ((steps: unknown[]) => void) | undefined
     const events: unknown[] = []
     const jsonAnswer = JSON.stringify({
       name: 'Airi',
       parameters: { likes: 'games' },
+    })
+    const jsonReasoning = JSON.stringify({
+      name: 'analysis',
+      parameters: { format: 'json' },
     })
     const sparkTool = {
       type: 'function',
@@ -384,7 +484,8 @@ describe('streamFrom tool errors', () => {
 
       queueMicrotask(async () => {
         await options.onEvent({ type: 'step.start' })
-        await options.onEvent({ type: 'reasoning.delta', delta: 'I should answer with ordinary JSON.' })
+        await options.onEvent({ type: 'reasoning.delta', delta: jsonReasoning.slice(0, 10) })
+        await options.onEvent({ type: 'reasoning.delta', delta: jsonReasoning.slice(10) })
         await options.onEvent({ type: 'text.delta', delta: jsonAnswer.slice(0, 10) })
         await options.onEvent({ type: 'text.delta', delta: jsonAnswer.slice(10) })
         await options.onEvent({ type: 'step.done', usage: {} })
@@ -406,7 +507,13 @@ describe('streamFrom tool errors', () => {
       },
     })
 
-    expect(events).toContainEqual({ type: 'reasoning-delta', text: 'I should answer with ordinary JSON.' })
+    expect(events
+      .filter((event): event is { type: 'reasoning-delta', text: string } => (
+        typeof event === 'object' && event !== null && (event as { type?: unknown }).type === 'reasoning-delta'
+      ))
+      .map(event => event.text)
+      .join(''))
+      .toBe(jsonReasoning)
     expect(events
       .filter((event): event is { type: 'text-delta', text: string } => (
         typeof event === 'object' && event !== null && (event as { type?: unknown }).type === 'text-delta'

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -3,7 +3,7 @@ import type { Message, Tool } from '@xsai/shared-chat'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { isContentArrayRelatedError, sanitizeMessages, streamFrom } from './llm-service'
+import { isContentArrayRelatedError, isPlainTextToolCallError, sanitizeMessages, streamFrom } from './llm-service'
 
 const { streamTextMock } = vi.hoisted(() => ({
   streamTextMock: vi.fn(),
@@ -279,6 +279,124 @@ describe('streamFrom tool errors', () => {
       toolName: 'play_chess',
     })
     expect(events).toContainEqual({ type: 'text-delta', text: 'ok' })
+    expect(events).toContainEqual({ type: 'finish' })
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2161
+  it('rejects reasoning and a known plain-text tool call before emitting them for Issue #2161', async () => {
+    let resolveSteps: ((steps: unknown[]) => void) | undefined
+    const events: unknown[] = []
+    const rawToolCall = JSON.stringify({
+      name: 'builtIn_emitSparkCommand',
+      parameters: {
+        destinations: [],
+        guidance: 'x'.repeat(70 * 1024),
+      },
+    })
+    const sparkTool = {
+      type: 'function',
+      function: {
+        name: 'builtIn_emitSparkCommand',
+        description: 'Send a command to a connected game module.',
+        parameters: { type: 'object', properties: {} },
+      },
+      execute: vi.fn(async () => 'ok'),
+    } satisfies Tool
+
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => Promise<void> }) => {
+      const steps = new Promise<unknown[]>((resolve) => {
+        resolveSteps = resolve
+      })
+
+      queueMicrotask(async () => {
+        await options.onEvent({ type: 'step.start' })
+        await options.onEvent({ type: 'reasoning.delta', delta: 'I should call the game tool.' })
+        await options.onEvent({ type: 'text.delta', delta: rawToolCall })
+        await options.onEvent({ type: 'step.done', usage: {} })
+        resolveSteps?.([])
+      })
+
+      return createMockStreamResult(steps)
+    })
+
+    const error = await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'Can you play games?' }] as Message[],
+      options: {
+        tools: [sparkTool],
+        onStreamEvent: (event) => {
+          events.push(event)
+        },
+      },
+    }).then(
+      () => undefined,
+      error => error,
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(String(error)).toContain('tool call "builtIn_emitSparkCommand" as plain text')
+    expect(isPlainTextToolCallError(error)).toBe(true)
+    expect(isPlainTextToolCallError(new Error('A provider mentioned a tool call as plain text.'))).toBe(false)
+    expect(events).not.toContainEqual({ type: 'reasoning-delta', text: 'I should call the game tool.' })
+    expect(events).not.toContainEqual({ type: 'text-delta', text: rawToolCall })
+    expect(events).not.toContainEqual({ type: 'finish' })
+  })
+
+  it('preserves a JSON answer that does not name an available tool', async () => {
+    let resolveSteps: ((steps: unknown[]) => void) | undefined
+    const events: unknown[] = []
+    const jsonAnswer = JSON.stringify({
+      name: 'Airi',
+      parameters: { likes: 'games' },
+    })
+    const sparkTool = {
+      type: 'function',
+      function: {
+        name: 'builtIn_emitSparkCommand',
+        description: 'Send a command to a connected game module.',
+        parameters: { type: 'object', properties: {} },
+      },
+      execute: vi.fn(async () => 'ok'),
+    } satisfies Tool
+
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => Promise<void> }) => {
+      const steps = new Promise<unknown[]>((resolve) => {
+        resolveSteps = resolve
+      })
+
+      queueMicrotask(async () => {
+        await options.onEvent({ type: 'step.start' })
+        await options.onEvent({ type: 'reasoning.delta', delta: 'I should answer with ordinary JSON.' })
+        await options.onEvent({ type: 'text.delta', delta: jsonAnswer.slice(0, 10) })
+        await options.onEvent({ type: 'text.delta', delta: jsonAnswer.slice(10) })
+        await options.onEvent({ type: 'step.done', usage: {} })
+        resolveSteps?.([])
+      })
+
+      return createMockStreamResult(steps)
+    })
+
+    await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'Answer as JSON.' }] as Message[],
+      options: {
+        tools: [sparkTool],
+        onStreamEvent: (event) => {
+          events.push(event)
+        },
+      },
+    })
+
+    expect(events).toContainEqual({ type: 'reasoning-delta', text: 'I should answer with ordinary JSON.' })
+    expect(events
+      .filter((event): event is { type: 'text-delta', text: string } => (
+        typeof event === 'object' && event !== null && (event as { type?: unknown }).type === 'text-delta'
+      ))
+      .map(event => event.text)
+      .join(''))
+      .toBe(jsonAnswer)
     expect(events).toContainEqual({ type: 'finish' })
   })
 

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -80,6 +80,23 @@ describe('streamFrom tool errors', () => {
     expect(onMessages).toHaveBeenCalledWith(finalMessages)
   })
 
+  it('rejects a required tool choice before the provider when tools are explicitly disabled', async () => {
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'Play the game.' }] as Message[],
+      options: {
+        supportsTools: false,
+        toolChoice: {
+          type: 'function',
+          function: { name: 'builtIn_emitSparkCommand' },
+        },
+      },
+    })).rejects.toThrow('Cannot satisfy a required tool choice because no tools are available')
+
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
   it('ignores provider errors after steps resolve while final messages are pending', async () => {
     let onEvent: ((event: unknown) => Promise<void>) | undefined
     let resolveMessages: ((messages: Message[]) => void) | undefined

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -249,6 +249,9 @@ describe('streamFrom tool errors', () => {
         options.onEvent(mode === 'step-end'
           ? { type: 'step.done', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } }
           : { type: 'tool-call.done', toolCallId: 'call-1', toolCallType: 'function', toolName: 'builtIn_emitSparkCommand', args: '{}' })
+        // Native events no longer release JSON. End the step to start its flush.
+        if (mode === 'native-tool')
+          options.onEvent({ type: 'step.done', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } })
       }
       options.onEvent({ type: 'text.delta', delta: 'queued output' })
       return createMockStreamResult(steps.promise)
@@ -614,6 +617,72 @@ describe('streamFrom tool errors', () => {
     })
     expect(events).toContainEqual({ type: 'text-delta', text: 'ok' })
     expect(events).toContainEqual({ type: 'finish' })
+  })
+
+  // ROOT CAUSE:
+  // Native tool events released buffered JSON and disabled the guard mid-step.
+  // The guard must inspect the full step, including candidates across native events.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440962
+  it.each(['text.delta', 'reasoning.delta'] as const)('guards %s around native tool events for Issue #2161', async (type) => {
+    const call = '{"name":"builtIn_emitSparkCommand","arguments":{}}'
+    const nativeEvents: Event[] = [
+      { type: 'tool-call.start', toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand' },
+      { type: 'tool-call.delta', delta: '{}' },
+      { type: 'tool-call.done', toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand', toolCallType: 'function', args: '{}' },
+    ]
+    for (const nativeEvent of nativeEvents) {
+      for (const splitAt of [0, 20, call.length]) {
+        const onStreamEvent = vi.fn()
+        const onMessages = vi.fn()
+        const events: Event[] = [
+          { type, delta: call.slice(0, splitAt) },
+          nativeEvent,
+          { type, delta: call.slice(splitAt) },
+        ]
+        mockStreamEvents(events)
+        await expect(streamFrom({
+          model: 'model-a',
+          chatProvider: provider,
+          messages: [],
+          options: { tools: [createSparkTool()], onStreamEvent, onMessages },
+        })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+        expect(onStreamEvent.mock.calls.flat()).not.toContainEqual(expect.objectContaining({ type: type === 'text.delta' ? 'text-delta' : 'reasoning-delta' }))
+        expect(onMessages).not.toHaveBeenCalled()
+        expect(onStreamEvent).not.toHaveBeenCalledWith({ type: 'finish' })
+      }
+    }
+  })
+
+  // ROOT CAUSE:
+  // A native event can split a valid outer object before its closing brace.
+  // Inspect at step completion so its nested example remains ordinary JSON.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440962
+  it('preserves nested JSON and native event order for Issue #2161', async () => {
+    const first = '{"example":{"name":"builtIn_emitSparkCommand","arguments":{}}'
+    const events: Event[] = [
+      { type: 'reasoning.delta', delta: first },
+      { type: 'tool-call.start', toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand' },
+      { type: 'tool-call.done', toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand', toolCallType: 'function', args: '{}' },
+      { type: 'reasoning.delta', delta: '}' },
+      { type: 'tool-result.done', toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand', args: {}, result: 'ok', isError: false },
+      { type: 'text.delta', delta: 'Done.' },
+    ]
+    mockStreamEvents(events)
+    const onStreamEvent = vi.fn()
+    await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'reasoning-delta', text: first },
+      expect.objectContaining({ type: 'tool-call', toolCallId: 'call-1' }),
+      { type: 'reasoning-delta', text: '}' },
+      { type: 'tool-result', toolCallId: 'call-1', result: 'ok' },
+      { type: 'text-delta', text: 'Done.' },
+      { type: 'finish' },
+    ])
   })
 
   // ROOT CAUSE:

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -40,6 +40,31 @@ function createMockStreamResult(
   }
 }
 
+function mockStreamEvents(events: unknown[]) {
+  streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => void }) => {
+    const steps = new Promise<unknown[]>((resolve) => {
+      queueMicrotask(() => {
+        for (const event of events)
+          options.onEvent(event)
+        resolve([])
+      })
+    })
+    return createMockStreamResult(steps)
+  })
+}
+
+function createSparkTool(): Tool {
+  return {
+    type: 'function',
+    function: {
+      name: 'builtIn_emitSparkCommand',
+      description: 'Send a command to a connected game module.',
+      parameters: { type: 'object', properties: {} },
+    },
+    execute: vi.fn(async () => 'ok'),
+  }
+}
+
 describe('streamFrom tool errors', () => {
   beforeEach(() => {
     streamTextMock.mockReset()
@@ -454,6 +479,144 @@ describe('streamFrom tool errors', () => {
       { type: 'text.delta', delta: 'I cannot play that game.' },
     ])
     expect(streamTextMock).toHaveBeenCalledTimes(2)
+  })
+
+  // ROOT CAUSE:
+  //
+  // A text prefix disabled the guard for the rest of the model step.
+  // Before the fix, a later tool JSON reached the caller as normal output.
+  // We keep the guard active and inspect complete JSON objects after prefixes.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3932132863
+  it.each([
+    ['text.delta', 'I will call the game tool.\n'],
+    ['text.delta', '```json\n'],
+    ['text.delta', '{not JSON}\n{"status":"ready"}\n'],
+    ['reasoning.delta', 'I will call the game tool.\n'],
+    ['reasoning.delta', '```json\n'],
+  ])('rejects a prefixed tool JSON in %s with prefix %j for Issue #2161', async (type, prefix) => {
+    const rawToolCall = JSON.stringify({
+      name: 'builtIn_emitSparkCommand',
+      parameters: { guidance: 'Use {braces}, a "quote", and a \\ slash.' },
+    })
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([
+      { type: 'step.start' },
+      { type, delta: prefix },
+      ...Array.from(rawToolCall, delta => ({ type, delta })),
+      { type, delta: '\n```\nDone.' },
+      { type: 'step.done', usage: {} },
+    ])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'Can you play games?' }],
+      options: { tools: [createSparkTool()], onStreamEvent, onMessages },
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    const output = onStreamEvent.mock.calls.map(([event]) => event.text ?? '').join('')
+    expect(output).not.toContain('{')
+    expect(onStreamEvent).not.toHaveBeenCalledWith({ type: 'finish' })
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  //
+  // A prose prefix and its tool JSON can arrive in the same provider chunk.
+  // Before the fix, the prefix made the whole chunk bypass JSON detection.
+  // We inspect complete objects regardless of the provider chunk boundaries.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3932132863
+  it('rejects a prefix and tool JSON in one chunk for Issue #2161', async () => {
+    const onStreamEvent = vi.fn()
+    mockStreamEvents([{
+      type: 'text.delta',
+      delta: 'Here is the call: ```json\n{"name":"builtIn_emitSparkCommand","arguments":{}}\n```',
+    }])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(onStreamEvent).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'A plain answer without JSON.',
+    'Use {score} for the value. Then {not JSON}.',
+    '```json\n{"name":"Airi","parameters":{}}\n```',
+    'Result: {"name":"builtIn_emitSparkCommand","description":"A tool name without a call."}',
+    'Result: {"example":{"name":"builtIn_emitSparkCommand","parameters":{}}}',
+    'Result: {"text":"A brace } and an escaped quote \\" followed by {"}',
+    'An incomplete object: {"name":"builtIn_emitSparkCommand",',
+  ])('preserves ordinary output %j after inspecting JSON candidates', async (answer) => {
+    const onStreamEvent = vi.fn()
+    mockStreamEvents(Array.from(answer, delta => ({ type: 'text.delta', delta })))
+
+    await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })
+
+    expect(onStreamEvent.mock.calls.map(([event]) => event.text ?? '').join('')).toBe(answer)
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
+  it('streams ordinary text before the provider finishes the step', async () => {
+    let emit: ((event: unknown) => void) | undefined
+    let finish: ((steps: unknown[]) => void) | undefined
+    const onStreamEvent = vi.fn()
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => void }) => {
+      emit = options.onEvent
+      return createMockStreamResult(new Promise((resolve) => {
+        finish = resolve
+      }))
+    })
+    const pending = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })
+
+    await vi.waitFor(() => expect(emit).toBeTypeOf('function'))
+    emit!({ type: 'text.delta', delta: 'Hello' })
+    await vi.waitFor(() => expect(onStreamEvent).toHaveBeenCalledWith({ type: 'text-delta', text: 'Hello' }))
+    emit!({ type: 'text.delta', delta: ' there.' })
+    await vi.waitFor(() => expect(onStreamEvent).toHaveBeenCalledWith({ type: 'text-delta', text: ' there.' }))
+    expect(onStreamEvent).not.toHaveBeenCalledWith({ type: 'finish' })
+    finish?.([])
+    await pending
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
+  // ROOT CAUSE:
+  //
+  // Assistant text can arrive between chunks of a reasoning JSON object.
+  // Before the fix, normal text flushed the incomplete candidate to the caller.
+  // We retain both channels until their JSON candidates are complete.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3932132863
+  it('holds an interleaved reasoning candidate for Issue #2161', async () => {
+    const onStreamEvent = vi.fn()
+    mockStreamEvents([
+      { type: 'reasoning.delta', delta: 'Call: {"name":"builtIn_emitSparkCommand",' },
+      { type: 'text.delta', delta: 'I can try.' },
+      { type: 'reasoning.delta', delta: '"parameters":{}}' },
+    ])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(onStreamEvent).not.toHaveBeenCalled()
   })
 
   it('preserves a JSON answer that does not name an available tool', async () => {

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -1,5 +1,7 @@
 import type { ChatProvider } from '@xsai-ext/providers/utils'
-import type { Message, Tool } from '@xsai/shared-chat'
+import type { Event, Message, Tool } from '@xsai/shared-chat'
+
+import type { StreamOptions } from '../types/llm'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -164,6 +166,286 @@ describe('streamFrom tool errors', () => {
     resolveMessages?.([])
 
     await expect(pending).resolves.toBeUndefined()
+  })
+
+  // ROOT CAUSE:
+  //
+  // A slow output listener leaves an accepted error behind it in the queue.
+  // Before the fix, stepsSettled made rejectOnce ignore that error.
+  // The stream then saved partial messages and emitted finish.
+  // Accepted errors now reject the queue even after provider completion.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949844407
+  it.each([false, true])('rejects an accepted error after steps resolve with tools=%s for Issue #2161', async (withTools) => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    const streamError = new Error('accepted provider error')
+    const onMessages = vi.fn()
+    const onUsage = vi.fn()
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async (event) => {
+      if (event.type === 'text-delta') {
+        listenerStarted.resolve()
+        await releaseListener.promise
+      }
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      options.onEvent({ type: 'text.delta', delta: 'partial answer' })
+      options.onEvent({ type: 'error', message: streamError.message, cause: streamError })
+      options.onEvent({ type: 'text.delta', delta: 'must not escape' })
+      return createMockStreamResult(steps.promise)
+    })
+    const result = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hello' }],
+      options: { tools: withTools ? [createSparkTool()] : undefined, onStreamEvent, onMessages, onUsage },
+    }).then(() => undefined, error => error)
+
+    await listenerStarted.promise
+    steps.resolve([])
+    await new Promise(resolve => setImmediate(resolve))
+    releaseListener.resolve()
+
+    expect(await result).toBe(streamError)
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'text-delta', text: 'partial answer' },
+      { type: 'error', error: streamError },
+    ])
+    expect(onMessages).not.toHaveBeenCalled()
+    expect(onUsage).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  //
+  // A provider failure can arrive while an output listener waits on a plugin.
+  // Before the fix, the caller received rejection before that listener returned.
+  // Queued events and buffered output then continued to change the session.
+  // Failure now stops pending output and waits for the active listener before rejection.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949844417
+  it.each(['plain', 'step-end', 'native-tool'] as const)('stops %s output and drains the active listener on failure for Issue #2161', async (mode) => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    const streamError = new Error('steps failed during output')
+    const onMessages = vi.fn()
+    const onUsage = vi.fn()
+    const mutations: string[] = []
+    let settled = false
+    const firstEvent = mode === 'plain'
+      ? { type: 'text-delta', text: 'first' }
+      : { type: 'reasoning-delta', text: '{"ordinary":1}' }
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async () => {
+      listenerStarted.resolve()
+      await releaseListener.promise
+      mutations.push(settled ? 'after rejection' : 'before rejection')
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      if (mode === 'plain') {
+        options.onEvent({ type: 'text.delta', delta: 'first' })
+      }
+      else {
+        options.onEvent({ type: 'reasoning.delta', delta: '{"ordinary":1}' })
+        options.onEvent({ type: 'text.delta', delta: 'buffered output' })
+        options.onEvent(mode === 'step-end'
+          ? { type: 'step.done', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } }
+          : { type: 'tool-call.done', toolCallId: 'call-1', toolCallType: 'function', toolName: 'builtIn_emitSparkCommand', args: '{}' })
+      }
+      options.onEvent({ type: 'text.delta', delta: 'queued output' })
+      return createMockStreamResult(steps.promise)
+    })
+    const result = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hello' }],
+      options: { tools: [createSparkTool()], onStreamEvent, onMessages, onUsage },
+    }).then(
+      () => {
+        settled = true
+      },
+      (error) => {
+        settled = true
+        return error
+      },
+    )
+
+    await listenerStarted.promise
+    steps.reject(streamError)
+    await new Promise(resolve => setImmediate(resolve))
+    const settledBeforeRelease = settled
+    releaseListener.resolve()
+    const error = await result
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(settledBeforeRelease).toBe(false)
+    expect(error).toBe(streamError)
+    expect(mutations).toEqual(['before rejection'])
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([firstEvent])
+    expect(onMessages).not.toHaveBeenCalled()
+    expect(onUsage).not.toHaveBeenCalled()
+  })
+
+  it('drains accepted output but ignores new provider events after steps resolve', async () => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    let onEvent: (event: Event) => void = () => {
+      throw new Error('provider not started')
+    }
+    const onMessages = vi.fn()
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async (event) => {
+      if (event.type === 'text-delta') {
+        listenerStarted.resolve()
+        await releaseListener.promise
+      }
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: typeof onEvent }) => {
+      onEvent = options.onEvent
+      onEvent({ type: 'text.delta', delta: 'accepted output' })
+      return createMockStreamResult(steps.promise)
+    })
+    const pending = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [{ role: 'user', content: 'hello' }],
+      options: { onStreamEvent, onMessages },
+    })
+    await listenerStarted.promise
+    steps.resolve([])
+    await new Promise(resolve => setImmediate(resolve))
+    onEvent({ type: 'error', message: 'late provider error' })
+    onEvent({ type: 'text.delta', delta: 'late output' })
+    expect(onMessages).not.toHaveBeenCalled()
+    releaseListener.resolve()
+    await pending
+
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'text-delta', text: 'accepted output' },
+      { type: 'finish' },
+    ])
+    expect(onMessages).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([false, true])('stops the queue when an output listener rejects with steps complete=%s', async (stepsComplete) => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    const listenerError = new Error('output listener failed')
+    const onMessages = vi.fn()
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async () => {
+      listenerStarted.resolve()
+      await releaseListener.promise
+      throw listenerError
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      options.onEvent({ type: 'text.delta', delta: 'first' })
+      options.onEvent({ type: 'text.delta', delta: 'second' })
+      return createMockStreamResult(steps.promise)
+    })
+    const result = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { onStreamEvent, onMessages },
+    }).then(() => undefined, error => error)
+
+    await listenerStarted.promise
+    if (stepsComplete)
+      steps.resolve([])
+    await new Promise(resolve => setImmediate(resolve))
+    releaseListener.resolve()
+    try {
+      expect(await result).toBe(listenerError)
+    }
+    finally {
+      steps.resolve([])
+    }
+    await new Promise(resolve => setImmediate(resolve))
+    expect(onStreamEvent).toHaveBeenCalledTimes(1)
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
+  it('keeps the provider failure when the active listener also rejects', async () => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    const streamError = new Error('provider failed first')
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async () => {
+      listenerStarted.resolve()
+      await releaseListener.promise
+      throw new Error('listener failed later')
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      options.onEvent({ type: 'text.delta', delta: 'first' })
+      options.onEvent({ type: 'text.delta', delta: 'second' })
+      return createMockStreamResult(steps.promise)
+    })
+    const result = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { onStreamEvent },
+    }).then(() => undefined, error => error)
+    await listenerStarted.promise
+    steps.reject(streamError)
+    await new Promise(resolve => setImmediate(resolve))
+    releaseListener.resolve()
+
+    expect(await result).toBe(streamError)
+    expect(onStreamEvent).toHaveBeenCalledTimes(1)
+  })
+
+  // ROOT CAUSE:
+  //
+  // Before the fix, an error rejected the caller but left queued output and success callbacks active.
+  // Failure now stops both paths even if the provider later resolves its steps.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949844407
+  it('rejects an accepted error before steps complete without later success callbacks for Issue #2161', async () => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const streamError = new Error('provider event failed')
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    const onUsage = vi.fn()
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      options.onEvent({ type: 'error', message: streamError.message, cause: streamError })
+      options.onEvent({ type: 'text.delta', delta: 'must not escape' })
+      return createMockStreamResult(steps.promise)
+    })
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { onStreamEvent, onMessages, onUsage },
+    })).rejects.toBe(streamError)
+    steps.resolve([])
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([{ type: 'error', error: streamError }])
+    expect(onMessages).not.toHaveBeenCalled()
+    expect(onUsage).not.toHaveBeenCalled()
+  })
+
+  it.each(['messages', 'listener'] as const)('does not emit finish when the final %s rejects', async (failureSource) => {
+    const persistenceError = new Error('transcript failed')
+    const onStreamEvent = vi.fn()
+    const onUsage = vi.fn()
+    const onMessages = vi.fn(() => {
+      throw persistenceError
+    })
+    streamTextMock.mockReturnValueOnce(createMockStreamResult(
+      Promise.resolve([]),
+      Promise.resolve(undefined),
+      failureSource === 'messages' ? Promise.reject(persistenceError) : Promise.resolve([]),
+    ))
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { onMessages, onStreamEvent, onUsage },
+    })).rejects.toBe(persistenceError)
+
+    expect(onMessages).toHaveBeenCalledTimes(failureSource === 'messages' ? 0 : 1)
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onUsage).not.toHaveBeenCalled()
   })
 
   it('requests final streaming usage and emits the reported token totals once', async () => {

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -976,6 +976,90 @@ describe('streamFrom tool errors', () => {
     expect(onStreamEvent).not.toHaveBeenCalled()
   })
 
+  // ROOT CAUSE:
+  //
+  // Balanced but invalid nested objects caused JSON.parse to scan overlapping suffixes.
+  // The guard now limits total parse work and rejects before it releases unchecked output.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3953824377
+  it.each(['text.delta', 'reasoning.delta'] as const)('bounds invalid nested JSON in %s for Issue #2161', async (type) => {
+    const answer = `${'{"a":'.repeat(512)}x${'}'.repeat(512)}`
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    const onUsage = vi.fn()
+    mockStreamEvents([{ type, delta: answer }, { type: 'step.done' }])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent, onMessages, onUsage },
+    })).rejects.toThrow('Model output exceeded the JSON inspection work limit.')
+
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+    expect(onUsage).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  //
+  // Exhausted inspection must not release later unchecked tool calls.
+  // Exhaustion rejects the whole buffer, including output in the other channel.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3953824377
+  it.each(['text.delta', 'reasoning.delta'] as const)('withholds later tool JSON after the work limit in %s for Issue #2161', async (type) => {
+    const answer = `${'{"a":'.repeat(512)}x${'}'.repeat(512)}`
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([
+      { type, delta: answer },
+      { type, delta: '{"name":"builtIn_emitSparkCommand","arguments":{}}' },
+      { type: type === 'text.delta' ? 'reasoning.delta' : 'text.delta', delta: 'Also buffered.' },
+    ])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent, onMessages },
+    })).rejects.toThrow('Model output exceeded the JSON inspection work limit.')
+
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  //
+  // Size, depth, and candidate-count limits reject some output that takes linear work.
+  // The budget counts candidate lengths and resets for each channel and step.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3953824377
+  it.each([
+    ['deep valid JSON', `${'{"a":'.repeat(20_000)}{"name":"builtIn_emitSparkCommand","arguments":{}}${'}'.repeat(20_000)}`],
+    ['separate invalid candidates', '{"a":x} '.repeat(2000)],
+    ['nested candidates near the budget', `${'{"a":'.repeat(14)}x${'}'.repeat(14)}`],
+  ])('preserves %s across channels and steps for Issue #2161', async (_, answer) => {
+    const onStreamEvent = vi.fn()
+    mockStreamEvents([
+      { type: 'text.delta', delta: answer },
+      { type: 'reasoning.delta', delta: answer },
+      { type: 'step.done' },
+      { type: 'step.start' },
+      { type: 'text.delta', delta: answer },
+    ])
+
+    await streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })
+
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'text-delta', text: answer },
+      { type: 'reasoning-delta', text: answer },
+      { type: 'text-delta', text: answer },
+      { type: 'finish' },
+    ])
+  })
+
   it('streams ordinary text before the provider finishes the step', async () => {
     let emit: ((event: unknown) => void) | undefined
     let finish: ((steps: unknown[]) => void) | undefined

--- a/packages/core-agent/src/runtime/llm-service.test.ts
+++ b/packages/core-agent/src/runtime/llm-service.test.ts
@@ -339,13 +339,12 @@ describe('streamFrom tool errors', () => {
   // Some providers serialize an offered tool call as assistant text instead
   // of emitting the native tool-call protocol events.
   //
-  // Before the fix, both the raw JSON and its preceding reasoning reached the
-  // UI as ordinary model output.
+  // Before the fix, the raw JSON reached the UI as ordinary model output.
   //
-  // We fixed this by buffering each candidate step and rejecting a complete
-  // JSON call that names one of the tools offered in that step.
+  // We reject complete JSON calls for known tools. Ordinary reasoning can
+  // stream before a candidate starts, so callers must not replay that output.
   // https://github.com/moeru-ai/airi/issues/2161
-  it('rejects reasoning and a known plain-text tool call before emitting them for Issue #2161', async () => {
+  it('rejects a known plain-text tool call after ordinary reasoning for Issue #2161', async () => {
     let resolveSteps: ((steps: unknown[]) => void) | undefined
     const events: unknown[] = []
     const rawToolCall = JSON.stringify({
@@ -400,7 +399,7 @@ describe('streamFrom tool errors', () => {
     expect(String(error)).toContain('tool call "builtIn_emitSparkCommand" as plain text')
     expect(isPlainTextToolCallError(error)).toBe(true)
     expect(isPlainTextToolCallError(new Error('A provider mentioned a tool call as plain text.'))).toBe(false)
-    expect(events).not.toContainEqual({ type: 'reasoning-delta', text: 'I should call the game tool.' })
+    expect(events).toContainEqual({ type: 'reasoning-delta', text: 'I should call the game tool.' })
     expect(events).not.toContainEqual({ type: 'text-delta', text: rawToolCall })
     expect(events).not.toContainEqual({ type: 'finish' })
   })
@@ -544,6 +543,41 @@ describe('streamFrom tool errors', () => {
     expect(onStreamEvent).not.toHaveBeenCalled()
   })
 
+  // ROOT CAUSE:
+  //
+  // An unmatched opening brace kept the first candidate open for the whole step.
+  // Before the fix, a later complete tool call remained inside that invalid candidate.
+  // We inspect later objects independently, but skip children of valid JSON objects.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949439841
+  it.each([
+    ['text.delta', 'Use {value here.\n'],
+    ['reasoning.delta', 'Use {value here.\n'],
+    ['text.delta', '{{{'],
+    ['reasoning.delta', '{{{'],
+    ['text.delta', '{"unfinished":"prefix '],
+    ['reasoning.delta', '{"unfinished":"prefix '],
+    ['text.delta', '{invalid: '],
+    ['reasoning.delta', '{invalid: '],
+  ])('rejects a tool JSON in %s after malformed prefix %j for Issue #2161', async (type, prefix) => {
+    const rawToolCall = '{"name":"builtIn_emitSparkCommand","arguments":{"text":"A } brace and a { brace."}}'
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([
+      { type, delta: prefix },
+      ...Array.from(rawToolCall, delta => ({ type, delta })),
+    ])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent, onMessages },
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
   it.each([
     'A plain answer without JSON.',
     'Use {score} for the value. Then {not JSON}.',
@@ -552,6 +586,8 @@ describe('streamFrom tool errors', () => {
     'Result: {"example":{"name":"builtIn_emitSparkCommand","parameters":{}}}',
     'Result: {"text":"A brace } and an escaped quote \\" followed by {"}',
     'An incomplete object: {"name":"builtIn_emitSparkCommand",',
+    'Malformed { prefix, then {"example":{"name":"builtIn_emitSparkCommand","parameters":{}}}',
+    JSON.stringify({ text: '{"name":"builtIn_emitSparkCommand","parameters":{}}', escaped: '\\"{}\\' }),
   ])('preserves ordinary output %j after inspecting JSON candidates', async (answer) => {
     const onStreamEvent = vi.fn()
     mockStreamEvents(Array.from(answer, delta => ({ type: 'text.delta', delta })))
@@ -565,6 +601,28 @@ describe('streamFrom tool errors', () => {
 
     expect(onStreamEvent.mock.calls.map(([event]) => event.text ?? '').join('')).toBe(answer)
     expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
+  // ROOT CAUSE:
+  //
+  // A malformed enclosing object hid a complete tool call even with balanced braces.
+  // We skip nested candidates only after JSON.parse accepts their enclosing object.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949439841
+  it.each([
+    '{{"name":"builtIn_emitSparkCommand","arguments":{}}}',
+    `${'{'.repeat(20_000)}{"name":"builtIn_emitSparkCommand","arguments":{}}`,
+  ])('recovers from malformed enclosing braces for Issue #2161 %#', async (answer) => {
+    const onStreamEvent = vi.fn()
+    mockStreamEvents([{ type: 'text.delta', delta: answer }])
+
+    await expect(streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(onStreamEvent).not.toHaveBeenCalled()
   })
 
   it('streams ordinary text before the provider finishes the step', async () => {
@@ -592,6 +650,44 @@ describe('streamFrom tool errors', () => {
     expect(onStreamEvent).not.toHaveBeenCalledWith({ type: 'finish' })
     finish?.([])
     await pending
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
+  // ROOT CAUSE:
+  //
+  // The reasoning path buffered every delta while tools were available.
+  // Before the fix, ordinary reasoning stayed hidden until another event flushed it.
+  // We stream reasoning until either output channel starts a JSON candidate.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949439849
+  it('streams reasoning before text or step completion for Issue #2161', async () => {
+    let emit: ((event: unknown) => void) | undefined
+    let finish: ((steps: unknown[]) => void) | undefined
+    const onStreamEvent = vi.fn()
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => void }) => {
+      emit = options.onEvent
+      return createMockStreamResult(new Promise((resolve) => {
+        finish = resolve
+      }))
+    })
+    const pending = streamFrom({
+      model: 'model-a',
+      chatProvider: provider,
+      messages: [],
+      options: { tools: [createSparkTool()], onStreamEvent },
+    })
+
+    try {
+      await vi.waitFor(() => expect(emit).toBeTypeOf('function'))
+      emit!({ type: 'reasoning.delta', delta: 'Let me think.' })
+      await vi.waitFor(() => expect(onStreamEvent).toHaveBeenCalledWith({ type: 'reasoning-delta', text: 'Let me think.' }))
+      emit!({ type: 'reasoning.delta', delta: ' I can explain.' })
+      await vi.waitFor(() => expect(onStreamEvent).toHaveBeenCalledWith({ type: 'reasoning-delta', text: ' I can explain.' }))
+      expect(onStreamEvent).not.toHaveBeenCalledWith({ type: 'finish' })
+    }
+    finally {
+      finish?.([])
+      await pending
+    }
     expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
   })
 

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -73,9 +73,28 @@ export function modelKey(model: string, chatProvider: ChatProvider): string {
   return `${chatProvider.chat(model).baseURL}-${model}`
 }
 
+function toolChoiceRequiresTools(toolChoice: StreamOptions['toolChoice']): boolean {
+  if (toolChoice === 'required')
+    return true
+  if (typeof toolChoice !== 'object' || toolChoice === null)
+    return false
+
+  return toolChoice.type === 'function'
+    || (toolChoice.type === 'allowed_tools' && toolChoice.mode === 'required')
+}
+
+/**
+ * Resolve whether tools may be attached to the provider request.
+ *
+ * An explicit `supportsTools: false` always wins. A required tool choice takes
+ * precedence over the runtime incompatibility cache so a mandatory tool call
+ * is retried with its tools instead of being silently downgraded to text.
+ */
 export function streamOptionsToolsCompatibilityOk(model: string, chatProvider: ChatProvider, options?: StreamOptions): boolean {
   if (options?.supportsTools === false)
     return false
+  if (toolChoiceRequiresTools(options?.toolChoice))
+    return true
   const key = modelKey(model, chatProvider)
   return options?.toolsCompatibility?.get(key) !== false
 }
@@ -208,6 +227,8 @@ export async function streamFrom({
   const customTools = supportedTools ? await resolveTools(options) : []
   const mergedTools = supportedTools ? [...builtinTools, ...customTools] : []
   const tools = mergedTools.length > 0 ? mergedTools : undefined
+  if (!tools && toolChoiceRequiresTools(options?.toolChoice))
+    throw new Error('Cannot satisfy a required tool choice because no tools are available for this request.')
   const toolNames = new Set(mergedTools.flatMap(tool => toolNameFrom(tool) ?? []))
 
   return new Promise<void>((resolve, reject) => {
@@ -487,6 +508,15 @@ export function isToolRelatedError(error: unknown): boolean {
   return TOOLS_RELATED_ERROR_PATTERNS.some(pattern => pattern.test(message))
 }
 
+/**
+ * Return whether an error is the internal sentinel emitted when this module's
+ * leak guard catches a complete plain-text call to a tool offered in the same
+ * model step. Message text alone never matches.
+ *
+ * A `true` result does not make replay safe by itself. Callers must separately
+ * verify that no output or tool side effects were committed and that the tool
+ * choice does not require a tool before retrying without tools.
+ */
 export function isPlainTextToolCallError(error: unknown): boolean {
   return typeof error === 'object'
     && error !== null

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -74,8 +74,8 @@ export function modelKey(model: string, chatProvider: ChatProvider): string {
 }
 
 export function streamOptionsToolsCompatibilityOk(model: string, chatProvider: ChatProvider, options?: StreamOptions): boolean {
-  if (options?.supportsTools !== undefined)
-    return options.supportsTools
+  if (options?.supportsTools === false)
+    return false
   const key = modelKey(model, chatProvider)
   return options?.toolsCompatibility?.get(key) !== false
 }
@@ -99,6 +99,53 @@ async function resolveTools(options?: StreamOptions) {
     ? await options.tools()
     : options?.tools
   return tools ?? []
+}
+
+const PLAIN_TEXT_TOOL_CALL_ERROR_CODE = 'AIRI_PLAIN_TEXT_TOOL_CALL'
+
+type BufferedOutputEvent
+  = | { type: 'text-delta', text: string }
+    | { type: 'reasoning-delta', text: string }
+
+function plainTextToolCallError(toolName: string): Error {
+  return Object.assign(
+    new Error(`Model returned tool call "${toolName}" as plain text instead of native tool calling.`),
+    { code: PLAIN_TEXT_TOOL_CALL_ERROR_CODE },
+  )
+}
+
+function leakedToolCallName(text: string, toolNames: Set<string>): string | undefined {
+  const candidate = text.trim()
+  if (!candidate.startsWith('{') || !candidate.endsWith('}'))
+    return undefined
+
+  try {
+    const parsed = JSON.parse(candidate) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
+      return undefined
+
+    const record = parsed as Record<string, unknown>
+    if (typeof record.name !== 'string' || !toolNames.has(record.name))
+      return undefined
+    if (!Object.hasOwn(record, 'parameters') && !Object.hasOwn(record, 'arguments'))
+      return undefined
+
+    return record.name
+  }
+  catch {
+    return undefined
+  }
+}
+
+function toolNameFrom(tool: unknown): string | undefined {
+  if (typeof tool !== 'object' || tool === null)
+    return undefined
+
+  const candidate = tool as {
+    name?: string
+    function?: { name?: string }
+  }
+  return candidate.function?.name ?? candidate.name
 }
 
 /**
@@ -161,10 +208,14 @@ export async function streamFrom({
   const customTools = supportedTools ? await resolveTools(options) : []
   const mergedTools = supportedTools ? [...builtinTools, ...customTools] : []
   const tools = mergedTools.length > 0 ? mergedTools : undefined
+  const toolNames = new Set(mergedTools.flatMap(tool => toolNameFrom(tool) ?? []))
 
   return new Promise<void>((resolve, reject) => {
     let settled = false
     let stepsSettled = false
+    let bufferPossibleToolCall = toolNames.size > 0
+    let bufferedOutputEvents: BufferedOutputEvent[] = []
+    let bufferedText = ''
     const resolveOnce = () => {
       if (settled)
         return
@@ -178,17 +229,124 @@ export async function streamFrom({
       reject(error)
     }
 
-    const onEvent = async (event: Event) => {
-      try {
-        const streamEvent = toAiriStreamEvent(event)
-        if (streamEvent != null)
-          await options?.onStreamEvent?.(streamEvent)
-        if (streamEvent?.type === 'error')
-          rejectOnce(streamEvent.error)
+    const emitOutputEvent = async (event: BufferedOutputEvent) => {
+      if (event.text)
+        await options?.onStreamEvent?.(event)
+    }
+
+    const bufferOutputEvent = (event: BufferedOutputEvent) => {
+      const previous = bufferedOutputEvents.at(-1)
+      if (previous?.type === event.type)
+        previous.text += event.text
+      else
+        bufferedOutputEvents.push(event)
+    }
+
+    const takeBufferedOutput = () => {
+      const events = bufferedOutputEvents
+      bufferedOutputEvents = []
+      bufferedText = ''
+      return events
+    }
+
+    const flushBufferedOutput = async () => {
+      const events = takeBufferedOutput()
+      for (const event of events)
+        await emitOutputEvent(event)
+    }
+
+    const passThroughBufferedOutput = async () => {
+      bufferPossibleToolCall = false
+      await flushBufferedOutput()
+    }
+
+    const finishPossibleToolCall = async () => {
+      if (!bufferPossibleToolCall)
+        return
+
+      bufferPossibleToolCall = false
+      const toolName = leakedToolCallName(bufferedText, toolNames)
+      if (toolName) {
+        takeBufferedOutput()
+        throw plainTextToolCallError(toolName)
       }
-      catch (error) {
-        rejectOnce(error)
+
+      await flushBufferedOutput()
+    }
+
+    const startToolCallGuardStep = async () => {
+      await finishPossibleToolCall()
+      bufferPossibleToolCall = toolNames.size > 0
+    }
+
+    const consumeTextDelta = async (text: string) => {
+      if (!bufferPossibleToolCall) {
+        await emitOutputEvent({ type: 'text-delta', text })
+        return
       }
+
+      bufferOutputEvent({ type: 'text-delta', text })
+      bufferedText += text
+      const firstNonWhitespace = bufferedText.trimStart().at(0)
+      // xsAI already retains the full step text. Keep any JSON-shaped candidate
+      // until the step ends; releasing a large candidate would expose the leak.
+      if (firstNonWhitespace !== undefined && firstNonWhitespace !== '{') {
+        await passThroughBufferedOutput()
+      }
+    }
+
+    const consumeReasoningDelta = async (text: string) => {
+      if (!bufferPossibleToolCall) {
+        await emitOutputEvent({ type: 'reasoning-delta', text })
+        return
+      }
+
+      bufferOutputEvent({ type: 'reasoning-delta', text })
+    }
+
+    const processEvent = async (event: Event) => {
+      if (event.type === 'step.start') {
+        await startToolCallGuardStep()
+        return
+      }
+      if (event.type === 'step.done') {
+        await finishPossibleToolCall()
+        return
+      }
+      if (event.type === 'text.delta') {
+        await consumeTextDelta(event.delta)
+        return
+      }
+      if (event.type === 'reasoning.delta') {
+        await consumeReasoningDelta(event.delta)
+        return
+      }
+      if (
+        event.type === 'tool-call.start'
+        || event.type === 'tool-call.delta'
+        || event.type === 'tool-call.done'
+      ) {
+        // A native tool-call event proves this step used the provider protocol.
+        // Release any reasoning that arrived before it.
+        await passThroughBufferedOutput()
+      }
+
+      const streamEvent = toAiriStreamEvent(event)
+      if (streamEvent != null)
+        await options?.onStreamEvent?.(streamEvent)
+      if (streamEvent?.type === 'error')
+        rejectOnce(streamEvent.error)
+    }
+
+    // xsAI intentionally does not await onEvent. Keep our own chain so output
+    // events retain provider order and completion waits for accepted deltas.
+    let eventQueue = Promise.resolve()
+    const onEvent = (event: Event) => {
+      if (settled || stepsSettled)
+        return
+
+      eventQueue = eventQueue.then(() => processEvent(event))
+      void eventQueue.catch(error => rejectOnce(error))
     }
 
     try {
@@ -200,7 +358,7 @@ export async function streamFrom({
         streamOptions: { includeUsage: true },
         stopWhen: stepCountAtLeast(10),
         tools,
-        toolChoice: options?.toolChoice,
+        toolChoice: tools ? options?.toolChoice : undefined,
         onEvent,
       })
 
@@ -219,9 +377,22 @@ export async function streamFrom({
       // Keep `steps.then(resolveOnce)` so evaluation runners observe the real end
       // of the stream lifecycle instead of an intermediate tool boundary.
       void streamResult.steps.then(async () => {
-        // Ignore any late provider error event emitted after xsAI has already
-        // resolved the authoritative full-step lifecycle.
+        const acceptedEvents = eventQueue
+        // Mark the provider lifecycle settled before awaiting accepted events.
+        // Late provider errors must not invalidate an already completed stream.
         stepsSettled = true
+        try {
+          await acceptedEvents
+          await finishPossibleToolCall()
+        }
+        catch (error) {
+          if (!settled) {
+            settled = true
+            reject(error)
+          }
+          return
+        }
+
         try {
           const finalMessages = await streamResult.messages
           await options?.onMessages?.(finalMessages)
@@ -309,8 +480,17 @@ const TOOLS_RELATED_ERROR_PATTERNS: RegExp[] = [
 ]
 
 export function isToolRelatedError(error: unknown): boolean {
+  if (isPlainTextToolCallError(error))
+    return true
+
   const message = String(error)
   return TOOLS_RELATED_ERROR_PATTERNS.some(pattern => pattern.test(message))
+}
+
+export function isPlainTextToolCallError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && (error as { code?: unknown }).code === PLAIN_TEXT_TOOL_CALL_ERROR_CODE
 }
 
 // Runtime auto-degrade: patterns that indicate the provider rejected

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -236,6 +236,7 @@ export async function streamFrom({
     let stepsSettled = false
     let bufferPossibleToolCall = toolNames.size > 0
     let bufferedOutputEvents: BufferedOutputEvent[] = []
+    let bufferedReasoningText = ''
     let bufferedText = ''
     const resolveOnce = () => {
       if (settled)
@@ -266,6 +267,7 @@ export async function streamFrom({
     const takeBufferedOutput = () => {
       const events = bufferedOutputEvents
       bufferedOutputEvents = []
+      bufferedReasoningText = ''
       bufferedText = ''
       return events
     }
@@ -287,6 +289,7 @@ export async function streamFrom({
 
       bufferPossibleToolCall = false
       const toolName = leakedToolCallName(bufferedText, toolNames)
+        ?? leakedToolCallName(bufferedReasoningText, toolNames)
       if (toolName) {
         takeBufferedOutput()
         throw plainTextToolCallError(toolName)
@@ -312,7 +315,7 @@ export async function streamFrom({
       // xsAI already retains the full step text. Keep any JSON-shaped candidate
       // until the step ends; releasing a large candidate would expose the leak.
       if (firstNonWhitespace !== undefined && firstNonWhitespace !== '{') {
-        await passThroughBufferedOutput()
+        await finishPossibleToolCall()
       }
     }
 
@@ -323,6 +326,7 @@ export async function streamFrom({
       }
 
       bufferOutputEvent({ type: 'reasoning-delta', text })
+      bufferedReasoningText += text
     }
 
     const processEvent = async (event: Event) => {

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -133,7 +133,7 @@ function plainTextToolCallError(toolName: string): Error {
   )
 }
 
-function leakedToolCallName(text: string, toolNames: Set<string>): string | undefined {
+function serializedToolCallName(text: string, toolNames: Set<string>): string | undefined {
   const candidate = text.trim()
   if (!candidate.startsWith('{') || !candidate.endsWith('}'))
     return undefined
@@ -154,6 +154,50 @@ function leakedToolCallName(text: string, toolNames: Set<string>): string | unde
   catch {
     return undefined
   }
+}
+
+function leakedToolCallName(text: string, toolNames: Set<string>): string | undefined {
+  let start = 0
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  // Scan complete objects after prose or Markdown fences. Braces inside JSON
+  // strings do not end an object, and nested objects belong to their outer object.
+  for (let index = 0; index < text.length; index++) {
+    const character = text[index]
+    if (depth === 0) {
+      if (character === '{') {
+        start = index
+        depth = 1
+      }
+      continue
+    }
+    if (inString) {
+      if (escaped)
+        escaped = false
+      else if (character === '\\')
+        escaped = true
+      else if (character === '"')
+        inString = false
+      continue
+    }
+    if (character === '"') {
+      inString = true
+    }
+    else if (character === '{') {
+      depth++
+    }
+    else if (character === '}') {
+      depth--
+      if (depth === 0) {
+        const toolName = serializedToolCallName(text.slice(start, index + 1), toolNames)
+        if (toolName)
+          return toolName
+      }
+    }
+  }
+  return undefined
 }
 
 function toolNameFrom(tool: unknown): string | undefined {
@@ -215,6 +259,7 @@ export async function streamFrom({
   messages,
   options,
   builtinToolsResolver,
+  toolCallGuardNames,
 }: StreamFromOptions) {
   const chatConfig = chatProvider.chat(model)
   const supportsContentArray = streamOptionsContentArrayCompatibilityOk(model, chatProvider, options)
@@ -229,7 +274,12 @@ export async function streamFrom({
   const tools = mergedTools.length > 0 ? mergedTools : undefined
   if (!tools && toolChoiceRequiresTools(options?.toolChoice))
     throw new Error('Cannot satisfy a required tool choice because no tools are available for this request.')
-  const toolNames = new Set(mergedTools.flatMap(tool => toolNameFrom(tool) ?? []))
+  const toolNames = new Set(toolCallGuardNames)
+  for (const tool of mergedTools) {
+    const name = toolNameFrom(tool)
+    if (name)
+      toolNames.add(name)
+  }
 
   return new Promise<void>((resolve, reject) => {
     let settled = false
@@ -238,6 +288,10 @@ export async function streamFrom({
     let bufferedOutputEvents: BufferedOutputEvent[] = []
     let bufferedReasoningText = ''
     let bufferedText = ''
+    // The guard stays active until step completion or a native tool event.
+    // After either channel starts a JSON candidate, preserve all output order
+    // until the complete objects can be checked at the end of the step.
+    let hasBufferedJsonCandidate = false
     const resolveOnce = () => {
       if (settled)
         return
@@ -257,6 +311,7 @@ export async function streamFrom({
     }
 
     const bufferOutputEvent = (event: BufferedOutputEvent) => {
+      hasBufferedJsonCandidate ||= event.text.includes('{')
       const previous = bufferedOutputEvents.at(-1)
       if (previous?.type === event.type)
         previous.text += event.text
@@ -269,6 +324,7 @@ export async function streamFrom({
       bufferedOutputEvents = []
       bufferedReasoningText = ''
       bufferedText = ''
+      hasBufferedJsonCandidate = false
       return events
     }
 
@@ -311,12 +367,10 @@ export async function streamFrom({
 
       bufferOutputEvent({ type: 'text-delta', text })
       bufferedText += text
-      const firstNonWhitespace = bufferedText.trimStart().at(0)
-      // xsAI already retains the full step text. Keep any JSON-shaped candidate
-      // until the step ends; releasing a large candidate would expose the leak.
-      if (firstNonWhitespace !== undefined && firstNonWhitespace !== '{') {
-        await finishPossibleToolCall()
-      }
+      // Stream plain text without disabling detection for later JSON. Once a
+      // prefix reaches the caller, a later failure cannot safely replay it.
+      if (!hasBufferedJsonCandidate && bufferedText.trim().length > 0)
+        await flushBufferedOutput()
     }
 
     const consumeReasoningDelta = async (text: string) => {
@@ -513,9 +567,9 @@ export function isToolRelatedError(error: unknown): boolean {
 }
 
 /**
- * Return whether an error is the internal sentinel emitted when this module's
- * leak guard catches a complete plain-text call to a tool offered in the same
- * model step. Message text alone never matches.
+ * Identify this module's sentinel for a plain-text call to a known tool.
+ * Known names include tools from an earlier attempt of the same request.
+ * Message text alone never matches.
  *
  * A `true` result does not make replay safe by itself. Callers must separately
  * verify that no output or tool side effects were committed and that the tool

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -126,6 +126,8 @@ type BufferedOutputEvent
   = | { type: 'text-delta', text: string }
     | { type: 'reasoning-delta', text: string }
 
+type BufferedToolEvent = Extract<Event, { type: 'tool-call.done' | 'tool-result.done' }>
+
 function plainTextToolCallError(toolName: string): Error {
   return Object.assign(
     new Error(`Model returned tool call "${toolName}" as plain text instead of native tool calling.`),
@@ -260,6 +262,7 @@ export async function streamFrom({
   options,
   builtinToolsResolver,
   toolCallGuardNames,
+  onNativeToolCall,
 }: StreamFromOptions) {
   const chatConfig = chatProvider.chat(model)
   const supportsContentArray = streamOptionsContentArrayCompatibilityOk(model, chatProvider, options)
@@ -290,10 +293,10 @@ export async function streamFrom({
     let failed = false
     let eventQueue = Promise.resolve()
     let bufferPossibleToolCall = toolNames.size > 0
-    let bufferedOutputEvents: BufferedOutputEvent[] = []
+    let bufferedOutputEvents: (BufferedOutputEvent | BufferedToolEvent)[] = []
     let bufferedReasoningText = ''
     let bufferedText = ''
-    // The guard stays active until step completion or a native tool event.
+    // The guard stays active until step completion, even after native tool events.
     // After either channel starts a JSON candidate, preserve all output order
     // until the complete objects can be checked at the end of the step.
     let hasBufferedJsonCandidate = false
@@ -345,13 +348,15 @@ export async function streamFrom({
       for (const event of events) {
         if (failed)
           return
-        await emitOutputEvent(event)
+        if (event.type === 'text-delta' || event.type === 'reasoning-delta') {
+          await emitOutputEvent(event)
+        }
+        else {
+          const streamEvent = toAiriStreamEvent(event)
+          if (streamEvent != null)
+            await options?.onStreamEvent?.(streamEvent)
+        }
       }
-    }
-
-    const passThroughBufferedOutput = async () => {
-      bufferPossibleToolCall = false
-      await flushBufferedOutput()
     }
 
     const finishPossibleToolCall = async () => {
@@ -417,16 +422,13 @@ export async function streamFrom({
         await consumeReasoningDelta(event.delta)
         return
       }
-      if (
-        event.type === 'tool-call.start'
-        || event.type === 'tool-call.delta'
-        || event.type === 'tool-call.done'
-      ) {
-        // A native tool-call event proves this step used the provider protocol.
-        // Release any reasoning that arrived before it.
-        await passThroughBufferedOutput()
-        if (failed)
+      if (event.type === 'tool-call.done' || event.type === 'tool-result.done') {
+        // Native events do not prove that other channels are safe. Keep their
+        // UI notifications behind any candidate to preserve output order.
+        if (bufferPossibleToolCall && bufferedOutputEvents.length > 0) {
+          bufferedOutputEvents.push(event)
           return
+        }
       }
 
       const streamEvent = toAiriStreamEvent(event)
@@ -441,6 +443,18 @@ export async function streamFrom({
     const onEvent = (event: Event) => {
       if (settled || stepsSettled || failed)
         return
+
+      if (event.type === 'tool-call.start' || event.type === 'tool-call.delta' || event.type === 'tool-call.done' || event.type === 'tool-result.done') {
+        // xsAI does not await our queue before tool execution. Notify the retry
+        // owner now, even if inspection later rejects buffered UI events.
+        try {
+          onNativeToolCall?.()
+        }
+        catch (error) {
+          rejectOnce(error)
+          return
+        }
+      }
 
       eventQueue = eventQueue.then(() => {
         if (!failed)

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -247,6 +247,12 @@ function toAiriStreamEvent(event: Event): StreamEvent | null {
   }
 }
 
+/**
+ * Forwards provider events in order and completes after the accepted callbacks.
+ * On failure, pending output stops before this promise rejects. An active callback
+ * must settle first because the runtime cannot cancel consumer side effects.
+ * Events received after provider completion do not enter the queue.
+ */
 export async function streamFrom({
   model,
   chatProvider,
@@ -276,8 +282,13 @@ export async function streamFrom({
   }
 
   return new Promise<void>((resolve, reject) => {
+    // Provider completion closes admission, but accepted events can still fail.
+    // Failure stops queued work. Settlement waits for the active callback so
+    // consumers cannot receive a rejection while that callback still changes state.
     let settled = false
     let stepsSettled = false
+    let failed = false
+    let eventQueue = Promise.resolve()
     let bufferPossibleToolCall = toolNames.size > 0
     let bufferedOutputEvents: BufferedOutputEvent[] = []
     let bufferedReasoningText = ''
@@ -287,18 +298,11 @@ export async function streamFrom({
     // until the complete objects can be checked at the end of the step.
     let hasBufferedJsonCandidate = false
     const resolveOnce = () => {
-      if (settled)
+      if (settled || failed)
         return
       settled = true
       resolve()
     }
-    const rejectOnce = (error: unknown) => {
-      if (settled || stepsSettled)
-        return
-      settled = true
-      reject(error)
-    }
-
     const emitOutputEvent = async (event: BufferedOutputEvent) => {
       if (event.text)
         await options?.onStreamEvent?.(event)
@@ -322,10 +326,27 @@ export async function streamFrom({
       return events
     }
 
+    const rejectOnce = (error: unknown) => {
+      if (settled || failed)
+        return
+      failed = true
+      const rejectAfterEvents = () => {
+        takeBufferedOutput()
+        settled = true
+        reject(error)
+      }
+      // Both queue outcomes retain the first failure. The queue can itself
+      // reject, or finish after an active listener returns from a provider failure.
+      void eventQueue.then(rejectAfterEvents, rejectAfterEvents)
+    }
+
     const flushBufferedOutput = async () => {
       const events = takeBufferedOutput()
-      for (const event of events)
+      for (const event of events) {
+        if (failed)
+          return
         await emitOutputEvent(event)
+      }
     }
 
     const passThroughBufferedOutput = async () => {
@@ -404,23 +425,27 @@ export async function streamFrom({
         // A native tool-call event proves this step used the provider protocol.
         // Release any reasoning that arrived before it.
         await passThroughBufferedOutput()
+        if (failed)
+          return
       }
 
       const streamEvent = toAiriStreamEvent(event)
       if (streamEvent != null)
         await options?.onStreamEvent?.(streamEvent)
       if (streamEvent?.type === 'error')
-        rejectOnce(streamEvent.error)
+        throw streamEvent.error
     }
 
     // xsAI intentionally does not await onEvent. Keep our own chain so output
     // events retain provider order and completion waits for accepted deltas.
-    let eventQueue = Promise.resolve()
     const onEvent = (event: Event) => {
-      if (settled || stepsSettled)
+      if (settled || stepsSettled || failed)
         return
 
-      eventQueue = eventQueue.then(() => processEvent(event))
+      eventQueue = eventQueue.then(() => {
+        if (!failed)
+          return processEvent(event)
+      })
       void eventQueue.catch(error => rejectOnce(error))
     }
 
@@ -453,18 +478,16 @@ export async function streamFrom({
       // of the stream lifecycle instead of an intermediate tool boundary.
       void streamResult.steps.then(async () => {
         const acceptedEvents = eventQueue
-        // Mark the provider lifecycle settled before awaiting accepted events.
-        // Late provider errors must not invalidate an already completed stream.
+        // Reject new provider events, not errors already accepted into the queue.
         stepsSettled = true
         try {
           await acceptedEvents
+          if (failed)
+            return
           await finishPossibleToolCall()
         }
         catch (error) {
-          if (!settled) {
-            settled = true
-            reject(error)
-          }
+          rejectOnce(error)
           return
         }
 
@@ -475,23 +498,14 @@ export async function streamFrom({
         catch (error) {
           // Transcript persistence is part of the completed response contract,
           // unlike late provider events and optional usage observation.
-          if (!settled) {
-            settled = true
-            reject(error)
-          }
+          rejectOnce(error)
           return
         }
         try {
           await options?.onStreamEvent?.({ type: 'finish' } as const)
         }
         catch (error) {
-          // The finish listener runs after steps settled, so rejectOnce would
-          // ignore this error as a "late provider event". A listener failure
-          // is still a real failure and must reject the outer promise.
-          if (!settled) {
-            settled = true
-            reject(error)
-          }
+          rejectOnce(error)
           return
         }
         let usage: Usage | undefined
@@ -515,13 +529,6 @@ export async function streamFrom({
         }
         resolveOnce()
       }).catch((error) => {
-        // A failure after `steps` resolved belongs to optional usage
-        // observation and cannot invalidate the completed response.
-        if (stepsSettled) {
-          console.error('Stream usage observation error:', error)
-          resolveOnce()
-          return
-        }
         rejectOnce(error)
         console.error('Stream steps error:', error)
       })

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -133,68 +133,62 @@ function plainTextToolCallError(toolName: string): Error {
   )
 }
 
-function serializedToolCallName(text: string, toolNames: Set<string>): string | undefined {
-  const candidate = text.trim()
-  if (!candidate.startsWith('{') || !candidate.endsWith('}'))
+function serializedToolCallName(parsed: unknown, toolNames: Set<string>): string | undefined {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
     return undefined
 
-  try {
-    const parsed = JSON.parse(candidate) as unknown
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
-      return undefined
-
-    const record = parsed as Record<string, unknown>
-    if (typeof record.name !== 'string' || !toolNames.has(record.name))
-      return undefined
-    if (!Object.hasOwn(record, 'parameters') && !Object.hasOwn(record, 'arguments'))
-      return undefined
-
-    return record.name
-  }
-  catch {
+  const record = parsed as Record<string, unknown>
+  if (typeof record.name !== 'string' || !toolNames.has(record.name))
     return undefined
-  }
+  if (!Object.hasOwn(record, 'parameters') && !Object.hasOwn(record, 'arguments'))
+    return undefined
+
+  return record.name
 }
 
 function leakedToolCallName(text: string, toolNames: Set<string>): string | undefined {
-  let start = 0
-  let depth = 0
-  let inString = false
-  let escaped = false
-
-  // Scan complete objects after prose or Markdown fences. Braces inside JSON
-  // strings do not end an object, and nested objects belong to their outer object.
-  for (let index = 0; index < text.length; index++) {
+  // Each opening brace needs its own boundary, independent of malformed prefixes.
+  // Build suffix boundaries once instead of rescanning the rest of the channel
+  // for every unmatched opening brace. -1 means that no closing boundary exists.
+  const stringEnds = new Int32Array(text.length + 2).fill(-1)
+  const objectEnds = new Int32Array(text.length + 2).fill(-1)
+  for (let index = text.length - 1; index >= 0; index--) {
     const character = text[index]
-    if (depth === 0) {
-      if (character === '{') {
-        start = index
-        depth = 1
-      }
+    // Inside a string, a backslash consumes the next character, including a quote.
+    stringEnds[index] = character === '"'
+      ? index
+      : stringEnds[index + (character === '\\' ? 2 : 1)]
+
+    if (character === '}') {
+      objectEnds[index] = index
+    }
+    else if (character === '"' || character === '{') {
+      const end = character === '"' ? stringEnds[index + 1] : objectEnds[index + 1]
+      // Outside strings, skip a complete string or nested object to find the
+      // closing brace for the enclosing object.
+      objectEnds[index] = end < 0 ? -1 : objectEnds[end + 1]
+    }
+    else {
+      objectEnds[index] = objectEnds[index + 1]
+    }
+  }
+
+  for (let start = text.indexOf('{'); start >= 0; start = text.indexOf('{', start + 1)) {
+    const end = objectEnds[start + 1]
+    if (end < 0)
       continue
+
+    try {
+      const parsed: unknown = JSON.parse(text.slice(start, end + 1))
+      const toolName = serializedToolCallName(parsed, toolNames)
+      if (toolName)
+        return toolName
+      // A valid ordinary object owns its children and quoted examples.
+      // Only malformed candidates permit recovery at a later opening brace.
+      start = end
     }
-    if (inString) {
-      if (escaped)
-        escaped = false
-      else if (character === '\\')
-        escaped = true
-      else if (character === '"')
-        inString = false
+    catch {
       continue
-    }
-    if (character === '"') {
-      inString = true
-    }
-    else if (character === '{') {
-      depth++
-    }
-    else if (character === '}') {
-      depth--
-      if (depth === 0) {
-        const toolName = serializedToolCallName(text.slice(start, index + 1), toolNames)
-        if (toolName)
-          return toolName
-      }
     }
   }
   return undefined
@@ -381,6 +375,8 @@ export async function streamFrom({
 
       bufferOutputEvent({ type: 'reasoning-delta', text })
       bufferedReasoningText += text
+      if (!hasBufferedJsonCandidate && bufferedReasoningText.trim().length > 0)
+        await flushBufferedOutput()
     }
 
     const processEvent = async (event: Event) => {

--- a/packages/core-agent/src/runtime/llm-service.ts
+++ b/packages/core-agent/src/runtime/llm-service.ts
@@ -175,10 +175,20 @@ function leakedToolCallName(text: string, toolNames: Set<string>): string | unde
     }
   }
 
+  // Allow eight full-channel passes for recovery from malformed prefixes.
+  // A valid object needs one pass, with no extra size or depth limit.
+  let remainingParseWork = text.length * 8
   for (let start = text.indexOf('{'); start >= 0; start = text.indexOf('{', start + 1)) {
     const end = objectEnds[start + 1]
     if (end < 0)
       continue
+
+    // Charge overlapping spans before slicing or parsing them. On exhaustion,
+    // reject the step so unchecked buffered output cannot reach consumers.
+    const candidateLength = end - start + 1
+    if (candidateLength > remainingParseWork)
+      throw new Error('Model output exceeded the JSON inspection work limit.')
+    remainingParseWork -= candidateLength
 
     try {
       const parsed: unknown = JSON.parse(text.slice(start, end + 1))

--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -35,7 +35,7 @@ export interface StreamOptions {
     roundId: string
   }
   toolsCompatibility?: Map<string, boolean>
-  /** Request-level gate. `false` disables tools; cached incompatibility also wins. */
+  /** Request-level gate. `false` disables tools; otherwise cached incompatibility wins unless the tool choice requires tools. */
   supportsTools?: boolean
   waitForTools?: boolean
   /** Provider tool-selection directive for one request. */

--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -35,6 +35,7 @@ export interface StreamOptions {
     roundId: string
   }
   toolsCompatibility?: Map<string, boolean>
+  /** Request-level gate. `false` disables tools; cached incompatibility also wins. */
   supportsTools?: boolean
   waitForTools?: boolean
   /** Provider tool-selection directive for one request. */

--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -68,4 +68,10 @@ export interface StreamFromOptions {
   messages: Message[]
   options?: StreamOptions
   builtinToolsResolver?: BuiltinToolsResolver
+  /**
+   * Names from an earlier attempt of this request that the leak guard must retain.
+   * These names only control output inspection. They do not enable tools or enter
+   * the provider payload. The caller must scope them to one request and its retries.
+   */
+  toolCallGuardNames?: ReadonlySet<string>
 }

--- a/packages/core-agent/src/types/llm.ts
+++ b/packages/core-agent/src/types/llm.ts
@@ -69,6 +69,12 @@ export interface StreamFromOptions {
   options?: StreamOptions
   builtinToolsResolver?: BuiltinToolsResolver
   /**
+   * Synchronous retry-safety signal when xsAI admits native tool activity.
+   * UI events can remain buffered for inspection while xsAI executes tools.
+   * This callback must not perform asynchronous work.
+   */
+  onNativeToolCall?: () => void
+  /**
    * Names from an earlier attempt of this request that the leak guard must retain.
    * These names only control output inspection. They do not enable tools or enter
    * the provider payload. The caller must scope them to one request and its retries.

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -76,6 +76,32 @@ function toolNameFrom(tool: unknown) {
   return candidate.function?.name ?? candidate.name
 }
 
+function mockStreamEvents(events: unknown[]) {
+  streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => void }) => {
+    const steps = new Promise<unknown[]>((resolve) => {
+      queueMicrotask(() => {
+        for (const event of events)
+          options.onEvent(event)
+        resolve([])
+      })
+    })
+
+    return { ...createMockStreamResult(), steps }
+  })
+}
+
+function createSparkTool(): Tool {
+  return {
+    type: 'function',
+    function: {
+      name: 'builtIn_emitSparkCommand',
+      description: 'Send a command to a connected game module.',
+      parameters: { type: 'object', properties: {} },
+    },
+    execute: vi.fn(async () => 'ok'),
+  }
+}
+
 describe('isToolRelatedError', () => {
   beforeEach(() => {
     streamTextMock.mockReset()
@@ -221,6 +247,138 @@ describe('isToolRelatedError', () => {
     const secondCallTools = streamTextMock.mock.calls[1]?.[0]?.tools
     expect(Array.isArray(secondCallTools)).toBe(true)
     expect(secondCallTools?.map(toolNameFrom)).toContain('runtime_play_chess_match')
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2161
+  it('retries without tools when a model emits a plain-text tool call for Issue #2161', async () => {
+    const rawToolCall = JSON.stringify({
+      name: 'builtIn_emitSparkCommand',
+      parameters: { destinations: [] },
+    })
+    const fallbackText = 'I cannot play a game because no game tool is available.'
+    const customTool = createSparkTool()
+    const events: unknown[] = []
+    const splitAt = Math.floor(rawToolCall.length / 2)
+
+    mockStreamEvents([
+      { type: 'text.delta', delta: rawToolCall.slice(0, splitAt) },
+      { type: 'text.delta', delta: rawToolCall.slice(splitAt) },
+    ])
+    mockStreamEvents([
+      { type: 'text.delta', delta: fallbackText },
+    ])
+
+    const store = useLLM()
+    await store.stream('model-a', provider, [{ role: 'user', content: 'Can you play games?' }] as Message[], {
+      supportsTools: true,
+      toolChoice: 'auto',
+      tools: [customTool],
+      onStreamEvent: (event) => {
+        events.push(event)
+      },
+    })
+
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(streamTextMock.mock.calls[0]?.[0]?.tools?.map(toolNameFrom)).toContain('builtIn_emitSparkCommand')
+    expect(streamTextMock.mock.calls[0]?.[0]?.toolChoice).toBe('auto')
+    expect(streamTextMock.mock.calls[1]?.[0]?.tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[1]?.[0]?.toolChoice).toBeUndefined()
+    expect(events
+      .filter((event): event is { type: 'text-delta', text: string } => (
+        typeof event === 'object' && event !== null && (event as { type?: unknown }).type === 'text-delta'
+      ))
+      .map(event => event.text)
+      .join(''))
+      .toBe(fallbackText)
+
+    streamTextMock.mockImplementationOnce(() => createMockStreamResult())
+    await store.stream('model-a', provider, [{ role: 'user', content: 'Try again.' }] as Message[], {
+      supportsTools: true,
+      toolChoice: 'auto',
+      tools: [customTool],
+    })
+
+    expect(streamTextMock).toHaveBeenCalledTimes(3)
+    expect(streamTextMock.mock.calls[2]?.[0]?.tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[2]?.[0]?.toolChoice).toBeUndefined()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2161
+  it('does not replay earlier native tool work after a later plain-text tool call for Issue #2161', async () => {
+    const rawToolCall = JSON.stringify({
+      name: 'builtIn_emitSparkCommand',
+      parameters: { destinations: [] },
+    })
+    const customTool = createSparkTool()
+    const events: unknown[] = []
+
+    mockStreamEvents([
+      { type: 'step.start' },
+      {
+        type: 'tool-call.done',
+        args: '{}',
+        toolCallId: 'call-1',
+        toolCallType: 'function',
+        toolName: 'builtIn_emitSparkCommand',
+      },
+      { type: 'step.done', usage: {} },
+      { type: 'step.start' },
+      { type: 'text.delta', delta: rawToolCall },
+      { type: 'step.done', usage: {} },
+    ])
+    streamTextMock.mockImplementationOnce(() => createMockStreamResult())
+
+    const store = useLLM()
+    await expect(store.stream('model-a', provider, [{ role: 'user', content: 'Can you play games?' }] as Message[], {
+      supportsTools: true,
+      toolChoice: 'auto',
+      tools: [customTool],
+      onStreamEvent: (event) => {
+        events.push(event)
+      },
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+    }))
+
+    await store.stream('model-a', provider, [{ role: 'user', content: 'Try again.' }] as Message[], {
+      supportsTools: true,
+      toolChoice: 'auto',
+      tools: [customTool],
+    })
+
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(streamTextMock.mock.calls[1]?.[0]?.tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[1]?.[0]?.toolChoice).toBeUndefined()
+  })
+
+  // https://github.com/moeru-ai/airi/issues/2161
+  it('does not retry a forced tool choice without tools for Issue #2161', async () => {
+    const rawToolCall = JSON.stringify({
+      name: 'builtIn_emitSparkCommand',
+      parameters: { destinations: [] },
+    })
+    const customTool = createSparkTool()
+
+    mockStreamEvents([
+      { type: 'text.delta', delta: rawToolCall },
+    ])
+    streamTextMock.mockImplementationOnce(() => createMockStreamResult())
+
+    const store = useLLM()
+    await expect(store.stream('model-a', provider, [{ role: 'user', content: 'You must play a game.' }] as Message[], {
+      supportsTools: true,
+      toolChoice: {
+        type: 'function',
+        function: { name: 'builtIn_emitSparkCommand' },
+      },
+      tools: [customTool],
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
   })
 
   it('merges runtime-registered tools from the llm-tools store into the builtin tool resolver', async () => {

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -250,6 +250,16 @@ describe('isToolRelatedError', () => {
     expect(secondCallTools?.map(toolNameFrom)).toContain('runtime_play_chess_match')
   })
 
+  // ROOT CAUSE:
+  //
+  // Some providers emit a registered tool call as assistant text instead of
+  // using the native tool protocol.
+  //
+  // Before the fix, that raw JSON reached the chat UI and later requests kept
+  // sending the same incompatible tool payload.
+  //
+  // We fixed this by retrying once without tools only before any output or tool
+  // work is committed, then caching the model's incompatibility.
   // https://github.com/moeru-ai/airi/issues/2161
   it('retries without tools when a model emits a plain-text tool call for Issue #2161', async () => {
     const rawToolCall = JSON.stringify({
@@ -304,6 +314,16 @@ describe('isToolRelatedError', () => {
     expect(streamTextMock.mock.calls[2]?.[0]?.toolChoice).toBeUndefined()
   })
 
+  // ROOT CAUSE:
+  //
+  // A later plain-text tool-call failure could occur after an earlier native
+  // tool event had already committed work in the same request.
+  //
+  // Before the fix, automatically replaying that request could execute the
+  // earlier tool work a second time.
+  //
+  // We fixed this by caching the incompatibility without replaying any attempt
+  // that has already emitted output or native tool activity.
   // https://github.com/moeru-ai/airi/issues/2161
   it('does not replay earlier native tool work after a later plain-text tool call for Issue #2161', async () => {
     const rawToolCall = JSON.stringify({
@@ -356,6 +376,16 @@ describe('isToolRelatedError', () => {
     expect(streamTextMock.mock.calls[1]?.[0]?.toolChoice).toBeUndefined()
   })
 
+  // ROOT CAUSE:
+  //
+  // A forced request that leaked a text tool call marked the model as tool-
+  // incompatible, so the cache stripped tools from the next forced request.
+  //
+  // Before the fix, that later request could resolve without ever performing
+  // the required Spark command.
+  //
+  // We fixed this by letting required choices bypass the compatibility cache
+  // while still rejecting them when no tools are actually available.
   // https://github.com/moeru-ai/airi/issues/2161
   it('does not downgrade a forced tool choice after a plain-text leak for Issue #2161', async () => {
     const rawToolCall = JSON.stringify({

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -1,3 +1,4 @@
+import type { StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message, Tool } from '@xsai/shared-chat'
 
@@ -356,7 +357,7 @@ describe('isToolRelatedError', () => {
   })
 
   // https://github.com/moeru-ai/airi/issues/2161
-  it('does not retry a forced tool choice without tools for Issue #2161', async () => {
+  it('does not downgrade a forced tool choice after a plain-text leak for Issue #2161', async () => {
     const rawToolCall = JSON.stringify({
       name: 'builtIn_emitSparkCommand',
       parameters: { destinations: [] },
@@ -366,19 +367,30 @@ describe('isToolRelatedError', () => {
     mockStreamEvents([
       { type: 'text.delta', delta: rawToolCall },
     ])
-    streamTextMock.mockImplementationOnce(() => createMockStreamResult())
 
     const store = useLLM()
-    await expect(store.stream('model-a', provider, [{ role: 'user', content: 'You must play a game.' }] as Message[], {
+    const options = {
       supportsTools: true,
       toolChoice: {
         type: 'function',
         function: { name: 'builtIn_emitSparkCommand' },
       },
       tools: [customTool],
-    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+    } satisfies StreamOptions
+
+    await expect(store.stream('model-a', provider, [{ role: 'user', content: 'You must play a game.' }] as Message[], options)).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
 
     expect(streamTextMock).toHaveBeenCalledTimes(1)
+
+    mockStreamEvents([
+      { type: 'text.delta', delta: rawToolCall },
+    ])
+
+    await expect(store.stream('model-a', provider, [{ role: 'user', content: 'You still must play a game.' }] as Message[], options)).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(streamTextMock.mock.calls[1]?.[0]?.tools?.map(toolNameFrom)).toContain('builtIn_emitSparkCommand')
+    expect(streamTextMock.mock.calls[1]?.[0]?.toolChoice).toEqual(options.toolChoice)
   })
 
   it('merges runtime-registered tools from the llm-tools store into the builtin tool resolver', async () => {

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -835,6 +835,39 @@ describe('isToolRelatedError', () => {
 
   // ROOT CAUSE:
   //
+  // Balanced but invalid nested objects exhausted synchronous parsing work.
+  // This failure rejects without a retry or a tool compatibility downgrade.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3953824377
+  it.each(['text.delta', 'reasoning.delta'] as const)('rejects excessive JSON inspection in %s without a downgrade for Issue #2161', async (type) => {
+    const store = useLLM()
+    const customTool = createSparkTool()
+    const answer = `${'{"a":'.repeat(512)}x${'}'.repeat(512)}`
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([{ type, delta: answer }])
+
+    await expect(store.stream('model-a', provider, [], {
+      tools: [customTool],
+      onStreamEvent,
+      onMessages,
+    })).rejects.toThrow('Model output exceeded the JSON inspection work limit.')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    expect(customTool.execute).not.toHaveBeenCalled()
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+
+    mockStreamEvents([{ type: 'text.delta', delta: 'A safe answer.' }])
+    await store.stream('model-a', provider, [], { tools: [customTool], onStreamEvent })
+
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(streamTextMock.mock.calls[1]?.[0]?.tools?.map(toolNameFrom)).toContain(customTool.function.name)
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'text-delta', text: 'A safe answer.' })
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
+  // ROOT CAUSE:
+  //
   // A later JSON call can follow a prefix that already reached the caller.
   // Before the fix, this call bypassed the guard and the stream succeeded.
   // We reject the call without retrying or replaying the visible prefix.

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -1,6 +1,6 @@
 import type { StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
-import type { Message, Tool } from '@xsai/shared-chat'
+import type { Event, Message, Tool } from '@xsai/shared-chat'
 
 import type { ExecutableTool } from './tools'
 
@@ -156,6 +156,90 @@ describe('isToolRelatedError', () => {
     })
   }
 
+  // ROOT CAUSE:
+  //
+  // The store forwards events through an async listener, even for synchronous consumers.
+  // Before the fix, provider completion hid an error accepted behind that listener.
+  // The core queue now rejects accepted errors before the store can report success.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949844407
+  it('rejects a queued error without saving partial messages or retrying for Issue #2161', async () => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    const streamError = new Error('accepted provider error')
+    const onMessages = vi.fn()
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async (event) => {
+      if (event.type === 'text-delta') {
+        listenerStarted.resolve()
+        await releaseListener.promise
+      }
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      options.onEvent({ type: 'text.delta', delta: 'partial answer' })
+      options.onEvent({ type: 'error', message: streamError.message, cause: streamError })
+      options.onEvent({ type: 'text.delta', delta: 'must not escape' })
+      return { ...createMockStreamResult(), steps: steps.promise }
+    })
+    const result = useLLM().stream('model-a', provider, [], { onStreamEvent, onMessages }).then(() => undefined, error => error)
+    await listenerStarted.promise
+    steps.resolve([])
+    await new Promise(resolve => setImmediate(resolve))
+    releaseListener.resolve()
+
+    expect(await result).toBe(streamError)
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'text-delta', text: 'partial answer' },
+      { type: 'error', error: streamError },
+    ])
+    expect(onMessages).not.toHaveBeenCalled()
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+  })
+
+  // ROOT CAUSE:
+  //
+  // Before the fix, provider failure rejected the store call while its listener still ran.
+  // Later output could change consumer state after the caller handled failure.
+  // The core queue now stops later events and waits for the active listener.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949844417
+  it('finishes the active consumer before rejection and discards queued output for Issue #2161', async () => {
+    const steps = Promise.withResolvers<unknown[]>()
+    const listenerStarted = Promise.withResolvers<void>()
+    const releaseListener = Promise.withResolvers<void>()
+    const streamError = new Error('steps failed during output')
+    const mutations: string[] = []
+    let settled = false
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>(async () => {
+      listenerStarted.resolve()
+      await releaseListener.promise
+      mutations.push(settled ? 'after rejection' : 'before rejection')
+    })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      options.onEvent({ type: 'text.delta', delta: 'first' })
+      options.onEvent({ type: 'text.delta', delta: 'second' })
+      return { ...createMockStreamResult(), steps: steps.promise }
+    })
+    const result = useLLM().stream('model-a', provider, [], { onStreamEvent }).then(
+      () => { settled = true },
+      (error) => {
+        settled = true
+        return error
+      },
+    )
+    await listenerStarted.promise
+    steps.reject(streamError)
+    await new Promise(resolve => setImmediate(resolve))
+    const settledBeforeRelease = settled
+    releaseListener.resolve()
+    const error = await result
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(settledBeforeRelease).toBe(false)
+    expect(error).toBe(streamError)
+    expect(mutations).toEqual(['before rejection'])
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([{ type: 'text-delta', text: 'first' }])
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+  })
+
   it('resolves from steps and emits a single finish event', async () => {
     streamTextMock.mockImplementation(() => createMockStreamResult())
 
@@ -197,6 +281,9 @@ describe('isToolRelatedError', () => {
   })
 
   it('keeps builtin tools when stream steps resolve before a tool-related error event', async () => {
+    const transcriptStarted = Promise.withResolvers<void>()
+    const releaseTranscript = Promise.withResolvers<void>()
+    const providerStarted = Promise.withResolvers<(event: Event) => void>()
     const store = useLLM()
     const llmToolsStore = useLlmToolsStore()
     const customTool = {
@@ -221,16 +308,25 @@ describe('isToolRelatedError', () => {
 
     llmToolsStore.addTools(runtimeTool)
 
-    streamTextMock.mockImplementationOnce((options: { onEvent: (event: unknown) => Promise<void>, tools?: unknown[] }) => {
-      queueMicrotask(async () => {
-        await options.onEvent({ type: 'error', message: 'model does not support tools', cause: new Error('model does not support tools') })
-      })
+    streamTextMock.mockImplementationOnce((options: { onEvent: (event: Event) => void }) => {
+      providerStarted.resolve(options.onEvent)
       return createMockStreamResult()
     })
 
-    await expect(store.stream('model-a', provider, [{ role: 'user', content: 'hello' }] as Message[], {
+    const pending = store.stream('model-a', provider, [{ role: 'user', content: 'hello' }] as Message[], {
       tools: [customTool],
-    })).resolves.toBeUndefined()
+      onMessages: async () => {
+        transcriptStarted.resolve()
+        await releaseTranscript.promise
+      },
+    })
+    // The old fixture queued its error before the completion observer ran.
+    // Transcript delivery proves that accepted events finished and admission closed.
+    await transcriptStarted.promise
+    const onEvent = await providerStarted.promise
+    onEvent({ type: 'error', message: 'model does not support tools', cause: new Error('model does not support tools') })
+    releaseTranscript.resolve()
+    await expect(pending).resolves.toBeUndefined()
 
     const firstCallTools = streamTextMock.mock.calls[0]?.[0]?.tools
     expect(Array.isArray(firstCallTools)).toBe(true)

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -480,6 +480,64 @@ describe('isToolRelatedError', () => {
     expect(customTool.execute).not.toHaveBeenCalled()
   })
 
+  // ROOT CAUSE:
+  //
+  // A later request had no guard names because the capability cache skipped its resolver.
+  // Before the fix, the default Spark prompt could produce an unchecked JSON call.
+  // We resolve current names for cache-disabled requests without sending tools or retrying them.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949439833
+  it.each(['text.delta', 'reasoning.delta'])('guards a later cache-disabled request in %s for Issue #2161', async (type) => {
+    const sparkTool = createSparkTool()
+    sparkTool.function.name = 'builtIn_sparkCommand'
+    createSparkCommandToolMock.mockResolvedValueOnce([sparkTool]).mockResolvedValueOnce([sparkTool])
+    const rawToolCall = '{"name":"builtIn_sparkCommand","arguments":{}}'
+    const store = useLLM()
+    mockStreamEvents([{ type: 'text.delta', delta: rawToolCall }])
+    mockStreamEvents([{ type: 'text.delta', delta: 'No tool is available.' }])
+    await store.stream('model-a', provider, [])
+
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([{ type, delta: rawToolCall }])
+    await expect(store.stream('model-a', provider, [
+      { role: 'system', content: 'Use builtIn_sparkCommand to send a game command.' },
+    ], { toolChoice: 'auto', onStreamEvent, onMessages })).rejects.toThrow('tool call "builtIn_sparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(3)
+    expect(streamTextMock.mock.calls[2]?.[0]?.tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[2]?.[0]?.toolChoice).toBeUndefined()
+    expect(createSparkCommandToolMock).toHaveBeenCalledTimes(2)
+    expect(sparkTool.execute).not.toHaveBeenCalled()
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  //
+  // Ordinary reasoning was hidden, so a later leak could replay the whole request.
+  // We now emit ordinary reasoning immediately and treat it as committed output.
+  // A later leak rejects without replaying that output or emitting the raw JSON.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949439849
+  it('does not retry a leak after visible reasoning for Issue #2161', async () => {
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([
+      { type: 'reasoning.delta', delta: 'Let me think.' },
+      { type: 'text.delta', delta: '{"name":"builtIn_emitSparkCommand","parameters":{}}' },
+    ])
+    mockStreamEvents([{ type: 'text.delta', delta: 'A repeated answer.' }])
+
+    await expect(useLLM().stream('model-a', provider, [], {
+      tools: [createSparkTool()],
+      onStreamEvent,
+      onMessages,
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    expect(onStreamEvent).toHaveBeenCalledExactlyOnceWith({ type: 'reasoning-delta', text: 'Let me think.' })
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
   it('keeps retry tool names isolated between requests to the same model', async () => {
     const rawToolCall = '{"name":"builtIn_emitSparkCommand","parameters":{}}'
     const store = useLLM()
@@ -488,14 +546,54 @@ describe('isToolRelatedError', () => {
     await store.stream('model-a', provider, [], { tools: [createSparkTool()] })
 
     const onStreamEvent = vi.fn()
+    const customTools = vi.fn(async () => [createSparkTool()])
     mockStreamEvents([{ type: 'text.delta', delta: rawToolCall }])
     await store.stream('model-a', provider, [
       { role: 'user', content: 'Quote this JSON as a documentation example.' },
-    ], { supportsTools: false, onStreamEvent })
+    ], { supportsTools: false, tools: customTools, onStreamEvent })
 
     expect(streamTextMock).toHaveBeenCalledTimes(3)
+    expect(customTools).not.toHaveBeenCalled()
+    expect(mcpMock).toHaveBeenCalledTimes(1)
     expect(onStreamEvent).toHaveBeenCalledWith({ type: 'text-delta', text: rawToolCall })
     expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
+  // ROOT CAUSE:
+  //
+  // The capability cache skipped tool resolution on later requests.
+  // Reusing old names would instead mix unrelated request tools.
+  // We resolve each request's current tools for detection, even after cache downgrade.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3949439833
+  it('uses current custom tools after a cached downgrade for Issue #2161', async () => {
+    const store = useLLM()
+    const oldCall = '{"name":"builtIn_emitSparkCommand","arguments":{}}'
+    mockStreamEvents([{ type: 'text.delta', delta: oldCall }])
+    mockStreamEvents([{ type: 'text.delta', delta: 'No tool is available.' }])
+    await store.stream('model-a', provider, [], { tools: [createSparkTool()] })
+
+    const newTool = createSparkTool()
+    newTool.function.name = 'new_game_tool'
+    const currentTools = vi.fn(async () => [newTool])
+    const onStreamEvent = vi.fn()
+    mockStreamEvents([{ type: 'text.delta', delta: oldCall }])
+    await store.stream('model-a', provider, [], { tools: currentTools, onStreamEvent })
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'text-delta', text: oldCall })
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+
+    onStreamEvent.mockClear()
+    mockStreamEvents([{ type: 'text.delta', delta: '{"name":"new_game_tool","arguments":{}}' }])
+    await expect(store.stream('model-a', provider, [], {
+      tools: currentTools,
+      onStreamEvent,
+    })).rejects.toThrow('tool call "new_game_tool" as plain text')
+
+    expect(currentTools).toHaveBeenCalledTimes(2)
+    expect(newTool.execute).not.toHaveBeenCalled()
+    expect(streamTextMock).toHaveBeenCalledTimes(4)
+    expect(streamTextMock.mock.calls[2]?.[0]?.tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[3]?.[0]?.tools).toBeUndefined()
+    expect(onStreamEvent).not.toHaveBeenCalled()
   })
 
   it('merges runtime-registered tools from the llm-tools store into the builtin tool resolver', async () => {

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -1,8 +1,12 @@
 import type { StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Event, Message, Tool } from '@xsai/shared-chat'
+import type { StreamTextChunkResult, StreamTextOptions, StreamTextResult } from '@xsai/stream-text'
 
 import type { ExecutableTool } from './tools'
+
+import { createServer } from 'node:http'
+import { env } from 'node:process'
 
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,10 +23,13 @@ const {
   streamTextMock: vi.fn(),
   mcpMock: vi.fn(async (): Promise<Tool[]> => []),
   debugMock: vi.fn(async (): Promise<Tool[]> => []),
-  createSparkCommandToolMock: vi.fn(async (): Promise<unknown> => [{
-    name: 'spark',
-    description: '',
-    parameters: {},
+  createSparkCommandToolMock: vi.fn(async (): Promise<Tool[]> => [{
+    type: 'function',
+    function: {
+      name: 'spark',
+      description: '',
+      parameters: { type: 'object', properties: {} },
+    },
     execute: vi.fn(),
   }]),
 }))
@@ -33,10 +40,6 @@ vi.mock('@xsai/model', () => ({
 
 vi.mock('@xsai/stream-text', () => ({
   streamText: streamTextMock,
-}))
-
-vi.mock('@xsai/shared-chat', () => ({
-  stepCountAtLeast: vi.fn(),
 }))
 
 vi.mock('../../../tools', () => ({
@@ -344,6 +347,287 @@ describe('isToolRelatedError', () => {
     const secondCallTools = streamTextMock.mock.calls[1]?.[0]?.tools
     expect(Array.isArray(secondCallTools)).toBe(true)
     expect(secondCallTools?.map(toolNameFrom)).toContain('runtime_play_chess_match')
+  })
+
+  // ROOT CAUSE:
+  // Native events disabled inspection before the store saw a leak error.
+  // Native activity must also prevent retries when its UI event is still buffered.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440962
+  it.each(['tool-call.start', 'tool-call.delta', 'tool-call.done'] as const)('does not replay buffered output after %s for Issue #2161', async (type) => {
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    const nativeEvent: Event = type === 'tool-call.start'
+      ? { type, toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand' }
+      : type === 'tool-call.delta'
+        ? { type, delta: '{}' }
+        : { type, toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand', toolCallType: 'function', args: '{}' }
+    mockStreamEvents([
+      { type: 'reasoning.delta', delta: '{"name":"builtIn_emitSparkCommand","arguments":{}}' },
+      nativeEvent,
+    ] satisfies Event[])
+    await expect(useLLM().stream('model-a', provider, [], {
+      tools: [createSparkTool()],
+      onStreamEvent,
+      onMessages,
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  // Native events released leaks, and retry errors bypassed compatibility checks.
+  // These tests use the real SDK and scripted HTTP responses to check both fixes.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440962
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440972
+  it.runIf(env.AIRI_TEST_REAL_SSE === '1').each(['native-text', 'native-reasoning', 'native-safe', 'tools-first', 'arrays-first'] as const)('checks %s with real xsAI and HTTP/SSE for Issue #2161', async (scenario) => {
+    const { streamText } = await vi.importActual<typeof import('@xsai/stream-text')>('@xsai/stream-text')
+    const sdkResults: StreamTextResult[] = []
+    streamTextMock.mockImplementation((options: Parameters<typeof streamText>[0]) => {
+      const result = streamText(options)
+      sdkResults.push(result)
+      return result
+    })
+    const requests: Pick<StreamTextOptions, 'messages' | 'tools'>[] = []
+    const call = '{"name":"builtIn_emitSparkCommand","arguments":{}}'
+    const native = scenario.startsWith('native')
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    const tool = createSparkTool()
+    const controller = new AbortController()
+    const server = createServer((request, response) => {
+      void (async () => {
+        let raw = ''
+        for await (const part of request)
+          raw += part.toString()
+        requests.push(JSON.parse(raw))
+        const attempt = requests.length
+        if (!native && attempt === (scenario === 'tools-first' ? 2 : 1)) {
+          response.writeHead(400, { 'Content-Type': 'application/json' })
+          response.end(JSON.stringify({ error: { message: 'messages[0]: invalid type: sequence, expected a string' } }))
+          return
+        }
+        response.writeHead(200, { 'Content-Type': 'text/event-stream' })
+        const send = (delta: StreamTextChunkResult['choices'][number]['delta'], finishReason = 'stop') => {
+          response.write(`data: ${JSON.stringify({
+            id: 'fixture',
+            object: 'chat.completion.chunk',
+            model: 'fixture',
+            choices: [{ index: 0, delta, finish_reason: finishReason }],
+          })}\n\n`)
+        }
+        if (native && attempt === 1) {
+          const text = scenario === 'native-safe' ? '{"note":"safe"}' : call
+          send(scenario === 'native-text'
+            ? { role: 'assistant', content: text }
+            : { role: 'assistant', reasoning_content: text }, 'tool_calls')
+          send({ role: 'assistant', tool_calls: [{
+            index: 0,
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'builtIn_emitSparkCommand', arguments: '{}' },
+          }] }, 'tool_calls')
+        }
+        else {
+          const leakAttempt = !native && attempt === (scenario === 'tools-first' ? 1 : 2)
+          send({ role: 'assistant', content: leakAttempt ? call : 'Recovered.' })
+        }
+        response.end('data: [DONE]\n\n')
+      })().catch((error) => { response.destroy(error) })
+    })
+    try {
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+      const address = server.address()
+      if (!address || typeof address === 'string')
+        throw new Error('The loopback server did not get a TCP port.')
+      const localProvider = {
+        chat: (model: string) => ({ model, baseURL: `http://127.0.0.1:${address.port}/v1/` }),
+      } as ChatProvider
+      const outcome = await useLLM().stream('fixture', localProvider, [{ role: 'user', content: [
+        { type: 'text', text: 'Play.' },
+        { type: 'image_url', image_url: { url: 'https://example.com/game.png' } },
+      ] }], { tools: [tool], abortSignal: controller.signal, onStreamEvent, onMessages }).then(() => undefined, error => error)
+      // The SDK can finish its tool round after the guard rejects UI output.
+      await Promise.allSettled(sdkResults.map(result => result.steps))
+      if (native) {
+        expect(tool.execute).toHaveBeenCalledTimes(1)
+        expect(streamTextMock).toHaveBeenCalledTimes(1)
+        expect(requests).toHaveLength(2)
+        expect(requests[1].messages).toContainEqual(expect.objectContaining({ role: 'tool', tool_call_id: 'call-1' }))
+        if (scenario === 'native-safe') {
+          expect(outcome).toBeUndefined()
+          expect(onMessages).toHaveBeenCalledTimes(1)
+          expect(onStreamEvent.mock.calls.map(([event]) => event.type)).toEqual(['reasoning-delta', 'tool-call', 'tool-result', 'text-delta', 'finish'])
+        }
+        else {
+          expect(String(outcome)).toContain('as plain text')
+          expect(onStreamEvent).not.toHaveBeenCalled()
+          expect(onMessages).not.toHaveBeenCalled()
+        }
+      }
+      else {
+        expect(outcome).toBeUndefined()
+        expect(tool.execute).not.toHaveBeenCalled()
+        expect(streamTextMock).toHaveBeenCalledTimes(3)
+        expect(requests.map(body => ({ tools: !!body.tools, array: Array.isArray(body.messages[0].content) }))).toEqual([
+          { tools: true, array: true },
+          { tools: scenario === 'arrays-first', array: scenario === 'tools-first' },
+          { tools: false, array: false },
+        ])
+        expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+          { type: 'text-delta', text: 'Recovered.' },
+          { type: 'finish' },
+        ])
+        expect(onMessages).toHaveBeenCalledTimes(1)
+      }
+    }
+    finally {
+      controller.abort()
+      server.closeAllConnections()
+      await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+    }
+  })
+
+  // ROOT CAUSE:
+  // Errors from an inline retry bypassed the other compatibility classifier.
+  // Every attempt must use the same classifier, with at most one retry per capability.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440972
+  it.each(['tools-first', 'arrays-first'] as const)('combines both compatibility fallbacks, %s, for Issue #2161', async (order) => {
+    const messages: Message[] = [{ role: 'user', content: [
+      { type: 'text', text: 'Play.' },
+      { type: 'image_url', image_url: { url: 'https://example.com/game.png' } },
+    ] }]
+    const arrayError = new Error('messages[0]: invalid type: sequence, expected a string')
+    const mockLeak = () => mockStreamEvents([{ type: 'reasoning.delta', delta: '{"name":"builtIn_emitSparkCommand","arguments":{}}' }])
+    const mockArrayError = () => streamTextMock.mockImplementationOnce(() => {
+      throw arrayError
+    })
+    if (order === 'tools-first') {
+      mockLeak()
+      mockArrayError()
+    }
+    else {
+      mockArrayError()
+      mockLeak()
+    }
+    mockStreamEvents([{ type: 'text.delta', delta: 'Recovered.' }])
+    const store = useLLM()
+    const onStreamEvent = vi.fn()
+    const options = { tools: [createSparkTool()], onStreamEvent }
+    await store.stream('model-a', provider, messages, options)
+    expect(streamTextMock).toHaveBeenCalledTimes(3)
+    const attempts = streamTextMock.mock.calls.map(([attempt]) => ({
+      tools: attempt.tools !== undefined,
+      array: Array.isArray(attempt.messages[0].content),
+    }))
+    expect(attempts).toEqual([
+      { tools: true, array: true },
+      { tools: order !== 'tools-first', array: order === 'tools-first' },
+      { tools: false, array: false },
+    ])
+    expect(onStreamEvent.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'text-delta', text: 'Recovered.' },
+      { type: 'finish' },
+    ])
+    mockStreamEvents([])
+    await store.stream('model-a', provider, messages, options)
+    expect(streamTextMock.mock.calls[3][0].tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[3][0].messages[0].content).toBe('Play.')
+    expect(Array.isArray(messages[0].content)).toBe(true)
+  })
+
+  // ROOT CAUSE:
+  // Reclassifying retry errors must not create unbounded retries.
+  // Each capability changes once, so repeated errors stop the request.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440972
+  it.each(['tool-leak', 'array-error'] as const)('stops after both fallbacks when %s repeats for Issue #2161', async (failure) => {
+    const arrayError = new Error('messages[0]: invalid type: sequence, expected a string')
+    const leak: Event = { type: 'text.delta', delta: '{"name":"builtIn_emitSparkCommand","arguments":{}}' }
+    mockStreamEvents([leak])
+    streamTextMock.mockImplementationOnce(() => {
+      throw arrayError
+    })
+    if (failure === 'tool-leak') {
+      mockStreamEvents([leak])
+    }
+    else {
+      streamTextMock.mockImplementationOnce(() => {
+        throw arrayError
+      })
+    }
+    const onStreamEvent = vi.fn()
+    await expect(useLLM().stream('model-a', provider, [], {
+      tools: [createSparkTool()],
+      onStreamEvent,
+    })).rejects.toThrow(failure === 'tool-leak' ? 'as plain text' : arrayError.message)
+    expect(streamTextMock).toHaveBeenCalledTimes(3)
+    expect(streamTextMock.mock.calls[2][0].tools).toBeUndefined()
+    expect(onStreamEvent).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  // The array fallback ignored committed output and tool activity.
+  // Both fallbacks now reject after a consumer or native tool can change state.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440972
+  it.each(['text.delta', 'reasoning.delta', 'native', 'messages', 'finish'] as const)('does not replay a content-array error after %s for Issue #2161', async (activity) => {
+    const arrayError = new Error('messages[0]: invalid type: sequence, expected a string')
+    const onStreamEvent = vi.fn<NonNullable<StreamOptions['onStreamEvent']>>((event) => {
+      if (activity === 'finish' && event.type === 'finish')
+        throw arrayError
+    })
+    const onMessages = vi.fn(() => {
+      if (activity === 'messages')
+        throw arrayError
+    })
+    const events: Event[] = activity === 'native'
+      ? [
+          { type: 'reasoning.delta', delta: '{"ordinary":1}' },
+          { type: 'tool-call.start', toolCallId: 'call-1', toolName: 'builtIn_emitSparkCommand' },
+          { type: 'error', message: arrayError.message, cause: arrayError },
+        ]
+      : activity === 'messages' || activity === 'finish'
+        ? []
+        : [{ type: activity, delta: 'visible prefix' }, { type: 'error', message: arrayError.message, cause: arrayError }]
+    mockStreamEvents(events)
+    await expect(useLLM().stream('model-a', provider, [], {
+      tools: [createSparkTool()],
+      onStreamEvent,
+      onMessages,
+    })).rejects.toBe(arrayError)
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    if (activity === 'native')
+      expect(onStreamEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'reasoning-delta' }))
+  })
+
+  // ROOT CAUSE:
+  // Explicit array support overrides the cache, so a cached downgrade changes nothing.
+  // Reject the error instead of retrying the same payload.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440972
+  it.each([true, false] as const)('does not retry unchanged explicit array support %s for Issue #2161', async (supportsContentArray) => {
+    const arrayError = new Error('messages[0]: invalid type: sequence, expected a string')
+    streamTextMock.mockImplementationOnce(() => {
+      throw arrayError
+    })
+    await expect(useLLM().stream('model-a', provider, [], { supportsContentArray })).rejects.toBe(arrayError)
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+  })
+
+  // ROOT CAUSE:
+  // A retry can expose a second capability error on a required-tool request.
+  // Array fallback must preserve the tool choice and reject a later leak.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3950440972
+  it('keeps a required tool choice after the array fallback for Issue #2161', async () => {
+    streamTextMock.mockImplementationOnce(() => {
+      throw new Error('messages[0]: invalid type: sequence, expected a string')
+    })
+    mockStreamEvents([{ type: 'text.delta', delta: '{"name":"builtIn_emitSparkCommand","arguments":{}}' }])
+    await expect(useLLM().stream('model-a', provider, [], {
+      toolChoice: 'required',
+      tools: [createSparkTool()],
+    })).rejects.toThrow('as plain text')
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(streamTextMock.mock.calls[1][0].toolChoice).toBe('required')
+    expect(streamTextMock.mock.calls[1][0].tools.map(toolNameFrom)).toContain('builtIn_emitSparkCommand')
   })
 
   // ROOT CAUSE:

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.test.ts
@@ -423,6 +423,81 @@ describe('isToolRelatedError', () => {
     expect(streamTextMock.mock.calls[1]?.[0]?.toolChoice).toEqual(options.toolChoice)
   })
 
+  // ROOT CAUSE:
+  //
+  // The tool-free retry skipped tool resolution and lost the original tool names.
+  // Before the fix, a repeated JSON call reached the UI and the request succeeded.
+  // We retain the resolved names for detection across attempts of the same request.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3932132876
+  it.each(['text.delta', 'reasoning.delta'])('rejects a repeated tool JSON in %s on the tool-free retry for Issue #2161', async (type) => {
+    const customTool = createSparkTool()
+    const customTools = vi.fn(async () => [customTool])
+    const rawToolCall = JSON.stringify({ name: 'builtIn_emitSparkCommand', parameters: { destinations: [] } })
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    mockStreamEvents([{ type: 'text.delta', delta: rawToolCall }])
+    mockStreamEvents([{ type, delta: rawToolCall }])
+
+    await expect(useLLM().stream('model-a', provider, [
+      { role: 'system', content: 'Use builtIn_emitSparkCommand to play games.' },
+      { role: 'user', content: 'Can you play games?' },
+    ], { tools: customTools, toolChoice: 'auto', onStreamEvent, onMessages })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(streamTextMock.mock.calls[0]?.[0]?.tools?.map(toolNameFrom)).toContain('builtIn_emitSparkCommand')
+    expect(streamTextMock.mock.calls[1]?.[0]?.tools).toBeUndefined()
+    expect(streamTextMock.mock.calls[1]?.[0]?.toolChoice).toBeUndefined()
+    expect(customTools).toHaveBeenCalledTimes(1)
+    expect(customTool.execute).not.toHaveBeenCalled()
+    expect(onStreamEvent).not.toHaveBeenCalled()
+    expect(onMessages).not.toHaveBeenCalled()
+  })
+
+  // ROOT CAUSE:
+  //
+  // A later JSON call can follow a prefix that already reached the caller.
+  // Before the fix, this call bypassed the guard and the stream succeeded.
+  // We reject the call without retrying or replaying the visible prefix.
+  // https://github.com/moeru-ai/airi/pull/2459#discussion_r3932132863
+  it('does not retry a leak after visible text for Issue #2161', async () => {
+    const onStreamEvent = vi.fn()
+    const onMessages = vi.fn()
+    const customTool = createSparkTool()
+    mockStreamEvents([
+      { type: 'text.delta', delta: 'I will call the game tool.\n' },
+      { type: 'text.delta', delta: '{"name":"builtIn_emitSparkCommand","parameters":{}}' },
+    ])
+
+    await expect(useLLM().stream('model-a', provider, [], {
+      tools: [customTool],
+      onStreamEvent,
+      onMessages,
+    })).rejects.toThrow('tool call "builtIn_emitSparkCommand" as plain text')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    expect(onStreamEvent).toHaveBeenCalledExactlyOnceWith({ type: 'text-delta', text: 'I will call the game tool.\n' })
+    expect(onMessages).not.toHaveBeenCalled()
+    expect(customTool.execute).not.toHaveBeenCalled()
+  })
+
+  it('keeps retry tool names isolated between requests to the same model', async () => {
+    const rawToolCall = '{"name":"builtIn_emitSparkCommand","parameters":{}}'
+    const store = useLLM()
+    mockStreamEvents([{ type: 'text.delta', delta: rawToolCall }])
+    mockStreamEvents([{ type: 'text.delta', delta: 'No tool is available.' }])
+    await store.stream('model-a', provider, [], { tools: [createSparkTool()] })
+
+    const onStreamEvent = vi.fn()
+    mockStreamEvents([{ type: 'text.delta', delta: rawToolCall }])
+    await store.stream('model-a', provider, [
+      { role: 'user', content: 'Quote this JSON as a documentation example.' },
+    ], { supportsTools: false, onStreamEvent })
+
+    expect(streamTextMock).toHaveBeenCalledTimes(3)
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'text-delta', text: rawToolCall })
+    expect(onStreamEvent).toHaveBeenCalledWith({ type: 'finish' })
+  })
+
   it('merges runtime-registered tools from the llm-tools store into the builtin tool resolver', async () => {
     const store = useLLM()
     const llmToolsStore = useLlmToolsStore()

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
@@ -1,8 +1,8 @@
-import type { StreamOptions } from '@proj-airi/core-agent'
+import type { StreamEvent, StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
-import { streamFrom as coreStreamFrom, isContentArrayRelatedError, isToolRelatedError, modelKey } from '@proj-airi/core-agent'
+import { streamFrom as coreStreamFrom, isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError, modelKey } from '@proj-airi/core-agent'
 import { listModels } from '@xsai/model'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
@@ -10,7 +10,17 @@ import { ref } from 'vue'
 import { resolveLlmTools } from './tool-resolver'
 
 export type { StreamEvent, StreamOptions } from '@proj-airi/core-agent'
-export { isContentArrayRelatedError, isToolRelatedError } from '@proj-airi/core-agent'
+export { isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError } from '@proj-airi/core-agent'
+
+function toolChoiceRequiresTools(toolChoice: StreamOptions['toolChoice']): boolean {
+  if (toolChoice === 'required')
+    return true
+  if (typeof toolChoice !== 'object' || toolChoice === null)
+    return false
+
+  return toolChoice.type === 'function'
+    || (toolChoice.type === 'allowed_tools' && toolChoice.mode === 'required')
+}
 
 export const useLLM = defineStore('llm', () => {
   const toolsCompatibility = ref<Map<string, boolean>>(new Map())
@@ -20,6 +30,7 @@ export const useLLM = defineStore('llm', () => {
     const key = modelKey(model, chatProvider)
     const { tools: customTools, ...streamOptions } = options ?? {}
     const builtinToolsResolver = () => resolveLlmTools({ customTools })
+    let hasCommittedAttemptOutput = false
 
     const runStream = () => coreStreamFrom({
       model,
@@ -29,6 +40,11 @@ export const useLLM = defineStore('llm', () => {
         ...streamOptions,
         toolsCompatibility: toolsCompatibility.value,
         contentArrayCompatibility: contentArrayCompatibility.value,
+        onStreamEvent: async (event: StreamEvent) => {
+          if (event.type !== 'error' && event.type !== 'finish')
+            hasCommittedAttemptOutput = true
+          await streamOptions.onStreamEvent?.(event)
+        },
       },
       builtinToolsResolver,
     })
@@ -37,9 +53,19 @@ export const useLLM = defineStore('llm', () => {
       await runStream()
     }
     catch (err) {
+      const shouldRetryWithoutTools = isPlainTextToolCallError(err)
+        && !hasCommittedAttemptOutput
+        && !toolChoiceRequiresTools(streamOptions.toolChoice)
       if (isToolRelatedError(err)) {
-        console.warn(`[llm] Auto-disabling tools for "${key}" due to tool-related error`)
+        const retryMessage = shouldRetryWithoutTools ? ' and retrying once' : ''
+        console.warn(`[llm] Auto-disabling tools for "${key}" due to tool-related error${retryMessage}`)
         toolsCompatibility.value.set(key, false)
+      }
+      // The leak guard buffers this failure before any text reaches the UI, so
+      // retrying cannot duplicate partial output from the failed attempt.
+      if (shouldRetryWithoutTools) {
+        await runStream()
+        return
       }
       // NOTICE:
       // Auto-degrade content-part arrays to plain strings on the next attempt

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
@@ -2,7 +2,7 @@ import type { StreamEvent, StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
-import { streamFrom as coreStreamFrom, isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError, modelKey, streamOptionsToolsCompatibilityOk } from '@proj-airi/core-agent'
+import { streamFrom as coreStreamFrom, isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError, modelKey, streamOptionsContentArrayCompatibilityOk, streamOptionsToolsCompatibilityOk } from '@proj-airi/core-agent'
 import { listModels } from '@xsai/model'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
@@ -50,6 +50,11 @@ export const useLLM = defineStore('llm', () => {
     if (!startsWithTools && streamOptions.supportsTools !== false)
       await builtinToolsResolver()
     let hasCommittedAttemptOutput = false
+    let supportsTools = startsWithTools
+    let supportsContentArray = streamOptionsContentArrayCompatibilityOk(model, chatProvider, {
+      ...streamOptions,
+      contentArrayCompatibility: contentArrayCompatibility.value,
+    })
 
     const runStream = () => coreStreamFrom({
       model,
@@ -59,48 +64,63 @@ export const useLLM = defineStore('llm', () => {
         ...streamOptions,
         toolsCompatibility: toolsCompatibility.value,
         contentArrayCompatibility: contentArrayCompatibility.value,
+        supportsTools,
+        supportsContentArray,
         onStreamEvent: async (event: StreamEvent) => {
-          if (event.type !== 'error' && event.type !== 'finish')
+          if (event.type !== 'error')
             hasCommittedAttemptOutput = true
           await streamOptions.onStreamEvent?.(event)
+        },
+        onMessages: async (finalMessages) => {
+          hasCommittedAttemptOutput = true
+          await streamOptions.onMessages?.(finalMessages)
         },
       },
       builtinToolsResolver,
       toolCallGuardNames,
+      onNativeToolCall: () => { hasCommittedAttemptOutput = true },
     })
 
-    try {
-      await runStream()
-    }
-    catch (err) {
-      const shouldRetryWithoutTools = isPlainTextToolCallError(err)
-        && startsWithTools
-        && !hasCommittedAttemptOutput
-        && !toolChoiceRequiresTools(streamOptions.toolChoice)
-      if (isToolRelatedError(err)) {
-        const retryMessage = shouldRetryWithoutTools ? ' and retrying once' : ''
-        console.warn(`[llm] Auto-disabling tools for "${key}" due to tool-related error${retryMessage}`)
-        toolsCompatibility.value.set(key, false)
-      }
-      // The leak guard buffers this failure before any text reaches the UI, so
-      // retrying cannot duplicate partial output from the failed attempt.
-      if (shouldRetryWithoutTools) {
+    // Each retry disables one remaining capability. Neither capability returns
+    // during this request, so there are at most three stream attempts.
+    while (true) {
+      try {
         await runStream()
         return
       }
-      // NOTICE:
-      // Auto-degrade content-part arrays to plain strings on the next attempt
-      // when the provider returned the Rust/serde-style "expected a string"
-      // 400. We retry once inline so the user's failing turn recovers without
-      // requiring them to resend; subsequent calls reuse the cached degrade.
-      // See: https://github.com/moeru-ai/airi/issues/1500
-      if (isContentArrayRelatedError(err) && contentArrayCompatibility.value.get(key) !== false) {
-        console.warn(`[llm] Auto-disabling content-part arrays for "${key}" and retrying once`)
-        contentArrayCompatibility.value.set(key, false)
-        await runStream()
-        return
+      catch (err) {
+        const shouldRetryWithoutTools = isPlainTextToolCallError(err)
+          && supportsTools
+          && !hasCommittedAttemptOutput
+          && !toolChoiceRequiresTools(streamOptions.toolChoice)
+        if (isToolRelatedError(err)) {
+          const retryMessage = shouldRetryWithoutTools ? ' and retrying once' : ''
+          console.warn(`[llm] Auto-disabling tools for "${key}" due to tool-related error${retryMessage}`)
+          toolsCompatibility.value.set(key, false)
+        }
+        // Keep explicit array support intact. Its request-level override takes
+        // precedence over the cache, so the same payload cannot recover inline.
+        const shouldRetryWithoutArrays = isContentArrayRelatedError(err)
+          && supportsContentArray
+          && streamOptions.supportsContentArray !== true
+          && !hasCommittedAttemptOutput
+        if (isContentArrayRelatedError(err)) {
+          const retryMessage = shouldRetryWithoutArrays ? ' and retrying once' : ''
+          console.warn(`[llm] Auto-disabling content-part arrays for "${key}"${retryMessage}`)
+          contentArrayCompatibility.value.set(key, false)
+        }
+        if (shouldRetryWithoutTools) {
+          supportsTools = false
+          continue
+        }
+        // Issue #1500: string-only providers reject content-part arrays.
+        // Retry errors return to this classifier so both fallbacks can apply.
+        if (shouldRetryWithoutArrays) {
+          supportsContentArray = false
+          continue
+        }
+        throw err
       }
-      throw err
     }
   }
 

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
@@ -7,7 +7,7 @@ import { listModels } from '@xsai/model'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-import { resolveLlmTools } from './tool-resolver'
+import { resolveLlmTools, toolNameFrom } from './tool-resolver'
 
 export type { StreamEvent, StreamOptions } from '@proj-airi/core-agent'
 export { isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError } from '@proj-airi/core-agent'
@@ -29,7 +29,18 @@ export const useLLM = defineStore('llm', () => {
   async function stream(model: string, chatProvider: ChatProvider, messages: Message[], options?: StreamOptions) {
     const key = modelKey(model, chatProvider)
     const { tools: customTools, ...streamOptions } = options ?? {}
-    const builtinToolsResolver = () => resolveLlmTools({ customTools })
+    // Keep names for this request's retries even after the capability cache
+    // disables tool resolution. Do not carry these names into another request.
+    const toolCallGuardNames = new Set<string>()
+    const builtinToolsResolver = async () => {
+      const tools = await resolveLlmTools({ customTools })
+      for (const tool of tools) {
+        const name = toolNameFrom(tool)
+        if (name)
+          toolCallGuardNames.add(name)
+      }
+      return tools
+    }
     let hasCommittedAttemptOutput = false
 
     const runStream = () => coreStreamFrom({
@@ -47,6 +58,7 @@ export const useLLM = defineStore('llm', () => {
         },
       },
       builtinToolsResolver,
+      toolCallGuardNames,
     })
 
     try {

--- a/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
+++ b/packages/stage-ui/src/stores/ai/chat-llm/llm.ts
@@ -2,7 +2,7 @@ import type { StreamEvent, StreamOptions } from '@proj-airi/core-agent'
 import type { ChatProvider } from '@xsai-ext/providers/utils'
 import type { Message } from '@xsai/shared-chat'
 
-import { streamFrom as coreStreamFrom, isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError, modelKey } from '@proj-airi/core-agent'
+import { streamFrom as coreStreamFrom, isContentArrayRelatedError, isPlainTextToolCallError, isToolRelatedError, modelKey, streamOptionsToolsCompatibilityOk } from '@proj-airi/core-agent'
 import { listModels } from '@xsai/model'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
@@ -29,8 +29,12 @@ export const useLLM = defineStore('llm', () => {
   async function stream(model: string, chatProvider: ChatProvider, messages: Message[], options?: StreamOptions) {
     const key = modelKey(model, chatProvider)
     const { tools: customTools, ...streamOptions } = options ?? {}
-    // Keep names for this request's retries even after the capability cache
-    // disables tool resolution. Do not carry these names into another request.
+    const startsWithTools = streamOptionsToolsCompatibilityOk(model, chatProvider, {
+      ...streamOptions,
+      toolsCompatibility: toolsCompatibility.value,
+    })
+    // Each request owns its current tool names and retains them for retries.
+    // The capability cache controls provider tools, not output inspection.
     const toolCallGuardNames = new Set<string>()
     const builtinToolsResolver = async () => {
       const tools = await resolveLlmTools({ customTools })
@@ -41,6 +45,10 @@ export const useLLM = defineStore('llm', () => {
       }
       return tools
     }
+    // Cache-disabled requests still need detection, but explicitly tool-free
+    // requests must not resolve tools or inherit names from other requests.
+    if (!startsWithTools && streamOptions.supportsTools !== false)
+      await builtinToolsResolver()
     let hasCommittedAttemptOutput = false
 
     const runStream = () => coreStreamFrom({
@@ -66,6 +74,7 @@ export const useLLM = defineStore('llm', () => {
     }
     catch (err) {
       const shouldRetryWithoutTools = isPlainTextToolCallError(err)
+        && startsWithTools
         && !hasCommittedAttemptOutput
         && !toolChoiceRequiresTools(streamOptions.toolChoice)
       if (isToolRelatedError(err)) {


### PR DESCRIPTION
## Description

Prevent registered tool calls from appearing as plain JSON in text or reasoning output.

- Inspect known tool names with a top-level `parameters` or `arguments` field.
- Retain unmatched candidates across tool rounds. Check the combined channel at stream completion without rescanning it at intermediate boundaries.
- Preserve complete ordinary JSON, nested examples, and output order. Native tool activity signals replay risk before buffered UI callbacks.
- Bound compatibility retries and parsing work. Preserve required tool choices and explicit content-array overrides.
- Stop queued output on failure and wait for active consumer callbacks before rejection.

## Linked Issues

Closes #2161

## Behavior and limits

Ordinary text and reasoning stream until a JSON candidate starts. Complete candidates can flush at step boundaries.

If a candidate is unmatched, all subsequent text, reasoning, and native UI notifications remain buffered until stream completion. This adds display latency for those responses. It prevents both cross-step leaks and premature rejection of valid nested examples. Each channel and request keeps its own text. Native tool execution does not wait for buffered UI notifications.

Each channel inspection limits candidate lengths to eight times its input length. Deferred prefixes receive no intermediate rescans. Exhaustion rejects without releasing unchecked output or retrying. Deeply malformed ordinary output can also reject. This is a work bound, not an absolute size or time limit.

Tool and content-array fallbacks each apply at most once, in either order. Neither fallback replays committed output or native tool activity. Cached tool-disabled requests retain current tool names for inspection. Explicit tool-disabled requests skip tool resolution.

Already-emitted output and native tool side effects cannot be rolled back. Active consumer callbacks must eventually settle.

## Verification

- `pnpm -F @proj-airi/core-agent exec vitest run`: 151 tests passed.
- `AIRI_TEST_REAL_SSE=1 pnpm -F @proj-airi/stage-ui exec vitest run`: 819 tests passed, including browser tests.
- `pnpm typecheck`: passed across 58 workspace projects.
- `pnpm lint`: passed with 10 existing warnings.
- `pnpm build:packages`: 33 tasks passed.
- Changed-file lint and `git diff --check` passed.

This revision adds 13 tests. Four core regressions and three real SDK/SSE cases failed on the previous code before the fix.

Core tests cover every character split of the call fixture in both channels with three step-boundary variants. Further cases cover split nested examples, escaped strings, completion, failure, channel/request isolation, and deferred parse limits.

Four new opt-in cases use the real chat store, public core build, xsAI, and HTTP/SSE across a native tool round. They cover text/reasoning leaks, a valid nested example, and failure in the next HTTP request. Each executes the native tool once without a store retry. All nine opt-in SSE cases passed.

These are scripted transport fixtures, not model inference. Earlier model experiments and performance measurements were not rerun for this revision.

## Visual changes

The original comparison records initial chat recovery. This revision changes stream handling, not component layout, and includes no new captures.

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/2ce256cd-42c8-42e1-826f-0ceca163e91e) | ![](https://github.com/user-attachments/assets/d82bf3e8-69cf-48e7-95a4-f16f1c5543f8) |
| Chat / raw tool JSON | Chat / tool-free recovery |
