### PR TITLE
docs(readme): add missing NixOS section to zh-CN README

### DIFF
--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -293,6 +293,15 @@ pnpm dev:tamagotchi
 nix run github:moeru-ai/airi
 ```
 
+#### NixOS
+
+在 NixOS 上，Electron 需要一些不在标准路径下的共享库。请使用 `flake.nix` 中定义的 FHS shell：
+
+```shell
+nix develop .#fhs
+pnpm dev:tamagotchi
+```
+
 ### Stage Pocket（移动版）
 
 启动 Capacitor Web 版本的开发服务器：


### PR DESCRIPTION
## Summary

- 中文 README（`docs/README.zh-CN.md`）缺失了英文 README 中存在的 `#### NixOS` 安装说明 section（英文版第 300-307 行）。
- 补上该 section 的中文翻译，使中文文档与英文版保持同步。

## Context

英文 README 在桌面版的 `nix run` 说明之后、移动版之前，有一段 NixOS 专属的 FHS shell 说明；中文版直接跳过了这部分，导致 NixOS 用户在中文文档里看不到对应的安装指引。

## Verification

- 对比 `README.md`（第 300-307 行）与 `docs/README.zh-CN.md`，确认该 section 在中文版缺失。
- 新增内容为英文版的准确中文翻译，技术术语（NixOS / FHS / `flake.nix`）与英文版保持一致。
- `git diff --stat`：仅 1 个文件、9 行新增，无其他改动。