### PR TITLE
docs(readme): mark Azure OpenAI as supported in zh-CN README

### DIFF
--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -352,7 +352,7 @@ npx bumpp --no-commit --no-tag
 - [x] [Ollama](https://github.com/ollama/ollama)
 - [x] [302.AI (sponsored)](https://share.302.ai/514k2v)
 - [x] [OpenAI](https://platform.openai.com/docs/guides/gpt/chat-completions-api)
-  - [ ] [Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)（欢迎 PR）
+  - [x] [Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)
 - [x] [Anthropic Claude](https://anthropic.com)
   - [ ] [AWS Claude](https://docs.anthropic.com/en/api/claude-on-amazon-bedrock)（欢迎 PR）
 - [x] [深度求索 DeepSeek](https://www.deepseek.com/)


### PR DESCRIPTION
## Summary

- 中文 README 将 Azure OpenAI API 错误标记为未支持（`[ ]` + "欢迎 PR"），但 Azure OpenAI 实际已支持。
- 同步为 `[x]`，与英文 README 及实际代码保持一致。

## Context

`packages/provider-inference/src/providers/cloud/azure-openai/` 已提供专门的 Azure OpenAI provider，英文 README 也已将其标记为 `[x]` 已支持。中文 README 仍停留在旧的 `[ ]`（欢迎 PR）状态，会误导中文用户以为 Azure OpenAI 尚未支持。

## Verification

- 代码：`packages/provider-inference/src/providers/cloud/azure-openai/index.ts` 存在。
- 英文 README 第 354 行：`- [x] [Azure OpenAI API]`。
- 本 PR 将中文 README 第 355 行从 `- [ ] ...（欢迎 PR）` 改为 `- [x] ...`，与英文一致。
- `git diff --stat`：仅 1 个文件、1 行改动。