### PR TITLE
fix(auth): discard stale authentication requests

### DIFF
--- a/apps/stage-tamagotchi/src/main/services/airi/auth.test.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/auth.test.ts
@@ -1,0 +1,118 @@
+import type { ElectronMainContextExtensions, ElectronMainEmitOptions } from '@moeru/eventa/adapters/electron/main'
+import type { BrowserWindow, IpcMainEvent } from 'electron'
+
+import { EventEmitter } from 'node:events'
+import { setImmediate } from 'node:timers/promises'
+
+import { createContext, defineInvoke } from '@moeru/eventa'
+import { shell } from 'electron'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { electronAuthCallback, electronAuthLogout, electronAuthStartLogin } from '../../../shared/eventa'
+import { createAuthService } from './auth'
+
+vi.mock('electron', () => ({ shell: { openExternal: vi.fn().mockResolvedValue(undefined) } }))
+
+describe('electron login request ownership', () => {
+  const cleanups: Array<() => Promise<void>> = []
+  const networkFetch = globalThis.fetch
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0))
+      await cleanup()
+    vi.restoreAllMocks()
+    vi.mocked(shell.openExternal).mockReset().mockResolvedValue(undefined)
+  })
+
+  function windowLogin(id: number) {
+    const context = createContext<ElectronMainContextExtensions, ElectronMainEmitOptions>()
+    const window = Object.assign(new EventEmitter(), { webContents: { id }, isDestroyed: () => false }) as BrowserWindow
+    createAuthService({ context, window })
+    const options = { raw: { ipcMainEvent: { sender: { id } } as IpcMainEvent, event: undefined } }
+    const start = defineInvoke(context, electronAuthStartLogin)
+    const logout = defineInvoke(context, electronAuthLogout)
+    const received = vi.fn()
+    context.on(electronAuthCallback, received)
+    cleanups.push(async () => {
+      await logout(undefined, options)
+    })
+    return { start: () => start(undefined, options), logout: () => logout(undefined, options), received, window }
+  }
+
+  async function callback(index: number) {
+    const authorization = new URL(vi.mocked(shell.openExternal).mock.calls[index]![0])
+    const [port, state] = authorization.searchParams.get('state')!.split(':')
+    const response = await networkFetch(`http://127.0.0.1:${port}/callback?code=test-code&state=${state}`)
+    expect(response.ok).toBe(true)
+  }
+
+  // ROOT CAUSE:
+  // Closing the loopback does not cancel a token exchange that already started.
+  // Only the current login attempt can publish tokens or clear the active attempt.
+  it('discards a token exchange after another window starts a new login', async () => {
+    const exchange = Promise.withResolvers<Response>()
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockReturnValue(exchange.promise)
+    const first = windowLogin(1)
+    const second = windowLogin(2)
+    await first.start()
+    await callback(0)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await second.start()
+    exchange.resolve(Response.json({ access_token: 'discarded', expires_in: 3600 }))
+    // Drain the response body and background completion microtasks.
+    await setImmediate()
+    expect(first.received).not.toHaveBeenCalled()
+    // The old completion must not remove the new loopback's cleanup handle.
+    await second.logout()
+    const url = new URL(vi.mocked(shell.openExternal).mock.calls[1]![0])
+    const port = url.searchParams.get('state')!.split(':')[0]
+    await vi.waitFor(async () => {
+      await expect(networkFetch(`http://127.0.0.1:${port}/callback`)).rejects.toThrow()
+    })
+  })
+
+  it('publishes only the new login result after replacement', async () => {
+    const first = windowLogin(5)
+    const second = windowLogin(6)
+    await first.start()
+    await second.start()
+    // Closing the old owner must not cancel the new owner's attempt.
+    first.window.emit('closed')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json({ access_token: 'current', expires_in: 3600 }))
+    await callback(1)
+    await vi.waitFor(() => expect(second.received).toHaveBeenCalledTimes(1))
+    expect(first.received).not.toHaveBeenCalled()
+    expect(second.received.mock.calls[0]![0].body.accessToken).toBe('current')
+  })
+
+  it('keeps only the latest attempt during concurrent startup', async () => {
+    const first = windowLogin(7)
+    const second = windowLogin(8)
+    await Promise.all([first.start(), second.start()])
+    expect(shell.openExternal).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards a token exchange after logout', async () => {
+    const exchange = Promise.withResolvers<Response>()
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(exchange.promise)
+    const login = windowLogin(3)
+    await login.start()
+    await callback(0)
+    await login.logout()
+    exchange.resolve(Response.json({ access_token: 'discarded', expires_in: 3600 }))
+    await setImmediate()
+    expect(login.received).not.toHaveBeenCalled()
+  })
+
+  it('discards a token exchange after its window closes', async () => {
+    const exchange = Promise.withResolvers<Response>()
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(exchange.promise)
+    const login = windowLogin(4)
+    await login.start()
+    await callback(0)
+    login.window.emit('closed')
+    exchange.resolve(Response.json({ access_token: 'discarded', expires_in: 3600 }))
+    await setImmediate()
+    expect(login.received).not.toHaveBeenCalled()
+  })
+})

--- a/apps/stage-tamagotchi/src/main/services/airi/auth.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/auth.ts
@@ -30,9 +30,23 @@ const SERVER_URL = import.meta.env.VITE_SERVER_URL || 'https://api.airi.build'
 const OIDC_AUTHORIZE_PATH = '/api/auth/oauth2/authorize'
 const OIDC_TOKEN_PATH = '/api/auth/oauth2/token'
 
-// Active loopback server cleanup handle
-let closeLoopback: (() => void) | null = null
-let signingInFlight = false
+// One main-process attempt owns the callback across all renderer windows.
+// Replacement, logout, and owner closure invalidate it before cleanup. Async
+// continuations can publish results or clear ownership only while it is current.
+interface LoginAttempt {
+  window: BrowserWindow
+  controller: AbortController
+  closeLoopback?: () => void
+}
+
+let activeAttempt: LoginAttempt | undefined
+
+function cancelLogin(): void {
+  const attempt = activeAttempt
+  activeAttempt = undefined
+  attempt?.controller.abort()
+  attempt?.closeLoopback?.()
+}
 
 /**
  * Create the auth service IPC handlers for a given window context.
@@ -41,31 +55,40 @@ export function createAuthService(params: {
   context: MainContext
   window: BrowserWindow
 }): void {
+  params.window.once('closed', () => {
+    if (activeAttempt?.window === params.window)
+      cancelLogin()
+  })
+
   defineInvokeHandler(params.context, electronAuthStartLogin, async (_, options) => {
     if (params.window.webContents.id !== options?.raw.ipcMainEvent.sender.id) {
       return
     }
 
-    if (signingInFlight) {
-      log.withFields({ windowId: params.window.webContents.id }).warn('Replacing in-flight OIDC login attempt with a new request')
-      closeLoopback?.()
-      closeLoopback = null
-      signingInFlight = false
-    }
-
-    signingInFlight = true
+    cancelLogin()
+    const attempt: LoginAttempt = { window: params.window, controller: new AbortController() }
+    activeAttempt = attempt
 
     try {
-      // Clean up any previous in-flight login
-      closeLoopback?.()
-
       const codeVerifier = generateCodeVerifier()
       const codeChallenge = await generateCodeChallenge(codeVerifier)
+      if (activeAttempt !== attempt)
+        return
       const state = generateState()
 
       // Start loopback server to receive the callback
       const loopback = await startLoopbackServer(state)
-      closeLoopback = loopback.close
+      attempt.closeLoopback = loopback.close
+      // Attach a rejection handler before browser launch or cancellation. Either
+      // can happen before the callback arrives, including during server startup.
+      const result = loopback.result.then(
+        callback => ({ callback }),
+        error => ({ error }),
+      )
+      if (activeAttempt !== attempt) {
+        loopback.close()
+        return
+      }
 
       // Use the server-side relay as redirect_uri. The relay page serves HTML
       // that forwards the authorization code to the loopback via JS fetch().
@@ -88,30 +111,43 @@ export function createAuthService(params: {
       url.searchParams.set('prompt', 'login')
       url.searchParams.set('resource', SERVER_URL)
 
-      // Open system browser
-      await shell.openExternal(url.toString())
-
-      // Wait for the callback in the background
-      loopback.result
-        .then(async ({ code }) => {
-          const tokens = await exchangeCode(code, codeVerifier, redirectUri)
+      // The IPC request completes when the browser opens. This background task
+      // owns the callback and token exchange until success, failure, or cancellation.
+      async function completeLogin(): Promise<void> {
+        try {
+          const outcome = await result
+          if (activeAttempt !== attempt)
+            return
+          if ('error' in outcome)
+            throw outcome.error
+          const tokens = await exchangeCode(outcome.callback.code, codeVerifier, redirectUri, attempt.controller.signal)
+          if (activeAttempt !== attempt)
+            return
           params.context.emit(electronAuthCallback, tokens)
           log.log('OIDC token exchange successful')
-        })
-        .catch((err) => {
-          log.withError(err).error('OIDC signing in failed')
-          params.context.emit(electronAuthCallbackError, { error: errorMessageFrom(err) ?? 'OIDC signing in failed' })
-        })
-        .finally(() => {
-          closeLoopback = null
-          signingInFlight = false
-        })
+        }
+        catch (error) {
+          if (activeAttempt !== attempt)
+            return
+          log.withError(error).error('OIDC signing in failed')
+          params.context.emit(electronAuthCallbackError, { error: errorMessageFrom(error) ?? 'OIDC signing in failed' })
+        }
+        finally {
+          loopback.close()
+          if (activeAttempt === attempt)
+            activeAttempt = undefined
+        }
+      }
+
+      void completeLogin()
+      await shell.openExternal(url.toString())
     }
-    catch (err) {
-      closeLoopback = null
-      signingInFlight = false
-      log.withError(err).error('Failed to start OIDC signing in flow')
-      params.context.emit(electronAuthCallbackError, { error: errorMessageFrom(err) ?? 'OIDC signing in failed' })
+    catch (error) {
+      if (activeAttempt !== attempt)
+        return
+      cancelLogin()
+      log.withError(error).error('Failed to start OIDC signing in flow')
+      params.context.emit(electronAuthCallbackError, { error: errorMessageFrom(error) ?? 'OIDC signing in failed' })
     }
   })
 
@@ -120,9 +156,7 @@ export function createAuthService(params: {
       return
     }
 
-    closeLoopback?.()
-    closeLoopback = null
-    signingInFlight = false
+    cancelLogin()
   })
 }
 
@@ -135,7 +169,7 @@ interface TokenExchangeResult {
   expiresIn: number
 }
 
-async function exchangeCode(code: string, codeVerifier: string, redirectUri: string): Promise<TokenExchangeResult> {
+async function exchangeCode(code: string, codeVerifier: string, redirectUri: string, signal: AbortSignal): Promise<TokenExchangeResult> {
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
@@ -147,6 +181,7 @@ async function exchangeCode(code: string, codeVerifier: string, redirectUri: str
 
   const response = await fetch(new URL(OIDC_TOKEN_PATH, SERVER_URL), {
     method: 'POST',
+    signal,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body,
   })

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/controls-island-auth-button.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/controls-island-auth-button.vue
@@ -55,11 +55,9 @@ context.value.on(electronAuthCallbackError, () => {
 })
 
 // React to needsLogin from other components (e.g. onboarding)
-watch(needsLogin, (val) => {
-  if (val && !isAuthenticated.value) {
+watch(needsLogin, async (val) => {
+  if (val && !isAuthenticated.value && await authStore.consumeLoginRequest())
     doSigningIn()
-    needsLogin.value = false
-  }
 })
 
 // Clear loading when authenticated

--- a/apps/stage-tamagotchi/src/renderer/composables/use-onboarding-authentication.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/composables/use-onboarding-authentication.test.ts
@@ -18,6 +18,10 @@ describe('useOnboardingAuthentication', () => {
     // The main process later sent the token callback to that closed renderer, so the first sign-in was lost.
     // The window must stay open until synchronized authentication state confirms the completed sign-in.
     scope.run(() => useOnboardingAuthentication({
+      consumeLoginRequest: async () => {
+        needsLogin.value = false
+        return true
+      },
       closeRequestId,
       closeWindow,
       isAuthenticated,
@@ -47,6 +51,7 @@ describe('useOnboardingAuthentication', () => {
     const scope = effectScope()
 
     scope.run(() => useOnboardingAuthentication({
+      consumeLoginRequest: vi.fn().mockResolvedValue(false),
       closeRequestId,
       closeWindow,
       isAuthenticated: shallowRef(false),
@@ -69,6 +74,7 @@ describe('useOnboardingAuthentication', () => {
     const onCloseError = vi.fn()
     const scope = effectScope()
     const controls = scope.run(() => useOnboardingAuthentication({
+      consumeLoginRequest: vi.fn().mockResolvedValue(false),
       closeRequestId: shallowRef(0),
       closeWindow,
       isAuthenticated: shallowRef(false),

--- a/apps/stage-tamagotchi/src/renderer/composables/use-onboarding-authentication.ts
+++ b/apps/stage-tamagotchi/src/renderer/composables/use-onboarding-authentication.ts
@@ -3,10 +3,11 @@ import type { Ref } from 'vue'
 import { watch } from 'vue'
 
 interface UseOnboardingAuthenticationOptions {
+  consumeLoginRequest: () => Promise<boolean>
   closeRequestId: Readonly<Ref<number>>
   closeWindow: () => Promise<unknown>
   isAuthenticated: Readonly<Ref<boolean>>
-  needsLogin: Ref<boolean>
+  needsLogin: Readonly<Ref<boolean>>
   onCloseError: (error: unknown) => void
   startLogin: () => Promise<void>
 }
@@ -55,8 +56,10 @@ export function useOnboardingAuthentication(options: UseOnboardingAuthentication
     if (!needsLogin || options.isAuthenticated.value)
       return
 
-    await options.startLogin()
-    options.needsLogin.value = false
+    // All login-capable renderers can receive the same snapshot. The leader
+    // grants consumption once, before the winning renderer starts its IPC flow.
+    if (await options.consumeLoginRequest())
+      await options.startLogin()
   })
 
   return { closeOnboardingWindow }

--- a/apps/stage-tamagotchi/src/renderer/pages/onboarding.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/onboarding.vue
@@ -19,6 +19,7 @@ const { isDark } = useTheme()
 const startLogin = useElectronEventaInvoke(electronAuthStartLogin)
 const closeWindow = useElectronEventaInvoke(electronOnboardingClose)
 const { closeOnboardingWindow } = useOnboardingAuthentication({
+  consumeLoginRequest: () => authStore.consumeLoginRequest(),
   closeRequestId,
   closeWindow,
   isAuthenticated,

--- a/apps/stage-tamagotchi/src/renderer/pages/settings/account/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/pages/settings/account/index.vue
@@ -16,8 +16,10 @@ async function handleLogin() {
 }
 
 async function handleLogout() {
-  await signOut()
+  // Cancel the current browser flow before waiting for server logout. A later
+  // cancellation could otherwise stop a new login started during that wait.
   await logout()
+  await signOut()
   router.push('/settings')
 }
 </script>

--- a/packages/stage-ui/src/libs/auth-fetch.ts
+++ b/packages/stage-ui/src/libs/auth-fetch.ts
@@ -23,6 +23,7 @@ export async function authedFetch(
   init?: RequestInit,
 ): Promise<Response> {
   const authStore = useAuthStore()
+  const version = authStore.sessionVersion
   const doFetch = (token: string | null): Promise<Response> => {
     const headers = new Headers(init?.headers)
     if (token)
@@ -37,7 +38,8 @@ export async function authedFetch(
   }
 
   const response = await doFetch(authStore.token)
-  if (response.status !== 401)
+  // Do not refresh or retry an earlier account's request under a new identity.
+  if (response.status !== 401 || version !== authStore.sessionVersion)
     return response
 
   // Don't recurse on the token endpoint itself
@@ -47,15 +49,18 @@ export async function authedFetch(
   if (url.includes('/oauth2/token'))
     return response
 
-  const newToken = await authStore.refreshTokenNow()
+  const newToken = await authStore.refreshTokenNow(version)
+  if (version !== authStore.sessionVersion)
+    return response
+
   if (!newToken) {
-    await promptReLogin(authStore)
+    await authStore.expireSession(version)
     return response
   }
 
   const retried = await doFetch(newToken)
   if (retried.status === 401)
-    await promptReLogin(authStore)
+    await authStore.expireSession(version)
   return retried
 }
 
@@ -65,9 +70,4 @@ function shouldAttachPosthogIdentity(input: RequestInfo | URL): boolean {
     : input instanceof URL ? input.toString() : input.url
 
   return new URL(url, SERVER_URL).origin === new URL(SERVER_URL).origin
-}
-
-async function promptReLogin(authStore: ReturnType<typeof useAuthStore>): Promise<void> {
-  await authStore.clearAllAuthState()
-  authStore.needsLogin = true
 }

--- a/packages/stage-ui/src/stores/auth.browser.test.ts
+++ b/packages/stage-ui/src/stores/auth.browser.test.ts
@@ -1,0 +1,208 @@
+import { createPinia, disposePinia, setActivePinia } from 'pinia'
+import { createSyncedPiniaPlugin } from 'pinia-plugin-synced'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import { authedFetch } from '../libs/auth-fetch'
+import { useAuthStore } from './auth'
+
+// Better Auth captures fetch when the client is created. Keep its real client,
+// but forward its network boundary to the fetch controlled by each test.
+vi.mock('better-auth/vue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('better-auth/vue')>()
+  return {
+    ...actual,
+    createAuthClient: (options: Parameters<typeof actual.createAuthClient>[0]) => actual.createAuthClient({
+      ...options,
+      fetchOptions: { ...options?.fetchOptions, customFetchImpl: (...args) => globalThis.fetch(...args) },
+    }),
+  }
+})
+
+describe('authentication request ownership', () => {
+  let pinia: ReturnType<typeof createPinia>
+  const requests: Array<{ path: string, resolve: (response: Response) => void }> = []
+
+  beforeEach(() => {
+    localStorage.clear()
+    requests.length = 0
+    pinia = createPinia()
+    setActivePinia(pinia)
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = input instanceof Request ? input.url : input.toString()
+      if (url.includes('/flux'))
+        return Promise.resolve(Response.json({ flux: 0 }))
+      return new Promise(resolve => requests.push({ path: new URL(url).pathname, resolve }))
+    })
+  })
+
+  afterEach(() => {
+    disposePinia(pinia)
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  async function reply(path: string, body: unknown, status = 200) {
+    await vi.waitFor(() => expect(requests.map(request => request.path)).toContain(path))
+    const index = requests.findIndex(request => request.path === path)
+    requests.splice(index, 1)[0]!.resolve(Response.json(body, { status }))
+  }
+
+  function identity(id: string) {
+    return {
+      user: { id, name: id, email: `${id}@example.test`, emailVerified: true, createdAt: new Date(), updatedAt: new Date() },
+      session: { id, userId: id, token: id, expiresAt: new Date(Date.now() + 3600000), createdAt: new Date(), updatedAt: new Date() },
+    }
+  }
+
+  async function signIn(id: string) {
+    const result = useAuthStore().completeSignIn({ accessToken: id, refreshToken: `${id}-refresh`, clientId: 'test-client', expiresIn: 3600 })
+    await reply('/api/auth/get-session', identity(id))
+    await result
+  }
+
+  it('consumes one login request across synchronized renderers without snapshot writeback', async () => {
+    vi.stubEnv('RUNTIME_ENVIRONMENT', 'electron')
+    const namespace = `auth-races-${crypto.randomUUID()}`
+    const onError = vi.fn()
+    const leader = createSyncedPiniaPlugin({ namespace, leadership: 'leader-only', onError })
+    const follower = createSyncedPiniaPlugin({ namespace, leadership: 'follower-only', onError })
+    const followerPinia = createPinia().use(follower.plugin)
+    pinia.use(leader.plugin)
+    createApp({}).use(pinia)
+    createApp({}).use(followerPinia)
+    const owner = useAuthStore(pinia)
+    const replica = useAuthStore(followerPinia)
+    try {
+      await expect.poll(() => leader.isLeader()).toBe(true)
+      owner.needsLogin = true
+      await expect.poll(() => replica.needsLogin).toBe(true)
+      const results = await Promise.all([owner.consumeLoginRequest(), replica.consumeLoginRequest()])
+      expect(results.filter(Boolean)).toHaveLength(1)
+      await expect.poll(() => replica.needsLogin).toBe(false)
+      const traffic = vi.spyOn(BroadcastChannel.prototype, 'postMessage')
+      await owner.clearAllAuthState()
+      await expect.poll(() => replica.sessionVersion).toBe(owner.sessionVersion)
+      await nextTick()
+      expect(traffic.mock.calls.filter(([message]) => JSON.stringify(message).includes('replaceState'))).toHaveLength(0)
+      expect(onError).not.toHaveBeenCalled()
+    }
+    finally {
+      leader.dispose()
+      follower.dispose()
+      disposePinia(followerPinia)
+      vi.unstubAllEnvs()
+    }
+  })
+
+  // ROOT CAUSE:
+  // An old session response wrote identity after logout cleared the credentials.
+  // The response must belong to the current authentication version before it commits.
+  it('ignores a session response after local authentication is cleared', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = store.fetchSession()
+    await store.clearAllAuthState()
+    await reply('/api/auth/get-session', identity('first'))
+    await pending
+    expect(store.isAuthenticated).toBe(false)
+    expect(store.token).toBeNull()
+  })
+
+  it('does not let an old rejected session clear a newer sign-in', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = store.fetchSession()
+    await vi.waitFor(() => expect(requests).toHaveLength(1))
+    const oldRequest = requests.shift()!
+    await signIn('second')
+    oldRequest.resolve(Response.json(null))
+    await pending
+    expect(store.user?.id).toBe('second')
+    expect(store.token).toBe('second')
+  })
+
+  it('does not restore credentials when a refresh completes after logout', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = store.refreshTokenNow()
+    await vi.waitFor(() => expect(requests).toHaveLength(1))
+    await store.clearAllAuthState()
+    await reply('/api/auth/oauth2/token', { access_token: 'late', refresh_token: 'late-refresh', expires_in: 3600 })
+    // A stale refresh must finish without requesting a session with the discarded token.
+    await vi.waitFor(() => expect(store.token).toBeNull())
+    expect(await pending).toBeNull()
+    expect(localStorage.getItem('auth/v1/token')).toBeNull()
+  })
+
+  it('refreshes the current session and keeps the new credential', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = store.refreshTokenNow()
+    await reply('/api/auth/oauth2/token', { access_token: 'renewed', refresh_token: 'renewed-refresh', expires_in: 3600 })
+    await reply('/api/auth/get-session', identity('first'))
+    expect(await pending).toBe('renewed')
+    expect(store.token).toBe('renewed')
+    expect(store.user?.id).toBe('first')
+  })
+
+  it('does not let a failed old refresh clear a newer sign-in', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = store.refreshTokenNow()
+    await signIn('second')
+    await reply('/api/auth/oauth2/token', { error: 'invalid_grant' }, 400)
+    await pending
+    expect(store.user?.id).toBe('second')
+    expect(store.token).toBe('second')
+  })
+
+  it('does not clear a new sign-in when an earlier logout finishes', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = store.signOut()
+    await signIn('second')
+    await reply('/api/auth/sign-out', {})
+    await pending
+    expect(store.user?.id).toBe('second')
+  })
+
+  it('does not prompt for login when an API refresh finishes after logout', async () => {
+    await signIn('first')
+    const store = useAuthStore()
+    const pending = authedFetch('https://api.example.test/action')
+    await reply('/action', {}, 401)
+    await vi.waitFor(() => expect(requests.map(request => request.path)).toContain('/api/auth/oauth2/token'))
+    await store.clearAllAuthState()
+    await reply('/api/auth/oauth2/token', { error: 'invalid_grant' }, 400)
+    expect((await pending).status).toBe(401)
+    expect(store.needsLogin).toBe(false)
+    expect(store.isAuthenticated).toBe(false)
+  })
+
+  it('requests login when the current API refresh fails', async () => {
+    vi.stubEnv('RUNTIME_ENVIRONMENT', 'electron')
+    try {
+      await signIn('first')
+      const pending = authedFetch('https://api.example.test/action')
+      await reply('/action', {}, 401)
+      await reply('/api/auth/oauth2/token', { error: 'invalid_grant' }, 400)
+      expect((await pending).status).toBe(401)
+      expect(useAuthStore().needsLogin).toBe(true)
+      expect(useAuthStore().token).toBeNull()
+    }
+    finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('does not retry an old API request under a new account after a late 401', async () => {
+    await signIn('first')
+    const pending = authedFetch('https://api.example.test/action', { method: 'POST' })
+    await signIn('second')
+    await reply('/action', {}, 401)
+    expect((await pending).status).toBe(401)
+    expect(useAuthStore().user?.id).toBe('second')
+    expect(requests).toHaveLength(0)
+  })
+})

--- a/packages/stage-ui/src/stores/auth.test.ts
+++ b/packages/stage-ui/src/stores/auth.test.ts
@@ -75,6 +75,8 @@ describe('auth store sign-in requests', () => {
   beforeEach(() => {
     storage = new MemoryStorage()
     vi.stubGlobal('localStorage', storage)
+    // Authentication also requests credits. Keep that HTTP boundary inside the test.
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({ flux: 0 })))
     setActivePinia(createPinia())
     vi.mocked(triggerSignIn).mockReset()
     vi.mocked(triggerSignIn).mockResolvedValue()

--- a/packages/stage-ui/src/stores/auth.ts
+++ b/packages/stage-ui/src/stores/auth.ts
@@ -90,6 +90,10 @@ export const useAuthStore = defineStore('auth', () => {
   const oidcClientId = ref<string | null>(null)
   const tokenExpiry = ref<number | null>(null)
   const initialized = ref(false)
+  // This runtime version follows user intent across windows. New sign-in, logout,
+  // and explicit clearing advance it. Requests from older versions cannot commit.
+  const sessionVersion = ref(0)
+  let signingOut = false
 
   const credits = ref(0)
 
@@ -152,17 +156,29 @@ export const useAuthStore = defineStore('auth', () => {
   // must not trigger multiple token exchanges. All share one in-flight promise.
   let inflightRefresh: Promise<string | null> | null = null
 
-  async function refreshTokenNow(): Promise<string | null> {
+  /**
+   * Refreshes credentials only for the requested session version.
+   * Stale or rejected requests return null and never return another account's token.
+   * @param expectedVersion Session version captured by the caller. Defaults to the current version.
+   */
+  async function refreshTokenNow(expectedVersion = sessionVersion.value): Promise<string | null> {
+    if (expectedVersion !== sessionVersion.value || signingOut)
+      return null
     if (inflightRefresh)
       return inflightRefresh
 
     if (!refreshToken.value || !oidcClientId.value)
       return null
 
-    inflightRefresh = (async () => {
+    const version = sessionVersion.value
+    let requestToken = token.value
+    const refresh = (async () => {
       try {
         const tokens = await refreshAccessToken(oidcClientId.value!, refreshToken.value!)
+        if (version !== sessionVersion.value || requestToken !== token.value)
+          return null
         token.value = tokens.access_token
+        requestToken = tokens.access_token
         storage.setAccessToken(tokens.access_token)
         if (tokens.refresh_token) {
           refreshToken.value = tokens.refresh_token
@@ -174,20 +190,25 @@ export const useAuthStore = defineStore('auth', () => {
           scheduleTokenRefresh(tokens.expires_in)
         }
 
-        await fetchSession(tokens.access_token)
-        return tokens.access_token
+        const authenticated = await fetchSession(tokens.access_token)
+        return authenticated && version === sessionVersion.value ? tokens.access_token : null
       }
       catch (error) {
+        if (version !== sessionVersion.value || requestToken !== token.value)
+          return null
         console.error('OIDC token refresh failed', errorMessageFrom(error))
-        clearAuthState()
+        resetAuthState()
         return null
       }
-      finally {
-        inflightRefresh = null
-      }
     })()
-
-    return inflightRefresh
+    inflightRefresh = refresh
+    try {
+      return await refresh
+    }
+    finally {
+      if (inflightRefresh === refresh)
+        inflightRefresh = null
+    }
   }
 
   const { start: startRefreshTimer, stop: stopRefreshTimer } = useTimeoutFn(
@@ -255,6 +276,9 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function completeSignIn(tokens: AuthTokenSet): Promise<boolean> {
+    sessionVersion.value += 1
+    inflightRefresh = null
+    signingOut = false
     token.value = tokens.accessToken
     refreshToken.value = tokens.refreshToken ?? null
     idToken.value = tokens.idToken ?? null
@@ -273,14 +297,21 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function fetchSession(accessToken: string | null = token.value): Promise<boolean> {
+    if (signingOut || accessToken !== token.value)
+      return false
+    const version = sessionVersion.value
     const data = await requestAuthSession(accessToken)
+    // A refresh can replace the token without changing the user-intent version.
+    // Both must still match before identity or failure state is committed.
+    if (version !== sessionVersion.value || accessToken !== token.value)
+      return false
     if (data) {
       user.value = data.user
       session.value = data.session
       return true
     }
 
-    clearAuthState()
+    resetAuthState()
     return false
   }
 
@@ -299,6 +330,10 @@ export const useAuthStore = defineStore('auth', () => {
     const idTokenHint = idToken.value
     const clientId = oidcClientId.value
     const bearerToken = token.value
+    const version = ++sessionVersion.value
+    signingOut = true
+    stopRefreshTimer()
+    inflightRefresh = null
 
     // Delete the server session before local state. A new authorization request
     // can otherwise reuse the server cookie and restore the previous identity.
@@ -323,7 +358,8 @@ export const useAuthStore = defineStore('auth', () => {
       console.error('Server sign-out failed', errorMessageFrom(error))
     }
 
-    clearAuthState()
+    if (version === sessionVersion.value)
+      clearAuthState()
   }
 
   /**
@@ -338,6 +374,16 @@ export const useAuthStore = defineStore('auth', () => {
    * loop silently until the user lands on a page that calls fetchSession.
    */
   function clearAuthState(): void {
+    sessionVersion.value += 1
+    resetAuthState()
+  }
+
+  // A rejected credential clears the identity but keeps the user-intent version.
+  // The matching API caller can still request login. Token checks reject other
+  // responses for the removed credential, while new user actions advance the version.
+  function resetAuthState(): void {
+    signingOut = false
+    inflightRefresh = null
     stopRefreshTimer()
     user.value = null
     session.value = null
@@ -353,13 +399,31 @@ export const useAuthStore = defineStore('auth', () => {
     clearAuthState()
   }
 
+  /** Grants one renderer ownership of a shared login request. */
+  async function consumeLoginRequest(): Promise<boolean> {
+    if (!needsLogin.value || isAuthenticated.value)
+      return false
+    needsLogin.value = false
+    return true
+  }
+
+  /** Requests sign-in only if the failed request still belongs to this session. */
+  async function expireSession(expectedVersion: number): Promise<void> {
+    if (expectedVersion !== sessionVersion.value || signingOut)
+      return
+    clearAuthState()
+    needsLogin.value = true
+  }
+
   const updateCredits = async () => {
     if (!isAuthenticated.value)
       return
+    const version = sessionVersion.value
     const res = await client.api.v1.flux.$get()
     if (res.ok) {
       const data = await res.json()
-      credits.value = data.flux
+      if (version === sessionVersion.value && isAuthenticated.value)
+        credits.value = data.flux
     }
   }
 
@@ -417,6 +481,9 @@ export const useAuthStore = defineStore('auth', () => {
     listSessions,
     signOut,
     refreshTokenNow,
+    sessionVersion,
+    consumeLoginRequest,
+    expireSession,
     clearAllAuthState,
   }
 }, {
@@ -428,6 +495,8 @@ export const useAuthStore = defineStore('auth', () => {
       'signOut',
       'refreshTokenNow',
       'clearAllAuthState',
+      'expireSession',
+      'consumeLoginRequest',
     ],
     state: true,
   },


### PR DESCRIPTION
## Summary

An earlier login, session query, or token refresh could overwrite a newer sign-in or restore state after logout. This follows #2482.

- Give each Electron login attempt ownership of its callback, token exchange, and cleanup. Cancel it when replaced, on logout, or when its window closes.
- Check the shared session version before an asynchronous result changes authentication state. Keep API retries within the account that sent the request.
- Let the Pinia leader grant one renderer ownership of each shared login request.
- Cancel the desktop login flow before waiting for server logout.

No templates, styles, or visible text change.

## Verification

29 related tests pass, including 10 Chromium tests with real Pinia, browser storage, and synchronized leader/follower instances. Electron tests use real loopback HTTP callbacks and mock the Electron and remote HTTP boundaries. The regression cases failed before the fixes.

```sh
pnpm -F @proj-airi/stage-ui exec vitest run --project browser src/stores/auth.browser.test.ts
pnpm -F @proj-airi/stage-ui exec vitest run --project node src/stores/auth.test.ts src/libs/auth-fetch.test.ts
pnpm -F @proj-airi/stage-tamagotchi exec vitest run --project node src/main/services/airi/auth.test.ts src/main/services/airi/http-server/http/auth/index.test.ts src/renderer/composables/use-onboarding-authentication.test.ts src/renderer/bridges/electron-auth-callback.test.ts
pnpm typecheck
pnpm lint
```

No live provider sign-in or device acceptance was performed.
