### PR TITLE
chore(nix): update assets hash

### DIFF
--- a/nix/assets-hash.txt
+++ b/nix/assets-hash.txt
@@ -1,1 +1,1 @@
-sha256-69tCpJaxRUnyR9CrHlmWJWEWLDpYzyzska7ui9++QoY=
+sha256-p3mka3ObeSHWukOEc9quXBQZwNRcQ+8E4m4mRDJAsbM=


### PR DESCRIPTION
Auto-generated by CI to keep Nix asset hash up-to-date.