### PR TITLE
chore: optimize typecheck execution 

### DIFF
--- a/apps/stage-pocket/package.json
+++ b/apps/stage-pocket/package.json
@@ -136,7 +136,6 @@
     "@vitejs/plugin-vue": "catalog:",
     "@vue-macros/volar": "catalog:",
     "@vueuse/motion": "catalog:",
-    "@webgpu/types": "catalog:",
     "csstype": "catalog:",
     "hfup": "catalog:",
     "less": "catalog:",

--- a/apps/stage-pocket/tsconfig.json
+++ b/apps/stage-pocket/tsconfig.json
@@ -25,8 +25,7 @@
       "vue-macros/macros-global",
       "@types/audioworklet",
       "unplugin-info/client",
-      "node",
-      "@webgpu/types"
+      "node"
     ],
     "allowJs": true,
     "strict": true,

--- a/apps/stage-tamagotchi/package.json
+++ b/apps/stage-tamagotchi/package.json
@@ -189,7 +189,6 @@
     "@types/yauzl": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
     "@vue-macros/volar": "catalog:",
-    "@webgpu/types": "catalog:",
     "builder-util-runtime": "catalog:",
     "cac": "catalog:",
     "crossws": "catalog:",

--- a/apps/stage-tamagotchi/tsconfig.json
+++ b/apps/stage-tamagotchi/tsconfig.json
@@ -39,8 +39,7 @@
       "vue-macros/macros-global",
       "electron-vite/node",
       "unplugin-info/client",
-      "@proj-airi/stage-shared/electron-renderer",
-      "@webgpu/types"
+      "@proj-airi/stage-shared/electron-renderer"
     ],
     "allowJs": true,
     "strict": true,

--- a/apps/stage-web/package.json
+++ b/apps/stage-web/package.json
@@ -134,7 +134,6 @@
     "@vitejs/plugin-vue": "catalog:",
     "@vue-macros/volar": "catalog:",
     "@vueuse/motion": "catalog:",
-    "@webgpu/types": "catalog:",
     "csstype": "catalog:",
     "hfup": "catalog:",
     "less": "catalog:",

--- a/apps/stage-web/tsconfig.json
+++ b/apps/stage-web/tsconfig.json
@@ -26,8 +26,7 @@
       "vite-plugin-pwa/client",
       "vue-macros/macros-global",
       "@types/audioworklet",
-      "unplugin-info/client",
-      "@webgpu/types"
+      "unplugin-info/client"
     ],
     "allowJs": true,
     "strict": true,

--- a/apps/ui-server-auth/package.json
+++ b/apps/ui-server-auth/package.json
@@ -71,7 +71,6 @@
     "@vitejs/plugin-vue": "catalog:",
     "@vue-macros/volar": "catalog:",
     "@vueuse/motion": "catalog:",
-    "@webgpu/types": "catalog:",
     "unplugin-info": "catalog:",
     "unplugin-yaml": "catalog:",
     "vite": "catalog:",

--- a/apps/ui-server-auth/tsconfig.json
+++ b/apps/ui-server-auth/tsconfig.json
@@ -23,8 +23,7 @@
       "vite/client",
       "vite-plugin-vue-layouts/client",
       "vue-macros/macros-global",
-      "unplugin-info/client",
-      "@webgpu/types"
+      "unplugin-info/client"
     ],
     "allowJs": true,
     "strict": true,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "capture:tamagotchi": "pnpm exec vishot capture --target electron ./packages/scenarios-stage-tamagotchi-electron/src/scenarios/demo-controls-settings-chat-websocket/index.ts --app-entrypoint ./apps/stage-tamagotchi/out/main/index.js --cwd . --output-dir ./packages/scenarios-stage-tamagotchi-browser/artifacts/raw --format avif",
     "to-avif": "tsx docs/scripts/avif.ts",
     "sponsors:generate": "sponsorkit --output-dir docs/content/public/assets/sponsors",
-    "typecheck": "pnpm -rF=\"./packages/*\" -F=\"./apps/*\" -F=\"./server/**\" -F=\"./docs\" --parallel typecheck",
+    "typecheck": "turbo run typecheck -F=\"./packages/*\" -F=\"./apps/*\" -F=\"./server/**\" -F=\"./docs\"",
     "typecheck:engines": "pnpm -rF=\"./engines/*\" --parallel typecheck",
     "up": "taze -w -r -I && pnpm prune && pnpm dedupe",
     "nolyfill": "pnpm dlx nolyfill",

--- a/packages/stage-layouts/package.json
+++ b/packages/stage-layouts/package.json
@@ -64,7 +64,6 @@
     "@types/audioworklet": "catalog:",
     "@types/three": "catalog:",
     "@vue/test-utils": "catalog:",
-    "@webgpu/types": "catalog:",
     "jsdom": "catalog:",
     "unplugin-info": "catalog:",
     "vitest": "catalog:vitest",

--- a/packages/stage-layouts/tsconfig.json
+++ b/packages/stage-layouts/tsconfig.json
@@ -13,8 +13,7 @@
     "types": [
       "vitest",
       "vite/client",
-      "unplugin-info/client",
-      "@webgpu/types"
+      "unplugin-info/client"
     ],
     "allowJs": true,
     "strict": true,

--- a/packages/stage-pages/package.json
+++ b/packages/stage-pages/package.json
@@ -63,7 +63,6 @@
     "@types/audioworklet": "catalog:",
     "@types/splitpanes": "catalog:",
     "@types/three": "catalog:",
-    "@webgpu/types": "catalog:",
     "unplugin-info": "catalog:",
     "vue-tsc": "catalog:"
   }

--- a/packages/stage-pages/tsconfig.json
+++ b/packages/stage-pages/tsconfig.json
@@ -18,8 +18,7 @@
     "types": [
       "vitest",
       "vite/client",
-      "unplugin-info/client",
-      "@webgpu/types"
+      "unplugin-info/client"
     ],
     "allowJs": true,
     "strict": true,

--- a/packages/stage-ui/package.json
+++ b/packages/stage-ui/package.json
@@ -215,7 +215,6 @@
     "@types/ws": "catalog:",
     "@unocss/reset": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
-    "@webgpu/types": "catalog:",
     "clustr": "catalog:",
     "csstype": "catalog:",
     "histoire": "catalog:",

--- a/packages/stage-ui/tsconfig.json
+++ b/packages/stage-ui/tsconfig.json
@@ -14,8 +14,7 @@
       "vitest",
       "vite/client",
       "unplugin-info/client",
-      "@types/audioworklet",
-      "@webgpu/types"
+      "@types/audioworklet"
     ],
     "allowJs": true,
     "strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,9 +552,6 @@ catalogs:
     '@vueuse/shared':
       specifier: ^14.4.0
       version: 14.4.0
-    '@webgpu/types':
-      specifier: ^0.1.72
-      version: 0.1.72
     '@wxt-dev/module-vue':
       specifier: ^1.0.3
       version: 1.0.3
@@ -1793,9 +1790,6 @@ importers:
       '@vueuse/motion':
         specifier: 'catalog:'
         version: 3.0.3(magicast@0.5.4)(vue@3.5.41(typescript@6.0.3))
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       csstype:
         specifier: 'catalog:'
         version: 3.2.3
@@ -2277,9 +2271,6 @@ importers:
       '@vue-macros/volar':
         specifier: 'catalog:'
         version: 3.1.4(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       builder-util-runtime:
         specifier: 'catalog:'
         version: 9.7.0(supports-color@10.2.2)
@@ -2708,9 +2699,6 @@ importers:
       '@vueuse/motion':
         specifier: 'catalog:'
         version: 3.0.3(magicast@0.5.4)(vue@3.5.41(typescript@6.0.3))
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       csstype:
         specifier: 'catalog:'
         version: 3.2.3
@@ -2913,9 +2901,6 @@ importers:
       '@vueuse/motion':
         specifier: 'catalog:'
         version: 3.0.3(magicast@0.5.4)(vue@3.5.41(typescript@6.0.3))
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       unplugin-info:
         specifier: 'catalog:'
         version: 1.3.2(@nuxt/kit@3.21.11(magicast@0.5.4))(esbuild@0.28.2)(rollup@4.62.5)(supports-color@10.2.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@10.2.2))(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4171,9 +4156,6 @@ importers:
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3))
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1(@noble/hashes@2.3.0)(canvas@3.2.3)
@@ -4307,9 +4289,6 @@ importers:
       '@types/three':
         specifier: 'catalog:'
         version: 0.185.4
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       unplugin-info:
         specifier: 'catalog:'
         version: 1.3.2(@nuxt/kit@3.21.11(magicast@0.5.4))(esbuild@0.28.2)(rollup@4.62.5)(supports-color@10.2.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@10.2.2))(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4786,9 +4765,6 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
         version: 6.0.8(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@10.2.2))(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
-      '@webgpu/types':
-        specifier: 'catalog:'
-        version: 0.1.72
       clustr:
         specifier: 'catalog:'
         version: 1.0.2
@@ -12259,9 +12235,6 @@ packages:
 
   '@webext-core/match-patterns@2.0.0':
     resolution: {integrity: sha512-EsyMMKfQuSE4rWCjP/TifwvUWlhC/OhiGn5OK3p9F0d57UmtLib0nzguzPKyxM1/kZV7SkE+jYXkE8gsdPRLmw==}
-
-  '@webgpu/types@0.1.72':
-    resolution: {integrity: sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw==}
 
   '@wxt-dev/browser@0.2.7':
     resolution: {integrity: sha512-Dr3h3qS25Wah4LjoCSw5uazD+547Q0dLnxaRjkkLauus008daHAulgNKTU4HkojaS9QBdo3xUlwUYPTBCQb+XQ==}
@@ -26640,8 +26613,6 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
 
   '@webext-core/match-patterns@2.0.0': {}
-
-  '@webgpu/types@0.1.72': {}
 
   '@wxt-dev/browser@0.2.7':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -226,7 +226,6 @@ catalog:
   '@vueuse/core': ^14.4.0
   '@vueuse/motion': ^3.0.3
   '@vueuse/shared': ^14.4.0
-  '@webgpu/types': ^0.1.72
   '@wxt-dev/module-vue': ^1.0.3
   '@xsai-apple-speech/transcription': 0.1.3
   '@xsai-apple-speech/transcription-electron-plugin': 0.1.3

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,8 @@
       "outputs": ["dist/**"]
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^typecheck"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/tsconfig.json"]
     },
     "@proj-airi/electron-vueuse#build": {
       "dependsOn": ["@proj-airi/electron-eventa#build"],

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,9 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
     "@proj-airi/electron-vueuse#build": {
       "dependsOn": ["@proj-airi/electron-eventa#build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->
 - Run workspace typechecks through Turbo.
 - Remove unused global type declarations.

### benchmarks

| Result | AS-IS | TO-BE cold | TO-BE warm |
| --- | ---: | ---: | ---: |
| Wall-clock time | 415.11 s | 165.62 s | 0.70 s |
| Peak RSS | 2,260.8 MiB | 2,040.7 MiB | 187.5 MiB |
| TypeScript processes | ≥ 34 | 8 | 0 |
| Cache hits | n/a | 0/52 | 52/52 |

## Linked Issues

<!-- Optional, if you have any -->
close #2493 

but, there is room for further improvement.

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
###  My local Environment
```text
  OS: macOS 26.6.2
  CPU: arm64 Apple M1
  Node: 24.18.1
  npm: 11.16.0
  pnpm: 11.24.0
```

### Verified cases

  - A temporary source change in the shared stage package was used to confirm that only 9 affected tasks missed cache.
  - A temporary compiler setting change was used to confirm the same 9-task invalidation scope.
  - A temporary package metadata change was used to confirm dependency-based invalidation.
  - A temporary change in an unrelated workspace was used to confirm that only 1 task missed cache.
  - An intentional type error was added and then fixed to verify failure propagation and recovery.
  - A dependency metadata-only change was used to verify that valid cache entries remain reusable.
