### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-p3mka3ObeSHWukOEc9quXBQZwNRcQ+8E4m4mRDJAsbM=
+sha256-qTJgjqFLcAO6mkhLYTCAoXbCsgbf3ukQw3nbppLE1r8=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.