### PR TITLE
test(stage-tamagotchi): cover Fade on Hover interaction recovery

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/utils/fade-on-hover.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/utils/fade-on-hover.test.ts
@@ -38,4 +38,25 @@ describe('fade on hover interaction', () => {
     expect(interaction.fadeStage).toBe(false)
     expect(interaction.ignoreMouseEvents).toBe(false)
   })
+
+  // https://github.com/moeru-ai/airi/issues/2160
+  it('restores interaction after disabling Auto Hide from a faded state (Issue #2160)', () => {
+    const fadedInteraction = resolveFadeOnHoverInteraction({
+      cursorInsideWindow: true,
+      enabled: true,
+      transparentForFade: false,
+      transparentForPointer: false,
+    })
+    const restoredInteraction = resolveFadeOnHoverInteraction({
+      cursorInsideWindow: true,
+      enabled: false,
+      transparentForFade: false,
+      transparentForPointer: false,
+    })
+
+    expect(fadedInteraction.fadeStage).toBe(true)
+    expect(fadedInteraction.ignoreMouseEvents).toBe(true)
+    expect(restoredInteraction.fadeStage).toBe(false)
+    expect(restoredInteraction.ignoreMouseEvents).toBe(false)
+  })
 })


### PR DESCRIPTION
## Description

Add focused coverage for the restored visible and interactive state when Fade on Hover is disabled after a faded state. The production click-through fix is already implemented in #2210; this change documents the resolver state without adding runtime behavior.

## Linked Issues

Closes #2160

## Additional Context

The test is intentionally scoped to the existing pure interaction resolver and does not exercise the renderer watcher or Electron IPC boundary.