### PR TITLE
feat: custom Fish/OpenRouter TTS voices and OpenAI-compatible images

### DIFF
--- a/.github/workflows/build-windows-custom.yml
+++ b/.github/workflows/build-windows-custom.yml
@@ -1,0 +1,59 @@
+name: Build Windows (custom)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - custom-providers
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/setup@v2
+        with:
+          runtime: node@26.7.0
+          cache: true
+          install: false
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build:packages
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Godot
+        uses: chickensoft-games/setup-godot@v2
+        with:
+          version: '4.7.1'
+          use-dotnet: true
+          include-templates: true
+
+      - name: Export Godot Stage (Windows)
+        working-directory: ./engines/stage-tamagotchi-godot
+        shell: bash
+        run: |
+          mkdir -p out/win
+          godot --headless --export-release "Windows Desktop" out/win/godot-stage.exe
+
+      - name: Build Windows installer
+        run: pnpm run -F @proj-airi/stage-tamagotchi build && pnpm -F @proj-airi/stage-tamagotchi exec electron-builder build --windows --x64 --publish=never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: AIRI-windows-x64
+          path: |
+            apps/stage-tamagotchi/dist/*.exe
+            apps/stage-tamagotchi/bundle/*.exe
+          if-no-files-found: warn

--- a/apps/stage-tamagotchi/src/main/configs/artistry.ts
+++ b/apps/stage-tamagotchi/src/main/configs/artistry.ts
@@ -15,6 +15,9 @@ export const artistryConfigSchema = object({
     nanobananaApiKey: optional(string(), ''),
     nanobananaModel: optional(string(), 'gemini-3.1-flash-image-preview'),
     nanobananaResolution: optional(string(), '1K'),
+    openaiCompatibleImagesApiKey: optional(string(), ''),
+    openaiCompatibleImagesBaseUrl: optional(string(), 'https://openrouter.ai/api/v1/'),
+    openaiCompatibleImagesModel: optional(string(), 'google/gemini-2.5-flash-image'),
   }), {}),
 })
 

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/artistry-bridge.ts
@@ -17,6 +17,7 @@ import { injeca } from 'injeca'
 
 import { ComfyUIProvider } from './providers/comfyui'
 import { NanoBananaProvider } from './providers/nanobanana'
+import { OpenAICompatibleImagesProvider } from './providers/openai-compatible-images'
 import { ReplicateProvider } from './providers/replicate'
 
 const log = useLogg('artistry-bridge').useGlobalConfig()
@@ -103,6 +104,7 @@ export const artistryProviders = new Map<string, ArtistryProvider>()
 artistryProviders.set('comfyui', new ComfyUIProvider())
 artistryProviders.set('replicate', new ReplicateProvider())
 artistryProviders.set('nanobanana', new NanoBananaProvider())
+artistryProviders.set('openai-compatible-images', new OpenAICompatibleImagesProvider())
 
 // Deduplication map for headless requests
 const pendingHeadlessRequests = new Map<string, Promise<{ imageUrl?: string, base64?: string, error?: string }>>()
@@ -477,6 +479,9 @@ export async function setupArtistryBridge(params: {
           nanobananaApiKey: '',
           nanobananaModel: 'gemini-3.1-flash-image-preview',
           nanobananaResolution: '1K',
+          openaiCompatibleImagesApiKey: '',
+          openaiCompatibleImagesBaseUrl: 'https://openrouter.ai/api/v1/',
+          openaiCompatibleImagesModel: 'google/gemini-2.5-flash-image',
         },
       })
 

--- a/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/openai-compatible-images.ts
+++ b/apps/stage-tamagotchi/src/main/services/airi/widgets/providers/openai-compatible-images.ts
@@ -1,0 +1,115 @@
+import type { ArtistryJob, ArtistryJobStatus, ArtistryProvider, ArtistryRequest } from './base'
+
+import { useLogg } from '@guiiai/logg'
+
+const log = useLogg('providers-openai-compatible-images').useGlobalConfig()
+
+function normalizeBaseUrl(baseUrl: string) {
+  const value = baseUrl.trim()
+  if (!value)
+    return ''
+  return value.endsWith('/') ? value : `${value}/`
+}
+
+export class OpenAICompatibleImagesProvider implements ArtistryProvider {
+  readonly id = 'openai-compatible-images'
+  readonly name = 'OpenAI Compatible Images'
+  private apiKey = ''
+  private baseUrl = 'https://openrouter.ai/api/v1/'
+  private defaultModel = 'google/gemini-2.5-flash-image'
+
+  private jobResults = new Map<string, ArtistryJobStatus>()
+  private callbacks = new Map<string, (status: ArtistryJobStatus) => void>()
+
+  setJobCallback(jobId: string, callback: (status: ArtistryJobStatus) => void) {
+    this.callbacks.set(jobId, callback)
+    const result = this.jobResults.get(jobId)
+    if (result)
+      callback(result)
+  }
+
+  private updateStatus(jobId: string, status: ArtistryJobStatus) {
+    this.jobResults.set(jobId, status)
+    const callback = this.callbacks.get(jobId)
+    if (callback)
+      callback(status)
+  }
+
+  async initialize(config: Record<string, any>) {
+    this.apiKey = config.openaiCompatibleImagesApiKey || config.apiKey || ''
+    this.baseUrl = normalizeBaseUrl(config.openaiCompatibleImagesBaseUrl || this.baseUrl)
+    if (config.openaiCompatibleImagesModel)
+      this.defaultModel = config.openaiCompatibleImagesModel
+    log.log(`[OpenAI Compatible Images] Initialized. API Key present: ${!!this.apiKey}`)
+  }
+
+  async generate(request: ArtistryRequest): Promise<ArtistryJob> {
+    if (!this.apiKey)
+      throw new Error('OpenAI Compatible Images API key not configured')
+    if (!this.baseUrl)
+      throw new Error('OpenAI Compatible Images base URL not configured')
+
+    const jobId = request.extra?.internalJobId || `openai-compatible-images-${Date.now()}`
+    const model = request.model || this.defaultModel
+    this.runGeneration(jobId, model, request.prompt)
+    return { jobId, providerJobId: jobId }
+  }
+
+  private async runGeneration(jobId: string, model: string, prompt: string) {
+    this.updateStatus(jobId, { status: 'running', actionLabel: 'Generating image...' })
+
+    try {
+      const response = await fetch(new URL('images/generations', this.baseUrl), {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          prompt,
+          n: 1,
+          size: '1024x1024',
+          response_format: 'b64_json',
+        }),
+      })
+      const json = await response.json() as {
+        error?: { message?: string } | string
+        data?: Array<{ b64_json?: string, url?: string }>
+      }
+      if (!response.ok || json.error) {
+        const message = typeof json.error === 'string' ? json.error : json.error?.message || `HTTP ${response.status}`
+        throw new Error(message)
+      }
+
+      const image = json.data?.[0]
+      if (image?.b64_json) {
+        this.updateStatus(jobId, {
+          status: 'succeeded',
+          progress: 100,
+          imageUrl: `data:image/png;base64,${image.b64_json}`,
+        })
+        return
+      }
+      if (image?.url) {
+        this.updateStatus(jobId, { status: 'succeeded', progress: 100, imageUrl: image.url })
+        return
+      }
+      throw new Error('No image data returned from the images API')
+    }
+    catch (error: any) {
+      log.error(`[OpenAI Compatible Images] Generation failed: ${error.message}`)
+      this.updateStatus(jobId, { status: 'failed', error: error.message })
+    }
+    finally {
+      setTimeout(() => {
+        this.callbacks.delete(jobId)
+        this.jobResults.delete(jobId)
+      }, 10000)
+    }
+  }
+
+  async getStatus(jobId: string): Promise<ArtistryJobStatus> {
+    return this.jobResults.get(jobId) || { status: 'queued' }
+  }
+}

--- a/packages/provider-inference/src/providers/cloud/openai-audio/index.ts
+++ b/packages/provider-inference/src/providers/cloud/openai-audio/index.ts
@@ -5,6 +5,7 @@ import { listModels } from '@xsai/model'
 import { z } from 'zod'
 
 import { defineProvider } from '../../registry'
+import { fetchSpeechAudio } from '../speech-fetch'
 
 const OPENAI_BASE_URL = 'https://api.openai.com/v1/'
 
@@ -43,8 +44,20 @@ function normalizeBaseUrl(baseUrl: string | undefined) {
   return value && !value.endsWith('/') ? `${value}/` : value
 }
 
-function createAudioProvider(config: AudioConfig) {
-  return createOpenAI(config.apiKey.trim(), normalizeBaseUrl(config.baseUrl))
+export function createAudioProvider(config: AudioConfig) {
+  const apiKey = config.apiKey.trim()
+  const baseUrl = normalizeBaseUrl(config.baseUrl)
+  const provider = createOpenAI(apiKey, baseUrl)
+  const originalSpeech = provider.speech.bind(provider)
+  provider.speech = (model: string, extraOptions?: Record<string, unknown>) => ({
+    ...originalSpeech(model),
+    ...extraOptions,
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => fetchSpeechAudio(input, init, {
+      apiKey,
+      openRouter: baseUrl.includes('openrouter.ai'),
+    }),
+  })
+  return provider
 }
 
 function createTranscriptionProvider(config: AudioConfig) {
@@ -213,10 +226,9 @@ export const providerOpenAICompatibleAudioSpeech = defineProvider<OpenAICompatib
       if (!apiKey || !baseUrl)
         return []
 
-      const models = await listModels({ apiKey, baseURL: baseUrl })
-      return models
-        .filter(model => model.id.toLowerCase().includes('tts'))
-        .map(model => ({
+      try {
+        const models = await listModels({ apiKey, baseURL: baseUrl })
+        return models.map(model => ({
           id: model.id,
           name: model.id,
           provider: 'openai-compatible-audio-speech',
@@ -224,6 +236,10 @@ export const providerOpenAICompatibleAudioSpeech = defineProvider<OpenAICompatib
           contextLength: 0,
           deprecated: false,
         }))
+      }
+      catch {
+        return []
+      }
     },
   },
 })
@@ -263,6 +279,5 @@ export const providerOpenAICompatibleAudioTranscription = defineProvider<OpenAIC
   createProvider: createTranscriptionProvider,
   validationRequiredWhen: config => Boolean(config.apiKey?.trim() && config.baseUrl?.trim()),
   validators: createAudioValidators<OpenAICompatibleAudioConfig>(),
-  // Transcription model names are not reliably available from /v1/models.
   extraMethods: { listModels: async () => [] },
 })

--- a/packages/provider-inference/src/providers/cloud/openrouter-audio-speech/index.ts
+++ b/packages/provider-inference/src/providers/cloud/openrouter-audio-speech/index.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import { defineProvider } from '../../registry'
 import { OPENROUTER_ATTRIBUTION_HEADERS } from '../openrouter-ai'
+import { createAudioProvider } from '../openai-audio'
+import { isChatAudioModel } from '../speech-fetch'
 
 const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1/'
 const DEFAULT_MODEL = 'openai/gpt-audio-mini'
@@ -89,7 +91,7 @@ function decodeBase64Pcm(chunks: string[]) {
   return bytes
 }
 
-function createAudioFetch(apiKey: string, baseUrl: string, model: string) {
+function createChatAudioFetch(apiKey: string, baseUrl: string, model: string) {
   return async (_input: RequestInfo | URL, init?: RequestInit) => {
     if (!init?.body || typeof init.body !== 'string')
       throw new Error('Invalid request body')
@@ -135,14 +137,19 @@ export const providerOpenRouterAudioSpeech = defineProvider<OpenRouterAudioConfi
   createProvider(config) {
     const apiKey = config.apiKey.trim()
     const baseUrl = normalizeBaseUrl(config.baseUrl)
+    const speechProvider = createAudioProvider({ apiKey, baseUrl })
     return {
       speech: (model?: string) => {
         const resolvedModel = model || DEFAULT_MODEL
-        return {
-          baseURL: baseUrl,
-          model: resolvedModel,
-          fetch: createAudioFetch(apiKey, baseUrl, resolvedModel),
+        if (isChatAudioModel(resolvedModel)) {
+          return {
+            baseURL: baseUrl,
+            model: resolvedModel,
+            fetch: createChatAudioFetch(apiKey, baseUrl, resolvedModel),
+          }
         }
+
+        return speechProvider.speech(resolvedModel)
       },
     }
   },
@@ -176,7 +183,7 @@ export const providerOpenRouterAudioSpeech = defineProvider<OpenRouterAudioConfi
         const data = await response.json() as {
           data?: Array<{ id: string, name?: string, description?: string, context_length?: number }>
         }
-        return (data.data ?? []).map(model => ({
+        const models = (data.data ?? []).map(model => ({
           id: model.id,
           name: model.name || model.id,
           provider: 'openrouter-audio-speech',
@@ -184,6 +191,25 @@ export const providerOpenRouterAudioSpeech = defineProvider<OpenRouterAudioConfi
           contextLength: model.context_length || 0,
           deprecated: false,
         }))
+
+        const extras = [
+          'fish-audio/s2-pro',
+          'fish-audio/s2.1-pro',
+          'fish-audio/s2.1-pro-free',
+        ]
+        for (const id of extras) {
+          if (!models.some(model => model.id === id)) {
+            models.push({
+              id,
+              name: id,
+              provider: 'openrouter-audio-speech',
+              description: 'Fish Audio TTS (OpenRouter /audio/speech)',
+              contextLength: 0,
+              deprecated: false,
+            })
+          }
+        }
+        return models
       }
       catch (error) {
         console.error('Failed to fetch OpenRouter audio models:', error)

--- a/packages/provider-inference/src/providers/cloud/speech-fetch.test.ts
+++ b/packages/provider-inference/src/providers/cloud/speech-fetch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { enrichSpeechRequestBody, isChatAudioModel } from './speech-fetch'
+
+describe('speech-fetch', () => {
+  it('treats gpt-audio as chat-audio and fish as dedicated speech', () => {
+    expect(isChatAudioModel('openai/gpt-audio-mini')).toBe(true)
+    expect(isChatAudioModel('google/lyria-3-pro-preview')).toBe(true)
+    expect(isChatAudioModel('fish-audio/s2-pro')).toBe(false)
+  })
+
+  it('adds Fish reference_id from the voice code', () => {
+    const body = enrichSpeechRequestBody(JSON.stringify({
+      model: 'fish-audio/s2-pro',
+      input: 'hello',
+      voice: 'df3144db39a34a02bdeeb2d3ad172211',
+    }))
+    expect(JSON.parse(body)).toMatchObject({
+      model: 'fish-audio/s2-pro',
+      voice: 'df3144db39a34a02bdeeb2d3ad172211',
+      response_format: 'mp3',
+      extra_body: { reference_id: 'df3144db39a34a02bdeeb2d3ad172211' },
+    })
+  })
+})

--- a/packages/provider-inference/src/providers/cloud/speech-fetch.ts
+++ b/packages/provider-inference/src/providers/cloud/speech-fetch.ts
@@ -1,0 +1,73 @@
+import { OPENROUTER_ATTRIBUTION_HEADERS } from './openrouter-ai'
+
+export function isChatAudioModel(model: string | undefined) {
+  const id = (model || '').toLowerCase()
+  return id.includes('gpt-audio') || id.includes('lyria') || id.includes('lyra')
+}
+
+export function enrichSpeechRequestBody(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>
+    const model = String(parsed.model || '')
+    const voice = String(parsed.voice || '')
+    if (voice && /fish-audio/i.test(model)) {
+      const extraBody = (parsed.extra_body && typeof parsed.extra_body === 'object')
+        ? parsed.extra_body as Record<string, unknown>
+        : {}
+      parsed.extra_body = { ...extraBody, reference_id: voice }
+    }
+    if (!parsed.response_format)
+      parsed.response_format = 'mp3'
+    return JSON.stringify(parsed)
+  }
+  catch {
+    return body
+  }
+}
+
+export async function fetchSpeechAudio(input: RequestInfo | URL, init: RequestInit | undefined, options?: {
+  apiKey?: string
+  openRouter?: boolean
+}): Promise<Response> {
+  const headers = new Headers(init?.headers)
+  if (options?.apiKey)
+    headers.set('Authorization', `Bearer ${options.apiKey}`)
+  if (options?.openRouter) {
+    for (const [key, value] of Object.entries(OPENROUTER_ATTRIBUTION_HEADERS))
+      headers.set(key, value)
+  }
+
+  const nextInit: RequestInit = { ...init, headers }
+  if (typeof nextInit.body === 'string')
+    nextInit.body = enrichSpeechRequestBody(nextInit.body)
+
+  const response = await fetch(input, nextInit)
+  const contentType = response.headers.get('content-type') || ''
+  const buffer = await response.arrayBuffer()
+  const looksLikeJson = contentType.includes('json') || contentType.includes('text')
+  if (!response.ok || looksLikeJson) {
+    const text = new TextDecoder().decode(buffer)
+    let detail = text.slice(0, 800) || response.statusText
+    try {
+      const json = JSON.parse(text) as { error?: { message?: string } | string, message?: string }
+      if (typeof json.error === 'string')
+        detail = json.error
+      else if (json.error?.message)
+        detail = json.error.message
+      else if (json.message)
+        detail = json.message
+    }
+    catch {
+      // keep raw body
+    }
+    throw new Error(`TTS request failed (${response.status}): ${detail}`)
+  }
+
+  if (buffer.byteLength < 64)
+    throw new Error('TTS returned empty audio. Check the model id and voice code.')
+
+  return new Response(buffer, {
+    status: 200,
+    headers: { 'Content-Type': contentType || 'audio/mpeg' },
+  })
+}

--- a/packages/stage-pages/src/pages/settings/airi-card/components/CardCreationDialog.vue
+++ b/packages/stage-pages/src/pages/settings/airi-card/components/CardCreationDialog.vue
@@ -230,6 +230,7 @@ const artistryProviderOptions = computed(() => {
       : [
           { value: 'replicate', label: 'Replicate' },
           { value: 'nanobanana', label: 'Nano Banana' },
+          { value: 'openai-compatible-images', label: 'OpenAI Compatible' },
         ]),
   ], selectedArtistryProvider.value)
 })

--- a/packages/stage-pages/src/pages/settings/modules/artistry.vue
+++ b/packages/stage-pages/src/pages/settings/modules/artistry.vue
@@ -44,6 +44,13 @@ const availableProviders = computed(() => [
           icon: 'i-solar:gallery-round-bold-duotone',
           configRoute: '/settings/providers/artistry/nanobanana',
         },
+        {
+          id: 'openai-compatible-images',
+          name: 'OpenAI Compatible',
+          description: 'Endpoint + API key + model for /v1/images/generations',
+          icon: 'i-lobe-icons:openai',
+          configRoute: '/settings/providers/artistry/openai-compatible-images',
+        },
       ]),
 ])
 </script>

--- a/packages/stage-pages/src/pages/settings/modules/speech.vue
+++ b/packages/stage-pages/src/pages/settings/modules/speech.vue
@@ -406,7 +406,7 @@ async function generateTestSpeech() {
 
   const provider = await providersStore.getProviderInstance(activeSpeechProvider.value) as SpeechProviderWithExtraOptions<string, any>
   if (!provider) {
-    console.error('Failed to initialize speech provider')
+    errorMessage.value = 'Failed to initialize speech provider'
     return
   }
 
@@ -416,7 +416,8 @@ async function generateTestSpeech() {
   let model = activeSpeechModel.value
   let voice = activeSpeechVoice.value
 
-  if (activeSpeechProvider.value === 'openai-compatible-audio-speech') {
+  if (activeSpeechProvider.value === 'openai-compatible-audio-speech'
+    || activeSpeechProvider.value === 'openrouter-audio-speech') {
     if (!model && providerConfig?.model) {
       model = providerConfig.model as string
     }
@@ -434,12 +435,12 @@ async function generateTestSpeech() {
   }
 
   if (!model) {
-    console.error('No model selected')
+    errorMessage.value = 'No TTS model selected. Enter a model id such as fish-audio/s2-pro.'
     return
   }
 
   if (!voice) {
-    console.error('No voice selected')
+    errorMessage.value = 'No voice id. Paste a Fish Audio voice code or an OpenAI voice name.'
     return
   }
 
@@ -684,7 +685,7 @@ async function handleDeleteProvider(providerId: string) {
           </div>
 
           <!-- Manual input for OpenAI Compatible -->
-          <div v-if="activeSpeechProvider === 'openai-compatible-audio-speech'">
+          <div v-if="activeSpeechProvider === 'openai-compatible-audio-speech' || activeSpeechProvider === 'openrouter-audio-speech'">
             <FieldInput
               :model-value="activeSpeechModel || ''"
               label="Model"

--- a/packages/stage-pages/src/pages/settings/providers/artistry/openai-compatible-images.vue
+++ b/packages/stage-pages/src/pages/settings/providers/artistry/openai-compatible-images.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { useArtistryStore } from '@proj-airi/stage-ui/stores/modules/artistry'
+import { FieldInput } from '@proj-airi/ui'
+import { storeToRefs } from 'pinia'
+
+const artistryStore = useArtistryStore()
+const {
+  openaiCompatibleImagesApiKey,
+  openaiCompatibleImagesBaseUrl,
+  openaiCompatibleImagesModel,
+} = storeToRefs(artistryStore)
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <div>
+      <h2 class="text-lg text-neutral-500 md:text-2xl dark:text-neutral-400">
+        OpenAI Compatible Images
+      </h2>
+      <div class="text-neutral-400 dark:text-neutral-500">
+        Use any OpenAI-compatible /v1/images/generations endpoint. Paste base URL, API key, and model id.
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-4">
+      <FieldInput
+        v-model="openaiCompatibleImagesApiKey"
+        label="API Key"
+        description="Provider API key"
+        placeholder="sk-..."
+        type="password"
+      />
+      <FieldInput
+        v-model="openaiCompatibleImagesBaseUrl"
+        label="Base URL"
+        description="Must end with /v1/"
+        placeholder="https://openrouter.ai/api/v1/"
+      />
+      <FieldInput
+        v-model="openaiCompatibleImagesModel"
+        label="Model"
+        description="Image model id"
+        placeholder="google/gemini-2.5-flash-image"
+      />
+    </div>
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: settings
+  titleKey: settings.pages.modules.artistry.title
+  subtitleKey: settings.title
+  stageTransition:
+    name: slide
+</route>

--- a/packages/stage-pages/src/pages/settings/providers/index.vue
+++ b/packages/stage-pages/src/pages/settings/providers/index.vue
@@ -104,6 +104,21 @@ const allArtistryProvidersMetadata = computed<ProviderSourceCard[]>((): Provider
             deployment: 'cloud',
             iconImage: undefined,
           },
+          {
+            id: 'openai-compatible-images',
+            category: 'artistry',
+            icon: 'i-lobe-icons:openai',
+            iconColor: 'i-lobe-icons:openai-color',
+            name: 'OpenAI Compatible',
+            localizedName: 'OpenAI Compatible',
+            description: 'Any OpenAI-compatible images endpoint (URL + API key + model).',
+            localizedDescription: 'Any OpenAI-compatible images endpoint (URL + API key + model).',
+            configured: !!artistryStore.openaiCompatibleImagesApiKey,
+            to: '/settings/providers/artistry/openai-compatible-images',
+            pricing: 'paid',
+            deployment: 'cloud',
+            iconImage: undefined,
+          },
         ] satisfies ProviderSourceCard[])),
   ]
 })

--- a/packages/stage-pages/src/pages/settings/providers/speech/openrouter-audio-speech.vue
+++ b/packages/stage-pages/src/pages/settings/providers/speech/openrouter-audio-speech.vue
@@ -2,13 +2,13 @@
 import type { SpeechProvider } from '@xsai-ext/providers/utils'
 
 import {
-  SpeechPlayground,
+  SpeechPlaygroundOpenAICompatible,
   SpeechProviderSettings,
 } from '@proj-airi/stage-ui/components'
 import { useSpeechStore } from '@proj-airi/stage-ui/stores/modules/speech'
 import { useProviderConfigStore } from '@proj-airi/stage-ui/stores/providers/config'
 import { useProviderStore } from '@proj-airi/stage-ui/stores/providers/provider'
-import { FieldCombobox } from '@proj-airi/ui'
+import { FieldCombobox, FieldInput } from '@proj-airi/ui'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted } from 'vue'
 
@@ -19,6 +19,7 @@ const { configs: providers } = storeToRefs(providerStore)
 
 const providerId = 'openrouter-audio-speech'
 const defaultModel = 'openai/gpt-audio-mini'
+const defaultVoice = 'alloy'
 
 const model = computed({
   get: () => providers.value[providerId]?.model as string | undefined || defaultModel,
@@ -29,33 +30,41 @@ const model = computed({
   },
 })
 
+const voice = computed({
+  get: () => (providers.value[providerId]?.voice as string | undefined) || defaultVoice,
+  set: (value) => {
+    if (!providers.value[providerId])
+      providers.value[providerId] = {}
+    providers.value[providerId].voice = value
+  },
+})
+
 const providerModels = computed(() => providersStore.getModelsForProvider(providerId))
 const isLoadingModels = computed(() => providersStore.isLoadingModels[providerId] || false)
 const apiKeyConfigured = computed(() => !!providers.value[providerId]?.apiKey)
 
-const availableVoices = computed(() => {
-  return speechStore.availableVoices[providerId] || []
-})
-
 onMounted(async () => {
+  providers.value[providerId] ??= {}
+  providers.value[providerId].model ??= defaultModel
+  providers.value[providerId].voice ??= defaultVoice
   await providersStore.loadModelsForConfiguredProviders()
   await providersStore.fetchModelsForProvider(providerId)
   await speechStore.loadVoicesForProvider(providerId)
 })
 
-async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean) {
+async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: boolean, modelId?: string) {
   const provider = await providersStore.getProviderInstance<SpeechProvider<string>>(providerId)
   if (!provider)
     throw new Error('Failed to initialize speech provider')
 
   const providerConfig = providerStore.getProviderConfig(providerId)
-  const modelToUse = model.value || defaultModel
+  const modelToUse = modelId || model.value || defaultModel
 
   return await speechStore.speech(
     provider,
     modelToUse,
     input,
-    voiceId,
+    voiceId || voice.value || defaultVoice,
     providerConfig,
   )
 }
@@ -64,19 +73,26 @@ async function handleGenerateSpeech(input: string, voiceId: string, _useSSML: bo
 <template>
   <SpeechProviderSettings :provider-id="providerId" :default-model="defaultModel">
     <template #voice-settings>
-      <FieldCombobox
+      <FieldInput
         v-model="model"
         label="Model"
-        description="Select the audio-capable model to use for speech generation"
+        description="Any OpenRouter TTS model id, including Fish Audio (fish-audio/s2-pro)."
+        placeholder="fish-audio/s2-pro"
+      />
+      <FieldCombobox
+        v-model="model"
+        label="Catalog"
+        description="Optional catalog of audio-capable models. You can still type a custom id above."
         :options="providerModels.map(m => ({ value: m.id, label: m.name }))"
         :disabled="isLoadingModels || providerModels.length === 0"
-        placeholder="Select a model..."
+        placeholder="Select a catalog model..."
       />
     </template>
 
     <template #playground>
-      <SpeechPlayground
-        :available-voices="availableVoices"
+      <SpeechPlaygroundOpenAICompatible
+        v-model:model-value="model"
+        v-model:voice="voice"
         :generate-speech="handleGenerateSpeech"
         :api-key-configured="apiKeyConfigured"
         default-text="Hello! This is a test of OpenRouter Speech."

--- a/packages/stage-ui/src/stores/modules/artistry.ts
+++ b/packages/stage-ui/src/stores/modules/artistry.ts
@@ -84,6 +84,17 @@ export const useArtistryStore = defineStore('artistry', () => {
     '1K',
     persistenceOptions,
   )
+  const openaiCompatibleImagesApiKey = useLocalStorageManualReset<string>('artistry-openai-compatible-images-api-key', '', persistenceOptions)
+  const openaiCompatibleImagesBaseUrl = useLocalStorageManualReset<string>(
+    'artistry-openai-compatible-images-base-url',
+    'https://openrouter.ai/api/v1/',
+    persistenceOptions,
+  )
+  const openaiCompatibleImagesModel = useLocalStorageManualReset<string>(
+    'artistry-openai-compatible-images-model',
+    'google/gemini-2.5-flash-image',
+    persistenceOptions,
+  )
 
   /**
    * Resets active settings to match current global user preferences.
@@ -116,6 +127,9 @@ export const useArtistryStore = defineStore('artistry', () => {
     nanobananaApiKey.reset()
     nanobananaModel.reset()
     nanobananaResolution.reset()
+    openaiCompatibleImagesApiKey.reset()
+    openaiCompatibleImagesBaseUrl.reset()
+    openaiCompatibleImagesModel.reset()
 
     // Sync active state
     resetToGlobal()
@@ -148,6 +162,10 @@ export const useArtistryStore = defineStore('artistry', () => {
       return !!nanobananaApiKey.value
     }
 
+    if (activeProvider.value === 'openai-compatible-images') {
+      return !!openaiCompatibleImagesApiKey.value && !!openaiCompatibleImagesBaseUrl.value
+    }
+
     return true
   })
 
@@ -162,6 +180,9 @@ export const useArtistryStore = defineStore('artistry', () => {
     nanobananaApiKey: nanobananaApiKey.value,
     nanobananaModel: nanobananaModel.value,
     nanobananaResolution: nanobananaResolution.value,
+    openaiCompatibleImagesApiKey: openaiCompatibleImagesApiKey.value,
+    openaiCompatibleImagesBaseUrl: openaiCompatibleImagesBaseUrl.value,
+    openaiCompatibleImagesModel: openaiCompatibleImagesModel.value,
   }))
 
   return {
@@ -194,6 +215,9 @@ export const useArtistryStore = defineStore('artistry', () => {
     nanobananaApiKey,
     nanobananaModel,
     nanobananaResolution,
+    openaiCompatibleImagesApiKey,
+    openaiCompatibleImagesBaseUrl,
+    openaiCompatibleImagesModel,
 
     resetToGlobal,
     resetState,


### PR DESCRIPTION
OpenAI Compatible and OpenRouter speech now call /audio/speech for dedicated TTS models, keep chat-audio for GPT Audio/Lyria, accept opaque Fish voice codes, and surface API errors instead of silent empty playback. Artistry gains an OpenAI Compatible images provider with base URL, key, and model.

## Description

<!-- Please insert your description here and especially provide info about the "what" this PR is solving -->

## Linked Issues

<!-- Optional, if you have any -->

## Additional Context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
