### PR TITLE
fix(stage-ui): center mobile user message text

### DIFF
--- a/packages/stage-ui/src/components/scenarios/chat/components/user-item.vue
+++ b/packages/stage-ui/src/components/scenarios/chat/components/user-item.vue
@@ -53,7 +53,7 @@ const containerClasses = computed(() => [
 
 const boxClasses = computed(() => [
   props.variant === 'mobile'
-    ? ['px-2 pt-2 pb-1 text-sm', 'bg-neutral-100/60 backdrop-blur-xl dark:bg-neutral-800/60']
+    ? ['px-2 py-1.5 text-sm', 'bg-neutral-100/60 backdrop-blur-xl dark:bg-neutral-800/60']
     : ['px-3 pt-3 pb-2', 'bg-neutral-100/80 dark:bg-neutral-800/80'],
 ])
 const copyText = computed(() => getChatHistoryItemCopyText(props.message as ChatHistoryItem))


### PR DESCRIPTION
## Summary

- Use equal 6px vertical padding for mobile user message bubbles.
- Keep the existing 32px height for a single-line bubble.

## Visual changes

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/270865b6-dc64-4f08-b8d0-56e7c1d8b073) | ![](https://github.com/user-attachments/assets/56bcafb4-e047-4cb1-98a2-36034b49c422) |
| Stage UI / Mobile chat history | Stage UI / Mobile chat history |

## Verification

- `pnpm -F @proj-airi/stage-ui exec vitest run --project browser src/components/scenarios/chat/components/history.browser.test.ts`
- `pnpm typecheck`
- `pnpm lint`
