### PR TITLE
fix(server): trust moeru-ai Cloudflare Workers preview origins

### DIFF
--- a/server/apps/api/src/utils/origin.ts
+++ b/server/apps/api/src/utils/origin.ts
@@ -27,7 +27,7 @@ const TRUSTED_ORIGIN_PATTERNS = [
   /^https:\/\/localhost(:\d+)?$/,
   /^https:\/\/127\.0\.0\.1(:\d+)?$/,
   // Cloudflare Workers subdomains
-  /^https:\/\/.*\.kwaa\.workers\.dev$/,
+  /^https:\/\/.*\.moeru-ai\.workers\.dev$/,
 ]
 
 /**

--- a/server/apps/auth/src/origin.ts
+++ b/server/apps/auth/src/origin.ts
@@ -38,7 +38,7 @@ const TRUSTED_ORIGIN_PATTERNS = [
   /^https:\/\/localhost(:\d+)?$/,
   /^https:\/\/127\.0\.0\.1(:\d+)?$/,
   // Cloudflare Workers subdomains
-  /^https:\/\/.*\.kwaa\.workers\.dev$/,
+  /^https:\/\/.*\.moeru-ai\.workers\.dev$/,
 ]
 
 /**

--- a/server/apps/auth/src/tests/auth.test.ts
+++ b/server/apps/auth/src/tests/auth.test.ts
@@ -401,14 +401,14 @@ describe('ensureDynamicFirstPartyRedirectUri', () => {
 
     await ensureDynamicFirstPartyRedirectUri(
       db as any,
-      new Request('https://api.airi.build/api/auth/oauth2/authorize?client_id=airi-stage-web&redirect_uri=https%3A%2F%2Fpreview.kwaa.workers.dev%2Fauth%2Fcallback'),
+      new Request('https://api.airi.build/api/auth/oauth2/authorize?client_id=airi-stage-web&redirect_uri=https%3A%2F%2Fpreview.moeru-ai.workers.dev%2Fauth%2Fcallback'),
       [],
     )
 
     expect(setCalls).toHaveLength(1)
     expect(setCalls[0].redirectUris).toEqual([
       'https://airi.moeru.ai/auth/callback',
-      'https://preview.kwaa.workers.dev/auth/callback',
+      'https://preview.moeru-ai.workers.dev/auth/callback',
     ])
     expect(updateWhere).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary

- Auth and API origin policy now trusts `*.moeru-ai.workers.dev`.
- The retired `*.kwaa.workers.dev` suffix is removed. Server-dev stage-web previews on the moeru-ai Cloudflare account can complete OIDC login.

## Test plan

- [x] `pnpm exec vitest run server/apps/auth/src/tests/auth.test.ts server/apps/auth/src/tests/origin.test.ts server/apps/api/src/utils/tests/origin.test.ts`
- [x] After deploy, sign in from https://server-dev-moeru-ai-airi.moeru-ai.workers.dev and confirm `/auth/callback` is accepted.

## Visual changes

No user-visible changes.


Made with [Cursor](https://cursor.com)