### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/nix/pnpm-deps-hash.txt
+++ b/nix/pnpm-deps-hash.txt
@@ -1,1 +1,1 @@
-sha256-qTJgjqFLcAO6mkhLYTCAoXbCsgbf3ukQw3nbppLE1r8=
+sha256-Jxumvgr+4l6mVHVkg/F5b4Jui4lkg3OzgN0Gf9vLogI=


### PR DESCRIPTION
Auto-generated by CI to keep Nix pnpmDeps hash up-to-date.