### PR TITLE
fix(stage-layouts): center the mobile chat input

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.browser.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.browser.test.ts
@@ -182,6 +182,26 @@ describe('interactive area synchronized state', () => {
     await page.viewport(1280, 720)
   })
 
+  it('centers the mobile textarea when no reply preview is visible', async () => {
+    // ROOT CAUSE:
+    // The 40px bubble has spare height around its 32px textarea and borders.
+    // Bottom alignment put all spare height above the textarea. Center alignment
+    // divides that space equally without reserving space for a hidden reply.
+    await page.viewport(390, 844)
+    const { screen } = await renderArea(MobileInteractiveArea)
+    const bubble = screen.getByTestId('mobile-input-bubble').element()
+    const input = screen.getByRole('textbox')
+
+    for (const draft of ['', 'Hello', 'First line\nSecond line', '']) {
+      await input.fill(draft)
+      await expect.poll(() => {
+        const outer = bubble.getBoundingClientRect()
+        const inner = input.element().getBoundingClientRect()
+        return Math.abs((inner.top - outer.top) - (outer.bottom - inner.bottom))
+      }).toBeLessThanOrEqual(1)
+    }
+  })
+
   it('opens mobile settings from an icon-only header and restores focus', async () => {
     await page.viewport(390, 844)
     const { screen } = await renderArea(MobileInteractiveArea)
@@ -440,9 +460,9 @@ describe('interactive area synchronized state', () => {
     await expect.poll(() => input.getBoundingClientRect().height).toBe(32)
     expect(send.getBoundingClientRect().height).toBe(32)
     expect(bubble.getBoundingClientRect().bottom).toBe(send.getBoundingClientRect().bottom)
-    expect(input.getBoundingClientRect().bottom).toBe(
-      bubble.getBoundingClientRect().bottom - Number.parseFloat(getComputedStyle(bubble).borderBottomWidth),
-    )
+    const bubbleBounds = bubble.getBoundingClientRect()
+    const inputBounds = input.getBoundingClientRect()
+    expect(inputBounds.top - bubbleBounds.top).toBe(bubbleBounds.bottom - inputBounds.bottom)
   })
 
   it('closes mobile settings before requesting sign-in', async () => {

--- a/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.browser.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/components/InteractiveArea.browser.test.ts
@@ -184,9 +184,13 @@ describe('interactive area synchronized state', () => {
 
   it('centers the mobile textarea when no reply preview is visible', async () => {
     // ROOT CAUSE:
-    // The 40px bubble has spare height around its 32px textarea and borders.
-    // Bottom alignment put all spare height above the textarea. Center alignment
-    // divides that space equally without reserving space for a hidden reply.
+    //
+    // Without a reply preview, the 40px bubble has spare height around its
+    // 32px textarea and borders. Before the fix, justify-end put all spare
+    // height above the textarea: 6px above and 2px below.
+    //
+    // We fixed this with justify-center. The empty and single-line textarea
+    // now has 4px on each side, and multiline input stays centered.
     await page.viewport(390, 844)
     const { screen } = await renderArea(MobileInteractiveArea)
     const bubble = screen.getByTestId('mobile-input-bubble').element()

--- a/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
+++ b/packages/stage-layouts/src/components/Layouts/MobileInteractiveArea.vue
@@ -566,7 +566,7 @@ onUnmounted(() => {
           data-testid="mobile-input-bubble"
           :data-dragging="inputBubbleDragging"
           :class="[
-            'group relative mx-auto min-h-10 flex flex-col justify-end origin-center overflow-hidden',
+            'group relative mx-auto min-h-10 flex flex-col justify-center origin-center overflow-hidden',
             'touch-none select-none focus-within:touch-auto focus-within:select-text',
             'border-2 border-solid border-neutral-200/60 bg-neutral-100/80 backdrop-blur-md',
             'dark:border-neutral-700/60 dark:bg-neutral-950/80',


### PR DESCRIPTION
At mobile widths, the chat textarea had 6px above it and 2px below it. The 40px bubble used bottom alignment around a 32px textarea. The hidden reply preview occupied no height.

Center the textarea within the bubble. Empty and single-line inputs now have 4px on each side. The send action remains aligned with the bubble, and reply previews still expand normally.

## Verification

- `pnpm --config.verify-deps-before-run=false exec vitest run --config apps/stage-tamagotchi/vitest.config.ts --project browser apps/stage-tamagotchi/src/renderer/components/InteractiveArea.browser.test.ts` — 32 passed. The new regression failed before the fix with a 4px difference.
- `pnpm --config.verify-deps-before-run=false typecheck` — 52 tasks passed.
- `pnpm --config.verify-deps-before-run=false lint` — passed with existing warnings.
- Browser geometry check at 390 × 844: top/bottom spacing changed from 6px/2px to 4px/4px.

The dependency check flag permits the isolated worktree to reuse installed dependencies. Browser tests emit existing ResizeObserver diagnostics.

## Visual changes

Vishot captures compare merge base `69ca0a917` with this change at 390 × 844, English, device scale 2. Images show the composer region. Stage Pocket uses its local WebView; native keyboard behavior is outside this change. Model rendering and development overlays are disabled in both capture fixtures.

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/9f203ccb-3e36-4cb4-bd58-5123c7833be1) | ![](https://github.com/user-attachments/assets/d1422132-c620-469e-a4a4-e78c240514a9) |
| Stage Web / empty / light | Stage Web / empty / light |
| ![](https://github.com/user-attachments/assets/4b8ee2af-a4b1-46ac-9bb7-8566832f2004) | ![](https://github.com/user-attachments/assets/dfc7a21a-dc9a-4e53-af62-f6f36fc5d460) |
| Stage Web / typed / light | Stage Web / typed / light |
| ![](https://github.com/user-attachments/assets/b4a49841-5fbf-4ed7-b3d1-90eacf23f275) | ![](https://github.com/user-attachments/assets/21770c9a-b9e6-4ffe-aa7d-e4530a852512) |
| Stage Web / multiline / light | Stage Web / multiline / light |
| ![](https://github.com/user-attachments/assets/206f2431-e1c0-4c76-a306-3fd0cb98704a) | ![](https://github.com/user-attachments/assets/eac6f250-6f6b-4de1-b830-240bc1c9154a) |
| Stage Web / reply / light | Stage Web / reply / light |
| ![](https://github.com/user-attachments/assets/91c7582b-8dc4-48c2-addb-3ce529539662) | ![](https://github.com/user-attachments/assets/e88b287d-d812-46a3-82c9-eb897ccf8f10) |
| Stage Web / empty / dark | Stage Web / empty / dark |
| ![](https://github.com/user-attachments/assets/a869e17b-0ae2-4141-8215-038c27532075) | ![](https://github.com/user-attachments/assets/cafa7767-d815-4298-a1d9-da52001bc9f4) |
| Stage Web / typed / dark | Stage Web / typed / dark |
| ![](https://github.com/user-attachments/assets/62aab8a5-862c-40eb-8325-c00d58209b17) | ![](https://github.com/user-attachments/assets/3a040da6-6d1d-4b04-a3dc-3f992461e3d7) |
| Stage Web / multiline / dark | Stage Web / multiline / dark |
| ![](https://github.com/user-attachments/assets/5bc67db4-a080-4830-978d-57296cbb8a90) | ![](https://github.com/user-attachments/assets/4ccb250d-05b7-4a72-8e6d-12ae85e14d76) |
| Stage Web / reply / dark | Stage Web / reply / dark |
| ![](https://github.com/user-attachments/assets/eb699bc6-cebf-4c3f-b9f9-5d0a1c7d4ef3) | ![](https://github.com/user-attachments/assets/c3079fb4-2598-4709-93f3-b36b3d87e3b0) |
| Stage Pocket WebView / empty / light | Stage Pocket WebView / empty / light |
| ![](https://github.com/user-attachments/assets/17941a03-8412-4d14-bca6-344b4620c99a) | ![](https://github.com/user-attachments/assets/f52e2c02-2890-492e-891e-2278b0fc7a8a) |
| Stage Pocket WebView / typed / light | Stage Pocket WebView / typed / light |
| ![](https://github.com/user-attachments/assets/9420d11b-5b02-43f9-b1a7-1fd3f847668f) | ![](https://github.com/user-attachments/assets/ad7f5101-6a7e-49d6-9eed-dd120f148222) |
| Stage Pocket WebView / multiline / light | Stage Pocket WebView / multiline / light |
| ![](https://github.com/user-attachments/assets/433b337f-b55b-4835-b7e4-7784f144f77f) | ![](https://github.com/user-attachments/assets/b8490be4-7c88-4461-99bc-81fae5b849da) |
| Stage Pocket WebView / reply / light | Stage Pocket WebView / reply / light |
| ![](https://github.com/user-attachments/assets/09484a2f-a649-49b7-918c-3a4186e9448e) | ![](https://github.com/user-attachments/assets/0b129117-719b-417d-b59d-a6adaa2648b6) |
| Stage Pocket WebView / empty / dark | Stage Pocket WebView / empty / dark |
| ![](https://github.com/user-attachments/assets/223d861e-9270-4dd6-939c-6d63bd8ed907) | ![](https://github.com/user-attachments/assets/951600f0-e998-430d-9f9c-3a50d646dc68) |
| Stage Pocket WebView / typed / dark | Stage Pocket WebView / typed / dark |
| ![](https://github.com/user-attachments/assets/cf94bec2-6db4-40d8-84cb-dc10231e081a) | ![](https://github.com/user-attachments/assets/c13dc536-66e4-46fd-9ca1-4764e39f02d1) |
| Stage Pocket WebView / multiline / dark | Stage Pocket WebView / multiline / dark |
| ![](https://github.com/user-attachments/assets/32870593-6f9d-419c-a1fd-32d6d897a461) | ![](https://github.com/user-attachments/assets/19953b5a-c7fa-43d9-ad0c-308ecad92ca4) |
| Stage Pocket WebView / reply / dark | Stage Pocket WebView / reply / dark |
