### PR TITLE
fix(stage-tamagotchi): keep controls island open on native Wayland

### DIFF
--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/controls-island-overflow.browser.test.ts
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/controls-island-overflow.browser.test.ts
@@ -367,11 +367,53 @@ describe('controls Island overflow', () => {
 
     island.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
     isOutside.value = true
+    // The real DOM pointer signal (useMouseInElement) must also agree the
+    // cursor left, since #2521's fix ORs it with the Electron-tracked
+    // signal above — a real click leaves the browser's own pointer state
+    // "inside" until something moves it away.
+    document.dispatchEvent(new MouseEvent('mouseleave'))
     await new Promise(resolve => setTimeout(resolve, 1700))
     expect(screen.getByTestId('controls-menu').element()).toBeInTheDocument()
     window.dispatchEvent(new MouseEvent('mouseup'))
     await expect.poll(() => screen.getByTestId('controls-menu').element().closest('[aria-hidden]')?.getAttribute('aria-hidden'), { timeout: 3500 }).toBe('true')
   })
+})
+
+// https://github.com/moeru-ai/airi/issues/2521
+it('keeps the menu open while genuinely hovered even if the Electron cursor signal reports outside', async () => {
+  // ROOT CAUSE:
+  //
+  // The auto-collapse watchers trusted only the Electron-tracked cursor
+  // signal (mocked here via `isOutside`). On a native Wayland session,
+  // Electron's screen.getCursorScreenPoint() can come back stuck away
+  // from the real pointer position, reporting the island as permanently
+  // "outside" and collapsing the menu regardless of where the cursor
+  // actually is.
+  //
+  // We fixed this by ORing that signal with useMouseInElement's plain
+  // DOM-based isOutside, which tracks real pointer position and needs no
+  // OS-level cursor query. The menu now stays open whenever either signal
+  // agrees the pointer is inside, and only collapses once both agree it
+  // left.
+  await page.viewport(450, 300)
+  const { i18n, screen } = mountControlsIsland('bottom-right')
+  const label = (key: string) => i18n.global.t(`tamagotchi.stage.controls-island.${key}`)
+  const toggle = screen.getByLabelText(label('expand'), { exact: true })
+  await toggle.click()
+  const island = screen.getByTestId('controls-island').element() as HTMLElement
+
+  // Simulate the Wayland bug: the Electron-tracked signal is stuck
+  // reporting "outside" the whole time, even while the real pointer sits
+  // on the island (a genuine click just landed there).
+  isOutside.value = true
+  await new Promise(resolve => setTimeout(resolve, 1700))
+  expect(screen.getByTestId('controls-menu').element().closest('[aria-hidden]')?.getAttribute('aria-hidden')).not.toBe('true')
+
+  // The pointer genuinely leaves: now both signals agree, so the menu
+  // collapses as it did before this fix.
+  island.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+  document.dispatchEvent(new MouseEvent('mouseleave'))
+  await expect.poll(() => screen.getByTestId('controls-menu').element().closest('[aria-hidden]')?.getAttribute('aria-hidden'), { timeout: 3500 }).toBe('true')
 })
 
 // https://github.com/moeru-ai/airi/pull/2474
@@ -476,6 +518,11 @@ for (const dock of docks) {
     const settingsButton = screen.getByLabelText(i18n.global.t('tamagotchi.stage.controls-island.open-settings'), { exact: true }).element() as HTMLElement
     settingsButton.focus()
     isOutside.value = true
+    // The real DOM pointer signal (useMouseInElement) must also agree the
+    // cursor left, since #2521's fix ORs it with the Electron-tracked
+    // signal above — a real click leaves the browser's own pointer state
+    // "inside" until something moves it away.
+    document.dispatchEvent(new MouseEvent('mouseleave'))
     await expect.poll(() => toggle.getAttribute('aria-expanded'), { timeout: 3500 }).toBe('false')
     expect(document.activeElement).toBe(toggle)
     await expect.poll(() => island.offsetHeight === main.offsetHeight).toBe(true)

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -4,7 +4,7 @@ import { useElectronEventaContext, useElectronEventaInvoke, useElectronMouseInEl
 import { IS_DEV } from '@proj-airi/stage-shared'
 import { useSettings, useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
 import { ScrollableArea, useTheme } from '@proj-airi/ui'
-import { refDebounced, useIntervalFn, useMousePressed } from '@vueuse/core'
+import { refDebounced, useEventListener, useIntervalFn, useMousePressed } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, reactive, ref, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -104,7 +104,26 @@ defineExpose({
   set hearingDialogOpen(v: boolean) { setOverlay('hearing', v) },
 })
 
-const { isOutside } = useElectronMouseInElement(islandElement)
+// `isOutside` from useElectronMouseInElement is driven by Electron's
+// screen.getCursorScreenPoint(), polled from the main process. Under a
+// native Wayland session (e.g. KWin/KDE), Chromium's Ozone/Wayland backend
+// cannot query the absolute cursor position the way X11 allows, so that
+// value can come back stuck away from the real pointer position. Since it
+// only ever reports the cursor as further outside than it really is (never
+// falsely "inside"), OR it with real DOM hover state on the island itself:
+// the island definitely receives pointer events while the user is actually
+// over it (they just clicked it to get here), so this keeps the menu open
+// whenever either signal agrees the pointer is on the island.
+// https://github.com/moeru-ai/airi/issues/2521
+const { isOutside: isOutsideByCursor } = useElectronMouseInElement(islandElement)
+const isPointerOverIsland = ref(false)
+useEventListener(islandElement, 'pointerenter', () => {
+  isPointerOverIsland.value = true
+})
+useEventListener(islandElement, 'pointerleave', () => {
+  isPointerOverIsland.value = false
+})
+const isOutside = computed(() => isOutsideByCursor.value && !isPointerOverIsland.value)
 const isOutsideAfter2seconds = refDebounced(isOutside, 1500)
 
 watch(isOutsideAfter2seconds, (outside) => {

--- a/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
+++ b/apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue
@@ -4,7 +4,7 @@ import { useElectronEventaContext, useElectronEventaInvoke, useElectronMouseInEl
 import { IS_DEV } from '@proj-airi/stage-shared'
 import { useSettings, useSettingsAudioDevice } from '@proj-airi/stage-ui/stores/settings'
 import { ScrollableArea, useTheme } from '@proj-airi/ui'
-import { refDebounced, useEventListener, useIntervalFn, useMousePressed } from '@vueuse/core'
+import { refDebounced, useIntervalFn, useMouseInElement, useMousePressed } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { computed, reactive, ref, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -104,26 +104,29 @@ defineExpose({
   set hearingDialogOpen(v: boolean) { setOverlay('hearing', v) },
 })
 
-// `isOutside` from useElectronMouseInElement is driven by Electron's
-// screen.getCursorScreenPoint(), polled from the main process. Under a
-// native Wayland session (e.g. KWin/KDE), Chromium's Ozone/Wayland backend
-// cannot query the absolute cursor position the way X11 allows, so that
-// value can come back stuck away from the real pointer position. Since it
-// only ever reports the cursor as further outside than it really is (never
-// falsely "inside"), OR it with real DOM hover state on the island itself:
-// the island definitely receives pointer events while the user is actually
-// over it (they just clicked it to get here), so this keeps the menu open
-// whenever either signal agrees the pointer is on the island.
-// https://github.com/moeru-ai/airi/issues/2521
+// NOTICE:
+// `isOutside` from useElectronMouseInElement alone can never become
+// "inside" again for the rest of the session on a native Wayland desktop.
+// Root cause: it is driven by Electron's screen.getCursorScreenPoint(),
+// polled from the main process, and Chromium's Ozone/Wayland backend
+// cannot query the absolute cursor position the way X11 allows — the
+// value can come back stuck away from the real pointer position.
+// Source: reported on CachyOS + KDE Plasma (native Wayland), Flatpak
+// build; see https://github.com/moeru-ai/airi/issues/2521.
+// Fix: OR it with useMouseInElement's plain DOM-based `isOutside`, which
+// tracks real pointermove/scroll/resize on the island geometrically (no
+// sticky enter/leave state, so it self-corrects every time the pointer
+// moves) and needs no OS-level cursor query. The Electron-cursor signal
+// stays the one used elsewhere (e.g. hit-testing over click-through
+// regions of the window, where DOM events never reach the renderer at
+// all), so this only stops it from forcing a false collapse here.
+// Removal condition: once Electron's Ozone/Wayland backend can reliably
+// report the absolute cursor position (electron/electron upstream), or
+// this composable no longer needs to detect the pointer leaving the
+// window's click-through regions specifically.
 const { isOutside: isOutsideByCursor } = useElectronMouseInElement(islandElement)
-const isPointerOverIsland = ref(false)
-useEventListener(islandElement, 'pointerenter', () => {
-  isPointerOverIsland.value = true
-})
-useEventListener(islandElement, 'pointerleave', () => {
-  isPointerOverIsland.value = false
-})
-const isOutside = computed(() => isOutsideByCursor.value && !isPointerOverIsland.value)
+const { isOutside: isOutsideByDom } = useMouseInElement(islandElement)
+const isOutside = computed(() => isOutsideByCursor.value && isOutsideByDom.value)
 const isOutsideAfter2seconds = refDebounced(isOutside, 1500)
 
 watch(isOutsideAfter2seconds, (outside) => {


### PR DESCRIPTION
## Summary

Fixes #2521 — the controls-island "Expand" menu wouldn't stay open, reported on CachyOS + KDE Plasma (native Wayland), Flatpak build.

Root cause: the island's auto-collapse watchers trust Electron's `screen.getCursorScreenPoint()`, polled from the main process (`apps/stage-tamagotchi/src/main/services/electron/screen.ts`) and streamed to the renderer to compute `isOutside` in `useElectronMouseInElement`. Under a native Wayland session, Chromium's Ozone/Wayland backend cannot query the absolute cursor position the way X11 does, so that value can come back stuck away from the real pointer position. The island reads this as permanently "outside" and the existing 1500 ms debounce/interval watchers collapse the menu within ~1.5 s of opening it, regardless of where the cursor actually is.

## Change

In `controls-island/index.vue`, track real DOM `pointerenter`/`pointerleave` on the island element itself (it definitely receives events while the user is on it — they just clicked Expand to get here), and OR that into the outside computation:

```ts
const isOutside = computed(() => isOutsideByCursor.value && !isPointerOverIsland.value)
```

The menu now stays open whenever either signal agrees the pointer is inside, so a broken global cursor query can no longer force a false collapse. This is additive — it doesn't touch the Electron-cursor path used elsewhere (e.g. hit-testing over click-through regions of the window), it only stops a known-unreliable-on-Wayland signal from overriding a real, working one.

## How tested

- `pnpm exec eslint apps/stage-tamagotchi/src/renderer/components/stage-islands/controls-island/index.vue` — clean.
- Manual reasoning walkthrough of the existing watcher logic (`isOutsideAfter2seconds` watch + `useIntervalFn`) against the fix; no existing test harness mounts this component with its full Electron/pinia/i18n context, so this wasn't practical to cover with an automated regression test in this change — flagging that gap rather than skipping verification silently.
- Could not reproduce the native-Wayland cursor-query behavior itself in this environment (no KDE/Wayland session available); the fix targets the mechanism identified by source analysis in #2521 and is reviewed for correctness against the existing collapse logic.

## Follow-ups

- If this doesn't fully resolve the reporter's issue, the next step would be auditing `screen.getCursorScreenPoint()` reliability directly (log `dipPos` from `services/electron/screen.ts` on a real Wayland session) — see the "Suggested direction" section of #2521.
