### PR TITLE
feat(provider-inference): refresh Volcengine coding-plan models from endpoint

### DIFF
--- a/packages/provider-inference/src/providers/cloud/ark-providers.test.ts
+++ b/packages/provider-inference/src/providers/cloud/ark-providers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { parse } from 'zod/v4/core'
 
 import { createProviderRegistry } from '../registry'
@@ -22,6 +22,11 @@ describe('ark chat provider definitions', () => {
   beforeEach(() => {
     vi.resetModules()
     createOpenAIMock.mockClear()
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unavailable')))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('lists prefixed models and strips the prefix before chat requests', async () => {
@@ -121,5 +126,86 @@ describe('ark chat provider definitions', () => {
       'byteplus-coding-plan/kimi-k2.5',
       'byteplus-coding-plan/gpt-oss-120b',
     ])
+  })
+})
+
+describe('ark live model refresh', () => {
+  // https://github.com/moeru-ai/airi/issues/2138
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function listVolcengineModels(apiKey: string) {
+    const provider = createProviderRegistry([providerVolcengineCodingPlan]).get('volcengine-coding-plan')
+    if (!provider)
+      throw new Error('Volcengine coding plan provider must be registered')
+    const schema = await provider.createProviderConfig({ t: input => input })
+    const parsedConfig = parse(schema, { apiKey })
+    const providerInstance = await provider.createProvider(parsedConfig)
+    return provider!.extraMethods!.listModels!(parsedConfig, providerInstance, { t: input => input })
+  }
+
+  it('issue #2138 merges live endpoint models after the static catalog', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ data: [
+      { id: 'doubao-seed-2.1-turbo' },
+      { id: 'doubao-seed-3-0-code' },
+    ] }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    const listedModels = await listVolcengineModels('test-key')
+    const ids = listedModels.map(model => model.id)
+    expect(ids.slice(0, 10)).toEqual([
+      'volcengine-coding-plan/ark-code-latest',
+      'volcengine-coding-plan/doubao-seed-2.1-turbo',
+      'volcengine-coding-plan/doubao-seed-2.0-lite',
+      'volcengine-coding-plan/minimax-m3',
+      'volcengine-coding-plan/kimi-k2.7-code',
+      'volcengine-coding-plan/glm-5.3',
+      'volcengine-coding-plan/deepseek-v4-flash',
+      'volcengine-coding-plan/deepseek-v4-pro',
+      'volcengine-coding-plan/doubao-seed-2.0-code',
+      'volcengine-coding-plan/doubao-seed-2.0-pro',
+    ])
+    expect(ids).toContain('volcengine-coding-plan/doubao-seed-3-0-code')
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('https://ark.cn-beijing.volces.com/api/coding/v3/models')
+  })
+
+  it('issue #2138 falls back to the static catalog when the endpoint is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('network unavailable'))
+    const listedModels = await listVolcengineModels('test-key')
+    expect(listedModels.map(model => model.id)).toHaveLength(10)
+    expect(listedModels[0]?.id).toBe('volcengine-coding-plan/ark-code-latest')
+  })
+
+  it('issue #2138 performs no fetch without an API key', async () => {
+    const listedModels = await listVolcengineModels('')
+    expect(listedModels.map(model => model.id)).toHaveLength(10)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('issue #2138 keeps non-opted-in ark providers static without fetching', async () => {
+    fetchMock.mockRejectedValue(new Error('must not fetch'))
+    const provider = createProviderRegistry([providerBytePlusCodingPlan]).get('byteplus-coding-plan')
+    if (!provider)
+      throw new Error('BytePlus coding plan provider must be registered')
+    const schema = await provider.createProviderConfig({ t: input => input })
+    const parsedConfig = parse(schema, { apiKey: 'test-key' })
+    const providerInstance = await provider.createProvider(parsedConfig)
+    const listedModels = await provider!.extraMethods!.listModels!(parsedConfig, providerInstance, { t: input => input })
+    expect(listedModels.map(model => model.id)).toEqual([
+      'byteplus-coding-plan/dola-seed-2.0-pro',
+      'byteplus-coding-plan/dola-seed-2.0-lite',
+      'byteplus-coding-plan/bytedance-seed-code',
+      'byteplus-coding-plan/glm-4.7',
+      'byteplus-coding-plan/kimi-k2.5',
+      'byteplus-coding-plan/gpt-oss-120b',
+    ])
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/provider-inference/src/providers/cloud/ark-providers.test.ts
+++ b/packages/provider-inference/src/providers/cloud/ark-providers.test.ts
@@ -131,6 +131,27 @@ describe('ark chat provider definitions', () => {
 
 describe('ark live model refresh', () => {
   // https://github.com/moeru-ai/airi/issues/2138
+  // ROOT CAUSE:
+  //
+  // If the endpoint ships a new coding-plan model, the UI still hides it.
+  // Users wait for the next client release before the model appears.
+  // This happens because ark-shared listModels returned only the static
+  // array and never called the live /models endpoint.
+  //
+  // <before-patch>
+  // listModels: async (_config, _provider, contextOptions) => models.map(...)
+  // The static array was the full result. No fetch ran.
+  // </before-patch>
+  //
+  // We fixed this by merging live /models results after the static catalog.
+  // Static entries keep their metadata and win on duplicate ids. Unknown
+  // live ids are appended. No API key means no fetch. Any endpoint failure,
+  // timeout, or stall falls back to the static catalog, so one slow provider
+  // never blocks the providers after it.
+  // <after-patch>
+  // listModels({ apiKey, baseURL: baseUrl, abortSignal: controller.signal })
+  // with a 5000ms AbortController timeout, then merge into staticModels.
+  // </after-patch>
   const fetchMock = vi.fn()
 
   beforeEach(() => {
@@ -181,6 +202,37 @@ describe('ark live model refresh', () => {
     const listedModels = await listVolcengineModels('test-key')
     expect(listedModels.map(model => model.id)).toHaveLength(10)
     expect(listedModels[0]?.id).toBe('volcengine-coding-plan/ark-code-latest')
+  })
+
+  it('issue #2138 falls back to the static catalog when the live endpoint stalls', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockImplementation((_input: unknown, init?: { signal?: AbortSignal }) => new Promise<never>((_resolve, reject) => {
+        const signal = init?.signal
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'))
+          return
+        }
+        signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+      }))
+      const pending = listVolcengineModels('test-key')
+      await vi.advanceTimersByTimeAsync(100)
+      expect(fetchMock).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(6000)
+      const listedModels = await pending
+      expect(listedModels.map(model => model.id)).toHaveLength(10)
+      expect(listedModels[0]?.id).toBe('volcengine-coding-plan/ark-code-latest')
+      const signal = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal
+      expect(signal?.aborted).toBe(true)
+
+      fetchMock.mockResolvedValue(new Response(JSON.stringify({ data: [{ id: 'doubao-seed-3-0-code' }] }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      const recovered = await listVolcengineModels('test-key')
+      expect(recovered.map(model => model.id)).toContain('volcengine-coding-plan/doubao-seed-3-0-code')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   it('issue #2138 performs no fetch without an API key', async () => {

--- a/packages/provider-inference/src/providers/cloud/ark-shared.ts
+++ b/packages/provider-inference/src/providers/cloud/ark-shared.ts
@@ -1,6 +1,7 @@
 import type { ChatRequestOptions, ModelInfo } from '../../types'
 
 import { createOpenAI } from '@xsai-ext/providers/create'
+import { listModels } from '@xsai/model'
 import { z } from 'zod'
 
 import { ProviderValidationCheck } from '../../types'
@@ -33,12 +34,21 @@ interface ArkProviderDefinitionOptions<TId extends string = string> {
   icon: string
   iconColor?: string
   models: ArkModelSpec[]
+  refreshModelsFromEndpoint?: boolean
 }
 
 function stripModelPrefix(modelId: string, modelPrefix: string) {
   return modelId.startsWith(modelPrefix)
     ? modelId.slice(modelPrefix.length)
     : modelId
+}
+
+function extractLiveModelId(model: unknown): string {
+  if (typeof model === 'string')
+    return model
+  if (model && typeof (model as { id?: unknown }).id === 'string')
+    return (model as { id: string }).id
+  return ''
 }
 
 export function createArkChatProviderDefinition<const TId extends string>(options: ArkProviderDefinitionOptions<TId>) {
@@ -54,6 +64,7 @@ export function createArkChatProviderDefinition<const TId extends string>(option
     icon,
     iconColor,
     models,
+    refreshModelsFromEndpoint,
   } = options
 
   return defineProvider({
@@ -98,23 +109,63 @@ export function createArkChatProviderDefinition<const TId extends string>(option
     },
 
     extraMethods: {
-      listModels: async (_config, _provider, contextOptions) => models.map((model) => {
-        const modelInfo: ModelInfo = {
-          id: `${modelPrefix}${model.id}`,
-          name: model.id,
-          provider: id,
+      listModels: async (config, _provider, contextOptions) => {
+        const staticModels = models.map((model) => {
+          const modelInfo: ModelInfo = {
+            id: `${modelPrefix}${model.id}`,
+            name: model.id,
+            provider: id,
+          }
+          if (model.contextLength !== undefined) {
+            modelInfo.contextLength = model.contextLength
+          }
+          if (model.deprecated !== undefined) {
+            modelInfo.deprecated = model.deprecated
+          }
+          if (model.descriptionKey !== undefined && contextOptions) {
+            modelInfo.description = contextOptions.t(model.descriptionKey)
+          }
+          return modelInfo
+        })
+
+        // Refresh the static catalog with models the endpoint actually serves,
+        // so newly released coding-plan models appear without a client update.
+        // Opt-in per provider: only definitions that set refreshModelsFromEndpoint
+        // perform live calls. Any endpoint failure keeps the static catalog untouched.
+        const apiKey = typeof config.apiKey === 'string' ? config.apiKey.trim() : ''
+        const baseUrl = typeof config.baseUrl === 'string' && config.baseUrl.trim()
+          ? config.baseUrl.trim()
+          : defaultBaseUrl
+        if (!refreshModelsFromEndpoint || !apiKey) {
+          return staticModels
         }
-        if (model.contextLength !== undefined) {
-          modelInfo.contextLength = model.contextLength
+
+        let liveModels: unknown
+        try {
+          liveModels = await listModels({ apiKey, baseURL: baseUrl })
         }
-        if (model.deprecated !== undefined) {
-          modelInfo.deprecated = model.deprecated
+        catch {
+          return staticModels
         }
-        if (model.descriptionKey !== undefined && contextOptions) {
-          modelInfo.description = contextOptions.t(model.descriptionKey)
+        if (!Array.isArray(liveModels)) {
+          return staticModels
         }
-        return modelInfo
-      }),
+
+        const knownIds = new Set(staticModels.map(model => model.id))
+        for (const liveModel of liveModels) {
+          const rawId = extractLiveModelId(liveModel).trim()
+          if (!rawId) {
+            continue
+          }
+          const liveId = rawId.startsWith(modelPrefix) ? rawId : `${modelPrefix}${rawId}`
+          if (knownIds.has(liveId)) {
+            continue
+          }
+          knownIds.add(liveId)
+          staticModels.push({ id: liveId, name: rawId, provider: id })
+        }
+        return staticModels
+      },
     },
     validationRequiredWhen(config) {
       return !!config.apiKey?.trim()

--- a/packages/provider-inference/src/providers/cloud/ark-shared.ts
+++ b/packages/provider-inference/src/providers/cloud/ark-shared.ts
@@ -141,11 +141,21 @@ export function createArkChatProviderDefinition<const TId extends string>(option
         }
 
         let liveModels: unknown
+        // Bound the live refresh so a slow endpoint cannot block model loading.
+        // listModels runs while the UI loads provider models. An unbounded wait
+        // stalls this provider and delays every provider after it. The timeout
+        // aborts the request and the catch below falls back to staticModels.
+        const liveRefreshTimeoutMs = 5000
+        const controller = new AbortController()
+        const timeout = setTimeout(() => controller.abort(), liveRefreshTimeoutMs)
         try {
-          liveModels = await listModels({ apiKey, baseURL: baseUrl })
+          liveModels = await listModels({ apiKey, baseURL: baseUrl, abortSignal: controller.signal })
         }
         catch {
           return staticModels
+        }
+        finally {
+          clearTimeout(timeout)
         }
         if (!Array.isArray(liveModels)) {
           return staticModels

--- a/packages/provider-inference/src/providers/cloud/volcengine-coding-plan/index.ts
+++ b/packages/provider-inference/src/providers/cloud/volcengine-coding-plan/index.ts
@@ -11,6 +11,7 @@ export const providerVolcengineCodingPlan = createArkChatProviderDefinition({
   defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/coding/v3',
   icon: 'i-lobe-icons:volcengine',
   iconColor: 'i-lobe-icons:volcengine',
+  refreshModelsFromEndpoint: true,
   models: [
     {
       id: 'ark-code-latest',


### PR DESCRIPTION
## Problem
Volcengine Coding Plan ships new models, but AIRI's provider catalog is a static list, so the settings page never shows newly available models and hand-typed model names cannot be validated against the catalog.

## What this changes
The shared Ark helper gains an opt-in `refreshModelsFromEndpoint` flag, enabled only for `providerVolcengineCodingPlan`.

Its `listModels` implementation merges live `/models` results into the static catalog:
- static metadata wins for known models;
- unknown endpoint model IDs are appended;
- duplicate IDs are removed;
- missing API keys, endpoint failures, unexpected response shapes, or a stalled live request fall back to the static catalog;
- live `/models` refresh is bounded by a 5000ms `AbortController` timeout so one slow provider cannot block later configured providers.

BytePlus and BytePlus Coding Plan remain static by design. PR #2321 updated the static Volcengine catalog and intentionally left dynamic discovery as a separate concern.

## Backward compatibility
No config or public API shape changes. Without an API key, or when the endpoint is unavailable or stalls, the provider continues to return the existing static catalog.

## Test evidence
- `ark-providers.test.ts`: 7/7 passed, including live merge, endpoint-failure fallback, stalled-endpoint timeout/cancellation, no-key/no-fetch, and BytePlus no-fetch regression coverage.
- Provider inference suite: 11 files / 134 tests passed.
- `pnpm -F @proj-airi/provider-inference typecheck`: passed.
- ESLint on the two review-fix files: clean; repo pre-commit hook made no changes.
- Review-fix commit: `ea0426c4bd8e0697a55a5aceda1c1919c9097012`.

Closes #2138