### PR TITLE
feat(provider-inference): add API Route provider

### DIFF
--- a/packages/provider-inference/src/providers/cloud/api-route/index.ts
+++ b/packages/provider-inference/src/providers/cloud/api-route/index.ts
@@ -1,0 +1,53 @@
+import { createOpenAI } from '@xsai-ext/providers/create'
+import { z } from 'zod'
+
+import { ProviderValidationCheck } from '../../../types'
+import { createOpenAICompatibleValidators } from '../../../validators'
+import { defineProvider } from '../../registry'
+
+const apiRouteConfigSchema = z.object({
+  apiKey: z
+    .string('API Key'),
+  baseUrl: z
+    .string('Base URL')
+    .optional()
+    .default('https://global.api-route.com/v1'),
+})
+
+type ApiRouteConfig = z.input<typeof apiRouteConfigSchema>
+
+export const providerApiRoute = defineProvider<ApiRouteConfig, 'api-route'>({
+  id: 'api-route',
+  name: 'API Route',
+  nameLocalize: () => 'API Route',
+  description: 'api-route.com',
+  descriptionLocalize: () => 'api-route.com',
+  tasks: ['chat'],
+  icon: 'i-lobe-icons:openai',
+
+  createProviderConfig: ({ t }) => apiRouteConfigSchema.extend({
+    apiKey: apiRouteConfigSchema.shape.apiKey.meta({
+      labelLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.api-key.label'),
+      descriptionLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.api-key.description'),
+      placeholderLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.api-key.placeholder'),
+      type: 'password',
+    }),
+    baseUrl: apiRouteConfigSchema.shape.baseUrl.meta({
+      labelLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.base-url.label'),
+      descriptionLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.base-url.description'),
+      placeholderLocalized: t('settings.pages.providers.catalog.edit.config.common.fields.field.base-url.placeholder'),
+    }),
+  }),
+  createProvider(config) {
+    return createOpenAI(config.apiKey, config.baseUrl)
+  },
+
+  validationRequiredWhen(config) {
+    return !!config.apiKey?.trim()
+  },
+  validators: {
+    ...createOpenAICompatibleValidators({
+      checks: [ProviderValidationCheck.Connectivity, ProviderValidationCheck.ModelList, ProviderValidationCheck.ChatCompletions],
+    }),
+  },
+})

--- a/packages/provider-inference/src/providers/index.ts
+++ b/packages/provider-inference/src/providers/index.ts
@@ -4,6 +4,7 @@ import { provider302AI } from './cloud/302-ai'
 import { providerAIHubMix } from './cloud/aihubmix'
 import { providerAmazonBedrock } from './cloud/amazon-bedrock'
 import { providerAnthropic } from './cloud/anthropic'
+import { providerApiRoute } from './cloud/api-route'
 import { providerAtlasCloud } from './cloud/atlascloud'
 import { providerAzureAIFoundry } from './cloud/azure-ai-foundry'
 import { providerAzureOpenAI } from './cloud/azure-openai'
@@ -89,6 +90,7 @@ export const portableProviderDefinitions = eraseProviderDefinitions(
   providerAIHubMix,
   providerAmazonBedrock,
   providerAnthropic,
+  providerApiRoute,
   providerAtlasCloud,
   providerAzureAIFoundry,
   providerAzureOpenAI,

--- a/packages/provider-inference/src/providers/registry.test.ts
+++ b/packages/provider-inference/src/providers/registry.test.ts
@@ -6,9 +6,11 @@ import { createProviderRegistry, getDefinedProvider, listProviders, portableProv
 
 describe('portable provider registry', () => {
   it('exports the portable provider id union', () => {
+    expectTypeOf<'api-route'>().toExtend<PortableProviderId>()
     expectTypeOf<'openai'>().toExtend<PortableProviderId>()
     expectTypeOf<string>().not.toExtend<PortableProviderId>()
 
+    expect(getDefinedProvider('api-route')).toBeDefined()
     expect(getDefinedProvider('openai')).toBeDefined()
   })
 


### PR DESCRIPTION
## Summary

- Add API Route as an OpenAI-compatible chat provider.
- Use `https://global.api-route.com/v1` as the default endpoint.
- Add connectivity, model list, and chat completion validation.
- Add registry coverage for the new provider ID.

## Screenshots

Before:

![Provider list before API Route](https://github.com/user-attachments/assets/a2df2df1-6f3f-4397-b06e-f0c9b71fd20b)

After:

![Provider list with API Route](https://github.com/user-attachments/assets/57bebd1a-7b97-43bc-96f5-82f202ac317c)

## Tests

- `tsc --noEmit -p packages/provider-inference/tsconfig.json`
- `moeru-lint packages/provider-inference`
- `vitest run --config packages/provider-inference/vitest.config.ts packages/provider-inference/src/providers/registry.test.ts packages/provider-inference/src/providers/runtime-matrix.test.ts` (64 tests)
- `electron-vite build` in `apps/stage-tamagotchi`
- Vishot Electron capture for the provider settings page

## Environment note

`pnpm typecheck` stopped during dependency installation. The npm registry timed out while downloading an unrelated chess plugin dependency.