### PR TITLE
refactor(provider-inference): move provider tests closer to implementations

### DIFF
--- a/packages/provider-inference/package.json
+++ b/packages/provider-inference/package.json
@@ -53,6 +53,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@proj-airi/core-agent": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:vitest",
     "@xsai/generate-speech": "catalog:",

--- a/packages/provider-inference/src/providers/cloud/azure-openai/index.test.ts
+++ b/packages/provider-inference/src/providers/cloud/azure-openai/index.test.ts
@@ -1,10 +1,9 @@
-import type { ChatRequestOptions } from '@proj-airi/provider-inference'
-import type { ChatProviderWithExtraOptions } from '@xsai-ext/providers/utils'
 import type { JsonSchema } from 'xsschema'
 
 import { createSparkCommandTool } from '@proj-airi/core-agent/agents/spark-command'
-import { getDefinedProvider } from '@proj-airi/provider-inference'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { providerAzureOpenAI } from './index'
 
 interface ChatRequestBody {
   tools: Array<{
@@ -29,56 +28,37 @@ function getArraySchema(schema?: JsonSchema): JsonSchema | undefined {
   return schema.anyOf?.filter(isJsonSchema).find(candidate => candidate.type === 'array')
 }
 
-describe('providerOpenRouterAI tool schemas', () => {
+describe('providerAzureOpenAI tool schemas', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  it('maps AIRI reasoning modes to OpenRouter request fields', async () => {
-    const providerDefinition = getDefinedProvider('openrouter-ai')
-    if (!providerDefinition)
-      throw new Error('OpenRouter provider definition is not registered.')
-
-    const provider = await providerDefinition.createProvider({
-      apiKey: 'test-key',
-    }) as ChatProviderWithExtraOptions<string, ChatRequestOptions>
-
-    expect(provider.chat('openai/gpt-test', { reasoning: 'disabled' })).toMatchObject({
-      reasoning: { effort: 'none' },
-    })
-    expect(provider.chat('openai/gpt-test', { reasoning: 'enabled' })).toMatchObject({
-      reasoning: { effort: 'medium' },
-    })
-  })
-
-  it('keeps the canonical nullable anyOf when it sends a chat request', async () => {
+  // https://github.com/moeru-ai/airi/pull/2330#discussion_r3819919459
+  it('converts every nullable scalar anyOf before it sends a chat request (PR #2330 review)', async () => {
     const tools = await createSparkCommandTool({
       sendSparkCommand: () => undefined,
     })
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('{}'))
     vi.stubGlobal('fetch', fetchMock)
 
-    const providerDefinition = getDefinedProvider('openrouter-ai')
-    if (!providerDefinition)
-      throw new Error('OpenRouter provider definition is not registered.')
-
-    const provider = await providerDefinition.createProvider({
+    const provider = await providerAzureOpenAI.createProvider({
       apiKey: 'test-key',
+      baseUrl: 'https://example.openai.azure.com/openai/',
     })
     if (!('chat' in provider))
-      throw new Error('OpenRouter did not create a chat provider.')
+      throw new Error('Azure OpenAI did not create a chat provider.')
 
-    const providerFetch = provider.chat('google/gemini-test').fetch
+    const providerFetch = provider.chat('test-deployment').fetch
     if (!providerFetch)
-      throw new Error('OpenRouter did not create a fetch adapter.')
+      throw new Error('Azure OpenAI did not create a fetch adapter.')
 
-    await providerFetch(new URL('https://openrouter.ai/api/v1/chat/completions'), {
+    await providerFetch(new URL('https://example.openai.azure.com/openai/v1/chat/completions'), {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'google/gemini-test',
+        model: 'test-deployment',
         messages: [],
         tools,
       }),
@@ -86,7 +66,7 @@ describe('providerOpenRouterAI tool schemas', () => {
 
     const requestBody = fetchMock.mock.calls[0]?.[1]?.body
     if (typeof requestBody !== 'string')
-      throw new Error('OpenRouter did not send a JSON request body.')
+      throw new Error('Azure OpenAI did not send a JSON request body.')
 
     const body = JSON.parse(requestBody) as ChatRequestBody
     const sparkTool = body.tools.find(tool => tool.function.name === 'builtIn_emitSparkCommand')
@@ -96,12 +76,14 @@ describe('providerOpenRouterAI tool schemas', () => {
     const metadataItem = metadata?.items as JsonSchema
     const metadataValue = metadataItem.properties?.value as JsonSchema
 
-    expect(metadataValue.type).toBeUndefined()
-    expect(metadataValue.anyOf).toEqual([
-      { type: 'string' },
-      { type: 'number' },
-      { type: 'boolean' },
-      { type: 'null' },
-    ])
+    // ROOT CAUSE:
+    //
+    // The provider-neutral spark schema keeps this value as a nullable `anyOf`.
+    // Azure OpenAI rejects that schema before generation and disables all tools.
+    //
+    // We fixed this in the Azure request adapter. It converts the union only for
+    // Azure OpenAI and leaves the canonical tool schema unchanged.
+    expect(metadataValue.type).toEqual(['string', 'number', 'boolean', 'null'])
+    expect(metadataValue.anyOf).toBeUndefined()
   })
 })

--- a/packages/provider-inference/src/providers/cloud/openrouter-ai/index.test.ts
+++ b/packages/provider-inference/src/providers/cloud/openrouter-ai/index.test.ts
@@ -1,8 +1,12 @@
+import type { ChatProviderWithExtraOptions } from '@xsai-ext/providers/utils'
 import type { JsonSchema } from 'xsschema'
 
+import type { ChatRequestOptions } from '../../../types'
+
 import { createSparkCommandTool } from '@proj-airi/core-agent/agents/spark-command'
-import { getDefinedProvider } from '@proj-airi/provider-inference'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { providerOpenRouterAI } from './index'
 
 interface ChatRequestBody {
   tools: Array<{
@@ -27,41 +31,48 @@ function getArraySchema(schema?: JsonSchema): JsonSchema | undefined {
   return schema.anyOf?.filter(isJsonSchema).find(candidate => candidate.type === 'array')
 }
 
-describe('providerAzureOpenAI tool schemas', () => {
+describe('providerOpenRouterAI tool schemas', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  // https://github.com/moeru-ai/airi/pull/2330#discussion_r3819919459
-  it('converts every nullable scalar anyOf before it sends a chat request (PR #2330 review)', async () => {
+  it('maps AIRI reasoning modes to OpenRouter request fields', async () => {
+    const provider = await providerOpenRouterAI.createProvider({
+      apiKey: 'test-key',
+    }) as ChatProviderWithExtraOptions<string, ChatRequestOptions>
+
+    expect(provider.chat('openai/gpt-test', { reasoning: 'disabled' })).toMatchObject({
+      reasoning: { effort: 'none' },
+    })
+    expect(provider.chat('openai/gpt-test', { reasoning: 'enabled' })).toMatchObject({
+      reasoning: { effort: 'medium' },
+    })
+  })
+
+  it('keeps the canonical nullable anyOf when it sends a chat request', async () => {
     const tools = await createSparkCommandTool({
       sendSparkCommand: () => undefined,
     })
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('{}'))
     vi.stubGlobal('fetch', fetchMock)
 
-    const providerDefinition = getDefinedProvider('azure-openai')
-    if (!providerDefinition)
-      throw new Error('Azure OpenAI provider definition is not registered.')
-
-    const provider = await providerDefinition.createProvider({
+    const provider = await providerOpenRouterAI.createProvider({
       apiKey: 'test-key',
-      baseUrl: 'https://example.openai.azure.com/openai/',
     })
     if (!('chat' in provider))
-      throw new Error('Azure OpenAI did not create a chat provider.')
+      throw new Error('OpenRouter did not create a chat provider.')
 
-    const providerFetch = provider.chat('test-deployment').fetch
+    const providerFetch = provider.chat('google/gemini-test').fetch
     if (!providerFetch)
-      throw new Error('Azure OpenAI did not create a fetch adapter.')
+      throw new Error('OpenRouter did not create a fetch adapter.')
 
-    await providerFetch(new URL('https://example.openai.azure.com/openai/v1/chat/completions'), {
+    await providerFetch(new URL('https://openrouter.ai/api/v1/chat/completions'), {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        model: 'test-deployment',
+        model: 'google/gemini-test',
         messages: [],
         tools,
       }),
@@ -69,7 +80,7 @@ describe('providerAzureOpenAI tool schemas', () => {
 
     const requestBody = fetchMock.mock.calls[0]?.[1]?.body
     if (typeof requestBody !== 'string')
-      throw new Error('Azure OpenAI did not send a JSON request body.')
+      throw new Error('OpenRouter did not send a JSON request body.')
 
     const body = JSON.parse(requestBody) as ChatRequestBody
     const sparkTool = body.tools.find(tool => tool.function.name === 'builtIn_emitSparkCommand')
@@ -79,14 +90,12 @@ describe('providerAzureOpenAI tool schemas', () => {
     const metadataItem = metadata?.items as JsonSchema
     const metadataValue = metadataItem.properties?.value as JsonSchema
 
-    // ROOT CAUSE:
-    //
-    // The provider-neutral spark schema keeps this value as a nullable `anyOf`.
-    // Azure OpenAI rejects that schema before generation and disables all tools.
-    //
-    // We fixed this in the Azure request adapter. It converts the union only for
-    // Azure OpenAI and leaves the canonical tool schema unchanged.
-    expect(metadataValue.type).toEqual(['string', 'number', 'boolean', 'null'])
-    expect(metadataValue.anyOf).toBeUndefined()
+    expect(metadataValue.type).toBeUndefined()
+    expect(metadataValue.anyOf).toEqual([
+      { type: 'string' },
+      { type: 'number' },
+      { type: 'boolean' },
+      { type: 'null' },
+    ])
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3917,6 +3917,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@proj-airi/core-agent':
+        specifier: workspace:^
+        version: link:../core-agent
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
# Refactor: Move Provider Tests to provider-inference

## Summary

Move azure-openai and openrouter-ai provider tests from `stage-ui` to `provider-inference` package, placing them closer to their implementations.

## Changes

- **Moved test files**:
  - `packages/stage-ui/src/libs/providers/providers/azure-openai/index.test.ts` → `packages/provider-inference/src/providers/cloud/azure-openai/index.test.ts`
  - `packages/stage-ui/src/libs/providers/providers/openrouter-ai/index.test.ts` → `packages/provider-inference/src/providers/cloud/openrouter-ai/index.test.ts`

- **Simplified test imports**: Updated tests to use direct provider definitions instead of `getDefinedProvider()`, removing unnecessary lookup logic

- **Added dependency**: `@proj-airi/core-agent` as devDependency for test utilities

## Benefits

1. Tests are co-located with their implementations
2. Direct imports are simpler and more maintainable
3. Better package organization following module boundaries

## Verification

```bash
# Run tests for provider-inference
pnpm -F @proj-airi/provider-inference exec vitest run

# Typecheck
pnpm -F @proj-airi/provider-inference typecheck
```

## Test Results

All tests pass after the refactoring.