### PR TITLE
fix(stage-web): cache canonical app shell for payment returns

### DIFF
--- a/apps/stage-web/vite.config.ts
+++ b/apps/stage-web/vite.config.ts
@@ -218,6 +218,10 @@ export default defineConfig({
           },
           workbox: {
             maximumFileSizeToCacheInBytes: 64 * 1024 * 1024,
+            // Cloudflare redirects /index.html to /. Cache the canonical response
+            // so navigation fallbacks never replay a redirected response.
+            modifyURLPrefix: { 'index.html': './' },
+            navigateFallback: './',
             navigateFallbackDenylist: [
               /^\/docs\//,
               /^\/ui\//,


### PR DESCRIPTION
Payment completed and Flux was credited, but returning from Stripe showed `ERR_FAILED`. Edge reported that the service worker replayed a redirected response for a navigation request. Cloudflare redirects `/index.html` to `/`.

Precache the canonical root URL and use it as the navigation fallback. The new cache key also avoids reusing the old redirected app shell.

Validation: generated a service worker with the installed Workbox version and verified both its precache entry and navigation handler use `./`; ESLint passed. Production payment credited 500 Flux, and bypassing the service worker restored the page. Normal-cache production verification follows deployment.
