### PR TITLE
chore(nix): update assets hash

### DIFF
--- a/nix/assets-hash.txt
+++ b/nix/assets-hash.txt
@@ -1,1 +1,1 @@
-sha256-qTJgjqFLcAO6mkhLYTCAoXbCsgbf3ukQw3nbppLE1r8=
+sha256-69tCpJaxRUnyR9CrHlmWJWEWLDpYzyzska7ui9++QoY=


### PR DESCRIPTION
Auto-generated by CI to keep Nix asset hash up-to-date.